### PR TITLE
Add copy buttons for widget code and improve search spacing

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -2026,8 +2026,16 @@ class AffiliateManagerAI {
 
             <?php if ($created) : ?>
                 <div class="notice notice-success"><p><?php _e('Widget creato con successo!', 'affiliate-link-manager-ai'); ?></p></div>
-                <p><?php _e('Shortcode:', 'affiliate-link-manager-ai'); ?> <code><?php echo esc_html($shortcode); ?></code></p>
-                <p><?php _e('PHP:', 'affiliate-link-manager-ai'); ?> <code><?php echo esc_html($php_code); ?></code></p>
+                <p>
+                    <?php _e('Shortcode:', 'affiliate-link-manager-ai'); ?>
+                    <code><?php echo esc_html($shortcode); ?></code>
+                    <button type="button" class="button button-small alma-copy-btn" data-copy="<?php echo esc_attr($shortcode); ?>" style="margin-left:5px;">📋</button>
+                </p>
+                <p>
+                    <?php _e('PHP:', 'affiliate-link-manager-ai'); ?>
+                    <code><?php echo esc_html($php_code); ?></code>
+                    <button type="button" class="button button-small alma-copy-btn" data-copy="<?php echo esc_attr($php_code); ?>" style="margin-left:5px;">📋</button>
+                </p>
             <?php endif; ?>
 
             <form method="post">

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -604,6 +604,19 @@ button:disabled {
     margin-right: 2px;
 }
 
+/* Search results layout */
+.alma-affiliate-search {
+    margin: 20px 0 10px;
+}
+
+.alma-suggested-links {
+    margin-top: 10px;
+}
+
+.alma-suggested-links .alma-suggested-link {
+    margin-bottom: 10px;
+}
+
 /* Required fields */
 .alma-required label:after {
     content: ' *';


### PR DESCRIPTION
## Summary
- add copy-to-clipboard buttons for generated widget shortcode and PHP snippet
- refine widget creation search results with clearer spacing

## Testing
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb207ee4fc8332a4392e8908ccfb47