### PR TITLE
Migliora i suggerimenti AI per il titolo dei link affiliati

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Questo plugin gestisce link affiliati con funzionalità avanzate di monitoraggio e gestione.
 
+## Suggerimenti AI per il titolo
+
+Durante la creazione o modifica di un link affiliato è possibile generare automaticamente tre varianti di titolo ottimizzate per la SEO e pensate per aumentare le conversioni.
+
 ## Eliminazione link
 
 Nelle impostazioni del plugin puoi decidere come gestire gli shortcode quando un link viene eliminato. È inoltre possibile eliminare rapidamente un singolo link tramite ID oppure rimuovere tutti i link appartenenti a una specifica tipologia.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 1.9
+ * Version: 1.10
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '1.9');
+define('ALMA_VERSION', '1.10');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -2189,10 +2189,14 @@ class AffiliateManagerAI {
     }
 
     private function generate_title_suggestions($title, $description) {
+        $title       = wp_strip_all_tags($title);
+        $description = wp_strip_all_tags($description);
+        $content_part = $description ? sprintf(' e il contenuto "%s"', $description) : '';
+
         $prompt = sprintf(
-            'In base al titolo "%s" e al contenuto "%s", genera 5 varianti di testo in italiano per promuovere un link affiliato. Restituisci un JSON array con solo i testi delle varianti.',
-            wp_strip_all_tags($title),
-            wp_strip_all_tags($description)
+            'Sei un copywriter SEO. Analizza il titolo "%s"%s e proponi 3 alternative in italiano, ottimizzate per i motori di ricerca e con alto potenziale di conversione per un link affiliato. Rispondi con un array JSON contenente esclusivamente i tre titoli suggeriti.',
+            $title,
+            $content_part
         );
 
         $response = $this->call_claude_api($prompt);
@@ -2202,7 +2206,7 @@ class AffiliateManagerAI {
 
             if (is_array($decoded)) {
                 $suggestions = array();
-                foreach ($decoded as $text) {
+                foreach (array_slice($decoded, 0, 3) as $text) {
                     $suggestions[] = array(
                         'text'       => sanitize_text_field($text),
                         'confidence' => 90,


### PR DESCRIPTION
## Summary
- usa Claude per proporre 3 titoli alternativi SEO e orientati alla conversione
- documenta la nuova funzione di suggerimento titoli

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/ai.js`

------
https://chatgpt.com/codex/tasks/task_e_68b547150de88332b15d66a2bb06e15f