### PR TITLE
Usa Claude per suggerimenti AI dei link

### DIFF
--- a/assets/ai.js
+++ b/assets/ai.js
@@ -1,6 +1,6 @@
 /**
  * Affiliate Link Manager AI - AI Features JavaScript
- * Version: 1.5
+ * Version: 1.5.2
  * Author: Cosè Murciano
  */
 


### PR DESCRIPTION
## Summary
- usa l'API di Claude per generare le varianti dei suggerimenti in base a titolo e contenuto del link
- gestisci gli errori se l'AI non restituisce risultati
- aggiorna il plugin alla versione 1.5.2

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/ai.js`


------
https://chatgpt.com/codex/tasks/task_e_68b30017beb083328a9aa169e6fa0593