### PR TITLE
Fix Claude API integration

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -2364,7 +2364,7 @@ class AffiliateManagerAI {
         }
         $prompt .= "\nRestituisci un array JSON con massimo 3 oggetti {\"id\": ID, \"score\": COERENZA}, dove COERENZA è un numero da 0 a 100 che indica quanto il link è coerente con l'articolo. Rispondi esclusivamente con JSON valido, senza testo aggiuntivo.\n";
 
-        $response = ALMA_AI_Utils::call_claude_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo', 'json');
+        $response = ALMA_AI_Utils::call_claude_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo');
         if (empty($response['success'])) {
             $msg = $response['error'] ?? __('Impossibile generare suggerimenti con Claude.', 'affiliate-link-manager-ai');
             error_log('Claude API error: ' . $msg);
@@ -2931,7 +2931,7 @@ class AffiliateManagerAI {
         }
         $prompt .= "\nRestituisci un array JSON con massimo 10 oggetti {\"id\": ID, \"score\": PERTINENZA}, dove PERTINENZA è un numero da 0 a 100 che indica quanto il link è coerente con il titolo. Ordina dal più pertinente al meno pertinente. Rispondi esclusivamente con JSON valido, senza testo aggiuntivo.";
 
-        $response = ALMA_AI_Utils::call_claude_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo', 'json');
+        $response = ALMA_AI_Utils::call_claude_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo');
         if (empty($response['success'])) {
             return array();
         }
@@ -2993,7 +2993,7 @@ class AffiliateManagerAI {
             wp_strip_all_tags($post->post_content)
         );
 
-        $response = ALMA_AI_Utils::call_claude_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo', 'json');
+        $response = ALMA_AI_Utils::call_claude_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo');
 
         if (empty($response['success'])) {
             return new \WP_Error('claude_error', $response['error'] ?? __('Errore sconosciuto', 'affiliate-link-manager-ai'));
@@ -3036,7 +3036,7 @@ class AffiliateManagerAI {
             $content_part
         );
 
-        $response = ALMA_AI_Utils::call_claude_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo', 'json');
+        $response = ALMA_AI_Utils::call_claude_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo');
 
         if (empty($response['success'])) {
             return new \WP_Error('claude_error', $response['error'] ?? __('Errore sconosciuto', 'affiliate-link-manager-ai'));

--- a/includes/class-prompt-ai-admin.php
+++ b/includes/class-prompt-ai-admin.php
@@ -460,7 +460,7 @@ class ALMA_Prompt_AI_Admin {
         $message .= "\nRispondi esclusivamente con un oggetto JSON con i campi \"summary\" e \"results\". \"summary\" deve contenere una breve frase in italiano che spiega perché hai scelto i link. \"results\" è un array con massimo {$max_results} oggetti{\"id\":ID,\"description\":\"testo\",\"score\":COERENZA} dove COERENZA è 0-100. Rispondi esclusivamente con JSON valido, senza testo aggiuntivo.\n";
 
         $prompts  = self::build_prompt($message, 'search');
-        $response = ALMA_AI_Utils::call_claude_api($prompts['user'], $prompts['system'], 'json');
+        $response = ALMA_AI_Utils::call_claude_api($prompts['user'], $prompts['system']);
 
         if (empty($response['success'])) {
             return new \WP_Error('claude_error', $response['error'] ?? __('Errore AI', 'affiliate-link-manager-ai'));


### PR DESCRIPTION
## Summary
- remove unsupported `response_format` field from Claude API requests
- measure and return response time from `call_claude_api`
- update plugin calls to use revised helper

## Testing
- `php -l includes/class-ai-utils.php`
- `php -l affiliate-link-manager-ai.php`
- `php -l includes/class-prompt-ai-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68bafbdc128c8332be3a70e48c3426f3