### PR TITLE
Restyle Chat Ricerca results with images and WhatsApp layout

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -2585,6 +2585,7 @@ class AffiliateManagerAI {
                 'url'         => $affiliate_url,
                 'types'       => $types,
                 'description' => $description,
+                'image'       => get_the_post_thumbnail_url($id, 'thumbnail'),
                 'score'       => max(0, min(100, round($score))),
             );
         }

--- a/assets/search-chat.css
+++ b/assets/search-chat.css
@@ -1,7 +1,11 @@
-.alma-search-chat{border:1px solid #ccc;padding:10px;max-width:400px;}
-.alma-search-chat .alma-chat-messages{max-height:300px;overflow-y:auto;margin-bottom:10px;}
-.alma-msg{margin:5px 0;padding:5px;border-radius:4px;}
-.alma-msg.user{text-align:right;background:#e0f7fa;}
-.alma-msg.bot{text-align:left;background:#f1f1f1;}
+.alma-search-chat{border:1px solid #ccc;padding:10px;width:100%;}
+.alma-search-chat .alma-chat-messages{max-height:300px;overflow-y:auto;margin-bottom:10px;display:flex;flex-direction:column;}
+.alma-msg{margin:5px 0;padding:8px;border-radius:7px;max-width:80%;}
+.alma-msg.user{align-self:flex-end;background:#dcf8c6;}
+.alma-msg.bot{align-self:flex-start;background:#ffffff;}
+.alma-result{display:flex;align-items:flex-start;}
+.alma-result img{width:80px;height:80px;object-fit:cover;margin-right:10px;}
+.alma-result-content h4{margin:0 0 5px;}
+.alma-result-content p{margin:0;}
 .alma-chat-form{display:flex;gap:5px;}
 .alma-chat-input{flex:1;}

--- a/assets/search-chat.js
+++ b/assets/search-chat.js
@@ -2,8 +2,8 @@ jQuery(document).ready(function($){
   $('.alma-search-chat').each(function(){
     var container = $(this);
     var messages = container.find('.alma-chat-messages');
-    function addMessage(text, cls){
-      var div = $('<div>').addClass('alma-msg '+cls).html(text);
+    function addMessage(content, cls){
+      var div = $('<div>').addClass('alma-msg '+cls).append(content);
       messages.append(div);
       messages.scrollTop(messages.prop('scrollHeight'));
     }
@@ -11,7 +11,7 @@ jQuery(document).ready(function($){
       var input = container.find('.alma-chat-input');
       var text = input.val();
       if(!text){return;}
-      addMessage($('<div>').text(text).html(),'user');
+      addMessage($('<div>').text(text),'user');
       input.val('');
       $.post(almaChat.ajax_url,{action:'alma_nl_search',nonce:almaChat.nonce,query:text},function(resp){
         if(resp.success){
@@ -22,10 +22,23 @@ jQuery(document).ready(function($){
             grouped[type].push(item);
           });
           $.each(grouped,function(type,items){
-            addMessage('<strong>'+type+'</strong>','bot');
+            addMessage($('<strong>').text(type),'bot');
             items.forEach(function(it){
-              var link = '<a href="'+it.url+'" target="_blank">'+almaChat.strings.visit+'</a>';
-              addMessage('<strong>'+it.title+'</strong>: '+it.description+' '+link,'bot');
+              var result = $('<div>').addClass('alma-result');
+              if(it.image){
+                var imgLink = $('<a>').attr({href:it.url,target:'_blank'})
+                  .append($('<img>').attr({src:it.image,width:80,height:80}));
+                result.append(imgLink);
+              }
+              var content = $('<div>').addClass('alma-result-content');
+              var titleLink = $('<a>').attr({href:it.url,target:'_blank'})
+                .append($('<h4>').text(it.title));
+              content.append(titleLink);
+              if(it.description){
+                content.append($('<p>').text(it.description));
+              }
+              result.append(content);
+              addMessage(result,'bot');
             });
           });
         } else {


### PR DESCRIPTION
## Summary
- Display search results with linked 80×80 images, title, and optional description
- Stretch chat to full width and style messages like WhatsApp
- Include featured image in chat search AJAX response

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/search-chat.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b840bbb48c8332ace4a2cefee486d4