### PR TITLE
Include affiliate links in Content Analysis AI

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -1696,7 +1696,6 @@ class AffiliateManagerAI {
                             <td>
                                 <?php
                                 $post_types = get_post_types(array('show_ui' => true), 'objects');
-                                unset($post_types['affiliate_link']);
                                 $selected_analysis = get_option('alma_content_analysis_post_types', array());
                                 foreach ($post_types as $pt) {
                                     $checked = in_array($pt->name, $selected_analysis, true) ? 'checked' : '';


### PR DESCRIPTION
## Summary
- Allow affiliate links custom post type to be selected for Content Analysis AI

## Testing
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc3179ca088332b6e018ecff5f0468