### PR TITLE
Remove bulk import and improve link cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,8 @@
 # Affiliate Link Manager AI
 
-Questo plugin gestisce link affiliati e ora include una procedura guidata per l'importazione di massa.
+Questo plugin gestisce link affiliati con funzionalità avanzate di monitoraggio e gestione.
 
-## Importare link
-1. Vai su **Link affiliati → Importa link** nel pannello di amministrazione.
-2. Prepara un file **CSV**, **XLSX** o **XML** con intestazioni nella prima riga. I campi obbligatori sono **Titolo** (`post_title`) e **URL affiliato** (`_affiliate_url`). Campi opzionali: **Rel** (`_link_rel`), **Target** (`_link_target`), **Title** (`_link_title`) e **Tipologia** (`link_type`, più termini separati da virgole). Puoi scaricare un file di esempio dalla pagina di importazione.
+## Eliminazione link
 
-3. Carica il file, associa le colonne, scegli eventuali tipologie e verifica l'anteprima delle prime righe.
-4. Conferma l'importazione. Al termine ti verrà mostrato un **ID importazione**: conservalo per poter eliminare tutti i link di quel batch in futuro.
-
-### Eliminare link importati
-Nella pagina di importazione puoi inserire l'ID fornito al termine dell'operazione per cancellare tutti i link creati in quell'import.
-
-2. Carica un file CSV, XLSX o XML e mappa le colonne richieste (`post_title` e `_affiliate_url`).
-3. Visualizza l'anteprima, controlla le tipologie selezionate e conferma per creare i link affiliati.
-
+Nelle impostazioni del plugin puoi decidere come gestire gli shortcode quando un link viene eliminato. È inoltre possibile eliminare rapidamente un singolo link tramite ID oppure rimuovere tutti i link appartenenti a una specifica tipologia.
 

