### PR TITLE
Show affiliate link suggestions in AI test prompt

### DIFF
--- a/assets/prompt-ai-admin.css
+++ b/assets/prompt-ai-admin.css
@@ -1,6 +1,7 @@
 .alma-custom-prompt { margin-bottom: 10px; }
 .alma-custom-prompt textarea { display:block; margin-top:5px; }
 #alma-test-result { margin-top:20px; }
+#alma-affiliate-links { margin-top:15px; }
 
 .alma-field { margin-bottom:15px; }
 .alma-field label { display:block; font-weight:600; margin-bottom:3px; }

--- a/assets/prompt-ai-admin.js
+++ b/assets/prompt-ai-admin.js
@@ -61,6 +61,28 @@ jQuery(document).ready(function($){
             if(resp.success){
                 $('#alma-claude-response').text(resp.data.response);
                 $('#alma-final-prompt').text(resp.data.prompt);
+                var links = resp.data.links || {};
+                var container = $('#alma-affiliate-links');
+                container.empty();
+                if(links.summary){
+                    container.append($('<p>').text(links.summary));
+                }
+                if(Array.isArray(links.results)){
+                    var list = $('<ul>');
+                    links.results.forEach(function(item){
+                        var li = $('<li>');
+                        if(item.url){
+                            li.append($('<a>').attr({href:item.url,target:'_blank'}).text(item.title));
+                        } else {
+                            li.text(item.title);
+                        }
+                        if(item.description){
+                            li.append(' - ' + item.description);
+                        }
+                        list.append(li);
+                    });
+                    container.append(list);
+                }
                 $('#alma-test-result').show();
             } else {
                 alert(resp.data);


### PR DESCRIPTION
## Summary
- Include affiliate link suggestions when testing AI prompts
- Render summary and list of selected affiliate links in prompt test UI
- Style new affiliate link section for clarity

## Testing
- `php -l includes/class-prompt-ai-admin.php`
- `node --check assets/prompt-ai-admin.js && echo 'JS syntax OK'`
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68badf4bd2948332ada4f04cc770dad2