### PR TITLE
Use developer prompt settings in chat search and bump to 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Affiliate Link Manager AI
 
-Versione 2.3.2
+Versione 2.4
 
 Questo plugin gestisce e ottimizza i link affiliati all'interno di WordPress.
 

--- a/includes/class-prompt-ai-admin.php
+++ b/includes/class-prompt-ai-admin.php
@@ -317,7 +317,7 @@ class ALMA_Prompt_AI_Admin {
         $message = isset($_POST['message']) ? sanitize_text_field(wp_unslash($_POST['message'])) : '';
         $context = isset($_POST['context']) ? sanitize_text_field(wp_unslash($_POST['context'])) : 'general';
 
-        $final_prompt = $this->build_prompt($message, $context);
+        $final_prompt = self::build_prompt($message, $context);
         $response = $this->call_claude_api($final_prompt);
         if (empty($response['success'])) {
             wp_send_json_error($response['error'] ?? __('Errore AI', 'affiliate-link-manager-ai'));
@@ -331,7 +331,7 @@ class ALMA_Prompt_AI_Admin {
     /**
      * Costruisce il prompt finale
      */
-    private function build_prompt($message, $context) {
+    public static function build_prompt($message, $context) {
         $settings = get_option(self::OPTION_NAME, array());
         $parts = array();
         if (!empty($settings['base_prompt'])) {


### PR DESCRIPTION
## Summary
- Apply developer-configured AI prompts to Chat Ricerca results
- Expose prompt builder to other components via static method
- Bump plugin version and docs to 2.4

## Testing
- `php -l affiliate-link-manager-ai.php`
- `php -l includes/class-prompt-ai-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68b94e2bf2e08332a2a54ecc5f3e833e