### PR TITLE
Track affiliate click sources and display source chart

### DIFF
--- a/assets/tracking.js
+++ b/assets/tracking.js
@@ -39,6 +39,7 @@
         $('.alma-affiliate-link[data-track="1"]').each(function() {
             const $link = $(this);
             const linkId = $link.data('link-id');
+            const source = $link.data('source') || 'unknown';
             
             // Evita doppio binding
             if (trackedLinks.has(linkId + '_' + $link.get(0))) {
@@ -50,18 +51,18 @@
             // Bind eventi click
             $link.on('click', function(e) {
                 // Non bloccare il click, traccia in background
-                trackAffiliateClick(linkId, $link.attr('href'));
+                trackAffiliateClick(linkId, $link.attr('href'), 'click', source);
             });
             
             // Traccia anche right-click (apri in nuova scheda)
             $link.on('contextmenu', function(e) {
-                trackAffiliateClick(linkId, $link.attr('href'), 'contextmenu');
+                trackAffiliateClick(linkId, $link.attr('href'), 'contextmenu', source);
             });
             
             // Traccia middle-click (apri in nuova scheda)
             $link.on('mousedown', function(e) {
                 if (e.which === 2) {
-                    trackAffiliateClick(linkId, $link.attr('href'), 'middleclick');
+                    trackAffiliateClick(linkId, $link.attr('href'), 'middleclick', source);
                 }
             });
         });
@@ -75,7 +76,7 @@
     /**
      * Traccia click su link affiliato
      */
-    function trackAffiliateClick(linkId, url, clickType = 'click') {
+    function trackAffiliateClick(linkId, url, clickType = 'click', source = 'unknown') {
         // Evita tracking multipli simultanei
         if (isTracking) {
             return;
@@ -95,6 +96,7 @@
             link_id: linkId,
             referrer: document.referrer || window.location.href,
             click_type: clickType,
+            source: source,
             timestamp: Date.now()
         };
         
@@ -181,13 +183,13 @@
      */
     window.ALMA = window.ALMA || {};
     
-    window.ALMA.trackClick = function(linkId) {
+    window.ALMA.trackClick = function(linkId, source) {
         if (!linkId) {
             console.error('ALMA: ID link richiesto per tracking manuale');
             return;
         }
-        
-        trackAffiliateClick(linkId, '', 'manual');
+
+        trackAffiliateClick(linkId, '', 'manual', source || 'manual');
     };
     
     window.ALMA.getLocalStats = function() {

--- a/includes/class-affiliate-links-widget.php
+++ b/includes/class-affiliate-links-widget.php
@@ -64,7 +64,7 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
             $fields_attr = !empty($fields) ? ' fields="' . implode(',', $fields) . '"' : '';
             $button_attr = $show_button ? ' button="yes"' : ' button="no"';
             $text_attr = ($show_button && $button_text !== '') ? ' button_text="' . esc_attr($button_text) . '"' : '';
-            $shortcode = '[affiliate_link id="' . $id . '" img="' . $img . '" img_size="' . $img_size . '"' . $fields_attr . $button_attr . $text_attr . ']';
+            $shortcode = '[affiliate_link id="' . $id . '" img="' . $img . '" img_size="' . $img_size . '"' . $fields_attr . $button_attr . $text_attr . ' source="widget"]';
             $link_html = do_shortcode($shortcode);
 
             $output .= '<div class="alma-affiliate-item" style="' . esc_attr($item_style) . '">' . $link_html . '</div>';

--- a/includes/class-bot-affiliate.php
+++ b/includes/class-bot-affiliate.php
@@ -254,6 +254,7 @@ class ALMA_Bot_Affiliate {
                 $type_terms = get_the_terms($id, 'link_type');
                 $type       = ($type_terms && !is_wp_error($type_terms)) ? $type_terms[0]->name : '';
                 $links[]    = array(
+                    'id'    => $id,
                     'title' => get_the_title($id),
                     'url'   => esc_url_raw($url),
                     'img'   => $img ? esc_url_raw($img) : '',
@@ -299,12 +300,20 @@ class ALMA_Bot_Affiliate {
             $title = esc_html($link['title'] ?? $link['url'] ?? '');
             $img   = esc_url($link['img'] ?? '');
             $type  = esc_html($link['type'] ?? '');
+            $id    = intval($link['id'] ?? 0);
             echo '<li class="alma-bot-link-item">';
             if ($img) {
                 echo "<img src='{$img}' alt='{$title}' class='alma-bot-thumb' width='60' height='60' />";
             }
             echo '<div class="alma-bot-link-info">';
-            echo "<a href='{$url}' target='_blank' rel='sponsored noopener' class='alma-bot-link-title'>{$title}</a>";
+            $link_attrs = "href='{$url}' target='_blank' rel='sponsored noopener' class='alma-bot-link-title";
+            if ($id) {
+                $link_attrs .= " alma-affiliate-link";
+                $link_attrs .= "' data-link-id='{$id}' data-track='1' data-source='bot'";
+            } else {
+                $link_attrs .= "'";
+            }
+            echo '<a ' . $link_attrs . '>' . $title . '</a>';
             if ($type !== '') {
                 echo "<div class=\"alma-bot-link-type\">{$type}</div>";
             }
@@ -323,7 +332,8 @@ class ALMA_Bot_Affiliate {
             foreach ($links as &$link) {
                 $missing_img  = empty($link['img']);
                 $missing_type = empty($link['type']);
-                if ($missing_img || $missing_type) {
+                $missing_id   = empty($link['id']);
+                if ($missing_img || $missing_type || $missing_id) {
                     $url = $link['url'] ?? '';
                     if ($url) {
                         $posts = get_posts(array(
@@ -342,6 +352,9 @@ class ALMA_Bot_Affiliate {
                             if ($missing_type) {
                                 $type_terms   = get_the_terms($p->ID, 'link_type');
                                 $link['type'] = ($type_terms && !is_wp_error($type_terms)) ? $type_terms[0]->name : '';
+                            }
+                            if ($missing_id) {
+                                $link['id'] = $p->ID;
                             }
                             $needs_update = true;
                         } else {
@@ -381,6 +394,7 @@ class ALMA_Bot_Affiliate {
             $type_terms = get_the_terms($p->ID, 'link_type');
             $type       = ($type_terms && !is_wp_error($type_terms)) ? $type_terms[0]->name : '';
             $available[] = array(
+                'id'    => $p->ID,
                 'title' => get_the_title($p->ID),
                 'url'   => esc_url_raw($url),
                 'img'   => $img ? esc_url_raw($img) : '',


### PR DESCRIPTION
## Summary
- track affiliate clicks with origin metadata for shortcodes, widgets and bot popup
- store click source in analytics table and expose it in chart data endpoint
- show click source distribution pie chart in dashboard and send source info from tracking.js

## Testing
- `php -l affiliate-link-manager-ai.php`
- `php -l includes/class-affiliate-links-widget.php`
- `php -l includes/class-bot-affiliate.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd5977e2f48332a87c293a465974d1