### PR TITLE
Add CSV import wizard for affiliate links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Affiliate Link Manager AI
+
+Questo plugin gestisce link affiliati e ora include una procedura guidata per l'importazione di massa.
+
+## Importare link
+1. Vai su **Link affiliati → Importa link** nel pannello di amministrazione.
+2. Prepara un file **CSV** o **TSV** con intestazioni nella prima riga. I campi obbligatori sono **Titolo** (`post_title`) e **URL affiliato** (`_affiliate_url`). Campi opzionali: **Rel** (`_link_rel`), **Target** (`_link_target`) e **Title** (`_link_title`). Le **Tipologie** si scelgono nel secondo passo dell'import tramite apposite checkbox. Puoi scaricare un file di esempio dalla pagina di importazione.
+3. Carica il file, associa le colonne, scegli le tipologie e verifica l'anteprima delle prime righe.
+4. Conferma l'importazione. Al termine ti verrà mostrato un **ID importazione**: conservalo per poter eliminare tutti i link di quel batch in futuro.
+
+### Eliminare link importati
+Nella pagina di importazione puoi inserire l'ID fornito al termine dell'operazione per cancellare tutti i link creati in quell'import.
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Questo plugin gestisce link affiliati e ora include una procedura guidata per l'
 
 ## Importare link
 1. Vai su **Link affiliati → Importa link** nel pannello di amministrazione.
-2. Prepara un file **CSV** o **TSV** con intestazioni nella prima riga. I campi obbligatori sono **Titolo** (`post_title`) e **URL affiliato** (`_affiliate_url`). Campi opzionali: **Rel** (`_link_rel`), **Target** (`_link_target`) e **Title** (`_link_title`). Le **Tipologie** si scelgono nel secondo passo dell'import tramite apposite checkbox. Puoi scaricare un file di esempio dalla pagina di importazione.
+2. Prepara un file **CSV**, **TSV** o **XML** con intestazioni nella prima riga. I campi obbligatori sono **Titolo** (`post_title`) e **URL affiliato** (`_affiliate_url`). Campi opzionali: **Rel** (`_link_rel`), **Target** (`_link_target`) e **Title** (`_link_title`). Le **Tipologie** si scelgono nel secondo passo dell'import tramite apposite checkbox. Puoi scaricare un file di esempio (CSV o XML) dalla pagina di importazione.
 3. Carica il file, associa le colonne, scegli le tipologie e verifica l'anteprima delle prime righe.
 4. Conferma l'importazione. Al termine ti verrà mostrato un **ID importazione**: conservalo per poter eliminare tutti i link di quel batch in futuro.
 

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 1.7.1
+ * Version: 1.7.2
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '1.7.1');
+define('ALMA_VERSION', '1.7.2');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/assets/import-sample.csv
+++ b/assets/import-sample.csv
@@ -1,0 +1,2 @@
+post_title,_affiliate_url,_link_rel,_link_target,_link_title
+"Esempio prodotto","https://example.com","nofollow","_blank","Scopri di più"

--- a/assets/import-sample.xml
+++ b/assets/import-sample.xml
@@ -1,0 +1,9 @@
+<links>
+  <link>
+    <post_title>Esempio prodotto</post_title>
+    <_affiliate_url>https://example.com</_affiliate_url>
+    <_link_rel>nofollow</_link_rel>
+    <_link_target>_blank</_link_target>
+    <_link_title>Scopri di più</_link_title>
+  </link>
+</links>


### PR DESCRIPTION
## Summary
- ensure upload step explains each field and links a refreshed sample CSV
- fix step-two blank screen and let admins choose existing link types via checkboxes
- handle taxonomy assignment during import and bump plugin version to 1.7.1

## Testing
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3365a3a8c8332b44f1bbbdfdf0cf2