### PR TITLE
Refine chat interface with WhatsApp-like layout

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -287,11 +287,13 @@ class AffiliateManagerAI {
 
         ob_start();
         ?>
-        <form id="alma-chat-form">
-            <input type="text" id="alma-chat-query" placeholder="<?php esc_attr_e('Cerca link affiliati...', 'affiliate-link-manager-ai'); ?>" required />
-            <button type="submit"><?php esc_html_e('Cerca', 'affiliate-link-manager-ai'); ?></button>
-        </form>
-        <div id="alma-chat-response"></div>
+        <div id="alma-chat-container">
+            <iframe id="alma-chat-frame"></iframe>
+            <form id="alma-chat-form">
+                <input type="text" id="alma-chat-query" placeholder="<?php esc_attr_e('Cerca link affiliati...', 'affiliate-link-manager-ai'); ?>" required />
+                <button type="submit" id="alma-chat-submit"><?php esc_html_e('Chiedi', 'affiliate-link-manager-ai'); ?></button>
+            </form>
+        </div>
         <?php
         return ob_get_clean();
     }

--- a/assets/chat-ai.js
+++ b/assets/chat-ai.js
@@ -1,21 +1,33 @@
 jQuery(document).ready(function($){
+    var frame = document.getElementById('alma-chat-frame');
+    var doc = frame.contentDocument || frame.contentWindow.document;
+    doc.open();
+    doc.write('<style>body{font-family:inherit;margin:0;padding:10px;overflow-y:auto;} .msg{max-width:80%;margin:5px;padding:10px;border-radius:8px;} .user{background:#dcf8c6;margin-left:auto;text-align:right;} .ai{background:#f1f0f0;margin-right:auto;text-align:left;} .alma-affiliate-link{display:flex;align-items:center;text-decoration:none;margin-top:5px;} .alma-affiliate-img{width:80px;height:80px;border-radius:8px;object-fit:cover;margin-right:10px;} .alma-link-title{font-weight:bold;}</style><div id="messages"></div>');
+    doc.close();
+    var $messages = $(doc).find('#messages');
+
+    function escapeHtml(text){
+        return $('<div/>').text(text).html();
+    }
+
     $('#alma-chat-form').on('submit', function(e){
         e.preventDefault();
         var query = $('#alma-chat-query').val();
-        var $resp = $('#alma-chat-response');
-        $resp.text('...');
+        if(!query){ return; }
+        $('#alma-chat-query').val('');
+        $messages.append('<div class="msg user">'+escapeHtml(query)+'</div>');
+        doc.body.scrollTop = doc.body.scrollHeight;
         $.post(alma_chat_ai.ajax_url, {
             action: 'alma_affiliate_chat',
             nonce: alma_chat_ai.nonce,
             query: query
         }).done(function(res){
-            if(res.success){
-                $resp.html(res.data.reply.replace(/\n/g,'<br>'));
-            } else {
-                $resp.text(res.data);
-            }
+            var html = res.success ? res.data.reply.replace(/\n/g,'<br>') : res.data;
+            $messages.append('<div class="msg ai">'+html+'</div>');
+            doc.body.scrollTop = doc.body.scrollHeight;
         }).fail(function(jqXHR, textStatus){
-            $resp.text('Errore: ' + textStatus);
+            $messages.append('<div class="msg ai">Errore: '+textStatus+'</div>');
+            doc.body.scrollTop = doc.body.scrollHeight;
         });
     });
 });

--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -22,3 +22,43 @@
 .alma-widget-content {
     margin-bottom: 10px;
 }
+
+#alma-chat-container{
+    width:100%;
+    display:flex;
+    flex-direction:column;
+}
+#alma-chat-frame{
+    width:100%;
+    min-height:300px;
+    border:1px solid #ccc;
+    border-radius:8px;
+    overflow:hidden;
+    margin-bottom:10px;
+}
+#alma-chat-form{
+    position:relative;
+    width:100%;
+    padding:15px;
+    border:1px solid #ccc;
+    border-radius:100px;
+    background:#fff;
+    box-shadow:0 0 5px rgba(0,0,0,0.1);
+}
+#alma-chat-form input{
+    width:100%;
+    border:none;
+    outline:none;
+    padding-right:80px;
+}
+#alma-chat-form button{
+    position:absolute;
+    top:-10px;
+    right:20px;
+    background:#2271b1;
+    color:#fff;
+    border:none;
+    border-radius:20px;
+    padding:5px 10px;
+    cursor:pointer;
+}


### PR DESCRIPTION
## Summary
- Redesigned Affiliate Chat AI markup with an iframe conversation area and bottom-aligned form
- Added JS chat logic to append user and AI messages, styling affiliate links with images and titles
- Styled chat container and form for full-width WhatsApp-like appearance

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/chat-ai.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb0941ac288332a735261499fc1c0e