### PR TITLE
Add post affiliate link stats with pie chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Affiliate Link Manager AI
 
-Versione 2.0
+Versione 2.1
 
 Questo plugin gestisce e ottimizza i link affiliati all'interno di WordPress.
 


### PR DESCRIPTION
## Summary
- show counts of posts with and without affiliate links in dashboard
- link to posts lacking affiliate links and visualize via pie chart
- bump plugin version to 2.1

## Testing
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68b559a151548332a34bb7d2c5d268a5