### PR TITLE
feat: restore link type management menu

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -530,6 +530,7 @@ class AffiliateManagerAI {
             'hierarchical' => true,
             'show_ui' => true,
             'show_admin_column' => true,
+            'show_in_menu' => true,
             'query_var' => true,
             'rewrite' => array('slug' => 'link-type'),
         ));
@@ -1132,6 +1133,15 @@ class AffiliateManagerAI {
             'manage_options',
             'affiliate-link-import',
             array($this, 'render_import_page')
+        );
+
+        // Tipologie Link
+        add_submenu_page(
+            'edit.php?post_type=affiliate_link',
+            __('Tipologie Link', 'affiliate-link-manager-ai'),
+            __('Tipologie Link', 'affiliate-link-manager-ai'),
+            'manage_categories',
+            'edit-tags.php?taxonomy=link_type&post_type=affiliate_link'
         );
 
         // Creazione widget


### PR DESCRIPTION
## Summary
- ensure affiliate link types taxonomy shows in admin menu
- add Tipologie Link submenu for managing link types

## Testing
- `php -l affiliate-link-manager-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd78e4351c8332935d168d29ca5cec