### PR TITLE
Fix Claude API connection

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3474,8 +3474,8 @@ class AffiliateManagerAI {
     }
     
     private function call_claude_api($prompt) {
-        $api_key = get_option('alma_claude_api_key');
-        
+        $api_key = trim(get_option('alma_claude_api_key'));
+
         if (empty($api_key)) {
             return array('success' => false, 'error' => 'API Key non configurata');
         }
@@ -3511,15 +3511,15 @@ class AffiliateManagerAI {
         );
 
         $start    = microtime(true);
-        $response = wp_safe_remote_post('https://api.anthropic.com/v1/messages', array(
+        $response = wp_remote_post('https://api.anthropic.com/v1/messages', array(
             'headers' => array(
                 'Content-Type'      => 'application/json',
+                'Accept'            => 'application/json',
                 'x-api-key'         => $api_key,
                 'anthropic-version' => '2023-06-01',
             ),
-            'body'      => wp_json_encode($body, JSON_UNESCAPED_UNICODE),
-            'timeout'   => 30,
-            'sslverify' => true,
+            'body'    => wp_json_encode($body, JSON_UNESCAPED_UNICODE),
+            'timeout' => 30,
         ));
 
         $time = round((microtime(true) - $start) * 1000);
@@ -3531,7 +3531,12 @@ class AffiliateManagerAI {
         $code = wp_remote_retrieve_response_code($response);
         $data = json_decode(wp_remote_retrieve_body($response), true);
 
-        if (200 !== $code || empty($data['content'][0]['text'])) {
+        if (200 !== $code) {
+            $error = $data['error']['message'] ?? 'Errore di connessione a Claude';
+            return array('success' => false, 'error' => $error);
+        }
+
+        if (empty($data['content'][0]['text'])) {
             return array('success' => false, 'error' => 'Risposta non valida da Claude');
         }
 


### PR DESCRIPTION
## Summary
- ensure Claude API requests use `wp_remote_post` and include Accept header
- trim stored API key and return detailed errors from Claude responses

## Testing
- `php -l affiliate-link-manager-ai.php`
- `php -l includes/class-prompt-ai-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68bae4f0ce1c8332a41087e05d48b982