### PR TITLE
Improve alma chat form design and interactions

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -318,7 +318,7 @@ class AffiliateManagerAI {
             <div class="alma-chat-messages"></div>
             <div class="alma-chat-form">
                 <input type="text" class="alma-chat-input" placeholder="<?php esc_attr_e('Scrivi la tua richiesta...', 'affiliate-link-manager-ai'); ?>" />
-                <button type="button" class="alma-chat-send"><?php esc_html_e('Invia', 'affiliate-link-manager-ai'); ?></button>
+                <button type="button" class="alma-chat-send" disabled aria-label="<?php esc_attr_e('Invia', 'affiliate-link-manager-ai'); ?>">&#10148;</button>
             </div>
         </div>
         <?php

--- a/assets/search-chat.css
+++ b/assets/search-chat.css
@@ -13,5 +13,34 @@
 .alma-result img{width:80px;height:80px;object-fit:cover;margin-right:10px;}
 .alma-result-content h4{margin:0 0 5px;}
 .alma-result-content p{margin:0;}
-.alma-chat-form{display:flex;gap:5px;}
-.alma-chat-input{flex:1;}
+.alma-chat-form{display:flex;gap:8px;align-items:center;}
+
+.alma-chat-input{flex:1;background:#fff;border:1px solid #d1d5db;border-radius:12px;padding:12px 16px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;font-size:16px;line-height:1.5;color:#111827;min-height:44px;transition:border-color .2s ease,box-shadow .2s ease;}
+
+.alma-chat-input::placeholder{color:#9ca3af;}
+
+.alma-chat-input:hover{border-color:#9ca3af;}
+
+.alma-chat-input:focus{outline:none;border-color:#2563eb;box-shadow:0 0 0 3px rgba(37,99,235,.3);}
+
+@media (max-width:640px){
+  .alma-chat-input{min-height:48px;padding:14px 18px;font-size:16px;}
+}
+
+.alma-chat-send{width:40px;height:40px;border:none;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#9ca3af;color:rgba(255,255,255,.7);cursor:not-allowed;transition:transform .2s ease,box-shadow .2s ease,background .2s ease;}
+
+.alma-chat-send.is-active{background:linear-gradient(90deg,#2563eb,#3b82f6);color:#fff;cursor:pointer;box-shadow:0 2px 4px rgba(0,0,0,.1);}
+
+.alma-chat-send.is-active:hover{transform:scale(1.05);box-shadow:0 4px 6px rgba(0,0,0,.15);}
+
+.alma-chat-send.is-loading{background:linear-gradient(90deg,#2563eb,#3b82f6);opacity:.7;cursor:not-allowed;position:relative;}
+
+.alma-chat-send.is-loading:before{content:"";width:16px;height:16px;border:2px solid rgba(255,255,255,.6);border-top-color:#fff;border-radius:50%;animation:alma-spin 1s linear infinite;}
+
+.alma-chat-send.is-loading{color:transparent;}
+
+.alma-chat-send.is-success{background:#10b981;color:transparent;}
+
+.alma-chat-send.is-success:before{content:"\2713";color:#fff;}
+
+@keyframes alma-spin{to{transform:rotate(360deg);}}

--- a/assets/search-chat.js
+++ b/assets/search-chat.js
@@ -2,6 +2,17 @@ jQuery( document ).ready( function( $ ) {
   $( '.alma-search-chat' ).each( function() {
     var container = $( this );
     var messages = container.find( '.alma-chat-messages' );
+    var input    = container.find( '.alma-chat-input' );
+    var button   = container.find( '.alma-chat-send' );
+
+    function updateButton(){
+      var hasText = $.trim( input.val() ).length > 0;
+      button.prop( 'disabled', ! hasText );
+      button.toggleClass( 'is-active', hasText );
+    }
+
+    input.on( 'input', updateButton );
+    updateButton();
 
     function addMessage( content, cls ) {
       var div = $( '<div>' ).addClass( 'alma-msg ' + cls );
@@ -33,16 +44,17 @@ jQuery( document ).ready( function( $ ) {
     }
 
     function send() {
-      var input = container.find( '.alma-chat-input' );
-      var text  = input.val();
-
-      if ( ! text ) {
+      if ( button.prop( 'disabled' ) ) {
         return;
       }
 
+      var text  = input.val();
       addMessage( $( '<div>' ).text( text ), 'user' );
       input.val( '' );
+      updateButton();
       messages.scrollTop( messages[0].scrollHeight );
+
+      button.addClass( 'is-loading' ).prop( 'disabled', true );
 
       $.post(
         almaChat.ajax_url,
@@ -112,6 +124,12 @@ jQuery( document ).ready( function( $ ) {
       ).fail( function() {
         handleError();
         messages.scrollTop( messages[0].scrollHeight );
+      } ).always( function() {
+        button.removeClass( 'is-loading' ).addClass( 'is-success' );
+        setTimeout( function(){
+          button.removeClass( 'is-success' );
+          updateButton();
+        }, 500 );
       } );
     }
 


### PR DESCRIPTION
## Summary
- style search chat input and send button for modern look and responsive sizing
- add dynamic button states with loading spinner and success check
- disable send button until text is entered for better UX

## Testing
- `node --check assets/search-chat.js`
- `php -l affiliate-link-manager-ai.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b409fcec83328824d9c8f961bac2