### PR TITLE
Display AI score in search chat results

### DIFF
--- a/assets/search-chat.css
+++ b/assets/search-chat.css
@@ -13,6 +13,10 @@
 .alma-result img{width:80px;height:80px;object-fit:cover;margin-right:10px;}
 .alma-result-content h4{margin:0 0 5px;}
 .alma-result-content p{margin:0;}
+.alma-score{font-size:12px;margin-top:4px;}
+.alma-score-high{color:#00a32a;}
+.alma-score-medium{color:#dba617;}
+.alma-score-low{color:#d63638;}
 .alma-chat-form{position:relative;}
 
 .alma-chat-input{width:100%;background:#fff;border:1px solid #d1d5db;border-radius:12px;padding:12px 80px 12px 16px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;font-size:16px;line-height:1.5;color:#111827;min-height:44px;transition:border-color .2s ease,box-shadow .2s ease;}

--- a/assets/search-chat.js
+++ b/assets/search-chat.js
@@ -102,6 +102,10 @@ jQuery( document ).ready( function( $ ) {
                 if ( it.description ) {
                   content.append( $( '<p>' ).text( it.description ) );
                 }
+                if ( typeof it.score !== 'undefined' ) {
+                  var scoreClass = it.score >= 80 ? 'alma-score-high' : it.score >= 50 ? 'alma-score-medium' : 'alma-score-low';
+                  content.append( $( '<div>' ).addClass( 'alma-score ' + scoreClass ).text( '⭐ ' + it.score + '%' ) );
+                }
 
                 result.append( content );
                 addMessage( result, 'bot-result' );


### PR DESCRIPTION
## Summary
- show star-based AI score for each search chat result
- style score indicator with color-coded classes

## Testing
- `node --check assets/search-chat.js && echo 'Syntax OK'`
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68bae99333108332b181cb2c894cd1b0