### PR TITLE
Add responsive widget template layout controls

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -2101,7 +2101,8 @@ class AffiliateManagerAI {
             'show_content' => 0,
             'show_button'  => 0,
             'button_text'  => '',
-            'format'       => 'large',
+            'template_desktop_columns' => 1,
+            'template_mobile_columns'  => 1,
             'orientation'  => 'vertical',
             'links'        => array(),
             'manual_ids'   => array(),
@@ -2117,7 +2118,16 @@ class AffiliateManagerAI {
             $instance['show_content'] = !empty($_POST['show_content']) ? 1 : 0;
             $instance['show_button']  = !empty($_POST['show_button']) ? 1 : 0;
             $instance['button_text']  = sanitize_text_field($_POST['button_text'] ?? '');
-            $instance['format']       = ($_POST['format'] ?? 'large') === 'small' ? 'small' : 'large';
+            $desktop_columns = isset($_POST['template_desktop_columns']) ? intval($_POST['template_desktop_columns']) : 1;
+            if ($desktop_columns < 1 || $desktop_columns > 6) {
+                $desktop_columns = 1;
+            }
+            $mobile_columns = isset($_POST['template_mobile_columns']) ? intval($_POST['template_mobile_columns']) : 1;
+            if ($mobile_columns < 1 || $mobile_columns > 4) {
+                $mobile_columns = 1;
+            }
+            $instance['template_desktop_columns'] = $desktop_columns;
+            $instance['template_mobile_columns']  = $mobile_columns;
             $instance['orientation']  = ($_POST['orientation'] ?? 'vertical') === 'horizontal' ? 'horizontal' : 'vertical';
 
             $suggested_links = array_map('intval', $_POST['links'] ?? array());
@@ -2270,12 +2280,25 @@ class AffiliateManagerAI {
                             <td><input name="button_text" type="text" id="alma_widget_button_text" value="<?php echo esc_attr($instance['button_text']); ?>" class="regular-text"></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="alma-required"><label for="alma_widget_format"><?php _e('Formato', 'affiliate-link-manager-ai'); ?></label></th>
+                            <th scope="row" class="alma-required"><label for="alma_widget_template_desktop"><?php _e('Template Widget', 'affiliate-link-manager-ai'); ?></label></th>
                             <td>
-                                <select name="format" id="alma_widget_format" class="alma-required-field" required>
-                                    <option value="large" <?php selected($instance['format'], 'large'); ?>><?php _e('Immagine grande, titolo e contenuto', 'affiliate-link-manager-ai'); ?></option>
-                                    <option value="small" <?php selected($instance['format'], 'small'); ?>><?php _e('Immagine piccola e titolo', 'affiliate-link-manager-ai'); ?></option>
-                                </select>
+                                <fieldset>
+                                    <legend class="screen-reader-text"><span><?php _e('Template Widget', 'affiliate-link-manager-ai'); ?></span></legend>
+                                    <label for="alma_widget_template_desktop"><?php _e('Link per riga (Desktop)', 'affiliate-link-manager-ai'); ?></label>
+                                    <select name="template_desktop_columns" id="alma_widget_template_desktop" class="alma-required-field" required>
+                                        <?php for ($i = 1; $i <= 6; $i++) : ?>
+                                            <option value="<?php echo esc_attr($i); ?>" <?php selected((int) $instance['template_desktop_columns'], $i); ?>><?php echo esc_html($i); ?></option>
+                                        <?php endfor; ?>
+                                    </select>
+                                    <br>
+                                    <label for="alma_widget_template_mobile"><?php _e('Link per riga (Mobile)', 'affiliate-link-manager-ai'); ?></label>
+                                    <select name="template_mobile_columns" id="alma_widget_template_mobile" required>
+                                        <?php for ($i = 1; $i <= 4; $i++) : ?>
+                                            <option value="<?php echo esc_attr($i); ?>" <?php selected((int) $instance['template_mobile_columns'], $i); ?>><?php echo esc_html($i); ?></option>
+                                        <?php endfor; ?>
+                                    </select>
+                                    <p class="description"><?php _e('Imposta il numero di link da mostrare per riga su desktop e smartphone.', 'affiliate-link-manager-ai'); ?></p>
+                                </fieldset>
                             </td>
                         </tr>
                         <tr>
@@ -2377,7 +2400,21 @@ class AffiliateManagerAI {
             'manual_ids'     => array(),
             'show_button'    => 0,
             'button_text'    => '',
+            'template_desktop_columns' => 1,
+            'template_mobile_columns'  => 1,
         );
+        if (!array_key_exists('template_desktop_columns', $instances[$widget_id])) {
+            if (!empty($instance['format']) && $instance['format'] === 'small') {
+                $instance['template_desktop_columns'] = 2;
+            } elseif (($instance['orientation'] ?? 'vertical') === 'horizontal') {
+                $instance['template_desktop_columns'] = 2;
+            } else {
+                $instance['template_desktop_columns'] = 1;
+            }
+        }
+        if (!array_key_exists('template_mobile_columns', $instances[$widget_id])) {
+            $instance['template_mobile_columns'] = 1;
+        }
         $saved       = false;
         $suggestions = array();
         $suggestions_error = null;
@@ -2395,7 +2432,16 @@ class AffiliateManagerAI {
             $instance['show_content'] = !empty($_POST['show_content']) ? 1 : 0;
             $instance['show_button']  = !empty($_POST['show_button']) ? 1 : 0;
             $instance['button_text']  = sanitize_text_field($_POST['button_text'] ?? '');
-            $instance['format']       = ($_POST['format'] ?? 'large') === 'small' ? 'small' : 'large';
+            $desktop_columns = isset($_POST['template_desktop_columns']) ? intval($_POST['template_desktop_columns']) : (int) ($instance['template_desktop_columns'] ?? 1);
+            if ($desktop_columns < 1 || $desktop_columns > 6) {
+                $desktop_columns = 1;
+            }
+            $mobile_columns = isset($_POST['template_mobile_columns']) ? intval($_POST['template_mobile_columns']) : (int) ($instance['template_mobile_columns'] ?? 1);
+            if ($mobile_columns < 1 || $mobile_columns > 4) {
+                $mobile_columns = 1;
+            }
+            $instance['template_desktop_columns'] = $desktop_columns;
+            $instance['template_mobile_columns']  = $mobile_columns;
             $instance['orientation']  = ($_POST['orientation'] ?? 'vertical') === 'horizontal' ? 'horizontal' : 'vertical';
 
             $suggested_links = array_map('intval', $_POST['links'] ?? array());
@@ -2489,12 +2535,25 @@ class AffiliateManagerAI {
                             <td><input name="button_text" type="text" id="alma_widget_button_text" value="<?php echo esc_attr($instance['button_text']); ?>" class="regular-text"></td>
                         </tr>
                         <tr>
-                            <th scope="row"><label for="alma_widget_format"><?php _e('Formato', 'affiliate-link-manager-ai'); ?></label></th>
+                            <th scope="row"><label for="alma_widget_template_desktop"><?php _e('Template Widget', 'affiliate-link-manager-ai'); ?></label></th>
                             <td>
-                                <select name="format" id="alma_widget_format">
-                                    <option value="large" <?php selected($instance['format'], 'large'); ?>><?php _e('Immagine grande, titolo e contenuto', 'affiliate-link-manager-ai'); ?></option>
-                                    <option value="small" <?php selected($instance['format'], 'small'); ?>><?php _e('Immagine piccola e titolo', 'affiliate-link-manager-ai'); ?></option>
-                                </select>
+                                <fieldset>
+                                    <legend class="screen-reader-text"><span><?php _e('Template Widget', 'affiliate-link-manager-ai'); ?></span></legend>
+                                    <label for="alma_widget_template_desktop"><?php _e('Link per riga (Desktop)', 'affiliate-link-manager-ai'); ?></label>
+                                    <select name="template_desktop_columns" id="alma_widget_template_desktop">
+                                        <?php for ($i = 1; $i <= 6; $i++) : ?>
+                                            <option value="<?php echo esc_attr($i); ?>" <?php selected((int) $instance['template_desktop_columns'], $i); ?>><?php echo esc_html($i); ?></option>
+                                        <?php endfor; ?>
+                                    </select>
+                                    <br>
+                                    <label for="alma_widget_template_mobile"><?php _e('Link per riga (Mobile)', 'affiliate-link-manager-ai'); ?></label>
+                                    <select name="template_mobile_columns" id="alma_widget_template_mobile">
+                                        <?php for ($i = 1; $i <= 4; $i++) : ?>
+                                            <option value="<?php echo esc_attr($i); ?>" <?php selected((int) $instance['template_mobile_columns'], $i); ?>><?php echo esc_html($i); ?></option>
+                                        <?php endfor; ?>
+                                    </select>
+                                    <p class="description"><?php _e('Imposta il numero di link da mostrare per riga su desktop e smartphone.', 'affiliate-link-manager-ai'); ?></p>
+                                </fieldset>
                             </td>
                         </tr>
                         <tr>

--- a/includes/class-affiliate-links-widget.php
+++ b/includes/class-affiliate-links-widget.php
@@ -20,8 +20,23 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
         $show_content = !empty($instance['show_content']);
         $show_button = !empty($instance['show_button']);
         $button_text = isset($instance['button_text']) ? sanitize_text_field($instance['button_text']) : '';
-        $format = isset($instance['format']) && $instance['format'] === 'small' ? 'small' : 'large';
         $orientation = isset($instance['orientation']) && $instance['orientation'] === 'horizontal' ? 'horizontal' : 'vertical';
+        $desktop_columns = isset($instance['template_desktop_columns']) ? intval($instance['template_desktop_columns']) : 0;
+        $mobile_columns = isset($instance['template_mobile_columns']) ? intval($instance['template_mobile_columns']) : 0;
+
+        if ($desktop_columns < 1) {
+            if (!empty($instance['format']) && $instance['format'] === 'small') {
+                $desktop_columns = 2;
+            } else {
+                $desktop_columns = $orientation === 'horizontal' ? 2 : 1;
+            }
+        }
+        $desktop_columns = max(1, min(6, $desktop_columns));
+
+        if ($mobile_columns < 1) {
+            $mobile_columns = 1;
+        }
+        $mobile_columns = max(1, min(4, $mobile_columns));
 
         if (empty($links)) {
             return '';
@@ -49,13 +64,22 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
         }
 
         $img = $show_image ? 'yes' : 'no';
-        $img_size = $format === 'small' ? 'thumbnail' : 'full';
+        $img_size = $desktop_columns > 2 ? 'thumbnail' : 'full';
 
-        $container_classes = 'alma-affiliate-widget format-' . $format . ' orientation-' . $orientation;
-        $container_style = $orientation === 'horizontal' ? 'display:flex;flex-wrap:wrap;' : '';
-        $item_style = $orientation === 'horizontal' ? 'width:50%;padding:10px;box-sizing:border-box;' : 'margin-bottom:10px;';
+        $container_classes = 'alma-affiliate-widget orientation-' . $orientation . ' template-desktop-' . $desktop_columns . ' template-mobile-' . $mobile_columns;
+        $container_style = '--alma-desktop-columns:' . $desktop_columns . ';--alma-mobile-columns:' . $mobile_columns . ';display:grid;gap:20px;';
 
-        $output = '<div class="' . esc_attr($container_classes) . '" style="' . esc_attr($container_style) . '">';
+        static $styles_printed = false;
+        $output = '';
+        if (!$styles_printed) {
+            $styles_printed = true;
+            $inline_css = '.alma-affiliate-widget{display:grid;gap:20px;grid-template-columns:repeat(var(--alma-desktop-columns,1),minmax(0,1fr));}'
+                . '.alma-affiliate-item{min-width:0;}'
+                . '@media (max-width:782px){.alma-affiliate-widget{grid-template-columns:repeat(var(--alma-mobile-columns,1),minmax(0,1fr));}}';
+            $output .= '<style id="alma-affiliate-widget-template-styles">' . esc_html($inline_css) . '</style>';
+        }
+
+        $output .= '<div class="' . esc_attr($container_classes) . '" style="' . esc_attr($container_style) . '">';
 
         while ($q->have_posts()) {
             $q->the_post();
@@ -67,7 +91,7 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
             $shortcode = '[affiliate_link id="' . $id . '" img="' . $img . '" img_size="' . $img_size . '"' . $fields_attr . $button_attr . $text_attr . ' source="widget"]';
             $link_html = do_shortcode($shortcode);
 
-            $output .= '<div class="alma-affiliate-item" style="' . esc_attr($item_style) . '">' . $link_html . '</div>';
+            $output .= '<div class="alma-affiliate-item">' . $link_html . '</div>';
         }
         wp_reset_postdata();
 
@@ -96,8 +120,17 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
         $show_content = !empty($instance['show_content']);
         $show_button = !empty($instance['show_button']);
         $button_text = $instance['button_text'] ?? '';
-        $format = $instance['format'] ?? 'large';
         $orientation = $instance['orientation'] ?? 'vertical';
+        $desktop_columns = isset($instance['template_desktop_columns']) ? intval($instance['template_desktop_columns']) : 0;
+        $mobile_columns = isset($instance['template_mobile_columns']) ? intval($instance['template_mobile_columns']) : 0;
+        if ($desktop_columns < 1) {
+            $desktop_columns = $orientation === 'horizontal' ? 2 : 1;
+        }
+        $desktop_columns = max(1, min(6, $desktop_columns));
+        if ($mobile_columns < 1) {
+            $mobile_columns = 1;
+        }
+        $mobile_columns = max(1, min(4, $mobile_columns));
         $links = isset($instance['links']) ? implode(',', array_map('intval', (array) $instance['links'])) : '';
         ?>
         <p>
@@ -129,10 +162,22 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
             <input class="widefat" id="<?php echo esc_attr($this->get_field_id('button_text')); ?>" name="<?php echo esc_attr($this->get_field_name('button_text')); ?>" type="text" value="<?php echo esc_attr($button_text); ?>">
         </p>
         <p>
-            <label for="<?php echo esc_attr($this->get_field_id('format')); ?>"><?php _e('Formato:', 'affiliate-link-manager-ai'); ?></label>
-            <select class="widefat" id="<?php echo esc_attr($this->get_field_id('format')); ?>" name="<?php echo esc_attr($this->get_field_name('format')); ?>">
-                <option value="large" <?php selected($format, 'large'); ?>><?php _e('Immagine grande, titolo e contenuto', 'affiliate-link-manager-ai'); ?></option>
-                <option value="small" <?php selected($format, 'small'); ?>><?php _e('Immagine piccola e titolo', 'affiliate-link-manager-ai'); ?></option>
+            <strong><?php _e('Template Widget', 'affiliate-link-manager-ai'); ?></strong>
+        </p>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('template_desktop_columns')); ?>"><?php _e('Link per riga (Desktop)', 'affiliate-link-manager-ai'); ?></label>
+            <select class="widefat" id="<?php echo esc_attr($this->get_field_id('template_desktop_columns')); ?>" name="<?php echo esc_attr($this->get_field_name('template_desktop_columns')); ?>">
+                <?php for ($i = 1; $i <= 6; $i++) : ?>
+                    <option value="<?php echo esc_attr($i); ?>" <?php selected($desktop_columns, $i); ?>><?php echo esc_html($i); ?></option>
+                <?php endfor; ?>
+            </select>
+        </p>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('template_mobile_columns')); ?>"><?php _e('Link per riga (Mobile)', 'affiliate-link-manager-ai'); ?></label>
+            <select class="widefat" id="<?php echo esc_attr($this->get_field_id('template_mobile_columns')); ?>" name="<?php echo esc_attr($this->get_field_name('template_mobile_columns')); ?>">
+                <?php for ($i = 1; $i <= 4; $i++) : ?>
+                    <option value="<?php echo esc_attr($i); ?>" <?php selected($mobile_columns, $i); ?>><?php echo esc_html($i); ?></option>
+                <?php endfor; ?>
             </select>
         </p>
         <p>
@@ -158,8 +203,13 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
         $instance['show_content'] = !empty($new_instance['show_content']) ? 1 : 0;
         $instance['show_button'] = !empty($new_instance['show_button']) ? 1 : 0;
         $instance['button_text'] = sanitize_text_field($new_instance['button_text'] ?? '');
-        $instance['format'] = $new_instance['format'] === 'small' ? 'small' : 'large';
         $instance['orientation'] = $new_instance['orientation'] === 'horizontal' ? 'horizontal' : 'vertical';
+        $desktop_columns = isset($new_instance['template_desktop_columns']) ? intval($new_instance['template_desktop_columns']) : 1;
+        $desktop_columns = max(1, min(6, $desktop_columns));
+        $mobile_columns = isset($new_instance['template_mobile_columns']) ? intval($new_instance['template_mobile_columns']) : 1;
+        $mobile_columns = max(1, min(4, $mobile_columns));
+        $instance['template_desktop_columns'] = $desktop_columns;
+        $instance['template_mobile_columns'] = $mobile_columns;
         $links = array_filter(array_map('intval', explode(',', $new_instance['links'] ?? '')));
         $instance['links'] = array_slice(array_unique($links), 0, 20);
         return $instance;


### PR DESCRIPTION
## Summary
- replace the old "Formato" selector with a new Template Widget section that lets admins choose desktop (1-6) and mobile (1-4) affiliate link columns when creating or editing widgets
- update the widget rendering logic to honor the per-device column settings with a responsive CSS grid layout while keeping backward compatibility with legacy instances
- persist the new template options in both the widget form and shortcode output, including sanitized defaults and fallbacks for existing widgets

## Testing
- php -l includes/class-affiliate-links-widget.php
- php -l affiliate-link-manager-ai.php

------
https://chatgpt.com/codex/tasks/task_e_68de9e8d82648332b2fb6be01e4dfb09