### PR TITLE
feat: add affiliate link search and widget creation enhancements

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -603,3 +603,13 @@ button:disabled {
     color: #2271b1;
     margin-right: 2px;
 }
+
+/* Required fields */
+.alma-required label:after {
+    content: ' *';
+    color: #d63638;
+}
+
+.alma-required-field {
+    border-color: #d63638;
+}


### PR DESCRIPTION
## Summary
- rename suggestion trigger to "Genera suggerimenti AI" and add search for affiliate links with pagination
- highlight required widget fields and add final creation button

## Testing
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb1d5f092883328906a4f1f6e8d74e