### PR TITLE
Bump plugin version to 1.5.4

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 1.5.2
+ * Version: 1.5.4
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '1.5.2');
+define('ALMA_VERSION', '1.5.4');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -41,6 +41,9 @@ class AffiliateManagerAI {
         
         // Registra Custom Post Type
         $this->create_post_type();
+
+        // Abilita featured image per i link affiliati
+        add_theme_support('post-thumbnails', array('affiliate_link'));
         
         // Inizializza hooks
         $this->init_hooks();
@@ -121,7 +124,9 @@ class AffiliateManagerAI {
         $atts = shortcode_atts(array(
             'id' => 0,
             'text' => '',
-            'class' => 'affiliate-link-btn'
+            'class' => 'affiliate-link-btn',
+            'img' => 'no',
+            'fields' => ''
         ), $atts);
         
         if (!$atts['id']) {
@@ -138,28 +143,66 @@ class AffiliateManagerAI {
             return '<span style="color:red;">[Affiliate Link: URL non configurato]</span>';
         }
         
-        if (empty($atts['text'])) {
-            $atts['text'] = get_the_title($atts['id']);
+        $link_rel = get_post_meta($atts['id'], '_link_rel', true);
+        if ($link_rel === '') {
+            // Link interno: nessun attributo rel
+        } elseif (!$link_rel) {
+            $link_rel = 'sponsored noopener';
         }
-        
-        $link_rel = get_post_meta($atts['id'], '_link_rel', true) ?: 'sponsored noopener';
         $link_target = get_post_meta($atts['id'], '_link_target', true) ?: '_blank';
         $link_title = get_post_meta($atts['id'], '_link_title', true);
-        
+
         if (empty($link_title)) {
             $link_title = get_the_title($atts['id']);
         }
-        
+
+        // Campi richiesti
+        $fields = array_filter(array_map('trim', explode(',', $atts['fields'])));
+
+        // Contenuto interno al link (immagine + eventuale titolo)
+        $link_content = '';
+        // Contenuto dopo il link (es. descrizione)
+        $after_link = '';
+
+        if ($atts['img'] === 'yes') {
+            $link_content = get_the_post_thumbnail($atts['id'], 'full', array('class' => 'alma-affiliate-img'));
+            if (!$link_content) {
+                $atts['img'] = 'no';
+            } else {
+                if (in_array('title', $fields)) {
+                    $title_html = esc_html(get_the_title($atts['id']));
+                    if (in_array('content', $fields)) {
+                        $link_content .= '<h4 class="alma-link-title">' . $title_html . '</h4>';
+                    } else {
+                        $link_content .= '<span class="alma-link-title">' . $title_html . '</span>';
+                    }
+                }
+                if (in_array('content', $fields)) {
+                    $post_content = apply_filters('the_content', get_post_field('post_content', $atts['id']));
+                    $after_link = '<div class="alma-link-content">' . $post_content . '</div>';
+                }
+            }
+        }
+
+        if ($atts['img'] !== 'yes') {
+            if (empty($atts['text'])) {
+                $atts['text'] = get_the_title($atts['id']);
+            }
+            $link_content = esc_html($atts['text']);
+        }
+
         // NUOVO: Usa link diretto invece di redirect
         $link_html = '<a href="' . esc_url($affiliate_url) . '"';
         $link_html .= ' class="' . esc_attr($atts['class']) . ' alma-affiliate-link"';
         $link_html .= ' data-link-id="' . esc_attr($atts['id']) . '"';
         $link_html .= ' data-track="1"'; // Flag per tracking JavaScript
-        $link_html .= ' rel="' . esc_attr($link_rel) . '"';
+        if ($link_rel !== '') {
+            $link_html .= ' rel="' . esc_attr($link_rel) . '"';
+        }
         $link_html .= ' target="' . esc_attr($link_target) . '"';
         $link_html .= ' title="' . esc_attr($link_title) . '"';
-        $link_html .= '>' . esc_html($atts['text']) . '</a>';
-        
+        $link_html .= '>' . $link_content . '</a>' . $after_link;
+
         return $link_html;
     }
     
@@ -302,7 +345,7 @@ class AffiliateManagerAI {
             'show_in_menu' => true,
             'menu_position' => 25,
             'menu_icon' => 'dashicons-admin-links',
-            'supports' => array('title', 'editor'),
+            'supports' => array('title', 'editor', 'thumbnail'),
             'taxonomies' => array('link_type'),
             'has_archive' => false,
             'rewrite' => false,
@@ -456,7 +499,12 @@ class AffiliateManagerAI {
         wp_nonce_field('save_affiliate_link', 'affiliate_link_nonce');
         
         $affiliate_url = get_post_meta($post->ID, '_affiliate_url', true);
-        $link_rel = get_post_meta($post->ID, '_link_rel', true) ?: 'sponsored noopener';
+        $link_rel = get_post_meta($post->ID, '_link_rel', true);
+        if ($link_rel === '') {
+            // Link interno: nessun attributo rel
+        } elseif (!$link_rel) {
+            $link_rel = 'sponsored noopener';
+        }
         $link_target = get_post_meta($post->ID, '_link_target', true) ?: '_blank';
         $link_title = get_post_meta($post->ID, '_link_title', true);
         $click_count = get_post_meta($post->ID, '_click_count', true) ?: 0;
@@ -477,6 +525,7 @@ class AffiliateManagerAI {
         echo '<th><label for="link_rel">' . __('Tipo Relazione', 'affiliate-link-manager-ai') . '</label></th>';
         echo '<td>';
         echo '<select id="link_rel" name="link_rel" style="min-width:200px;">';
+        echo '<option value=""' . selected($link_rel, '', false) . '>' . __('Link interno (Follow)', 'affiliate-link-manager-ai') . '</option>';
         echo '<option value="sponsored noopener"' . selected($link_rel, 'sponsored noopener', false) . '>' . __('Sponsored + NoOpener (Raccomandato)', 'affiliate-link-manager-ai') . '</option>';
         echo '<option value="sponsored"' . selected($link_rel, 'sponsored', false) . '>' . __('Solo Sponsored', 'affiliate-link-manager-ai') . '</option>';
         echo '<option value="nofollow"' . selected($link_rel, 'nofollow', false) . '>' . __('Nofollow (Legacy)', 'affiliate-link-manager-ai') . '</option>';
@@ -534,8 +583,13 @@ class AffiliateManagerAI {
         echo '<th>' . __('Shortcode', 'affiliate-link-manager-ai') . '</th>';
         echo '<td>';
         echo '<div style="display:flex;gap:10px;align-items:center;">';
-        echo '<code style="padding:8px 12px;background:#f0f0f0;border-radius:4px;">[affiliate_link id="' . $post->ID . '"]</code>';
-        echo '<button type="button" class="button button-small alma-copy-btn" data-copy="[affiliate_link id=&quot;' . $post->ID . '&quot;]">📋 Copia</button>';
+        echo '<code id="alma-shortcode-display" data-id="' . $post->ID . '" style="padding:8px 12px;background:#f0f0f0;border-radius:4px;">[affiliate_link id="' . $post->ID . '"]</code>';
+        echo '<button type="button" id="alma-shortcode-copy" class="button button-small alma-copy-btn" data-copy="[affiliate_link id=&quot;' . $post->ID . '&quot;]">📋 Copia</button>';
+        echo '</div>';
+        echo '<div class="alma-shortcode-config" style="margin-top:8px;">';
+        echo '<label><input type="checkbox" id="alma-sc-img"> ' . __('Immagine', 'affiliate-link-manager-ai') . '</label> ';
+        echo '<label><input type="checkbox" id="alma-sc-title" disabled> ' . __('Titolo', 'affiliate-link-manager-ai') . '</label> ';
+        echo '<label><input type="checkbox" id="alma-sc-content" disabled> ' . __('Contenuto', 'affiliate-link-manager-ai') . '</label>';
         echo '</div>';
         echo '<p class="description">' . __('Usa questo shortcode per inserire il link nei tuoi contenuti', 'affiliate-link-manager-ai') . '</p>';
         echo '</td>';

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -138,6 +138,25 @@
     opacity: 1;
 }
 
+/* Stili frontend per link con immagine */
+.alma-affiliate-img {
+    max-width: 100%;
+    height: auto;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.alma-link-title {
+    margin-left: 5px;
+    vertical-align: middle;
+    display: inline-block;
+}
+
+.alma-link-content {
+    display: block;
+    margin-top: 4px;
+}
+
 /* Search Section */
 .alma-search-section {
     padding: 20px 25px;
@@ -548,4 +567,9 @@ button:disabled {
         opacity: 1;
         transform: translateY(0);
     }
+}
+
+/* Shortcode config in link metabox */
+.alma-shortcode-config label {
+    margin-right: 10px;
 }

--- a/assets/ai.js
+++ b/assets/ai.js
@@ -176,6 +176,33 @@ jQuery(document).ready(function($) {
             }, 2000);
         }
     });
+
+    // Configurazione dinamica dello shortcode nel metabox
+    function almaUpdateShortcodePreview() {
+        const codeEl = $('#alma-shortcode-display');
+        if (!codeEl.length) return;
+        const linkId = codeEl.data('id');
+        let shortcode = `[affiliate_link id="${linkId}"`;
+        const img = $('#alma-sc-img').is(':checked');
+        const title = $('#alma-sc-title').is(':checked');
+        const content = $('#alma-sc-content').is(':checked');
+        if (img) {
+            shortcode += ' img="yes"';
+            const fields = [];
+            if (title) fields.push('title');
+            if (content) fields.push('content');
+            if (fields.length) {
+                shortcode += ` fields="${fields.join(',')}"`;
+            }
+        }
+        shortcode += ']';
+        codeEl.text(shortcode);
+        $('#alma-shortcode-copy').data('copy', shortcode);
+        $('#alma-sc-title, #alma-sc-content').prop('disabled', !img);
+    }
+
+    $(document).on('change', '#alma-sc-img, #alma-sc-title, #alma-sc-content', almaUpdateShortcodePreview);
+    almaUpdateShortcodePreview();
     
     // 🤖 Gestisci rigenera suggerimenti
     $(document).on('click', '.alma-regenerate-suggestions', function(e) {

--- a/assets/editor.js
+++ b/assets/editor.js
@@ -165,9 +165,24 @@ jQuery(document).ready(function($) {
         $(document).on('change.alma_editor', 'input[name="alma_text_option"]', function() {
             const isCustom = $(this).val() === 'custom';
             $('#alma-custom-text').prop('disabled', !isCustom);
-            
+
             if (isCustom) {
                 $('#alma-custom-text').focus();
+            }
+        });
+
+        // Usa immagine in primo piano
+        $(document).on('change.alma_editor', '#alma-use-img', function() {
+            const useImg = $(this).is(':checked');
+            $('input[name="alma_text_option"]').prop('disabled', useImg);
+            $('.alma-field-option').prop('disabled', !useImg);
+            if (useImg) {
+                $('#alma-custom-text').prop('disabled', true);
+                $('.alma-fields-row').slideDown();
+            } else {
+                const isCustom = $('input[name="alma_text_option"]:checked').val() === 'custom';
+                $('#alma-custom-text').prop('disabled', !isCustom);
+                $('.alma-fields-row').slideUp();
             }
         });
         
@@ -306,7 +321,24 @@ jQuery(document).ready(function($) {
                 
                 <div class="alma-shortcode-options" style="display:none;padding:20px 25px;background:#f9f9f9;border-top:1px solid #e0e0e0;">
                     <h3 style="margin:0 0 15px 0;font-size:14px;color:#23282d;">⚙️ Opzioni Shortcode</h3>
-                    
+
+                    <div class="alma-option-row" style="display:flex;align-items:center;gap:15px;margin-bottom:15px;">
+                        <label style="min-width:150px;font-weight:600;color:#23282d;">Usa immagine in primo piano:</label>
+                        <input type="checkbox" id="alma-use-img">
+                    </div>
+
+                    <div class="alma-option-row alma-fields-row" style="display:none;align-items:center;gap:15px;margin-bottom:15px;">
+                        <label style="min-width:150px;font-weight:600;color:#23282d;">Campi dopo immagine:</label>
+                        <label style="font-weight:normal;display:flex;align-items:center;gap:5px;">
+                            <input type="checkbox" class="alma-field-option" value="title">
+                            Titolo
+                        </label>
+                        <label style="font-weight:normal;display:flex;align-items:center;gap:5px;">
+                            <input type="checkbox" class="alma-field-option" value="content">
+                            Contenuto
+                        </label>
+                    </div>
+
                     <div class="alma-option-row" style="display:flex;align-items:center;gap:15px;margin-bottom:15px;">
                         <label style="min-width:150px;font-weight:600;color:#23282d;">Testo del link:</label>
                         <div class="alma-radio-group" style="display:flex;gap:20px;">
@@ -320,20 +352,20 @@ jQuery(document).ready(function($) {
                             </label>
                         </div>
                     </div>
-                    
+
                     <div class="alma-option-row" style="display:flex;align-items:center;gap:15px;margin-bottom:15px;">
                         <label for="alma-custom-text" style="min-width:150px;font-weight:600;color:#23282d;">Testo personalizzato:</label>
-                        <input type="text" 
-                               id="alma-custom-text" 
+                        <input type="text"
+                               id="alma-custom-text"
                                placeholder="Es: Clicca qui per l'offerta"
                                disabled
                                style="flex:1;padding:8px 12px;border:1px solid #ddd;border-radius:4px;">
                     </div>
-                    
+
                     <div class="alma-option-row" style="display:flex;align-items:center;gap:15px;">
                         <label for="alma-custom-class" style="min-width:150px;font-weight:600;color:#23282d;">Classe CSS:</label>
-                        <input type="text" 
-                               id="alma-custom-class" 
+                        <input type="text"
+                               id="alma-custom-class"
                                value="affiliate-link-btn"
                                placeholder="affiliate-link-btn"
                                style="flex:1;padding:8px 12px;border:1px solid #ddd;border-radius:4px;">
@@ -390,7 +422,10 @@ jQuery(document).ready(function($) {
         $('#alma-type-filter').val('');
         $('#alma-custom-text').val('').prop('disabled', true);
         $('#alma-custom-class').val('affiliate-link-btn');
-        $('input[name="alma_text_option"][value="auto"]').prop('checked', true);
+        $('input[name="alma_text_option"][value="auto"]').prop('checked', true).prop('disabled', false);
+        $('#alma-use-img').prop('checked', false);
+        $('.alma-field-option').prop('checked', false).prop('disabled', true);
+        $('.alma-fields-row').hide();
         $('#alma-insert-shortcode').prop('disabled', true);
         $('.alma-shortcode-options').hide();
         $('.alma-link-item').removeClass('selected');
@@ -507,13 +542,23 @@ jQuery(document).ready(function($) {
      */
     function insertShortcode() {
         let shortcode = `[affiliate_link id="${selectedLinkId}"`;
-        
-        // Aggiungi testo personalizzato se selezionato
-        const textOption = $('input[name="alma_text_option"]:checked').val();
-        if (textOption === 'custom') {
-            const customText = $('#alma-custom-text').val().trim();
-            if (customText) {
-                shortcode += ` text="${escapeShortcodeAttr(customText)}"`;
+
+        // Opzione immagine
+        const useImg = $('#alma-use-img').is(':checked');
+        if (useImg) {
+            shortcode += ' img="yes"';
+            const fields = $('.alma-field-option:checked').map(function() { return $(this).val(); }).get();
+            if (fields.length) {
+                shortcode += ` fields="${fields.join(',')}"`;
+            }
+        } else {
+            // Aggiungi testo personalizzato se selezionato
+            const textOption = $('input[name="alma_text_option"]:checked').val();
+            if (textOption === 'custom') {
+                const customText = $('#alma-custom-text').val().trim();
+                if (customText) {
+                    shortcode += ` text="${escapeShortcodeAttr(customText)}"`;
+                }
             }
         }
         


### PR DESCRIPTION
## Summary
- update plugin version header and ALMA_VERSION constant to 1.5.4
- ensure affiliate shortcode only wraps image and title when content is included, placing description outside the anchor

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/ai.js`
- `node --check assets/editor.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3085e50fc8332a5cf04b4e4b70553