### PR TITLE
Add intro customization and collapse control to BotAffiliate Post

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -2458,12 +2458,15 @@ class AffiliateManagerAI {
         }
 
         wp_enqueue_media();
+        wp_enqueue_style('wp-color-picker');
+        wp_enqueue_script('wp-color-picker');
 
         if (isset($_POST['alma_bot_affiliate_settings_nonce']) && wp_verify_nonce($_POST['alma_bot_affiliate_settings_nonce'], 'alma_bot_affiliate_settings')) {
             $animation  = sanitize_text_field($_POST['alma_bot_affiliate_animation'] ?? 'fade');
             $intro      = sanitize_textarea_field($_POST['alma_bot_affiliate_intro'] ?? '');
             $num_links  = isset($_POST['alma_bot_affiliate_num_links']) ? (int) $_POST['alma_bot_affiliate_num_links'] : 3;
             $intro_img  = esc_url_raw($_POST['alma_bot_affiliate_intro_img'] ?? '');
+            $intro_bg   = sanitize_hex_color($_POST['alma_bot_affiliate_intro_bg'] ?? '#ffffff');
             if ($num_links < 1 || $num_links > 10) {
                 $num_links = 3;
             }
@@ -2471,6 +2474,7 @@ class AffiliateManagerAI {
             update_option('alma_bot_affiliate_intro', $intro);
             update_option('alma_bot_affiliate_num_links', $num_links);
             update_option('alma_bot_affiliate_intro_img', $intro_img);
+            update_option('alma_bot_affiliate_intro_bg', $intro_bg ?: '#ffffff');
             echo '<div class="notice notice-success"><p>' . esc_html__('Impostazioni salvate.', 'affiliate-link-manager-ai') . '</p></div>';
         }
 
@@ -2478,6 +2482,7 @@ class AffiliateManagerAI {
         $intro_text        = get_option('alma_bot_affiliate_intro', '');
         $current_num_links = get_option('alma_bot_affiliate_num_links', 3);
         $intro_img         = get_option('alma_bot_affiliate_intro_img', '');
+        $intro_bg          = get_option('alma_bot_affiliate_intro_bg', '#ffffff');
 
         ?>
         <div class="wrap">
@@ -2516,6 +2521,13 @@ class AffiliateManagerAI {
                         </td>
                     </tr>
                     <tr>
+                        <th scope="row"><?php _e('Colore sfondo testo', 'affiliate-link-manager-ai'); ?></th>
+                        <td>
+                            <input type="text" name="alma_bot_affiliate_intro_bg" value="<?php echo esc_attr($intro_bg); ?>" class="alma-color-field" />
+                            <p class="description"><?php _e('Colore di sfondo del testo introduttivo.', 'affiliate-link-manager-ai'); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
                         <th scope="row"><?php _e('Testo introduttivo', 'affiliate-link-manager-ai'); ?></th>
                         <td>
                             <textarea name="alma_bot_affiliate_intro" rows="4" class="large-text"><?php echo esc_textarea($intro_text); ?></textarea>
@@ -2545,6 +2557,7 @@ class AffiliateManagerAI {
                     });
                     frame.open();
                 });
+                $('.alma-color-field').wpColorPicker();
             });
             </script>
         </div>

--- a/assets/bot-affiliate.css
+++ b/assets/bot-affiliate.css
@@ -14,6 +14,7 @@
     display: flex;
     align-items: flex-start;
     margin-bottom: 10px;
+    cursor: pointer;
 }
 
 .alma-bot-avatar {
@@ -26,7 +27,7 @@
 
 .alma-bot-bubble {
     background: #fff;
-    border-radius: 8px;
+    border-radius: 100px;
     box-shadow: 0 2px 5px rgba(0,0,0,0.1);
     padding: 8px 12px;
     max-width: 80%;
@@ -41,14 +42,22 @@
     position: relative;
 }
 
-.alma-bot-box .alma-bot-affiliate-close {
+.alma-bot-box .alma-bot-affiliate-close,
+.alma-bot-box .alma-bot-affiliate-minimize {
     position: absolute;
     top: 5px;
-    right: 8px;
     background: transparent;
     border: none;
     font-size: 16px;
     cursor: pointer;
+}
+
+.alma-bot-box .alma-bot-affiliate-close {
+    right: 8px;
+}
+
+.alma-bot-box .alma-bot-affiliate-minimize {
+    right: 28px;
 }
 
 .alma-bot-box ul {

--- a/assets/bot-affiliate.js
+++ b/assets/bot-affiliate.js
@@ -12,5 +12,14 @@
         box.on('click', '.alma-bot-affiliate-close', function(){
             box.hide();
         });
+        box.on('click', '.alma-bot-affiliate-minimize', function(){
+            box.find('.alma-bot-box').slideUp();
+        });
+        box.on('click', '.alma-bot-intro-wrapper', function(){
+            var content = box.find('.alma-bot-box');
+            if(content.is(':hidden')){
+                content.slideDown();
+            }
+        });
     });
 })(jQuery);

--- a/includes/class-bot-affiliate.php
+++ b/includes/class-bot-affiliate.php
@@ -279,16 +279,18 @@ class ALMA_Bot_Affiliate {
             $intro = get_option('alma_bot_affiliate_intro', '');
         }
         $intro_img = esc_url(get_option('alma_bot_affiliate_intro_img', ''));
+        $intro_bg  = sanitize_hex_color(get_option('alma_bot_affiliate_intro_bg', '#ffffff'));
         echo '<div id="alma-bot-affiliate" class="alma-bot-affiliate">';
         if (!empty($intro)) {
             echo '<div class="alma-bot-intro-wrapper">';
             if ($intro_img !== '') {
                 echo "<img src='{$intro_img}' alt='' class='alma-bot-avatar' width='40' height='40' />";
             }
-            echo '<div class="alma-bot-bubble">' . wp_kses_post($intro) . '</div>';
+            echo '<div class="alma-bot-bubble" style="background:' . esc_attr($intro_bg) . ';">' . wp_kses_post($intro) . '</div>';
             echo '</div>';
         }
         echo '<div class="alma-bot-box">';
+        echo '<button type="button" class="alma-bot-affiliate-minimize" aria-label="' . esc_attr__('Riduci', 'affiliate-link-manager-ai') . '">&#x25BC;</button>';
         echo '<button type="button" class="alma-bot-affiliate-close" aria-label="' . esc_attr__('Chiudi', 'affiliate-link-manager-ai') . '">&times;</button>';
         echo '<ul>';
         foreach (array_slice($links, 0, $num_links) as $link) {


### PR DESCRIPTION
## Summary
- Round intro text background and style clickable area
- Allow custom intro background color via settings
- Add minimize button to collapse and restore BotAffiliate box

## Testing
- `php -l affiliate-link-manager-ai.php`
- `php -l includes/class-bot-affiliate.php`
- `npx eslint assets/bot-affiliate.js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68bd53af70408332a42d2b03a510c034