### PR TITLE
feat: expand widget suggestions limit with pagination

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -2035,7 +2035,13 @@ class AffiliateManagerAI {
                         <tr>
                             <th scope="row"><?php _e('Link suggeriti', 'affiliate-link-manager-ai'); ?></th>
                             <td>
-                                <?php foreach ($suggestions as $s) : ?>
+                                <?php
+                                $per_page           = 10;
+                                $page               = isset($_GET['suggestions_page']) ? max(1, intval($_GET['suggestions_page'])) : 1;
+                                $total_pages        = max(1, ceil(count($suggestions) / $per_page));
+                                $display_suggestions = array_slice($suggestions, ($page - 1) * $per_page, $per_page);
+                                foreach ($display_suggestions as $s) :
+                                ?>
                                     <label class="alma-suggested-link">
                                         <input type="checkbox" name="links[]" value="<?php echo esc_attr($s['id']); ?>">
                                         <?php echo esc_html($s['title']); ?><br>
@@ -2047,6 +2053,18 @@ class AffiliateManagerAI {
                                         </small>
                                     </label>
                                 <?php endforeach; ?>
+                                <?php if ($total_pages > 1) : ?>
+                                    <div class="tablenav"><div class="tablenav-pages">
+                                        <?php echo paginate_links(array(
+                                            'base'      => add_query_arg('suggestions_page', '%#%'),
+                                            'format'    => '',
+                                            'prev_text' => __('&laquo;', 'affiliate-link-manager-ai'),
+                                            'next_text' => __('&raquo;', 'affiliate-link-manager-ai'),
+                                            'total'     => $total_pages,
+                                            'current'   => $page,
+                                        )); ?>
+                                    </div></div>
+                                <?php endif; ?>
                             </td>
                         </tr>
                         <?php endif; ?>
@@ -2179,7 +2197,13 @@ class AffiliateManagerAI {
                         <tr>
                             <th scope="row"><?php _e('Link suggeriti', 'affiliate-link-manager-ai'); ?></th>
                             <td>
-                                <?php foreach ($suggestions as $s) : ?>
+                                <?php
+                                $per_page           = 10;
+                                $page               = isset($_GET['suggestions_page']) ? max(1, intval($_GET['suggestions_page'])) : 1;
+                                $total_pages        = max(1, ceil(count($suggestions) / $per_page));
+                                $display_suggestions = array_slice($suggestions, ($page - 1) * $per_page, $per_page);
+                                foreach ($display_suggestions as $s) :
+                                ?>
                                     <label class="alma-suggested-link">
                                         <input type="checkbox" name="links[]" value="<?php echo esc_attr($s['id']); ?>" <?php checked(in_array($s['id'], (array) ($instance['links'] ?? array()))); ?>>
                                         <?php echo esc_html($s['id']) . ' - ' . esc_html($s['title']); ?><br>
@@ -2191,6 +2215,18 @@ class AffiliateManagerAI {
                                         </small>
                                     </label>
                                 <?php endforeach; ?>
+                                <?php if ($total_pages > 1) : ?>
+                                    <div class="tablenav"><div class="tablenav-pages">
+                                        <?php echo paginate_links(array(
+                                            'base'      => add_query_arg('suggestions_page', '%#%'),
+                                            'format'    => '',
+                                            'prev_text' => __('&laquo;', 'affiliate-link-manager-ai'),
+                                            'next_text' => __('&raquo;', 'affiliate-link-manager-ai'),
+                                            'total'     => $total_pages,
+                                            'current'   => $page,
+                                        )); ?>
+                                    </div></div>
+                                <?php endif; ?>
                             </td>
                         </tr>
                         <?php else : ?>
@@ -3054,7 +3090,7 @@ class AffiliateManagerAI {
         $links = get_posts(array(
             'post_type'   => 'affiliate_link',
             'post_status' => 'publish',
-            'numberposts' => 50,
+            'numberposts' => 500,
             'orderby'     => 'title',
             'order'       => 'ASC',
         ));
@@ -3067,7 +3103,7 @@ class AffiliateManagerAI {
         foreach ($links as $link) {
             $prompt .= $link->ID . ': ' . $link->post_title . "\n";
         }
-        $prompt .= "\nRestituisci un array JSON con massimo 10 oggetti {\"id\": ID, \"score\": PERTINENZA}, dove PERTINENZA è un numero da 0 a 100 che indica quanto il link è coerente con il titolo. Ordina dal più pertinente al meno pertinente. Rispondi esclusivamente con JSON valido, senza testo aggiuntivo.";
+        $prompt .= "\nRestituisci un array JSON con massimo 500 oggetti {\"id\": ID, \"score\": PERTINENZA}, dove PERTINENZA è un numero da 0 a 100 che indica quanto il link è coerente con il titolo. Ordina dal più pertinente al meno pertinente. Rispondi esclusivamente con JSON valido, senza testo aggiuntivo.";
 
         $response = ALMA_AI_Utils::call_claude_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo');
         if (empty($response['success'])) {
@@ -3086,7 +3122,7 @@ class AffiliateManagerAI {
         });
 
         $suggestions = array();
-        foreach (array_slice($items, 0, 10) as $item) {
+        foreach (array_slice($items, 0, 500) as $item) {
             $id    = intval($item['id'] ?? 0);
             $score = floatval($item['score'] ?? 0);
 


### PR DESCRIPTION
## Summary
- increase widget AI link suggestion pool up to 500 links
- paginate widget AI suggestions 10 per page in create and edit screens

## Testing
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb181d7aa88332bb76bc00b2c5d299