### PR TITLE
Add editable AI-powered affiliate widgets

### DIFF
--- a/includes/class-affiliate-links-widget.php
+++ b/includes/class-affiliate-links-widget.php
@@ -14,29 +14,24 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
     }
 
     public static function render_links($instance) {
-        $number = isset($instance['number']) ? intval($instance['number']) : 5;
-        $types = isset($instance['types']) ? (array) $instance['types'] : array();
+        $links = isset($instance['links']) ? array_map('intval', (array) $instance['links']) : array();
         $show_image = !empty($instance['show_image']);
         $show_title = !empty($instance['show_title']);
         $show_content = !empty($instance['show_content']);
         $format = isset($instance['format']) && $instance['format'] === 'small' ? 'small' : 'large';
         $orientation = isset($instance['orientation']) && $instance['orientation'] === 'horizontal' ? 'horizontal' : 'vertical';
 
-        $query_args = array(
-            'post_type' => 'affiliate_link',
-            'posts_per_page' => $number,
-            'post_status' => 'publish',
-        );
-
-        if (!empty($types)) {
-            $query_args['tax_query'] = array(
-                array(
-                    'taxonomy' => 'link_type',
-                    'field' => 'term_id',
-                    'terms' => array_map('intval', $types),
-                ),
-            );
+        if (empty($links)) {
+            return '';
         }
+
+        $query_args = array(
+            'post_type'      => 'affiliate_link',
+            'post__in'       => $links,
+            'orderby'        => 'post__in',
+            'posts_per_page' => count($links),
+            'post_status'    => 'publish',
+        );
 
         $q = new WP_Query($query_args);
         if (!$q->have_posts()) {
@@ -62,9 +57,9 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
 
         while ($q->have_posts()) {
             $q->the_post();
-            $id = get_the_ID();
+            $id        = get_the_ID();
             $link_html = do_shortcode('[affiliate_link id="' . $id . '" img="' . $img . '" img_size="' . $img_size . '" fields="' . implode(',', $fields) . '" button="no"]');
-            $output .= '<div class="alma-affiliate-item" style="' . esc_attr($item_style) . '">' . $link_html . '</div>';
+            $output   .= '<div class="alma-affiliate-item" style="' . esc_attr($item_style) . '">' . $link_html . '</div>';
         }
         wp_reset_postdata();
 
@@ -87,12 +82,9 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
         $show_image = !empty($instance['show_image']);
         $show_title = !empty($instance['show_title']);
         $show_content = !empty($instance['show_content']);
-        $types = $instance['types'] ?? array();
         $format = $instance['format'] ?? 'large';
         $orientation = $instance['orientation'] ?? 'vertical';
-        $number = $instance['number'] ?? 5;
-
-        $all_types = get_terms(array('taxonomy' => 'link_type', 'hide_empty' => false));
+        $links = isset($instance['links']) ? implode(',', array_map('intval', (array) $instance['links'])) : '';
         ?>
         <p>
             <label for="<?php echo esc_attr($this->get_field_id('title')); ?>"><?php _e('Titolo:', 'affiliate-link-manager-ai'); ?></label>
@@ -111,14 +103,6 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
             <label for="<?php echo esc_attr($this->get_field_id('show_content')); ?>"><?php _e('Mostra contenuto', 'affiliate-link-manager-ai'); ?></label>
         </p>
         <p>
-            <label for="<?php echo esc_attr($this->get_field_id('types')); ?>"><?php _e('Tipologie:', 'affiliate-link-manager-ai'); ?></label>
-            <select multiple class="widefat" id="<?php echo esc_attr($this->get_field_id('types')); ?>" name="<?php echo esc_attr($this->get_field_name('types')); ?>[]">
-                <?php foreach ($all_types as $t) : ?>
-                    <option value="<?php echo esc_attr($t->term_id); ?>" <?php echo in_array($t->term_id, (array) $types) ? 'selected' : ''; ?>><?php echo esc_html($t->name); ?></option>
-                <?php endforeach; ?>
-            </select>
-        </p>
-        <p>
             <label for="<?php echo esc_attr($this->get_field_id('format')); ?>"><?php _e('Formato:', 'affiliate-link-manager-ai'); ?></label>
             <select class="widefat" id="<?php echo esc_attr($this->get_field_id('format')); ?>" name="<?php echo esc_attr($this->get_field_name('format')); ?>">
                 <option value="large" <?php selected($format, 'large'); ?>><?php _e('Immagine grande, titolo e contenuto', 'affiliate-link-manager-ai'); ?></option>
@@ -133,8 +117,8 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
             </select>
         </p>
         <p>
-            <label for="<?php echo esc_attr($this->get_field_id('number')); ?>"><?php _e('Numero di link:', 'affiliate-link-manager-ai'); ?></label>
-            <input class="tiny-text" id="<?php echo esc_attr($this->get_field_id('number')); ?>" name="<?php echo esc_attr($this->get_field_name('number')); ?>" type="number" step="1" min="1" value="<?php echo esc_attr($number); ?>">
+            <label for="<?php echo esc_attr($this->get_field_id('links')); ?>"><?php _e('ID Link (separati da virgola):', 'affiliate-link-manager-ai'); ?></label>
+            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('links')); ?>" name="<?php echo esc_attr($this->get_field_name('links')); ?>" type="text" value="<?php echo esc_attr($links); ?>">
         </p>
         <?php
     }
@@ -145,10 +129,9 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
         $instance['show_image'] = !empty($new_instance['show_image']) ? 1 : 0;
         $instance['show_title'] = !empty($new_instance['show_title']) ? 1 : 0;
         $instance['show_content'] = !empty($new_instance['show_content']) ? 1 : 0;
-        $instance['types'] = array_map('intval', $new_instance['types'] ?? array());
         $instance['format'] = $new_instance['format'] === 'small' ? 'small' : 'large';
         $instance['orientation'] = $new_instance['orientation'] === 'horizontal' ? 'horizontal' : 'vertical';
-        $instance['number'] = intval($new_instance['number'] ?? 5);
+        $instance['links'] = array_filter(array_map('intval', explode(',', $new_instance['links'] ?? '')));
         return $instance;
     }
 
@@ -162,7 +145,14 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
         if (!isset($instances[$id])) {
             return '';
         }
-        return self::render_links($instances[$id]);
+        $instance = $instances[$id];
+        $title = $instance['title'] ?? '';
+        $output = '';
+        if ($title) {
+            $output .= '<h2 class="alma-widget-title">' . esc_html($title) . '</h2>';
+        }
+        $output .= self::render_links($instance);
+        return $output;
     }
 }
 


### PR DESCRIPTION
## Summary
- reorder admin menu to show "Crea Widget" before shortcode overview and add hidden edit page
- refactor widget storage to track explicit link IDs and show widget titles
- integrate Claude AI suggestions when creating or editing widgets

## Testing
- `php -l affiliate-link-manager-ai.php`
- `php -l includes/class-affiliate-links-widget.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5ddb0184083329584646820e684b9