### PR TITLE
Enhance bulk import and link management

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ Questo plugin gestisce link affiliati e ora include una procedura guidata per l'
 
 ## Importare link
 1. Vai su **Link affiliati → Importa link** nel pannello di amministrazione.
-ì2. Prepara un file **CSV** o **TSV** con intestazioni nella prima riga. I campi obbligatori sono **Titolo** (`post_title`) e **URL affiliato** (`_affiliate_url`). Campi opzionali: **Rel** (`_link_rel`), **Target** (`_link_target`), **Title** (`_link_title`) e **Tipologia** (`link_type`, più termini separati da virgole). Puoi scaricare un file di esempio dalla pagina di importazione.
+2. Prepara un file **CSV**, **XLSX** o **XML** con intestazioni nella prima riga. I campi obbligatori sono **Titolo** (`post_title`) e **URL affiliato** (`_affiliate_url`). Campi opzionali: **Rel** (`_link_rel`), **Target** (`_link_target`), **Title** (`_link_title`) e **Tipologia** (`link_type`, più termini separati da virgole). Puoi scaricare un file di esempio dalla pagina di importazione.
 
-3. Carica il file, associa le colonne e verifica l'anteprima delle prime righe.
+3. Carica il file, associa le colonne, scegli eventuali tipologie e verifica l'anteprima delle prime righe.
 4. Conferma l'importazione. Al termine ti verrà mostrato un **ID importazione**: conservalo per poter eliminare tutti i link di quel batch in futuro.
 
 ### Eliminare link importati
 Nella pagina di importazione puoi inserire l'ID fornito al termine dell'operazione per cancellare tutti i link creati in quell'import.
 
-2. Carica un file CSV o TSV e mappa le colonne richieste (`post_title` e `_affiliate_url`).
-3. Visualizza l'anteprima e conferma per creare i link affiliati.
+2. Carica un file CSV, XLSX o XML e mappa le colonne richieste (`post_title` e `_affiliate_url`).
+3. Visualizza l'anteprima, controlla le tipologie selezionate e conferma per creare i link affiliati.
 
 


### PR DESCRIPTION
## Summary
- allow choosing link types from existing taxonomy in both link editor and import wizard
- support XML uploads for bulk import and drop legacy TSV handling
- show link IDs in the affiliate link list

## Testing
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4511c387483328568348e92974502