### PR TITLE
feat: keep affiliate chat conversations

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -308,6 +308,22 @@ class AffiliateManagerAI {
             wp_send_json_error(__('Richiesta mancante', 'affiliate-link-manager-ai'));
         }
 
+        $conversation = array();
+        if (!empty($_POST['conversation'])) {
+            $decoded = json_decode(stripslashes($_POST['conversation']), true);
+            if (is_array($decoded)) {
+                foreach ($decoded as $msg) {
+                    if (empty($msg['content'])) {
+                        continue;
+                    }
+                    $conversation[] = array(
+                        'role'    => $msg['role'] === 'assistant' ? 'assistant' : 'user',
+                        'content' => sanitize_textarea_field($msg['content'])
+                    );
+                }
+            }
+        }
+
         $posts = get_posts(array(
             'post_type'      => 'affiliate_link',
             'numberposts'    => -1,
@@ -349,7 +365,7 @@ class AffiliateManagerAI {
         $user_prompt = "Richiesta utente: $query\nLink disponibili:\n$links_text\n" .
             'Suggerisci i link più pertinenti organizzati per tipologia e spiega brevemente le tue scelte prima della lista.';
 
-        $result = ALMA_AI_Utils::call_claude_api($user_prompt, $system_prompt);
+        $result = ALMA_AI_Utils::call_claude_api($user_prompt, $system_prompt, $conversation);
 
         if (!$result['success']) {
             wp_send_json_error($result['error']);

--- a/assets/chat-ai.js
+++ b/assets/chat-ai.js
@@ -5,6 +5,7 @@ jQuery(document).ready(function($){
     doc.write('<style>body{font-family:inherit;margin:0;padding:10px;overflow-y:auto;} .msg{max-width:80%;margin:5px;padding:10px;border-radius:8px;} .user{background:#dcf8c6;margin-left:auto;text-align:right;} .ai{background:#f1f0f0;margin-right:auto;text-align:left;} .alma-affiliate-link{display:flex;align-items:center;text-decoration:none;margin-top:5px;} .alma-affiliate-img{width:80px;height:80px;border-radius:8px;object-fit:cover;margin-right:10px;} .alma-link-title{font-weight:bold;}</style><div id="messages"></div>');
     doc.close();
     var $messages = $(doc).find('#messages');
+    var conversation = [];
 
     function escapeHtml(text){
         return $('<div/>').text(text).html();
@@ -20,11 +21,16 @@ jQuery(document).ready(function($){
         $.post(alma_chat_ai.ajax_url, {
             action: 'alma_affiliate_chat',
             nonce: alma_chat_ai.nonce,
-            query: query
+            query: query,
+            conversation: JSON.stringify(conversation)
         }).done(function(res){
             var html = res.success ? res.data.reply.replace(/\n/g,'<br>') : res.data;
             $messages.append('<div class="msg ai">'+html+'</div>');
             doc.body.scrollTop = doc.body.scrollHeight;
+            if(res.success){
+                conversation.push({role:'user',content:query});
+                conversation.push({role:'assistant',content:res.data.reply});
+            }
         }).fail(function(jqXHR, textStatus){
             $messages.append('<div class="msg ai">Errore: '+textStatus+'</div>');
             doc.body.scrollTop = doc.body.scrollHeight;

--- a/includes/class-ai-utils.php
+++ b/includes/class-ai-utils.php
@@ -13,9 +13,10 @@ class ALMA_AI_Utils {
      *
      * @param string $user_prompt   Messaggio dell'utente
      * @param string $system_prompt Istruzioni di sistema opzionali
+     * @param array  $conversation  Array di messaggi precedenti per mantenere il contesto
      * @return array Risultato con chiavi success, response, model, response_time
      */
-    public static function call_claude_api($user_prompt, $system_prompt = '') {
+    public static function call_claude_api($user_prompt, $system_prompt = '', $conversation = array()) {
         $api_key = trim(get_option('alma_claude_api_key'));
         if (empty($api_key)) {
             return array('success' => false, 'error' => 'API Key non configurata');
@@ -28,15 +29,27 @@ class ALMA_AI_Utils {
             'model'       => $model,
             'max_tokens'  => 300,
             'temperature' => $temperature,
-            'messages'    => array(
-                array(
-                    'role'    => 'user',
-                    'content' => array(
-                        array(
-                            'type' => 'text',
-                            'text' => $user_prompt,
-                        )
+            'messages'    => array()
+        );
+
+        foreach ($conversation as $msg) {
+            $body['messages'][] = array(
+                'role'    => $msg['role'],
+                'content' => array(
+                    array(
+                        'type' => 'text',
+                        'text' => $msg['content'],
                     )
+                )
+            );
+        }
+
+        $body['messages'][] = array(
+            'role'    => 'user',
+            'content' => array(
+                array(
+                    'type' => 'text',
+                    'text' => $user_prompt,
                 )
             )
         );


### PR DESCRIPTION
## Summary
- preserve chat history in affiliate Chat AI until the page closes
- send conversation context to Claude API for consistent replies

## Testing
- `php -l affiliate-link-manager-ai.php`
- `php -l includes/class-ai-utils.php`
- `node --check assets/chat-ai.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68bb0fe646748332aa99e30c7e1f6d05