### PR TITLE
Show BotAffiliate popup per post and add left entrance animation

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -2429,7 +2429,7 @@ class AffiliateManagerAI {
                                 <option value="fade" <?php selected($current_animation, 'fade'); ?>><?php _e('Dissolvenza', 'affiliate-link-manager-ai'); ?></option>
                                 <option value="slide" <?php selected($current_animation, 'slide'); ?>><?php _e('Scorrimento', 'affiliate-link-manager-ai'); ?></option>
                                 <option value="zoom" <?php selected($current_animation, 'zoom'); ?>><?php _e('Zoom', 'affiliate-link-manager-ai'); ?></option>
-                                <option value="bounce" <?php selected($current_animation, 'bounce'); ?>><?php _e('Rimbalzo', 'affiliate-link-manager-ai'); ?></option>
+                                <option value="left" <?php selected($current_animation, 'left'); ?>><?php _e('Entrata da sinistra', 'affiliate-link-manager-ai'); ?></option>
                             </select>
                         </td>
                     </tr>

--- a/assets/bot-affiliate.css
+++ b/assets/bot-affiliate.css
@@ -70,13 +70,11 @@
     to { transform: translateX(-50%) scale(1); opacity: 1; }
 }
 
-.alma-bot-affiliate.alma-animation-bounce {
-    animation: alma-bounce 0.6s forwards;
+.alma-bot-affiliate.alma-animation-left {
+    animation: alma-left 0.6s forwards;
 }
 
-@keyframes alma-bounce {
-    0% { transform: translateX(-50%) scale(0.3); opacity: 0; }
-    50% { transform: translateX(-50%) scale(1.05); opacity: 1; }
-    70% { transform: translateX(-50%) scale(0.95); }
-    100% { transform: translateX(-50%) scale(1); }
+@keyframes alma-left {
+    from { transform: translate(-200%, 0); opacity: 0; }
+    to { transform: translate(-50%, 0); opacity: 1; }
 }

--- a/assets/bot-affiliate.js
+++ b/assets/bot-affiliate.js
@@ -4,16 +4,10 @@
         if(!box.length){
             return;
         }
-        if (sessionStorage.getItem('almaBotAffiliateClosed')) {
-            return;
-        }
         var anim = (typeof alma_bot_affiliate !== 'undefined' && alma_bot_affiliate.animation) ? alma_bot_affiliate.animation : 'fade';
         box.show().addClass('alma-animation-' + anim);
         box.on('click', '.alma-bot-affiliate-close', function(){
             box.hide();
-            try {
-                sessionStorage.setItem('almaBotAffiliateClosed', '1');
-            } catch(e) {}
         });
     });
 })(jQuery);


### PR DESCRIPTION
## Summary
- Remove session storage so closing the BotAffiliate popup only affects the current post
- Replace bounce popup animation with a new left entrance animation

## Testing
- `php -l affiliate-link-manager-ai.php`
- `node --check assets/bot-affiliate.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68bb3e1fec508332878582b16d73c224