### PR TITLE
Add fallback reply and enforce unique widget IDs

### DIFF
--- a/assets/search-chat.js
+++ b/assets/search-chat.js
@@ -25,7 +25,9 @@ jQuery(document).ready(function($){
             if(!grouped[type]) grouped[type]=[];
             grouped[type].push(item);
           });
+          var hasResults = false;
           $.each(grouped,function(type,items){
+            hasResults = true;
             addMessage($('<strong>').text(type),'bot');
             items.forEach(function(it){
               var result = $('<div>').addClass('alma-result');
@@ -45,8 +47,15 @@ jQuery(document).ready(function($){
               addMessage(result,'bot');
             });
           });
+          if(!hasResults && almaChat.fallback){
+            addMessage($('<div>').html(almaChat.fallback),'bot');
+          }
         } else {
-          addMessage(resp.data || 'Error','bot');
+          if(almaChat.fallback){
+            addMessage($('<div>').html(almaChat.fallback),'bot');
+          } else {
+            addMessage(resp.data || 'Error','bot');
+          }
         }
       });
     }


### PR DESCRIPTION
## Summary
- allow admins to define a default reply for search chat when AI fails
- ensure new widgets use non-reusable IDs via a persistent counter
- show fallback message in chat when no results are found

## Testing
- `php -l affiliate-link-manager-ai.php`
- `php -l includes/class-affiliate-links-widget.php`
- `node --check assets/search-chat.js`


------
https://chatgpt.com/codex/tasks/task_e_68b84ff04f2c8332a829236241217865