### PR TITLE
Add optional CTA button to affiliate links

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -574,3 +574,7 @@ button:disabled {
 .alma-shortcode-config label {
     margin-right: 10px;
 }
+.alma-shortcode-config input[type="text"],
+.alma-shortcode-config select {
+    margin-left: 5px;
+}

--- a/assets/ai.js
+++ b/assets/ai.js
@@ -186,6 +186,9 @@ jQuery(document).ready(function($) {
         const img = $('#alma-sc-img').is(':checked');
         const title = $('#alma-sc-title').is(':checked');
         const content = $('#alma-sc-content').is(':checked');
+        const button = $('#alma-sc-button').is(':checked');
+        const buttonSize = $('#alma-sc-button-size').val();
+        const buttonText = $('#alma-sc-button-text').val().trim();
         if (img) {
             shortcode += ' img="yes"';
         }
@@ -195,12 +198,30 @@ jQuery(document).ready(function($) {
         if (fields.length) {
             shortcode += ` fields="${fields.join(',')}"`;
         }
+        if (button) {
+            shortcode += ' button="yes"';
+            if (buttonSize) {
+                shortcode += ` button_size="${buttonSize}"`;
+            }
+            if (buttonText) {
+                shortcode += ` button_text="${escapeShortcodeAttr(buttonText)}"`;
+            }
+        }
         shortcode += ']';
         codeEl.text(shortcode);
         $('#alma-shortcode-copy').data('copy', shortcode);
     }
 
-    $(document).on('change', '#alma-sc-img, #alma-sc-title, #alma-sc-content', almaUpdateShortcodePreview);
+    $(document).on('change', '#alma-sc-img, #alma-sc-title, #alma-sc-content, #alma-sc-button, #alma-sc-button-size', almaUpdateShortcodePreview);
+    $(document).on('input', '#alma-sc-button-text', almaUpdateShortcodePreview);
+
+    // Abilita/disabilita campi pulsante
+    $(document).on('change', '#alma-sc-button', function() {
+        const enabled = $(this).is(':checked');
+        $('#alma-sc-button-size, #alma-sc-button-text').prop('disabled', !enabled);
+    });
+
+    $('#alma-sc-button').trigger('change');
     almaUpdateShortcodePreview();
     
     // 🤖 Gestisci rigenera suggerimenti
@@ -581,6 +602,10 @@ jQuery(document).ready(function($) {
         const div = document.createElement('div');
         div.textContent = text;
         return div.innerHTML;
+    }
+
+    function escapeShortcodeAttr(text) {
+        return text.replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/\[/g, '&#91;').replace(/\]/g, '&#93;');
     }
     
     /**

--- a/assets/editor.js
+++ b/assets/editor.js
@@ -171,6 +171,12 @@ jQuery(document).ready(function($) {
             }
         });
 
+        // Abilita/disabilita opzioni pulsante
+        $(document).on('change.alma_editor', '#alma-add-button', function() {
+            const enabled = $(this).is(':checked');
+            $('#alma-button-text, #alma-button-size').prop('disabled', !enabled);
+        });
+
         
         // Inserisci shortcode
         $(document).on('click.alma_editor', '#alma-insert-shortcode', function() {
@@ -348,6 +354,17 @@ jQuery(document).ready(function($) {
                                style="flex:1;padding:8px 12px;border:1px solid #ddd;border-radius:4px;">
                     </div>
 
+                    <div class="alma-option-row" style="display:flex;align-items:center;gap:15px;margin-bottom:15px;">
+                        <label style="min-width:150px;font-weight:600;color:#23282d;">Pulsante CTA:</label>
+                        <input type="checkbox" id="alma-add-button">
+                        <select id="alma-button-size" style="margin-left:10px;">
+                            <option value="small">Piccolo</option>
+                            <option value="medium" selected>Medio</option>
+                            <option value="large">Grande</option>
+                        </select>
+                        <input type="text" id="alma-button-text" placeholder="Testo pulsante" style="flex:1;padding:8px 12px;border:1px solid #ddd;border-radius:4px;">
+                    </div>
+
                     <div class="alma-option-row" style="display:flex;align-items:center;gap:15px;">
                         <label for="alma-custom-class" style="min-width:150px;font-weight:600;color:#23282d;">Classe CSS:</label>
                         <input type="text"
@@ -370,7 +387,10 @@ jQuery(document).ready(function($) {
         </div>`;
         
         $('body').append(modalHtml);
-        
+
+        // Disabilita campi pulsante inizialmente
+        $('#alma-button-text, #alma-button-size').prop('disabled', true);
+
         // Carica le tipologie dopo aver creato il modal
         loadLinkTypes();
     }
@@ -411,6 +431,9 @@ jQuery(document).ready(function($) {
         $('input[name="alma_text_option"][value="auto"]').prop('checked', true).prop('disabled', false);
         $('#alma-use-img').prop('checked', false);
         $('.alma-field-option').prop('checked', false);
+        $('#alma-add-button').prop('checked', false);
+        $('#alma-button-text').val('').prop('disabled', true);
+        $('#alma-button-size').val('medium').prop('disabled', true);
         $('#alma-insert-shortcode').prop('disabled', true);
         $('.alma-shortcode-options').hide();
         $('.alma-link-item').removeClass('selected');
@@ -546,7 +569,21 @@ jQuery(document).ready(function($) {
                 shortcode += ` text="${escapeShortcodeAttr(customText)}"`;
             }
         }
-        
+
+        // Aggiungi pulsante CTA se selezionato
+        const addButton = $('#alma-add-button').is(':checked');
+        if (addButton) {
+            shortcode += ' button="yes"';
+            const btnSize = $('#alma-button-size').val();
+            if (btnSize) {
+                shortcode += ` button_size="${btnSize}"`;
+            }
+            const btnText = $('#alma-button-text').val().trim();
+            if (btnText) {
+                shortcode += ` button_text="${escapeShortcodeAttr(btnText)}"`;
+            }
+        }
+
         // Aggiungi classe personalizzata se diversa dal default
         const customClass = $('#alma-custom-class').val().trim();
         if (customClass && customClass !== 'affiliate-link-btn') {

--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -1,0 +1,20 @@
+.alma-affiliate-button {
+    display: inline-block;
+    text-decoration: none;
+    background: #2271b1;
+    color: #fff;
+    border-radius: 4px;
+    margin-top: 8px;
+}
+.alma-btn-small {
+    padding: 6px 12px;
+    font-size: 14px;
+}
+.alma-btn-medium {
+    padding: 10px 20px;
+    font-size: 16px;
+}
+.alma-btn-large {
+    padding: 14px 28px;
+    font-size: 18px;
+}


### PR DESCRIPTION
## Summary
- add optional CTA button with customizable text and size to affiliate links
- update shortcode builders in admin and editor to include button options
- add frontend styles and bump plugin version to 1.8

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/ai.js`
- `node --check assets/editor.js`


------
https://chatgpt.com/codex/tasks/task_e_68b440084a6c83328c88b4eace74aa4f