### PR TITLE
Add CSV import wizard for affiliate links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Affiliate Link Manager AI
+
+Questo plugin gestisce link affiliati e ora include una procedura guidata per l'importazione di massa.
+
+## Importare link
+1. Vai su **Link affiliati → Importa link** nel pannello di amministrazione.
+2. Carica un file CSV o TSV e mappa le colonne richieste (`post_title` e `_affiliate_url`).
+3. Visualizza l'anteprima e conferma per creare i link affiliati.
+

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -818,6 +818,16 @@ class AffiliateManagerAI {
             'affiliate-link-manager-settings',
             array($this, 'render_settings_page')
         );
+
+        // Importa link
+        add_submenu_page(
+            'edit.php?post_type=affiliate_link',
+            __('Importa link', 'affiliate-link-manager-ai'),
+            __('Importa link', 'affiliate-link-manager-ai'),
+            'manage_options',
+            'alma-import',
+            array($this, 'render_import_page')
+        );
         
         // Pagina nascosta per dettagli utilizzo
         add_submenu_page(
@@ -846,6 +856,7 @@ class AffiliateManagerAI {
         <div class="wrap">
             <h1><?php _e('Dashboard AI - Affiliate Link Manager', 'affiliate-link-manager-ai'); ?></h1>
             <p style="font-size:14px;color:#666;">Versione <?php echo ALMA_VERSION; ?></p>
+            <p><a href="<?php echo admin_url('edit.php?post_type=affiliate_link&page=alma-import'); ?>" class="button button-primary">Importa link</a></p>
             
             <!-- Statistiche Principali -->
             <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:20px;margin:30px 0;">
@@ -946,6 +957,281 @@ class AffiliateManagerAI {
             </div>
         </div>
         <?php
+    }
+
+    /**
+     * Render Import Wizard Page
+     */
+    public function render_import_page() {
+        if (!current_user_can('manage_options')) {
+            wp_die(__('Non hai i permessi per accedere a questa pagina.'));
+        }
+
+        $step = isset($_GET['step']) ? intval($_GET['step']) : 1;
+        switch ($step) {
+            case 2:
+                $this->render_import_step2();
+                break;
+            case 3:
+                $this->render_import_step3();
+                break;
+            default:
+                $this->render_import_step1();
+                break;
+        }
+    }
+
+    private function render_import_step1() {
+        if (isset($_POST['alma_import_nonce']) && wp_verify_nonce($_POST['alma_import_nonce'], 'alma_import_step1')) {
+            if (!empty($_FILES['import_file']['name'])) {
+                $file = $_FILES['import_file'];
+                $ext = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
+                $allowed = array('csv', 'tsv', 'xlsx');
+                if (!in_array($ext, $allowed)) {
+                    echo '<div class="notice notice-error"><p>Formato file non supportato.</p></div>';
+                } else {
+                    $upload = wp_handle_upload($file, array('test_form' => false));
+                    if (!isset($upload['error'])) {
+                        set_transient($this->get_import_transient_name(), $upload['file'], HOUR_IN_SECONDS);
+                        wp_redirect(add_query_arg('step', 2, admin_url('edit.php?post_type=affiliate_link&page=alma-import')));
+                        exit;
+                    } else {
+                        echo '<div class="notice notice-error"><p>' . esc_html($upload['error']) . '</p></div>';
+                    }
+                }
+            }
+        }
+
+        ?>
+        <div class="wrap">
+            <h1><?php _e('Importa Link - Step 1', 'affiliate-link-manager-ai'); ?></h1>
+            <form method="post" enctype="multipart/form-data">
+                <?php wp_nonce_field('alma_import_step1', 'alma_import_nonce'); ?>
+                <input type="file" name="import_file" accept=".csv,.tsv,.xlsx" required />
+                <?php submit_button(__('Carica e continua', 'affiliate-link-manager-ai')); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    private function render_import_step2() {
+        $file = get_transient($this->get_import_transient_name());
+        if (!$file || !file_exists($file)) {
+            echo '<div class="wrap"><h1>Errore</h1><p>File non trovato.</p></div>';
+            return;
+        }
+
+        list($header) = $this->get_file_data($file);
+
+        if (isset($_POST['alma_map_nonce']) && wp_verify_nonce($_POST['alma_map_nonce'], 'alma_import_step2')) {
+            $mapping = array(
+                'post_title' => sanitize_text_field($_POST['map_post_title']),
+                '_affiliate_url' => sanitize_text_field($_POST['map_affiliate_url']),
+                '_link_rel' => sanitize_text_field($_POST['map_link_rel']),
+                '_link_target' => sanitize_text_field($_POST['map_link_target']),
+                '_link_title' => sanitize_text_field($_POST['map_link_title']),
+                'link_type' => sanitize_text_field($_POST['map_link_type']),
+            );
+
+            if (!$mapping['post_title'] || !$mapping['_affiliate_url']) {
+                echo '<div class="notice notice-error"><p>Campi obbligatori mancanti.</p></div>';
+            } else {
+                set_transient($this->get_import_transient_name() . '_map', $mapping, HOUR_IN_SECONDS);
+                wp_redirect(add_query_arg('step', 3, admin_url('edit.php?post_type=affiliate_link&page=alma-import')));
+                exit;
+            }
+        }
+
+        ?>
+        <div class="wrap">
+            <h1><?php _e('Importa Link - Step 2', 'affiliate-link-manager-ai'); ?></h1>
+            <form method="post">
+                <?php wp_nonce_field('alma_import_step2', 'alma_map_nonce'); ?>
+                <table class="form-table">
+                    <?php
+                    $fields = array(
+                        'map_post_title' => array('label' => 'Titolo (post_title)', 'required' => true),
+                        'map_affiliate_url' => array('label' => 'URL Affiliato (_affiliate_url)', 'required' => true),
+                        'map_link_rel' => array('label' => 'Rel (_link_rel)', 'required' => false),
+                        'map_link_target' => array('label' => 'Target (_link_target)', 'required' => false),
+                        'map_link_title' => array('label' => 'Title (_link_title)', 'required' => false),
+                        'map_link_type' => array('label' => 'Tipologia (link_type)', 'required' => false),
+                    );
+                    foreach ($fields as $name => $info) {
+                        echo '<tr><th><label for="' . $name . '">' . $info['label'];
+                        if ($info['required']) {
+                            echo ' *';
+                        }
+                        echo '</label></th><td><select name="' . $name . '" id="' . $name . '"><option value="">--</option>';
+                        foreach ($header as $col) {
+                            echo '<option value="' . esc_attr($col) . '">' . esc_html($col) . '</option>';
+                        }
+                        echo '</select></td></tr>';
+                    }
+                    ?>
+                </table>
+                <?php submit_button(__('Conferma mappatura', 'affiliate-link-manager-ai')); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    private function render_import_step3() {
+        $file = get_transient($this->get_import_transient_name());
+        $mapping = get_transient($this->get_import_transient_name() . '_map');
+
+        if (!$file || !$mapping || !file_exists($file)) {
+            echo '<div class="wrap"><h1>Errore</h1><p>Dati importazione mancanti.</p></div>';
+            return;
+        }
+
+        list($header, $rows) = $this->get_file_data($file, 5);
+
+        if (isset($_POST['alma_import_confirm']) && wp_verify_nonce($_POST['alma_import_confirm'], 'alma_import_step3')) {
+            $result = $this->process_import($file, $mapping);
+            delete_transient($this->get_import_transient_name());
+            delete_transient($this->get_import_transient_name() . '_map');
+            @unlink($file);
+
+            echo '<div class="wrap"><h1>Report Importazione</h1>';
+            echo '<p>Successi: ' . $result['success'] . ' | Fallimenti: ' . $result['failed'] . '</p>';
+            if (!empty($result['errors'])) {
+                echo '<ul>';
+                foreach ($result['errors'] as $err) {
+                    echo '<li>' . esc_html($err) . '</li>';
+                }
+                echo '</ul>';
+            }
+            echo '<p><a class="button" href="' . admin_url('edit.php?post_type=affiliate_link&page=alma-import') . '">Nuova Importazione</a></p>';
+            echo '</div>';
+            return;
+        }
+
+        ?>
+        <div class="wrap">
+            <h1><?php _e('Importa Link - Step 3', 'affiliate-link-manager-ai'); ?></h1>
+            <h2><?php _e('Anteprima', 'affiliate-link-manager-ai'); ?></h2>
+            <table class="widefat">
+                <thead>
+                    <tr>
+                        <?php foreach ($mapping as $field => $col) { if ($col) { echo '<th>' . esc_html($field) . '</th>'; } } ?>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($rows as $row) {
+                        $assoc = array_combine($header, $row);
+                        echo '<tr>';
+                        foreach ($mapping as $field => $col) {
+                            if ($col) {
+                                $val = $assoc[$col] ?? '';
+                                echo '<td>' . esc_html($val) . '</td>';
+                            }
+                        }
+                        echo '</tr>';
+                    } ?>
+                </tbody>
+            </table>
+            <form method="post">
+                <?php wp_nonce_field('alma_import_step3', 'alma_import_confirm'); ?>
+                <?php submit_button(__('Avvia importazione', 'affiliate-link-manager-ai')); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    private function process_import($file, $mapping) {
+        list($header, $rows) = $this->get_file_data($file);
+        $success = 0;
+        $failed = 0;
+        $errors = array();
+
+        foreach ($rows as $index => $row) {
+            $assoc = array_combine($header, $row);
+            $title = trim($assoc[$mapping['post_title']] ?? '');
+            $url = trim($assoc[$mapping['_affiliate_url']] ?? '');
+
+            if ($title === '' || $url === '') {
+                $failed++;
+                $errors[] = sprintf('Riga %d: campi obbligatori mancanti', $index + 2);
+                continue;
+            }
+
+            $post_id = wp_insert_post(
+                array(
+                    'post_title' => $title,
+                    'post_type' => 'affiliate_link',
+                    'post_status' => 'publish',
+                ),
+                true
+            );
+
+            if (is_wp_error($post_id)) {
+                $failed++;
+                $errors[] = sprintf('Riga %d: %s', $index + 2, $post_id->get_error_message());
+                continue;
+            }
+
+            update_post_meta($post_id, '_affiliate_url', $url);
+
+            foreach (array('_link_rel', '_link_target', '_link_title') as $meta_key) {
+                if (!empty($mapping[$meta_key])) {
+                    $val = $assoc[$mapping[$meta_key]] ?? '';
+                    if ($val !== '') {
+                        update_post_meta($post_id, $meta_key, $val);
+                    }
+                }
+            }
+
+            if (!empty($mapping['link_type'])) {
+                $terms_raw = $assoc[$mapping['link_type']] ?? '';
+                if ($terms_raw !== '') {
+                    $terms = array_map('trim', explode(',', $terms_raw));
+                    wp_set_object_terms($post_id, $terms, 'link_type');
+                }
+            }
+
+            $success++;
+        }
+
+        return array(
+            'success' => $success,
+            'failed' => $failed,
+            'errors' => $errors,
+        );
+    }
+
+    private function get_file_data($file, $limit = null) {
+        $ext = strtolower(pathinfo($file, PATHINFO_EXTENSION));
+
+        if ($ext === 'xlsx' && class_exists('SimpleXLSX')) {
+            $xlsx = SimpleXLSX::parse($file);
+            $rows = $xlsx ? $xlsx->rows() : array();
+            $header = array_shift($rows);
+            if ($limit !== null) {
+                $rows = array_slice($rows, 0, $limit);
+            }
+            return array($header, $rows);
+        }
+
+        $delimiter = $ext === 'tsv' ? "\t" : ',';
+        $header = array();
+        $rows = array();
+        if (($handle = fopen($file, 'r')) !== false) {
+            $header = fgetcsv($handle, 0, $delimiter);
+            $count = 0;
+            while (($data = fgetcsv($handle, 0, $delimiter)) !== false) {
+                $rows[] = $data;
+                if ($limit !== null && ++$count >= $limit) {
+                    break;
+                }
+            }
+            fclose($handle);
+        }
+        return array($header, $rows);
+    }
+
+    private function get_import_transient_name() {
+        return 'alma_import_' . get_current_user_id();
     }
     
     /**


### PR DESCRIPTION
## Summary
- add "Importa link" admin submenu and dashboard link
- implement three-step CSV/TSV import wizard with preview and bulk post creation
- document usage in new README

## Testing
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3365a3a8c8332b44f1bbbdfdf0cf2