### PR TITLE
Improve search JSON validation and fallback handling

### DIFF
--- a/assets/search-chat.css
+++ b/assets/search-chat.css
@@ -1,4 +1,4 @@
-.alma-search-chat{border:1px solid #ccc;padding:10px;width:100%;height:100%;display:flex;flex-direction:column;}
+.alma-search-chat{border:0;padding:10px;width:100%;height:100%;display:flex;flex-direction:column;}
 .alma-search-chat .alma-chat-messages{flex:1;overflow-y:auto;margin-bottom:10px;display:flex;flex-direction:column;}
 .alma-msg{margin:5px 0;display:flex;}
 .alma-msg.user{justify-content:flex-end;}

--- a/assets/search-chat.js
+++ b/assets/search-chat.js
@@ -34,9 +34,7 @@ jQuery( document ).ready( function( $ ) {
     }
 
     function handleError( msg ) {
-      if ( almaChat.ai_active ) {
-        addMessage( $( '<div>' ).text( msg || almaChat.strings.error ), 'bot' );
-      } else if ( almaChat.fallback ) {
+      if ( almaChat.fallback ) {
         addMessage( $( '<div>' ).text( almaChat.fallback ), 'bot' );
       } else {
         addMessage( $( '<div>' ).text( msg || almaChat.strings.error ), 'bot' );


### PR DESCRIPTION
## Summary
- Ensure search results from AI are valid JSON with required fields
- Always display fallback message on search errors
- Remove border from `.alma-search-chat` container

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/search-chat.js`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b7e31be483328dfa84f030a65d6a