### PR TITLE
Add BotAffiliate Post configuration and popup enhancements

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -1095,6 +1095,16 @@ class AffiliateManagerAI {
             array($this, 'render_widget_shortcode_page')
         );
 
+        // BotAffiliate Post settings
+        add_submenu_page(
+            'edit.php?post_type=affiliate_link',
+            __('BotAffiliate Post', 'affiliate-link-manager-ai'),
+            __('BotAffiliate Post', 'affiliate-link-manager-ai'),
+            'manage_options',
+            'alma-bot-affiliate-settings',
+            array($this, 'render_bot_affiliate_settings_page')
+        );
+
         // Affiliate Chat AI
         add_submenu_page(
             'edit.php?post_type=affiliate_link',
@@ -1145,6 +1155,7 @@ class AffiliateManagerAI {
             'edit-tags.php?taxonomy=link_type&post_type=affiliate_link',
             'alma-create-widget',
             'affiliate-link-widgets',
+            'alma-bot-affiliate-settings',
             'affiliate-chat-ai',
             'affiliate-link-import',
             'alma-prompt-ai-settings',
@@ -1173,6 +1184,9 @@ class AffiliateManagerAI {
                             break;
                         case 'affiliate-link-widgets':
                             $item[0] = __('Shortcode Widget', 'affiliate-link-manager-ai');
+                            break;
+                        case 'alma-bot-affiliate-settings':
+                            $item[0] = __('BotAffiliate Post', 'affiliate-link-manager-ai');
                             break;
                         case 'affiliate-chat-ai':
                             $item[0] = __('Affiliate Chat AI', 'affiliate-link-manager-ai');
@@ -2382,6 +2396,53 @@ class AffiliateManagerAI {
                     </tbody>
                 </table>
             <?php endif; ?>
+        </div>
+        <?php
+    }
+
+    public function render_bot_affiliate_settings_page() {
+        if (!current_user_can('manage_options')) {
+            wp_die(__('Non hai i permessi per accedere a questa pagina.'));
+        }
+
+        if (isset($_POST['alma_bot_affiliate_settings_nonce']) && wp_verify_nonce($_POST['alma_bot_affiliate_settings_nonce'], 'alma_bot_affiliate_settings')) {
+            $animation = sanitize_text_field($_POST['alma_bot_affiliate_animation'] ?? 'fade');
+            $intro     = sanitize_textarea_field($_POST['alma_bot_affiliate_intro'] ?? '');
+            update_option('alma_bot_affiliate_animation', $animation);
+            update_option('alma_bot_affiliate_intro', $intro);
+            echo '<div class="notice notice-success"><p>' . esc_html__('Impostazioni salvate.', 'affiliate-link-manager-ai') . '</p></div>';
+        }
+
+        $current_animation = get_option('alma_bot_affiliate_animation', 'fade');
+        $intro_text        = get_option('alma_bot_affiliate_intro', '');
+
+        ?>
+        <div class="wrap">
+            <h1><?php _e('BotAffiliate Post', 'affiliate-link-manager-ai'); ?></h1>
+            <form method="post">
+                <?php wp_nonce_field('alma_bot_affiliate_settings', 'alma_bot_affiliate_settings_nonce'); ?>
+                <table class="form-table">
+                    <tr>
+                        <th scope="row"><?php _e('Animazione popup', 'affiliate-link-manager-ai'); ?></th>
+                        <td>
+                            <select name="alma_bot_affiliate_animation">
+                                <option value="fade" <?php selected($current_animation, 'fade'); ?>><?php _e('Dissolvenza', 'affiliate-link-manager-ai'); ?></option>
+                                <option value="slide" <?php selected($current_animation, 'slide'); ?>><?php _e('Scorrimento', 'affiliate-link-manager-ai'); ?></option>
+                                <option value="zoom" <?php selected($current_animation, 'zoom'); ?>><?php _e('Zoom', 'affiliate-link-manager-ai'); ?></option>
+                                <option value="bounce" <?php selected($current_animation, 'bounce'); ?>><?php _e('Rimbalzo', 'affiliate-link-manager-ai'); ?></option>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e('Testo introduttivo', 'affiliate-link-manager-ai'); ?></th>
+                        <td>
+                            <textarea name="alma_bot_affiliate_intro" rows="4" class="large-text"><?php echo esc_textarea($intro_text); ?></textarea>
+                            <p class="description"><?php _e('Testo mostrato prima dei link affiliati.', 'affiliate-link-manager-ai'); ?></p>
+                        </td>
+                    </tr>
+                </table>
+                <?php submit_button(); ?>
+            </form>
         </div>
         <?php
     }

--- a/assets/bot-affiliate.css
+++ b/assets/bot-affiliate.css
@@ -11,6 +11,21 @@
     padding: 15px;
     z-index: 9999;
     display: none;
+    opacity: 0;
+}
+
+.alma-bot-affiliate .alma-bot-affiliate-close {
+    position: absolute;
+    top: 5px;
+    right: 8px;
+    background: transparent;
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+}
+
+.alma-bot-intro {
+    margin: 0 0 10px;
 }
 .alma-bot-affiliate ul {
     list-style: none;
@@ -26,4 +41,42 @@
 }
 .alma-bot-affiliate a:hover {
     text-decoration: underline;
+}
+
+.alma-bot-affiliate.alma-animation-fade {
+    animation: alma-fade 0.6s forwards;
+}
+
+@keyframes alma-fade {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.alma-bot-affiliate.alma-animation-slide {
+    animation: alma-slide 0.6s forwards;
+}
+
+@keyframes alma-slide {
+    from { transform: translate(-50%, 20px); opacity: 0; }
+    to { transform: translate(-50%, 0); opacity: 1; }
+}
+
+.alma-bot-affiliate.alma-animation-zoom {
+    animation: alma-zoom 0.6s forwards;
+}
+
+@keyframes alma-zoom {
+    from { transform: translateX(-50%) scale(0.8); opacity: 0; }
+    to { transform: translateX(-50%) scale(1); opacity: 1; }
+}
+
+.alma-bot-affiliate.alma-animation-bounce {
+    animation: alma-bounce 0.6s forwards;
+}
+
+@keyframes alma-bounce {
+    0% { transform: translateX(-50%) scale(0.3); opacity: 0; }
+    50% { transform: translateX(-50%) scale(1.05); opacity: 1; }
+    70% { transform: translateX(-50%) scale(0.95); }
+    100% { transform: translateX(-50%) scale(1); }
 }

--- a/assets/bot-affiliate.js
+++ b/assets/bot-affiliate.js
@@ -1,8 +1,19 @@
 (function($){
     $(function(){
         var box = $('#alma-bot-affiliate');
-        if(box.length){
-            box.fadeIn(600);
+        if(!box.length){
+            return;
         }
+        if (sessionStorage.getItem('almaBotAffiliateClosed')) {
+            return;
+        }
+        var anim = (typeof alma_bot_affiliate !== 'undefined' && alma_bot_affiliate.animation) ? alma_bot_affiliate.animation : 'fade';
+        box.show().addClass('alma-animation-' + anim);
+        box.on('click', '.alma-bot-affiliate-close', function(){
+            box.hide();
+            try {
+                sessionStorage.setItem('almaBotAffiliateClosed', '1');
+            } catch(e) {}
+        });
     });
 })(jQuery);

--- a/includes/class-bot-affiliate.php
+++ b/includes/class-bot-affiliate.php
@@ -97,6 +97,13 @@ class ALMA_Bot_Affiliate {
                 ALMA_VERSION,
                 true
             );
+            wp_localize_script(
+                'alma-bot-affiliate',
+                'alma_bot_affiliate',
+                array(
+                    'animation' => get_option('alma_bot_affiliate_animation', 'fade')
+                )
+            );
         }
     }
 
@@ -115,7 +122,13 @@ class ALMA_Bot_Affiliate {
         if (empty($links) || !is_array($links)) {
             return;
         }
-        echo '<div id="alma-bot-affiliate" class="alma-bot-affiliate"><ul>';
+        $intro = get_option('alma_bot_affiliate_intro', '');
+        echo '<div id="alma-bot-affiliate" class="alma-bot-affiliate">';
+        echo '<button type="button" class="alma-bot-affiliate-close" aria-label="' . esc_attr__('Chiudi', 'affiliate-link-manager-ai') . '">&times;</button>';
+        if (!empty($intro)) {
+            echo '<p class="alma-bot-intro">' . wp_kses_post($intro) . '</p>';
+        }
+        echo '<ul>';
         foreach (array_slice($links, 0, 3) as $link) {
             $url   = esc_url($link['url'] ?? '#');
             $title = esc_html($link['title'] ?? $link['url'] ?? '');


### PR DESCRIPTION
## Summary
- add "BotAffiliate Post" submenu with settings for popup animation and intro text
- show customizable intro text and close icon in affiliate popup
- support four popup animations with session-based dismissal

## Testing
- `php -l affiliate-link-manager-ai.php`
- `php -l includes/class-bot-affiliate.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb361ee58c8332b2d08918774edfbf