--- a/assets/ai.js
+++ b/assets/ai.js
@@ -189,6 +189,7 @@ jQuery(document).ready(function($) {
         const button = $('#alma-sc-button').is(':checked');
         const buttonSize = $('#alma-sc-button-size').val();
         const buttonText = $('#alma-sc-button-text').val().trim();
+        const buttonAlign = $('#alma-sc-button-align').val();
         if (img) {
             shortcode += ' img="yes"';
         }
@@ -206,23 +207,88 @@ jQuery(document).ready(function($) {
             if (buttonText) {
                 shortcode += ` button_text="${escapeShortcodeAttr(buttonText)}"`;
             }
+            if (buttonAlign && buttonAlign !== 'left') {
+                shortcode += ` button_align="${buttonAlign}"`;
+            }
         }
         shortcode += ']';
         codeEl.text(shortcode);
         $('#alma-shortcode-copy').data('copy', shortcode);
     }
 
-    $(document).on('change', '#alma-sc-img, #alma-sc-title, #alma-sc-content, #alma-sc-button, #alma-sc-button-size', almaUpdateShortcodePreview);
+    $(document).on('change', '#alma-sc-img, #alma-sc-title, #alma-sc-content, #alma-sc-button, #alma-sc-button-size, #alma-sc-button-align', almaUpdateShortcodePreview);
     $(document).on('input', '#alma-sc-button-text', almaUpdateShortcodePreview);
 
     // Abilita/disabilita campi pulsante
     $(document).on('change', '#alma-sc-button', function() {
         const enabled = $(this).is(':checked');
-        $('#alma-sc-button-size, #alma-sc-button-text').prop('disabled', !enabled);
+        $('#alma-sc-button-size, #alma-sc-button-text, #alma-sc-button-align').prop('disabled', !enabled);
     });
 
     $('#alma-sc-button').trigger('change');
     almaUpdateShortcodePreview();
+
+    // Gestione eliminazione link con scelta shortcode
+    function almaShowDeleteModal(deleteUrl) {
+        const options = [
+            {value: 'replace', label: 'Sostituisci con testo barrato'},
+            {value: 'remove', label: 'Rimuovi completamente'},
+            {value: 'comment', label: 'Converti in commento HTML'},
+            {value: 'none', label: 'Non modificare (sconsigliato)'}
+        ];
+        let select = '<select id="alma-delete-action">';
+        options.forEach(opt => {
+            const sel = opt.value === alma_ai.default_cleanup ? ' selected' : '';
+            select += `<option value="${opt.value}"${sel}>${opt.label}</option>`;
+        });
+        select += '</select>';
+        const modal = $(`
+            <div class="alma-modal-overlay" style="position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:100000;display:flex;align-items:center;justify-content:center;">
+                <div style="background:#fff;padding:20px;border-radius:6px;max-width:400px;width:90%;">
+                    <h2>Cosa fare con gli shortcode quando elimini un link?</h2>
+                    <p>${select}</p>
+                    <p style="text-align:right;margin-top:20px;">
+                        <button class="button alma-cancel-delete">Annulla</button>
+                        <button class="button button-primary alma-confirm-delete">Elimina</button>
+                    </p>
+                </div>
+            </div>
+        `);
+        $('body').append(modal);
+        modal.on('click', '.alma-cancel-delete', function(e){ e.preventDefault(); modal.remove(); });
+        modal.on('click', '.alma-confirm-delete', function(e){
+            e.preventDefault();
+            const choice = $('#alma-delete-action').val();
+            const url = new URL(deleteUrl);
+            url.searchParams.set('alma_sc_action', choice);
+            window.location = url.toString();
+        });
+    }
+
+    function almaHandleDelete(e) {
+        e.preventDefault();
+        const link = $(this);
+        const deleteUrl = link.attr('href');
+        const url = new URL(deleteUrl, window.location.origin);
+        const linkId = url.searchParams.get('post');
+        if (!linkId) {
+            window.location = deleteUrl;
+            return;
+        }
+        $.post(alma_ai.ajax_url, {
+            action: 'alma_check_usage',
+            link_id: linkId,
+            nonce: alma_ai.usage_nonce
+        }, function(resp){
+            if (resp.success && resp.data.usage) {
+                almaShowDeleteModal(deleteUrl);
+            } else {
+                window.location = deleteUrl;
+            }
+        });
+    }
+
+    $(document).on('click', 'a.submitdelete, #delete-action a', almaHandleDelete);
     
     // 🤖 Gestisci rigenera suggerimenti
     $(document).on('click', '.alma-regenerate-suggestions', function(e) {

--- a/assets/editor.js
+++ b/assets/editor.js
@@ -174,7 +174,7 @@ jQuery(document).ready(function($) {
         // Abilita/disabilita opzioni pulsante
         $(document).on('change.alma_editor', '#alma-add-button', function() {
             const enabled = $(this).is(':checked');
-            $('#alma-button-text, #alma-button-size').prop('disabled', !enabled);
+            $('#alma-button-text, #alma-button-size, #alma-button-align').prop('disabled', !enabled);
         });
 
         
@@ -362,6 +362,11 @@ jQuery(document).ready(function($) {
                             <option value="medium" selected>Medio</option>
                             <option value="large">Grande</option>
                         </select>
+                        <select id="alma-button-align" style="margin-left:10px;">
+                            <option value="left">Sinistra</option>
+                            <option value="center">Centro</option>
+                            <option value="right">Destra</option>
+                        </select>
                         <input type="text" id="alma-button-text" placeholder="Testo pulsante" style="flex:1;padding:8px 12px;border:1px solid #ddd;border-radius:4px;">
                     </div>
 
@@ -389,7 +394,7 @@ jQuery(document).ready(function($) {
         $('body').append(modalHtml);
 
         // Disabilita campi pulsante inizialmente
-        $('#alma-button-text, #alma-button-size').prop('disabled', true);
+        $('#alma-button-text, #alma-button-size, #alma-button-align').prop('disabled', true);
 
         // Carica le tipologie dopo aver creato il modal
         loadLinkTypes();
@@ -434,6 +439,7 @@ jQuery(document).ready(function($) {
         $('#alma-add-button').prop('checked', false);
         $('#alma-button-text').val('').prop('disabled', true);
         $('#alma-button-size').val('medium').prop('disabled', true);
+        $('#alma-button-align').val('left').prop('disabled', true);
         $('#alma-insert-shortcode').prop('disabled', true);
         $('.alma-shortcode-options').hide();
         $('.alma-link-item').removeClass('selected');
@@ -581,6 +587,10 @@ jQuery(document).ready(function($) {
             const btnText = $('#alma-button-text').val().trim();
             if (btnText) {
                 shortcode += ` button_text="${escapeShortcodeAttr(btnText)}"`;
+            }
+            const btnAlign = $('#alma-button-align').val();
+            if (btnAlign && btnAlign !== 'left') {
+                shortcode += ` button_align="${btnAlign}"`;
             }
         }
 

--- a/assets/import-sample.csv
+++ b/assets/import-sample.csv
@@ -1,2 +1,0 @@
-post_title,_affiliate_url,_link_rel,_link_target,_link_title,link_type
-"Esempio prodotto","https://example.com","nofollow","_blank","Scopri di più","coupon,news"


### PR DESCRIPTION
## Summary
- remove legacy bulk import wizard and assets
- allow deleting affiliate links by ID or type from settings
- prompt for shortcode handling when deleting used links
- support left/center/right alignment for call-to-action buttons

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/ai.js`
- `node --check assets/editor.js`


------
https://chatgpt.com/codex/tasks/task_e_68b45d1593c0833289ec21153b90b1c6