### PR TITLE
Add Affiliate Chat AI module and remove menu icon

### DIFF
--- a/assets/chat-ai.js
+++ b/assets/chat-ai.js
@@ -1,0 +1,21 @@
+jQuery(document).ready(function($){
+    $('#alma-chat-form').on('submit', function(e){
+        e.preventDefault();
+        var query = $('#alma-chat-query').val();
+        var $resp = $('#alma-chat-response');
+        $resp.text('...');
+        $.post(alma_chat_ai.ajax_url, {
+            action: 'alma_affiliate_chat',
+            nonce: alma_chat_ai.nonce,
+            query: query
+        }).done(function(res){
+            if(res.success){
+                $resp.html(res.data.reply.replace(/\n/g,'<br>'));
+            } else {
+                $resp.text(res.data);
+            }
+        }).fail(function(jqXHR, textStatus){
+            $resp.text('Errore: ' + textStatus);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- remove emoji icon from Affiliate AI menu label
- introduce Affiliate Chat AI module with shortcode and menu entry
- implement Claude-powered link suggestions with error handling

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/chat-ai.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb05cae7f88332be86cf3adf340b71