### PR TITLE
Allow independent shortcode field selection

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -599,8 +599,8 @@ class AffiliateManagerAI {
         echo '</div>';
         echo '<div class="alma-shortcode-config" style="margin-top:8px;">';
         echo '<label><input type="checkbox" id="alma-sc-img"> ' . __('Immagine', 'affiliate-link-manager-ai') . '</label> ';
-        echo '<label><input type="checkbox" id="alma-sc-title" disabled> ' . __('Titolo', 'affiliate-link-manager-ai') . '</label> ';
-        echo '<label><input type="checkbox" id="alma-sc-content" disabled> ' . __('Contenuto', 'affiliate-link-manager-ai') . '</label>';
+        echo '<label><input type="checkbox" id="alma-sc-title"> ' . __('Titolo', 'affiliate-link-manager-ai') . '</label> ';
+        echo '<label><input type="checkbox" id="alma-sc-content"> ' . __('Contenuto', 'affiliate-link-manager-ai') . '</label>';
         echo '</div>';
         echo '<p class="description">' . __('Usa questo shortcode per inserire il link nei tuoi contenuti', 'affiliate-link-manager-ai') . '</p>';
         echo '</td>';

--- a/assets/ai.js
+++ b/assets/ai.js
@@ -188,17 +188,16 @@ jQuery(document).ready(function($) {
         const content = $('#alma-sc-content').is(':checked');
         if (img) {
             shortcode += ' img="yes"';
-            const fields = [];
-            if (title) fields.push('title');
-            if (content) fields.push('content');
-            if (fields.length) {
-                shortcode += ` fields="${fields.join(',')}"`;
-            }
+        }
+        const fields = [];
+        if (title) fields.push('title');
+        if (content) fields.push('content');
+        if (fields.length) {
+            shortcode += ` fields="${fields.join(',')}"`;
         }
         shortcode += ']';
         codeEl.text(shortcode);
         $('#alma-shortcode-copy').data('copy', shortcode);
-        $('#alma-sc-title, #alma-sc-content').prop('disabled', !img);
     }
 
     $(document).on('change', '#alma-sc-img, #alma-sc-title, #alma-sc-content', almaUpdateShortcodePreview);

--- a/assets/editor.js
+++ b/assets/editor.js
@@ -171,18 +171,6 @@ jQuery(document).ready(function($) {
             }
         });
 
-        // Usa immagine in primo piano
-        $(document).on('change.alma_editor', '#alma-use-img', function() {
-            const useImg = $(this).is(':checked');
-            $('.alma-field-option').prop('disabled', !useImg);
-            if (useImg) {
-                $('.alma-fields-row').slideDown();
-            } else {
-                $('.alma-fields-row').slideUp();
-                const isCustom = $('input[name="alma_text_option"]:checked').val() === 'custom';
-                $('#alma-custom-text').prop('disabled', !isCustom);
-            }
-        });
         
         // Inserisci shortcode
         $(document).on('click.alma_editor', '#alma-insert-shortcode', function() {
@@ -325,8 +313,8 @@ jQuery(document).ready(function($) {
                         <input type="checkbox" id="alma-use-img">
                     </div>
 
-                    <div class="alma-option-row alma-fields-row" style="display:none;align-items:center;gap:15px;margin-bottom:15px;">
-                        <label style="min-width:150px;font-weight:600;color:#23282d;">Campi dopo immagine:</label>
+                    <div class="alma-option-row alma-fields-row" style="display:flex;align-items:center;gap:15px;margin-bottom:15px;">
+                        <label style="min-width:150px;font-weight:600;color:#23282d;">Elementi da includere:</label>
                         <label style="font-weight:normal;display:flex;align-items:center;gap:5px;">
                             <input type="checkbox" class="alma-field-option" value="title">
                             Titolo
@@ -422,8 +410,7 @@ jQuery(document).ready(function($) {
         $('#alma-custom-class').val('affiliate-link-btn');
         $('input[name="alma_text_option"][value="auto"]').prop('checked', true).prop('disabled', false);
         $('#alma-use-img').prop('checked', false);
-        $('.alma-field-option').prop('checked', false).prop('disabled', true);
-        $('.alma-fields-row').hide();
+        $('.alma-field-option').prop('checked', false);
         $('#alma-insert-shortcode').prop('disabled', true);
         $('.alma-shortcode-options').hide();
         $('.alma-link-item').removeClass('selected');
@@ -545,10 +532,10 @@ jQuery(document).ready(function($) {
         const useImg = $('#alma-use-img').is(':checked');
         if (useImg) {
             shortcode += ' img="yes"';
-            const fields = $('.alma-field-option:checked').map(function() { return $(this).val(); }).get();
-            if (fields.length) {
-                shortcode += ` fields="${fields.join(',')}"`;
-            }
+        }
+        const fields = $('.alma-field-option:checked').map(function() { return $(this).val(); }).get();
+        if (fields.length) {
+            shortcode += ` fields="${fields.join(',')}"`;
         }
 
         // Aggiungi testo personalizzato se selezionato


### PR DESCRIPTION
## Summary
- Allow Image, Title, and Content shortcode options to be toggled independently
- Generate shortcode fields regardless of image usage in link meta box and editor

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/ai.js`
- `node --check assets/editor.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b43c660c4483329c84b429706d9f29