### PR TITLE
Aggiungi ritardo e testo personalizzato al BotAffiliate

### DIFF
--- a/assets/bot-affiliate.js
+++ b/assets/bot-affiliate.js
@@ -5,7 +5,10 @@
             return;
         }
         var anim = (typeof alma_bot_affiliate !== 'undefined' && alma_bot_affiliate.animation) ? alma_bot_affiliate.animation : 'fade';
-        box.show().addClass('alma-animation-' + anim);
+        var delay = (typeof alma_bot_affiliate !== 'undefined' && alma_bot_affiliate.delay) ? parseInt(alma_bot_affiliate.delay, 10) : 0;
+        setTimeout(function(){
+            box.show().addClass('alma-animation-' + anim);
+        }, delay * 1000);
         box.on('click', '.alma-bot-affiliate-close', function(){
             box.hide();
         });


### PR DESCRIPTION
## Summary
- Consenti di definire un ritardo da 0 a 5 secondi prima di mostrare il popup BotAffiliate nel singolo post
- Aggiungi la possibilità di impostare un testo personalizzato per il popup che sovrascrive il valore globale
- Inietta il ritardo nel JS e aggiorna lo script per rispettare il valore impostato

## Testing
- `php -l includes/class-bot-affiliate.php`
- `node --check assets/bot-affiliate.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbde421dc08332a9c484652543a90d