### PR TITLE
Allow customizing intro text color and refine bot controls

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -2462,11 +2462,12 @@ class AffiliateManagerAI {
         wp_enqueue_script('wp-color-picker');
 
         if (isset($_POST['alma_bot_affiliate_settings_nonce']) && wp_verify_nonce($_POST['alma_bot_affiliate_settings_nonce'], 'alma_bot_affiliate_settings')) {
-            $animation  = sanitize_text_field($_POST['alma_bot_affiliate_animation'] ?? 'fade');
-            $intro      = sanitize_textarea_field($_POST['alma_bot_affiliate_intro'] ?? '');
-            $num_links  = isset($_POST['alma_bot_affiliate_num_links']) ? (int) $_POST['alma_bot_affiliate_num_links'] : 3;
-            $intro_img  = esc_url_raw($_POST['alma_bot_affiliate_intro_img'] ?? '');
-            $intro_bg   = sanitize_hex_color($_POST['alma_bot_affiliate_intro_bg'] ?? '#ffffff');
+            $animation   = sanitize_text_field($_POST['alma_bot_affiliate_animation'] ?? 'fade');
+            $intro       = sanitize_textarea_field($_POST['alma_bot_affiliate_intro'] ?? '');
+            $num_links   = isset($_POST['alma_bot_affiliate_num_links']) ? (int) $_POST['alma_bot_affiliate_num_links'] : 3;
+            $intro_img   = esc_url_raw($_POST['alma_bot_affiliate_intro_img'] ?? '');
+            $intro_bg    = sanitize_hex_color($_POST['alma_bot_affiliate_intro_bg'] ?? '#ffffff');
+            $intro_color = sanitize_hex_color($_POST['alma_bot_affiliate_intro_color'] ?? '#000000');
             if ($num_links < 1 || $num_links > 10) {
                 $num_links = 3;
             }
@@ -2475,6 +2476,7 @@ class AffiliateManagerAI {
             update_option('alma_bot_affiliate_num_links', $num_links);
             update_option('alma_bot_affiliate_intro_img', $intro_img);
             update_option('alma_bot_affiliate_intro_bg', $intro_bg ?: '#ffffff');
+            update_option('alma_bot_affiliate_intro_color', $intro_color ?: '#000000');
             echo '<div class="notice notice-success"><p>' . esc_html__('Impostazioni salvate.', 'affiliate-link-manager-ai') . '</p></div>';
         }
 
@@ -2483,6 +2485,7 @@ class AffiliateManagerAI {
         $current_num_links = get_option('alma_bot_affiliate_num_links', 3);
         $intro_img         = get_option('alma_bot_affiliate_intro_img', '');
         $intro_bg          = get_option('alma_bot_affiliate_intro_bg', '#ffffff');
+        $intro_color       = get_option('alma_bot_affiliate_intro_color', '#000000');
 
         ?>
         <div class="wrap">
@@ -2525,6 +2528,13 @@ class AffiliateManagerAI {
                         <td>
                             <input type="text" name="alma_bot_affiliate_intro_bg" value="<?php echo esc_attr($intro_bg); ?>" class="alma-color-field" />
                             <p class="description"><?php _e('Colore di sfondo del testo introduttivo.', 'affiliate-link-manager-ai'); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e('Colore testo', 'affiliate-link-manager-ai'); ?></th>
+                        <td>
+                            <input type="text" name="alma_bot_affiliate_intro_color" value="<?php echo esc_attr($intro_color); ?>" class="alma-color-field" />
+                            <p class="description"><?php _e('Colore del testo introduttivo.', 'affiliate-link-manager-ai'); ?></p>
                         </td>
                     </tr>
                     <tr>

--- a/assets/bot-affiliate.css
+++ b/assets/bot-affiliate.css
@@ -45,19 +45,26 @@
 .alma-bot-box .alma-bot-affiliate-close,
 .alma-bot-box .alma-bot-affiliate-minimize {
     position: absolute;
-    top: 5px;
-    background: transparent;
-    border: none;
+    top: 8px;
+    background: #fff;
+    border: 1px solid #ccc;
+    width: 24px;
+    height: 24px;
+    border-radius: 4px;
     font-size: 16px;
     cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #666;
 }
 
 .alma-bot-box .alma-bot-affiliate-close {
-    right: 8px;
+    right: 10px;
 }
 
 .alma-bot-box .alma-bot-affiliate-minimize {
-    right: 28px;
+    right: 44px;
 }
 
 .alma-bot-box ul {

--- a/includes/class-bot-affiliate.php
+++ b/includes/class-bot-affiliate.php
@@ -278,15 +278,16 @@ class ALMA_Bot_Affiliate {
         if (trim($intro) === '') {
             $intro = get_option('alma_bot_affiliate_intro', '');
         }
-        $intro_img = esc_url(get_option('alma_bot_affiliate_intro_img', ''));
-        $intro_bg  = sanitize_hex_color(get_option('alma_bot_affiliate_intro_bg', '#ffffff'));
+        $intro_img   = esc_url(get_option('alma_bot_affiliate_intro_img', ''));
+        $intro_bg    = sanitize_hex_color(get_option('alma_bot_affiliate_intro_bg', '#ffffff'));
+        $intro_color = sanitize_hex_color(get_option('alma_bot_affiliate_intro_color', '#000000'));
         echo '<div id="alma-bot-affiliate" class="alma-bot-affiliate">';
         if (!empty($intro)) {
             echo '<div class="alma-bot-intro-wrapper">';
             if ($intro_img !== '') {
                 echo "<img src='{$intro_img}' alt='' class='alma-bot-avatar' width='40' height='40' />";
             }
-            echo '<div class="alma-bot-bubble" style="background:' . esc_attr($intro_bg) . ';">' . wp_kses_post($intro) . '</div>';
+            echo '<div class="alma-bot-bubble" style="background:' . esc_attr($intro_bg) . ';color:' . esc_attr($intro_color) . ';font-weight:bold;">' . wp_kses_post($intro) . '</div>';
             echo '</div>';
         }
         echo '<div class="alma-bot-box">';


### PR DESCRIPTION
## Summary
- add configurable color option for introductory text and render it in bold
- style close and minimize icons as separated square buttons with subtle border

## Testing
- `php -l affiliate-link-manager-ai.php`
- `php -l includes/class-bot-affiliate.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd56d569308332a3768bd296e4dfa3