### PR TITLE
feat: add chat search summaries

### DIFF
--- a/assets/search-chat.js
+++ b/assets/search-chat.js
@@ -15,9 +15,13 @@ jQuery(document).ready(function($){
       input.val('');
       $.post(almaChat.ajax_url,{action:'alma_nl_search',nonce:almaChat.nonce,query:text},function(resp){
         if(resp.success){
+          var data = resp.data || {};
+          if(data.summary){
+            addMessage($('<div>').text(data.summary),'bot');
+          }
           var grouped = {};
-          resp.data.forEach(function(item){
-            var type = item.types.length ? item.types[0] : 'Altro';
+          (data.results || []).forEach(function(item){
+            var type = item.types && item.types.length ? item.types[0] : 'Altro';
             if(!grouped[type]) grouped[type]=[];
             grouped[type].push(item);
           });


### PR DESCRIPTION
## Summary
- request Claude to return summary text and results
- display summary text before grouped chat search links

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/search-chat.js && echo 'JS syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68b843b14aac8332a5d4da1600a3bf35