### PR TITLE
Use cached content types in AI chat

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -313,6 +313,14 @@ class AffiliateManagerAI {
             wp_send_json_error(__('Richiesta mancante', 'affiliate-link-manager-ai'));
         }
 
+        // Recupera contenuti pertinenti dalla cache
+        $cached       = ALMA_Content_Analysis_AI::search_cache($query);
+        $content_text = '';
+        foreach ($cached as $item) {
+            $snippet = mb_substr($item['content'], 0, 200);
+            $content_text .= '- ' . $item['title'] . ': ' . $snippet . "\n";
+        }
+
         $conversation = array();
         if (!empty($_POST['conversation'])) {
             $decoded = json_decode(stripslashes($_POST['conversation']), true);
@@ -367,7 +375,11 @@ class AffiliateManagerAI {
             }
         }
 
-        $user_prompt = "Richiesta utente: $query\nLink disponibili:\n$links_text\n" .
+        $user_prompt = "Richiesta utente: $query\n";
+        if ($content_text !== '') {
+            $user_prompt .= "Contenuti disponibili:\n$content_text\n";
+        }
+        $user_prompt .= "Link disponibili:\n$links_text\n" .
             "Sulla base esclusiva dei link forniti, suggerisci quelli più pertinenti organizzati per tipologia. " .
             "Non menzionare o generare link esterni alla lista. Se nessun link è adatto, segnala che non sono disponibili suggerimenti. " .
             "Spiega brevemente le tue scelte prima della lista.";

--- a/includes/class-content-analysis-ai.php
+++ b/includes/class-content-analysis-ai.php
@@ -55,4 +55,33 @@ class ALMA_Content_Analysis_AI {
 
         return $data;
     }
+
+    /**
+     * Cerca nei contenuti in cache in base a una query testuale
+     *
+     * @param string $query Testo da cercare
+     * @param int    $limit Numero massimo di risultati
+     * @return array Contenuti trovati (title, content)
+     */
+    public static function search_cache($query, $limit = 5) {
+        $query = trim($query);
+        if ($query === '') {
+            return array();
+        }
+
+        $cache = self::get_cache();
+        if (empty($cache)) {
+            return array();
+        }
+
+        $results = array();
+        foreach ($cache as $item) {
+            $haystack = $item['title'] . ' ' . $item['content'];
+            if (stripos($haystack, $query) !== false) {
+                $results[] = $item;
+            }
+        }
+
+        return array_slice($results, 0, $limit);
+    }
 }


### PR DESCRIPTION
## Summary
- add `search_cache` helper to access cached content types
- include cached content summaries in Affiliate Chat AI prompts

## Testing
- `php -l includes/class-content-analysis-ai.php`
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc363c9ad08332aceb3dde46ff55d9