### PR TITLE
Fix widget shortcode generation

### DIFF
--- a/includes/class-affiliate-links-widget.php
+++ b/includes/class-affiliate-links-widget.php
@@ -57,9 +57,13 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
 
         while ($q->have_posts()) {
             $q->the_post();
-            $id        = get_the_ID();
-            $link_html = do_shortcode('[affiliate_link id="' . $id . '" img="' . $img . '" img_size="' . $img_size . '" fields="' . implode(',', $fields) . '" button="no"]');
-            $output   .= '<div class="alma-affiliate-item" style="' . esc_attr($item_style) . '">' . $link_html . '</div>';
+            $id = get_the_ID();
+
+            $fields_attr = !empty($fields) ? ' fields="' . implode(',', $fields) . '"' : '';
+            $shortcode = '[affiliate_link id="' . $id . '" img="' . $img . '" img_size="' . $img_size . '"' . $fields_attr . ' button="no"]';
+            $link_html = do_shortcode($shortcode);
+
+            $output .= '<div class="alma-affiliate-item" style="' . esc_attr($item_style) . '">' . $link_html . '</div>';
         }
         wp_reset_postdata();
 


### PR DESCRIPTION
## Summary
- build affiliate link shortcode for widget safely
- ensure fields attribute is only included when needed

## Testing
- `php -l includes/class-affiliate-links-widget.php`
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68b69a00c7308332a0e0113427dcfbf3