### PR TITLE
Avoid fallback when AI active in search chat

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -298,10 +298,13 @@ class AffiliateManagerAI {
                 'nonce'     => wp_create_nonce('alma_nl_search'),
                 'fallback'  => wp_kses_post(get_option('alma_chat_default_reply', '')),
                 'avatar'    => esc_url(get_option('alma_chat_avatar', '')),
+                'ai_active' => !empty(get_option('alma_claude_api_key')),
                 'strings'   => array(
                     'visit'       => __('Visita', 'affiliate-link-manager-ai'),
                     'placeholder' => __('Scrivi la tua richiesta...', 'affiliate-link-manager-ai'),
                     'send'        => __('Invia', 'affiliate-link-manager-ai'),
+                    'no_results'  => __('Nessun risultato trovato.', 'affiliate-link-manager-ai'),
+                    'error'       => __('Si è verificato un errore.', 'affiliate-link-manager-ai'),
                 ),
             ));
         }

--- a/assets/search-chat.js
+++ b/assets/search-chat.js
@@ -52,14 +52,20 @@ jQuery(document).ready(function($){
               addMessage(result,'bot-result');
             });
           });
-          if(!hasResults && almaChat.fallback){
-            addMessage($('<div>').html(almaChat.fallback),'bot');
+          if(!hasResults){
+            if(almaChat.ai_active){
+              addMessage($('<div>').text(almaChat.strings.no_results),'bot');
+            } else if(almaChat.fallback){
+              addMessage($('<div>').html(almaChat.fallback),'bot');
+            }
           }
         } else {
-          if(almaChat.fallback){
+          if(almaChat.ai_active){
+            addMessage($('<div>').text(resp.data || almaChat.strings.error),'bot');
+          } else if(almaChat.fallback){
             addMessage($('<div>').html(almaChat.fallback),'bot');
           } else {
-            addMessage(resp.data || 'Error','bot');
+            addMessage(resp.data || almaChat.strings.error,'bot');
           }
         }
         messages.scrollTop(messages[0].scrollHeight);


### PR DESCRIPTION
## Summary
- Pass AI activation flag and add user-facing strings for no-result and error cases
- Skip default fallback messages when AI is active in search chat

## Testing
- `node --check assets/search-chat.js`
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68b952822f208332a6bdc25f7a1c8369