### PR TITLE
Add AI-powered affiliate search chat

### DIFF
--- a/assets/search-chat.css
+++ b/assets/search-chat.css
@@ -1,0 +1,7 @@
+.alma-search-chat{border:1px solid #ccc;padding:10px;max-width:400px;}
+.alma-search-chat .alma-chat-messages{max-height:300px;overflow-y:auto;margin-bottom:10px;}
+.alma-msg{margin:5px 0;padding:5px;border-radius:4px;}
+.alma-msg.user{text-align:right;background:#e0f7fa;}
+.alma-msg.bot{text-align:left;background:#f1f1f1;}
+.alma-chat-form{display:flex;gap:5px;}
+.alma-chat-input{flex:1;}

--- a/assets/search-chat.js
+++ b/assets/search-chat.js
@@ -1,0 +1,39 @@
+jQuery(document).ready(function($){
+  $('.alma-search-chat').each(function(){
+    var container = $(this);
+    var messages = container.find('.alma-chat-messages');
+    function addMessage(text, cls){
+      var div = $('<div>').addClass('alma-msg '+cls).html(text);
+      messages.append(div);
+      messages.scrollTop(messages.prop('scrollHeight'));
+    }
+    function send(){
+      var input = container.find('.alma-chat-input');
+      var text = input.val();
+      if(!text){return;}
+      addMessage($('<div>').text(text).html(),'user');
+      input.val('');
+      $.post(almaChat.ajax_url,{action:'alma_nl_search',nonce:almaChat.nonce,query:text},function(resp){
+        if(resp.success){
+          var grouped = {};
+          resp.data.forEach(function(item){
+            var type = item.types.length ? item.types[0] : 'Altro';
+            if(!grouped[type]) grouped[type]=[];
+            grouped[type].push(item);
+          });
+          $.each(grouped,function(type,items){
+            addMessage('<strong>'+type+'</strong>','bot');
+            items.forEach(function(it){
+              var link = '<a href="'+it.url+'" target="_blank">'+almaChat.strings.visit+'</a>';
+              addMessage('<strong>'+it.title+'</strong>: '+it.description+' '+link,'bot');
+            });
+          });
+        } else {
+          addMessage(resp.data || 'Error','bot');
+        }
+      });
+    }
+    container.on('click','.alma-chat-send',send);
+    container.on('keypress','.alma-chat-input',function(e){ if(e.which===13){send(); return false;} });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `[alma_search_chat]` shortcode with frontend chat UI
- Implement Claude-backed natural language affiliate search via AJAX
- Provide "Chat Ricerca" settings page for configuring chat results

## Testing
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8336c4f648332bf586e19fd2555a9