### PR TITLE
feat: add configurable avatar to search chat

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -297,6 +297,7 @@ class AffiliateManagerAI {
                 'ajax_url'  => admin_url('admin-ajax.php'),
                 'nonce'     => wp_create_nonce('alma_nl_search'),
                 'fallback'  => wp_kses_post(get_option('alma_chat_default_reply', '')),
+                'avatar'    => esc_url(get_option('alma_chat_avatar', '')),
                 'strings'   => array(
                     'visit'       => __('Visita', 'affiliate-link-manager-ai'),
                     'placeholder' => __('Scrivi la tua richiesta...', 'affiliate-link-manager-ai'),
@@ -2236,6 +2237,7 @@ class AffiliateManagerAI {
 
         if ($tab === 'general' && isset($_POST['alma_chat_save']) && check_admin_referer('alma_chat_settings')) {
             update_option('alma_chat_max_results', max(1, intval($_POST['alma_chat_max_results'] ?? 5)));
+            update_option('alma_chat_avatar', esc_url_raw($_POST['alma_chat_avatar'] ?? ''));
             echo '<div class="notice notice-success"><p>' . esc_html__('Impostazioni salvate.', 'affiliate-link-manager-ai') . '</p></div>';
         } elseif ($tab === 'fallback' && isset($_POST['alma_chat_save_fallback']) && check_admin_referer('alma_chat_fallback')) {
             update_option('alma_chat_default_reply', wp_kses_post($_POST['alma_chat_default_reply'] ?? ''));
@@ -2243,6 +2245,7 @@ class AffiliateManagerAI {
         }
 
         $max_results = get_option('alma_chat_max_results', 5);
+        $avatar      = get_option('alma_chat_avatar', '');
         $fallback    = get_option('alma_chat_default_reply', '');
         $base_url    = admin_url('admin.php?page=alma-chat-search');
         ?>
@@ -2260,6 +2263,10 @@ class AffiliateManagerAI {
                         <tr>
                             <th scope="row"><label for="alma_chat_max_results"><?php _e('Numero massimo risultati', 'affiliate-link-manager-ai'); ?></label></th>
                             <td><input type="number" min="1" max="10" id="alma_chat_max_results" name="alma_chat_max_results" value="<?php echo esc_attr($max_results); ?>" /></td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><label for="alma_chat_avatar"><?php _e('Immagine profilo AI (URL)', 'affiliate-link-manager-ai'); ?></label></th>
+                            <td><input type="url" id="alma_chat_avatar" name="alma_chat_avatar" value="<?php echo esc_attr($avatar); ?>" class="regular-text" /></td>
                         </tr>
                     </table>
                     <p><?php _e('Usa lo shortcode [alma_search_chat] per mostrare la chat sul sito.', 'affiliate-link-manager-ai'); ?></p>

--- a/assets/search-chat.css
+++ b/assets/search-chat.css
@@ -1,8 +1,12 @@
 .alma-search-chat{border:1px solid #ccc;padding:10px;width:100%;}
 .alma-search-chat .alma-chat-messages{max-height:300px;overflow-y:auto;margin-bottom:10px;display:flex;flex-direction:column;}
-.alma-msg{margin:5px 0;padding:8px;border-radius:7px;max-width:80%;}
-.alma-msg.user{align-self:flex-end;background:#dcf8c6;}
-.alma-msg.bot{align-self:flex-start;background:#ffffff;}
+.alma-msg{margin:5px 0;display:flex;}
+.alma-msg.user{justify-content:flex-end;}
+.alma-msg.bot{justify-content:flex-start;}
+.alma-avatar{width:32px;height:32px;border-radius:50%;margin-right:8px;}
+.alma-msg .alma-bubble{padding:8px;border-radius:7px;max-width:80%;}
+.alma-msg.user .alma-bubble{background:#dcf8c6;}
+.alma-msg.bot .alma-bubble{background:#ffffff;}
 .alma-result{display:flex;align-items:flex-start;}
 .alma-result img{width:80px;height:80px;object-fit:cover;margin-right:10px;}
 .alma-result-content h4{margin:0 0 5px;}

--- a/assets/search-chat.js
+++ b/assets/search-chat.js
@@ -3,7 +3,12 @@ jQuery(document).ready(function($){
     var container = $(this);
     var messages = container.find('.alma-chat-messages');
     function addMessage(content, cls){
-      var div = $('<div>').addClass('alma-msg '+cls).append(content);
+      var div = $('<div>').addClass('alma-msg '+cls);
+      if(cls==='bot' && almaChat.avatar){
+        div.append($('<img>').addClass('alma-avatar').attr('src', almaChat.avatar));
+      }
+      var bubble = $('<div>').addClass('alma-bubble').append(content);
+      div.append(bubble);
       messages.append(div);
       messages.scrollTop(messages.prop('scrollHeight'));
     }


### PR DESCRIPTION
## Summary
- allow specifying an AI avatar in Chat Ricerca settings
- display the avatar beside bot messages in Search Chat

## Testing
- `php -l affiliate-link-manager-ai.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8545466008332bbcb50e3efca766b