### PR TITLE
Remove orientation setting from AI widget forms

### DIFF
--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -2103,7 +2103,6 @@ class AffiliateManagerAI {
             'button_text'  => '',
             'template_desktop_columns' => 1,
             'template_mobile_columns'  => 1,
-            'orientation'  => 'vertical',
             'links'        => array(),
             'manual_ids'   => array(),
         );
@@ -2128,8 +2127,6 @@ class AffiliateManagerAI {
             }
             $instance['template_desktop_columns'] = $desktop_columns;
             $instance['template_mobile_columns']  = $mobile_columns;
-            $instance['orientation']  = ($_POST['orientation'] ?? 'vertical') === 'horizontal' ? 'horizontal' : 'vertical';
-
             $suggested_links = array_map('intval', $_POST['links'] ?? array());
 
             $raw_manual_ids = array_filter(array_map('intval', explode(',', $_POST['manual_ids'] ?? '')));
@@ -2301,15 +2298,6 @@ class AffiliateManagerAI {
                                 </fieldset>
                             </td>
                         </tr>
-                        <tr>
-                            <th scope="row" class="alma-required"><label for="alma_widget_orientation"><?php _e('Orientamento', 'affiliate-link-manager-ai'); ?></label></th>
-                            <td>
-                                <select name="orientation" id="alma_widget_orientation" class="alma-required-field" required>
-                                    <option value="vertical" <?php selected($instance['orientation'], 'vertical'); ?>><?php _e('Verticale', 'affiliate-link-manager-ai'); ?></option>
-                                    <option value="horizontal" <?php selected($instance['orientation'], 'horizontal'); ?>><?php _e('Orizzontale', 'affiliate-link-manager-ai'); ?></option>
-                                </select>
-                            </td>
-                        </tr>
                         <?php if (!empty($suggestions)) : ?>
                         <tr>
                             <th scope="row"><?php _e('Link suggeriti', 'affiliate-link-manager-ai'); ?></th>
@@ -2442,8 +2430,6 @@ class AffiliateManagerAI {
             }
             $instance['template_desktop_columns'] = $desktop_columns;
             $instance['template_mobile_columns']  = $mobile_columns;
-            $instance['orientation']  = ($_POST['orientation'] ?? 'vertical') === 'horizontal' ? 'horizontal' : 'vertical';
-
             $suggested_links = array_map('intval', $_POST['links'] ?? array());
             $raw_manual_ids = array_filter(array_map('intval', explode(',', $_POST['manual_ids'] ?? '')));
             $manual_ids = array();
@@ -2554,15 +2540,6 @@ class AffiliateManagerAI {
                                     </select>
                                     <p class="description"><?php _e('Imposta il numero di link da mostrare per riga su desktop e smartphone.', 'affiliate-link-manager-ai'); ?></p>
                                 </fieldset>
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row"><label for="alma_widget_orientation"><?php _e('Orientamento', 'affiliate-link-manager-ai'); ?></label></th>
-                            <td>
-                                <select name="orientation" id="alma_widget_orientation">
-                                    <option value="vertical" <?php selected($instance['orientation'], 'vertical'); ?>><?php _e('Verticale', 'affiliate-link-manager-ai'); ?></option>
-                                    <option value="horizontal" <?php selected($instance['orientation'], 'horizontal'); ?>><?php _e('Orizzontale', 'affiliate-link-manager-ai'); ?></option>
-                                </select>
                             </td>
                         </tr>
                         <?php if (!empty($suggestions)) : ?>

--- a/includes/class-affiliate-links-widget.php
+++ b/includes/class-affiliate-links-widget.php
@@ -20,15 +20,16 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
         $show_content = !empty($instance['show_content']);
         $show_button = !empty($instance['show_button']);
         $button_text = isset($instance['button_text']) ? sanitize_text_field($instance['button_text']) : '';
-        $orientation = isset($instance['orientation']) && $instance['orientation'] === 'horizontal' ? 'horizontal' : 'vertical';
         $desktop_columns = isset($instance['template_desktop_columns']) ? intval($instance['template_desktop_columns']) : 0;
         $mobile_columns = isset($instance['template_mobile_columns']) ? intval($instance['template_mobile_columns']) : 0;
 
         if ($desktop_columns < 1) {
             if (!empty($instance['format']) && $instance['format'] === 'small') {
                 $desktop_columns = 2;
+            } elseif (!empty($instance['orientation']) && $instance['orientation'] === 'horizontal') {
+                $desktop_columns = 2;
             } else {
-                $desktop_columns = $orientation === 'horizontal' ? 2 : 1;
+                $desktop_columns = 1;
             }
         }
         $desktop_columns = max(1, min(6, $desktop_columns));
@@ -66,7 +67,7 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
         $img = $show_image ? 'yes' : 'no';
         $img_size = $desktop_columns > 2 ? 'thumbnail' : 'full';
 
-        $container_classes = 'alma-affiliate-widget orientation-' . $orientation . ' template-desktop-' . $desktop_columns . ' template-mobile-' . $mobile_columns;
+        $container_classes = 'alma-affiliate-widget template-desktop-' . $desktop_columns . ' template-mobile-' . $mobile_columns;
         $container_style = '--alma-desktop-columns:' . $desktop_columns . ';--alma-mobile-columns:' . $mobile_columns . ';display:grid;gap:20px;';
 
         static $styles_printed = false;
@@ -120,11 +121,14 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
         $show_content = !empty($instance['show_content']);
         $show_button = !empty($instance['show_button']);
         $button_text = $instance['button_text'] ?? '';
-        $orientation = $instance['orientation'] ?? 'vertical';
         $desktop_columns = isset($instance['template_desktop_columns']) ? intval($instance['template_desktop_columns']) : 0;
         $mobile_columns = isset($instance['template_mobile_columns']) ? intval($instance['template_mobile_columns']) : 0;
         if ($desktop_columns < 1) {
-            $desktop_columns = $orientation === 'horizontal' ? 2 : 1;
+            if (!empty($instance['orientation']) && $instance['orientation'] === 'horizontal') {
+                $desktop_columns = 2;
+            } else {
+                $desktop_columns = 1;
+            }
         }
         $desktop_columns = max(1, min(6, $desktop_columns));
         if ($mobile_columns < 1) {
@@ -181,13 +185,6 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
             </select>
         </p>
         <p>
-            <label for="<?php echo esc_attr($this->get_field_id('orientation')); ?>"><?php _e('Orientamento:', 'affiliate-link-manager-ai'); ?></label>
-            <select class="widefat" id="<?php echo esc_attr($this->get_field_id('orientation')); ?>" name="<?php echo esc_attr($this->get_field_name('orientation')); ?>">
-                <option value="vertical" <?php selected($orientation, 'vertical'); ?>><?php _e('Verticale', 'affiliate-link-manager-ai'); ?></option>
-                <option value="horizontal" <?php selected($orientation, 'horizontal'); ?>><?php _e('Orizzontale', 'affiliate-link-manager-ai'); ?></option>
-            </select>
-        </p>
-        <p>
             <label for="<?php echo esc_attr($this->get_field_id('links')); ?>"><?php _e('ID Link (separati da virgola, max 20):', 'affiliate-link-manager-ai'); ?></label>
             <input class="widefat" id="<?php echo esc_attr($this->get_field_id('links')); ?>" name="<?php echo esc_attr($this->get_field_name('links')); ?>" type="text" value="<?php echo esc_attr($links); ?>">
         </p>
@@ -203,7 +200,9 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
         $instance['show_content'] = !empty($new_instance['show_content']) ? 1 : 0;
         $instance['show_button'] = !empty($new_instance['show_button']) ? 1 : 0;
         $instance['button_text'] = sanitize_text_field($new_instance['button_text'] ?? '');
-        $instance['orientation'] = $new_instance['orientation'] === 'horizontal' ? 'horizontal' : 'vertical';
+        if (isset($old_instance['orientation'])) {
+            $instance['orientation'] = $old_instance['orientation'] === 'horizontal' ? 'horizontal' : 'vertical';
+        }
         $desktop_columns = isset($new_instance['template_desktop_columns']) ? intval($new_instance['template_desktop_columns']) : 1;
         $desktop_columns = max(1, min(6, $desktop_columns));
         $mobile_columns = isset($new_instance['template_mobile_columns']) ? intval($new_instance['template_mobile_columns']) : 1;


### PR DESCRIPTION
## Summary
- remove the orientation selector from AI widget creation and edit forms
- adjust the widget renderer to drop the orientation class while keeping sensible column defaults

## Testing
- php -l includes/class-affiliate-links-widget.php
- php -l affiliate-link-manager-ai.php

------
https://chatgpt.com/codex/tasks/task_e_68dea729d3908332a8c96f3e78c0f3ad