### PR TITLE
Limit AI suggestions to existing affiliate links

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -367,7 +367,9 @@ class AffiliateManagerAI {
         }
 
         $user_prompt = "Richiesta utente: $query\nLink disponibili:\n$links_text\n" .
-            'Suggerisci i link più pertinenti organizzati per tipologia e spiega brevemente le tue scelte prima della lista.';
+            "Sulla base esclusiva dei link forniti, suggerisci quelli più pertinenti organizzati per tipologia. " .
+            "Non menzionare o generare link esterni alla lista. Se nessun link è adatto, segnala che non sono disponibili suggerimenti. " .
+            "Spiega brevemente le tue scelte prima della lista.";
 
         $result = ALMA_AI_Utils::call_claude_api($user_prompt, $system_prompt, $conversation);
 


### PR DESCRIPTION
## Summary
- Ensure Claude suggestions rely solely on affiliate links stored in the plugin database
- Restrict bot affiliate popup to choose links only from saved affiliate_link posts

## Testing
- `php -l affiliate-link-manager-ai.php`
- `php -l includes/class-bot-affiliate.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbe74a2ae48332943c7b27dbcf64a7