### PR TITLE
feat: enhance search chat avatar and layout

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -581,6 +581,19 @@ class AffiliateManagerAI {
                 }
             }
 
+            if ($hook === 'affiliate_link_page_alma-chat-search') {
+                wp_enqueue_media();
+                if (file_exists(ALMA_PLUGIN_DIR . 'assets/chat-admin.js')) {
+                    wp_enqueue_script(
+                        'alma-chat-admin',
+                        ALMA_PLUGIN_URL . 'assets/chat-admin.js',
+                        array('jquery'),
+                        ALMA_VERSION,
+                        true
+                    );
+                }
+            }
+
             if ($hook === 'affiliate_link_page_affiliate-link-manager-dashboard') {
                 wp_enqueue_script(
                     'chart.js',
@@ -2265,8 +2278,11 @@ class AffiliateManagerAI {
                             <td><input type="number" min="1" max="10" id="alma_chat_max_results" name="alma_chat_max_results" value="<?php echo esc_attr($max_results); ?>" /></td>
                         </tr>
                         <tr>
-                            <th scope="row"><label for="alma_chat_avatar"><?php _e('Immagine profilo AI (URL)', 'affiliate-link-manager-ai'); ?></label></th>
-                            <td><input type="url" id="alma_chat_avatar" name="alma_chat_avatar" value="<?php echo esc_attr($avatar); ?>" class="regular-text" /></td>
+                            <th scope="row"><label for="alma_chat_avatar"><?php _e('Immagine profilo AI', 'affiliate-link-manager-ai'); ?></label></th>
+                            <td>
+                                <input type="url" id="alma_chat_avatar" name="alma_chat_avatar" value="<?php echo esc_attr($avatar); ?>" class="regular-text" />
+                                <button type="button" class="button alma-chat-avatar-upload"><?php _e('Carica immagine', 'affiliate-link-manager-ai'); ?></button>
+                            </td>
                         </tr>
                     </table>
                     <p><?php _e('Usa lo shortcode [alma_search_chat] per mostrare la chat sul sito.', 'affiliate-link-manager-ai'); ?></p>

--- a/assets/chat-admin.js
+++ b/assets/chat-admin.js
@@ -1,0 +1,20 @@
+jQuery(document).ready(function($){
+  var frame;
+  $(document).on('click', '.alma-chat-avatar-upload', function(e){
+    e.preventDefault();
+    if(frame){
+      frame.open();
+      return;
+    }
+    frame = wp.media({
+      title: 'Seleziona o carica immagine',
+      button: { text: 'Usa questa immagine' },
+      multiple: false
+    });
+    frame.on('select', function(){
+      var attachment = frame.state().get('selection').first().toJSON();
+      $('#alma_chat_avatar').val(attachment.url);
+    });
+    frame.open();
+  });
+});

--- a/assets/search-chat.css
+++ b/assets/search-chat.css
@@ -3,10 +3,12 @@
 .alma-msg{margin:5px 0;display:flex;}
 .alma-msg.user{justify-content:flex-end;}
 .alma-msg.bot{justify-content:flex-start;}
+.alma-msg.bot-result{justify-content:flex-start;}
 .alma-avatar{width:32px;height:32px;border-radius:50%;margin-right:8px;}
 .alma-msg .alma-bubble{padding:8px;border-radius:7px;max-width:80%;}
 .alma-msg.user .alma-bubble{background:#dcf8c6;}
 .alma-msg.bot .alma-bubble{background:#ffffff;}
+.alma-msg.bot-result .alma-bubble{background:#ffffff;}
 .alma-result{display:flex;align-items:flex-start;}
 .alma-result img{width:80px;height:80px;object-fit:cover;margin-right:10px;}
 .alma-result-content h4{margin:0 0 5px;}

--- a/assets/search-chat.js
+++ b/assets/search-chat.js
@@ -10,12 +10,12 @@ jQuery(document).ready(function($){
       var bubble = $('<div>').addClass('alma-bubble').append(content);
       div.append(bubble);
       messages.append(div);
-      messages.scrollTop(messages.prop('scrollHeight'));
     }
     function send(){
       var input = container.find('.alma-chat-input');
       var text = input.val();
       if(!text){return;}
+      messages.empty();
       addMessage($('<div>').text(text),'user');
       input.val('');
       $.post(almaChat.ajax_url,{action:'alma_nl_search',nonce:almaChat.nonce,query:text},function(resp){
@@ -33,7 +33,7 @@ jQuery(document).ready(function($){
           var hasResults = false;
           $.each(grouped,function(type,items){
             hasResults = true;
-            addMessage($('<strong>').text(type),'bot');
+            addMessage($('<strong>').text(type),'bot-result');
             items.forEach(function(it){
               var result = $('<div>').addClass('alma-result');
               if(it.image){
@@ -49,7 +49,7 @@ jQuery(document).ready(function($){
                 content.append($('<p>').text(it.description));
               }
               result.append(content);
-              addMessage(result,'bot');
+              addMessage(result,'bot-result');
             });
           });
           if(!hasResults && almaChat.fallback){
@@ -62,6 +62,7 @@ jQuery(document).ready(function($){
             addMessage(resp.data || 'Error','bot');
           }
         }
+        messages.scrollTop(0);
       });
     }
     container.on('click','.alma-chat-send',send);


### PR DESCRIPTION
## Summary
- add media uploader to choose AI avatar in search chat settings
- show avatar only on AI summary and keep latest Q/A fixed at top

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/search-chat.js`
- `node --check assets/chat-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68b87c3a62a4833296c82a66bc005467