### PR TITLE
Move PROMPT AI Settings under Affiliate AI and fix widget IDs

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -1915,6 +1915,10 @@ class AffiliateManagerAI {
                 } else {
                     $instances = get_option('widget_affiliate_links_widget', array());
                     $id        = (int) get_option('alma_widget_next_id', 1);
+
+                    while (isset($instances[$id])) {
+                        $id++;
+                    }
                     update_option('alma_widget_next_id', $id + 1);
 
                     // Salva data di creazione

--- a/includes/class-prompt-ai-admin.php
+++ b/includes/class-prompt-ai-admin.php
@@ -21,13 +21,13 @@ class ALMA_Prompt_AI_Admin {
      * Registra la pagina di amministrazione
      */
     public function register_menu() {
-        add_menu_page(
+        add_submenu_page(
+            'edit.php?post_type=affiliate_link',
             __('PROMPT AI Settings', 'affiliate-link-manager-ai'),
             __('PROMPT AI Settings', 'affiliate-link-manager-ai'),
             'manage_options',
             'alma-prompt-ai-settings',
-            array($this, 'render_page'),
-            'dashicons-robot'
+            array($this, 'render_page')
         );
     }
 
@@ -35,7 +35,7 @@ class ALMA_Prompt_AI_Admin {
      * Carica script e stili
      */
     public function enqueue_assets($hook) {
-        if ($hook !== 'toplevel_page_alma-prompt-ai-settings') {
+        if ($hook !== 'affiliate_link_page_alma-prompt-ai-settings') {
             return;
         }
 
@@ -80,7 +80,7 @@ class ALMA_Prompt_AI_Admin {
                 <textarea name="base_prompt" rows="10" cols="80" placeholder="<?php esc_attr_e('Es: Sei un assistente customer service professionale per [nome azienda]...', 'affiliate-link-manager-ai'); ?>"><?php echo isset($settings['base_prompt']) ? esc_textarea($settings['base_prompt']) : ''; ?></textarea>
                 <p class="description"><?php esc_html_e('Istruzioni principali che definiscono il ruolo dell\'AI', 'affiliate-link-manager-ai'); ?></p>
 
-                <h2><?php esc_html_e('Personalit\xC3\A0', 'affiliate-link-manager-ai'); ?></h2>
+                <h2><?php esc_html_e('Personalit\xC3\A0 dell\'AI', 'affiliate-link-manager-ai'); ?></h2>
                 <select name="personality" id="alma-personality">
                     <?php $personality = $settings['personality'] ?? ''; ?>
                     <option value="professionale" <?php selected($personality, 'professionale'); ?>><?php esc_html_e('professionale', 'affiliate-link-manager-ai'); ?></option>


### PR DESCRIPTION
## Summary
- Integrate PROMPT AI Settings page into Affiliate AI menu
- Ensure each AI widget gets a unique ID on creation
- Rename personality section to "Personalità dell'AI"

## Testing
- `php -l includes/class-prompt-ai-admin.php`
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68b94766739c83329783833e67df4359