### PR TITLE
Enable HTML fallback messages

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -2258,6 +2258,10 @@ class AffiliateManagerAI {
 
         $tab = isset($_GET['tab']) ? sanitize_key($_GET['tab']) : 'general';
 
+        if ($tab === 'fallback') {
+            wp_enqueue_editor();
+        }
+
         if ($tab === 'general' && isset($_POST['alma_chat_save']) && check_admin_referer('alma_chat_settings')) {
             update_option('alma_chat_max_results', max(1, intval($_POST['alma_chat_max_results'] ?? 5)));
             update_option('alma_chat_avatar', esc_url_raw($_POST['alma_chat_avatar'] ?? ''));
@@ -2316,7 +2320,19 @@ class AffiliateManagerAI {
                     <table class="form-table">
                         <tr>
                             <th scope="row"><label for="alma_chat_default_reply"><?php _e('Messaggio di fallback', 'affiliate-link-manager-ai'); ?></label></th>
-                            <td><textarea id="alma_chat_default_reply" name="alma_chat_default_reply" rows="5" class="large-text code"><?php echo esc_textarea($fallback); ?></textarea></td>
+                            <td>
+                                <?php
+                                wp_editor(
+                                    wp_kses_post($fallback),
+                                    'alma_chat_default_reply',
+                                    array(
+                                        'textarea_name' => 'alma_chat_default_reply',
+                                        'textarea_rows' => 5,
+                                        'media_buttons' => true,
+                                    )
+                                );
+                                ?>
+                            </td>
                         </tr>
                     </table>
                     <?php submit_button(__('Salva', 'affiliate-link-manager-ai'), 'primary', 'alma_chat_save_fallback'); ?>

--- a/assets/search-chat.js
+++ b/assets/search-chat.js
@@ -35,7 +35,7 @@ jQuery( document ).ready( function( $ ) {
 
     function handleError( msg ) {
       if ( almaChat.fallback ) {
-        addMessage( $( '<div>' ).text( almaChat.fallback ), 'bot' );
+        addMessage( $( '<div>' ).html( almaChat.fallback ), 'bot' );
       } else {
         addMessage( $( '<div>' ).text( msg || almaChat.strings.error ), 'bot' );
       }
@@ -110,7 +110,7 @@ jQuery( document ).ready( function( $ ) {
               if ( almaChat.ai_active ) {
                 addMessage( $( '<div>' ).text( almaChat.strings.no_results ), 'bot' );
               } else if ( almaChat.fallback ) {
-                addMessage( $( '<div>' ).text( almaChat.fallback ), 'bot' );
+                addMessage( $( '<div>' ).html( almaChat.fallback ), 'bot' );
               }
             }
           } else {


### PR DESCRIPTION
## Summary
- Allow configuring fallback replies with the WordPress editor so HTML is preserved
- Render fallback replies as HTML in the chat frontend

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/search-chat.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68b9ba10f11083328b0fb6d6879a09f0