### PR TITLE
Add button alignment and custom class options

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 1.7
+ * Version: 1.9
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '1.7');
+define('ALMA_VERSION', '1.9');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -63,7 +63,7 @@ class AffiliateManagerAI {
      * Enqueue scripts frontend per tracking
      */
     public function enqueue_frontend_scripts() {
-        // Verifica se il file esiste prima di caricarlo
+        // Verifica se il file esiste prima di caricare script e stile
         $tracking_file = ALMA_PLUGIN_DIR . 'assets/tracking.js';
         if (file_exists($tracking_file)) {
             wp_enqueue_script(
@@ -73,13 +73,23 @@ class AffiliateManagerAI {
                 ALMA_VERSION,
                 true
             );
-            
+
             // Passa dati al JavaScript
             wp_localize_script('alma-tracking', 'alma_tracking', array(
                 'ajax_url' => admin_url('admin-ajax.php'),
                 'nonce' => wp_create_nonce('alma_track_click'),
                 'track_logged_out' => get_option('alma_track_logged_out', 'yes') === 'yes'
             ));
+        }
+
+        $style_file = ALMA_PLUGIN_DIR . 'assets/frontend.css';
+        if (file_exists($style_file)) {
+            wp_enqueue_style(
+                'alma-frontend',
+                ALMA_PLUGIN_URL . 'assets/frontend.css',
+                array(),
+                ALMA_VERSION
+            );
         }
     }
     
@@ -126,7 +136,12 @@ class AffiliateManagerAI {
             'text' => '',
             'class' => 'affiliate-link-btn',
             'img' => 'no',
-            'fields' => ''
+            'fields' => '',
+            'button' => 'no',
+            'button_text' => '',
+            'button_size' => 'medium',
+            'button_align' => 'center',
+            'button_class' => ''
         ), $atts);
         
         if (!$atts['id']) {
@@ -212,6 +227,29 @@ class AffiliateManagerAI {
 
         if ($content_html) {
             $link_html .= $content_html;
+        }
+
+        // Pulsante call to action opzionale
+        if ($atts['button'] === 'yes') {
+            $size = in_array($atts['button_size'], array('small','medium','large')) ? $atts['button_size'] : 'medium';
+            $align = in_array($atts['button_align'], array('left','center','right')) ? $atts['button_align'] : 'center';
+            $btn_classes = 'alma-affiliate-button alma-btn-' . esc_attr($size) . ' alma-affiliate-link';
+            if (!empty($atts['button_class'])) {
+                $btn_classes .= ' ' . esc_attr($atts['button_class']);
+            }
+            $btn_text = !empty($atts['button_text']) ? esc_html($atts['button_text']) : __('Scopri di più', 'affiliate-link-manager-ai');
+            $button_html = '<div class="alma-button-wrapper alma-align-' . esc_attr($align) . '">';
+            $button_html .= '<a href="' . esc_url($affiliate_url) . '"';
+            $button_html .= ' class="' . $btn_classes . '"';
+            $button_html .= ' data-link-id="' . esc_attr($atts['id']) . '"';
+            $button_html .= ' data-track="1"';
+            if ($link_rel !== '') {
+                $button_html .= ' rel="' . esc_attr($link_rel) . '"';
+            }
+            $button_html .= ' target="' . esc_attr($link_target) . '"';
+            $button_html .= ' title="' . esc_attr($link_title) . '"';
+            $button_html .= '>' . $btn_text . '</a></div>';
+            $link_html .= $button_html;
         }
 
         return $link_html;
@@ -601,6 +639,21 @@ class AffiliateManagerAI {
         echo '<label><input type="checkbox" id="alma-sc-img"> ' . __('Immagine', 'affiliate-link-manager-ai') . '</label> ';
         echo '<label><input type="checkbox" id="alma-sc-title"> ' . __('Titolo', 'affiliate-link-manager-ai') . '</label> ';
         echo '<label><input type="checkbox" id="alma-sc-content"> ' . __('Contenuto', 'affiliate-link-manager-ai') . '</label>';
+        echo '</div>';
+        echo '<div class="alma-shortcode-config" style="margin-top:8px;">';
+        echo '<label><input type="checkbox" id="alma-sc-button"> ' . __('Pulsante', 'affiliate-link-manager-ai') . '</label> ';
+        echo '<select id="alma-sc-button-size" style="margin-left:5px;" disabled>';
+        echo '<option value="small">' . __('Piccolo', 'affiliate-link-manager-ai') . '</option>';
+        echo '<option value="medium" selected>' . __('Medio', 'affiliate-link-manager-ai') . '</option>';
+        echo '<option value="large">' . __('Grande', 'affiliate-link-manager-ai') . '</option>';
+        echo '</select>';
+        echo '<select id="alma-sc-button-align" style="margin-left:5px;" disabled>';
+        echo '<option value="left">' . __('Sinistra', 'affiliate-link-manager-ai') . '</option>';
+        echo '<option value="center" selected>' . __('Centro', 'affiliate-link-manager-ai') . '</option>';
+        echo '<option value="right">' . __('Destra', 'affiliate-link-manager-ai') . '</option>';
+        echo '</select>';
+        echo '<input type="text" id="alma-sc-button-text" placeholder="' . esc_attr__('Testo pulsante', 'affiliate-link-manager-ai') . '" style="margin-left:5px;" disabled />';
+        echo '<input type="text" id="alma-sc-button-class" placeholder="' . esc_attr__('Classe pulsante', 'affiliate-link-manager-ai') . '" style="margin-left:5px;" disabled />';
         echo '</div>';
         echo '<p class="description">' . __('Usa questo shortcode per inserire il link nei tuoi contenuti', 'affiliate-link-manager-ai') . '</p>';
         echo '</td>';

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -574,3 +574,7 @@ button:disabled {
 .alma-shortcode-config label {
     margin-right: 10px;
 }
+.alma-shortcode-config input[type="text"],
+.alma-shortcode-config select {
+    margin-left: 5px;
+}

--- a/assets/ai.js
+++ b/assets/ai.js
@@ -186,6 +186,11 @@ jQuery(document).ready(function($) {
         const img = $('#alma-sc-img').is(':checked');
         const title = $('#alma-sc-title').is(':checked');
         const content = $('#alma-sc-content').is(':checked');
+        const button = $('#alma-sc-button').is(':checked');
+        const buttonSize = $('#alma-sc-button-size').val();
+        const buttonAlign = $('#alma-sc-button-align').val();
+        const buttonText = $('#alma-sc-button-text').val().trim();
+        const buttonClass = $('#alma-sc-button-class').val().trim();
         if (img) {
             shortcode += ' img="yes"';
         }
@@ -195,12 +200,36 @@ jQuery(document).ready(function($) {
         if (fields.length) {
             shortcode += ` fields="${fields.join(',')}"`;
         }
+        if (button) {
+            shortcode += ' button="yes"';
+            if (buttonSize) {
+                shortcode += ` button_size="${buttonSize}"`;
+            }
+            if (buttonAlign) {
+                shortcode += ` button_align="${buttonAlign}"`;
+            }
+            if (buttonText) {
+                shortcode += ` button_text="${escapeShortcodeAttr(buttonText)}"`;
+            }
+            if (buttonClass) {
+                shortcode += ` button_class="${escapeShortcodeAttr(buttonClass)}"`;
+            }
+        }
         shortcode += ']';
         codeEl.text(shortcode);
         $('#alma-shortcode-copy').data('copy', shortcode);
     }
 
-    $(document).on('change', '#alma-sc-img, #alma-sc-title, #alma-sc-content', almaUpdateShortcodePreview);
+    $(document).on('change', '#alma-sc-img, #alma-sc-title, #alma-sc-content, #alma-sc-button, #alma-sc-button-size, #alma-sc-button-align', almaUpdateShortcodePreview);
+    $(document).on('input', '#alma-sc-button-text, #alma-sc-button-class', almaUpdateShortcodePreview);
+
+    // Abilita/disabilita campi pulsante
+    $(document).on('change', '#alma-sc-button', function() {
+        const enabled = $(this).is(':checked');
+        $('#alma-sc-button-size, #alma-sc-button-align, #alma-sc-button-text, #alma-sc-button-class').prop('disabled', !enabled);
+    });
+
+    $('#alma-sc-button').trigger('change');
     almaUpdateShortcodePreview();
     
     // 🤖 Gestisci rigenera suggerimenti
@@ -581,6 +610,10 @@ jQuery(document).ready(function($) {
         const div = document.createElement('div');
         div.textContent = text;
         return div.innerHTML;
+    }
+
+    function escapeShortcodeAttr(text) {
+        return text.replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/\[/g, '&#91;').replace(/\]/g, '&#93;');
     }
     
     /**

--- a/assets/editor.js
+++ b/assets/editor.js
@@ -171,6 +171,12 @@ jQuery(document).ready(function($) {
             }
         });
 
+        // Abilita/disabilita opzioni pulsante
+        $(document).on('change.alma_editor', '#alma-add-button', function() {
+            const enabled = $(this).is(':checked');
+            $('#alma-button-text, #alma-button-size, #alma-button-align, #alma-button-class').prop('disabled', !enabled);
+        });
+
         
         // Inserisci shortcode
         $(document).on('click.alma_editor', '#alma-insert-shortcode', function() {
@@ -348,6 +354,27 @@ jQuery(document).ready(function($) {
                                style="flex:1;padding:8px 12px;border:1px solid #ddd;border-radius:4px;">
                     </div>
 
+                    <div class="alma-option-row" style="display:flex;align-items:center;gap:15px;margin-bottom:15px;">
+                        <label style="min-width:150px;font-weight:600;color:#23282d;">Pulsante CTA:</label>
+                        <input type="checkbox" id="alma-add-button">
+                        <select id="alma-button-size" style="margin-left:10px;">
+                            <option value="small">Piccolo</option>
+                            <option value="medium" selected>Medio</option>
+                            <option value="large">Grande</option>
+                        </select>
+                        <select id="alma-button-align" style="margin-left:10px;">
+                            <option value="left">Sinistra</option>
+                            <option value="center" selected>Centro</option>
+                            <option value="right">Destra</option>
+                        </select>
+                        <input type="text" id="alma-button-text" placeholder="Testo pulsante" style="flex:1;padding:8px 12px;border:1px solid #ddd;border-radius:4px;">
+                    </div>
+
+                    <div class="alma-option-row" style="display:flex;align-items:center;gap:15px;margin-bottom:15px;">
+                        <label for="alma-button-class" style="min-width:150px;font-weight:600;color:#23282d;">Classe pulsante:</label>
+                        <input type="text" id="alma-button-class" placeholder="classe-personalizzata" style="flex:1;padding:8px 12px;border:1px solid #ddd;border-radius:4px;">
+                    </div>
+
                     <div class="alma-option-row" style="display:flex;align-items:center;gap:15px;">
                         <label for="alma-custom-class" style="min-width:150px;font-weight:600;color:#23282d;">Classe CSS:</label>
                         <input type="text"
@@ -370,7 +397,10 @@ jQuery(document).ready(function($) {
         </div>`;
         
         $('body').append(modalHtml);
-        
+
+        // Disabilita campi pulsante inizialmente
+        $('#alma-button-text, #alma-button-size, #alma-button-align, #alma-button-class').prop('disabled', true);
+
         // Carica le tipologie dopo aver creato il modal
         loadLinkTypes();
     }
@@ -411,6 +441,11 @@ jQuery(document).ready(function($) {
         $('input[name="alma_text_option"][value="auto"]').prop('checked', true).prop('disabled', false);
         $('#alma-use-img').prop('checked', false);
         $('.alma-field-option').prop('checked', false);
+        $('#alma-add-button').prop('checked', false);
+        $('#alma-button-text').val('').prop('disabled', true);
+        $('#alma-button-size').val('medium').prop('disabled', true);
+        $('#alma-button-align').val('center').prop('disabled', true);
+        $('#alma-button-class').val('').prop('disabled', true);
         $('#alma-insert-shortcode').prop('disabled', true);
         $('.alma-shortcode-options').hide();
         $('.alma-link-item').removeClass('selected');
@@ -546,7 +581,29 @@ jQuery(document).ready(function($) {
                 shortcode += ` text="${escapeShortcodeAttr(customText)}"`;
             }
         }
-        
+
+        // Aggiungi pulsante CTA se selezionato
+        const addButton = $('#alma-add-button').is(':checked');
+        if (addButton) {
+            shortcode += ' button="yes"';
+            const btnSize = $('#alma-button-size').val();
+            if (btnSize) {
+                shortcode += ` button_size="${btnSize}"`;
+            }
+            const btnAlign = $('#alma-button-align').val();
+            if (btnAlign) {
+                shortcode += ` button_align="${btnAlign}"`;
+            }
+            const btnText = $('#alma-button-text').val().trim();
+            if (btnText) {
+                shortcode += ` button_text="${escapeShortcodeAttr(btnText)}"`;
+            }
+            const btnClass = $('#alma-button-class').val().trim();
+            if (btnClass) {
+                shortcode += ` button_class="${escapeShortcodeAttr(btnClass)}"`;
+            }
+        }
+
         // Aggiungi classe personalizzata se diversa dal default
         const customClass = $('#alma-custom-class').val().trim();
         if (customClass && customClass !== 'affiliate-link-btn') {

--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -1,0 +1,34 @@
+.alma-affiliate-button {
+    display: inline-block;
+    text-decoration: none;
+    background: #2271b1;
+    color: #fff;
+    border-radius: 4px;
+    margin-top: 8px;
+}
+.alma-btn-small {
+    padding: 6px 12px;
+    font-size: 14px;
+}
+.alma-btn-medium {
+    padding: 10px 20px;
+    font-size: 16px;
+}
+.alma-btn-large {
+    padding: 14px 28px;
+    font-size: 18px;
+}
+
+.alma-button-wrapper {
+    display: block;
+    width: 100%;
+}
+.alma-align-left {
+    text-align: left;
+}
+.alma-align-center {
+    text-align: center;
+}
+.alma-align-right {
+    text-align: right;
+}


### PR DESCRIPTION
## Summary
- add alignment and custom CSS class options for optional CTA buttons
- allow button to render on its own line with alignment wrappers and styles
- bump plugin version to 1.9

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/ai.js`
- `node --check assets/editor.js`


------
https://chatgpt.com/codex/tasks/task_e_68b440084a6c83328c88b4eace74aa4f