### PR TITLE
feat: allow persistent search chat history

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -306,9 +306,12 @@ class AffiliateManagerAI {
             ));
         }
 
+        $width  = esc_attr(get_option('alma_chat_width', '100%'));
+        $height = esc_attr(get_option('alma_chat_height', '100%'));
+
         ob_start();
         ?>
-        <div class="alma-search-chat">
+        <div class="alma-search-chat" style="width:<?php echo $width; ?>;height:<?php echo $height; ?>;">
             <div class="alma-chat-messages"></div>
             <div class="alma-chat-form">
                 <input type="text" class="alma-chat-input" placeholder="<?php esc_attr_e('Scrivi la tua richiesta...', 'affiliate-link-manager-ai'); ?>" />
@@ -2251,6 +2254,8 @@ class AffiliateManagerAI {
         if ($tab === 'general' && isset($_POST['alma_chat_save']) && check_admin_referer('alma_chat_settings')) {
             update_option('alma_chat_max_results', max(1, intval($_POST['alma_chat_max_results'] ?? 5)));
             update_option('alma_chat_avatar', esc_url_raw($_POST['alma_chat_avatar'] ?? ''));
+            update_option('alma_chat_width', sanitize_text_field($_POST['alma_chat_width'] ?? '100%'));
+            update_option('alma_chat_height', sanitize_text_field($_POST['alma_chat_height'] ?? '100%'));
             echo '<div class="notice notice-success"><p>' . esc_html__('Impostazioni salvate.', 'affiliate-link-manager-ai') . '</p></div>';
         } elseif ($tab === 'fallback' && isset($_POST['alma_chat_save_fallback']) && check_admin_referer('alma_chat_fallback')) {
             update_option('alma_chat_default_reply', wp_kses_post($_POST['alma_chat_default_reply'] ?? ''));
@@ -2259,6 +2264,8 @@ class AffiliateManagerAI {
 
         $max_results = get_option('alma_chat_max_results', 5);
         $avatar      = get_option('alma_chat_avatar', '');
+        $width       = get_option('alma_chat_width', '100%');
+        $height      = get_option('alma_chat_height', '100%');
         $fallback    = get_option('alma_chat_default_reply', '');
         $base_url    = admin_url('admin.php?page=alma-chat-search');
         ?>
@@ -2283,6 +2290,14 @@ class AffiliateManagerAI {
                                 <input type="url" id="alma_chat_avatar" name="alma_chat_avatar" value="<?php echo esc_attr($avatar); ?>" class="regular-text" />
                                 <button type="button" class="button alma-chat-avatar-upload"><?php _e('Carica immagine', 'affiliate-link-manager-ai'); ?></button>
                             </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><label for="alma_chat_width"><?php _e('Larghezza chat', 'affiliate-link-manager-ai'); ?></label></th>
+                            <td><input type="text" id="alma_chat_width" name="alma_chat_width" value="<?php echo esc_attr($width); ?>" class="regular-text" /></td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><label for="alma_chat_height"><?php _e('Altezza chat', 'affiliate-link-manager-ai'); ?></label></th>
+                            <td><input type="text" id="alma_chat_height" name="alma_chat_height" value="<?php echo esc_attr($height); ?>" class="regular-text" /></td>
                         </tr>
                     </table>
                     <p><?php _e('Usa lo shortcode [alma_search_chat] per mostrare la chat sul sito.', 'affiliate-link-manager-ai'); ?></p>

--- a/assets/search-chat.css
+++ b/assets/search-chat.css
@@ -1,5 +1,5 @@
-.alma-search-chat{border:1px solid #ccc;padding:10px;width:100%;}
-.alma-search-chat .alma-chat-messages{max-height:300px;overflow-y:auto;margin-bottom:10px;display:flex;flex-direction:column;}
+.alma-search-chat{border:1px solid #ccc;padding:10px;width:100%;height:100%;display:flex;flex-direction:column;}
+.alma-search-chat .alma-chat-messages{flex:1;overflow-y:auto;margin-bottom:10px;display:flex;flex-direction:column;}
 .alma-msg{margin:5px 0;display:flex;}
 .alma-msg.user{justify-content:flex-end;}
 .alma-msg.bot{justify-content:flex-start;}
@@ -7,7 +7,7 @@
 .alma-avatar{width:32px;height:32px;border-radius:50%;margin-right:8px;}
 .alma-msg .alma-bubble{padding:8px;border-radius:7px;max-width:80%;}
 .alma-msg.user .alma-bubble{background:#dcf8c6;}
-.alma-msg.bot .alma-bubble{background:#ffffff;}
+.alma-msg.bot .alma-bubble{background:#e6f3ff;}
 .alma-msg.bot-result .alma-bubble{background:#ffffff;}
 .alma-result{display:flex;align-items:flex-start;}
 .alma-result img{width:80px;height:80px;object-fit:cover;margin-right:10px;}

--- a/assets/search-chat.js
+++ b/assets/search-chat.js
@@ -15,9 +15,9 @@ jQuery(document).ready(function($){
       var input = container.find('.alma-chat-input');
       var text = input.val();
       if(!text){return;}
-      messages.empty();
       addMessage($('<div>').text(text),'user');
       input.val('');
+      messages.scrollTop(messages[0].scrollHeight);
       $.post(almaChat.ajax_url,{action:'alma_nl_search',nonce:almaChat.nonce,query:text},function(resp){
         if(resp.success){
           var data = resp.data || {};
@@ -62,7 +62,7 @@ jQuery(document).ready(function($){
             addMessage(resp.data || 'Error','bot');
           }
         }
-        messages.scrollTop(0);
+        messages.scrollTop(messages[0].scrollHeight);
       });
     }
     container.on('click','.alma-chat-send',send);


### PR DESCRIPTION
## Summary
- keep search chat messages for scrolling instead of clearing each request
- make search chat width and height configurable with 100% defaults
- style AI replies with a distinct background color

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/search-chat.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68b87f2062b08332babae9bcaffa25c7