### PR TITLE
Show server errors and handle missing AI configuration

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -2638,6 +2638,10 @@ class AffiliateManagerAI {
 
         $response = $this->call_claude_api($prompt);
 
+        if (!empty($response['error']) && $response['error'] === 'API Key non configurata') {
+            wp_send_json_error('AI non configurata');
+        }
+
         // Se l'AI non risponde correttamente, esegui una ricerca standard dei link
         if (empty($response['success'])) {
             $posts = get_posts(array(

--- a/assets/search-chat.js
+++ b/assets/search-chat.js
@@ -34,10 +34,12 @@ jQuery( document ).ready( function( $ ) {
     }
 
     function handleError( msg ) {
-      if ( almaChat.fallback ) {
+      if ( msg ) {
+        addMessage( $( '<div>' ).text( msg ), 'bot' );
+      } else if ( almaChat.fallback ) {
         addMessage( $( '<div>' ).html( almaChat.fallback ), 'bot' );
       } else {
-        addMessage( $( '<div>' ).text( msg || almaChat.strings.error ), 'bot' );
+        addMessage( $( '<div>' ).text( almaChat.strings.error ), 'bot' );
       }
     }
 
@@ -107,7 +109,10 @@ jQuery( document ).ready( function( $ ) {
             } );
 
             if ( ! hasResults ) {
-              if ( almaChat.ai_active ) {
+              var errMsg = data && ( typeof data === 'string' ? data : data.error );
+              if ( errMsg ) {
+                handleError( errMsg );
+              } else if ( almaChat.ai_active ) {
                 addMessage( $( '<div>' ).text( almaChat.strings.no_results ), 'bot' );
               } else if ( almaChat.fallback ) {
                 addMessage( $( '<div>' ).html( almaChat.fallback ), 'bot' );


### PR DESCRIPTION
## Summary
- Display server-provided errors in search chat, falling back only when necessary
- Detect missing AI API key and return explicit error message in natural language search

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/search-chat.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bad8a113e483329b4aef488002f639