### PR TITLE
Improve AI widget suggestions layout and shortcode management

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -581,9 +581,7 @@ button:disabled {
 
 /* Suggested links styling */
 .alma-suggested-link {
-    display: flex;
-    align-items: center;
-    gap: 4px;
+    display: block;
     padding: 6px 10px;
     border: 1px solid #ccd0d4;
     border-radius: 4px;
@@ -591,6 +589,17 @@ button:disabled {
     background: #fff;
 }
 
+.alma-suggested-link input[type="checkbox"] {
+    margin-right: 6px;
+}
+
+.alma-suggested-link small {
+    display: block;
+    margin-left: 22px;
+    color: #555;
+}
+
 .alma-suggested-link .dashicons {
     color: #2271b1;
+    margin-right: 2px;
 }


### PR DESCRIPTION
## Summary
- Hide "Genera suggerimenti" button after creating an AI widget
- Display AI link suggestions in a two-line format with metadata and add creation dates to shortcode list
- Warn that deleting a shortcode removes it sitewide and restyle suggested link labels

## Testing
- `php -l affiliate-link-manager-ai.php`
- `npx stylelint assets/admin.css` *(fails: Need to install the following packages: stylelint@16.23.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f0e038648332914b5f7a3a89fd9f