### PR TITLE
Add Affiliate Sources CRUD, remove legacy Import UI, and harden source-link tracking (v2.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.7.1 - Affiliate Sources CRUD & hardening
+- aggiunto CRUD base per `Affiliate Sources` (creazione/modifica) con form admin dedicato
+- aggiunti controlli sicurezza su salvataggio source (nonce, capability, sanitizzazione, JSON safe encode/decode)
+- rimossa la UI legacy `Importa Link` dal menu/submenu admin (backend preservato per backward compatibility)
+- aggiunta associazione visibile Source -> Affiliate Link nella UI del CPT (`Provenienza`, fallback `Manuale`)
+- aggiornata metabox tecnica con provider, source name, import status, AI visibility
+- hardening tracking URL: garanzia di uso `_affiliate_url` con fallback automatico da `_alma_affiliate_url`
+
 ## 2.7.0 - Affiliate Source Manager
 - aggiunto modulo Affiliate Sources con submenu dedicato sotto `affiliate_link`
 - introdotta architettura provider-based con interfaccia, registry, normalizer e importer

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Affiliate Link Manager AI
 
-Versione 2.7
+Versione 2.7.1
 
 Questo plugin gestisce e ottimizza i link affiliati all'interno di WordPress.
 
@@ -9,7 +9,6 @@ Questo plugin gestisce e ottimizza i link affiliati all'interno di WordPress.
 - Gestione dei link affiliati tramite un Custom Post Type dedicato.
 - Tracciamento dei click con report e statistiche nel pannello di controllo.
 - Suggerimenti AI per la generazione di titoli ottimizzati per la SEO e le conversioni.
-- Importazione massiva di link tramite un flusso guidato a step.
 - Assegnazione di tipologie personalizzate con creazione automatica delle categorie più comuni.
 - Pulizia automatica degli shortcode quando i link vengono eliminati o spostati nel cestino.
 - Dashboard riassuntiva con conteggio dei link attivi e dei click totali.
@@ -46,3 +45,12 @@ Miglioramenti principali:
 - Deduplicazione import con priorità: `provider+external_id`, `provider+sync_hash`, fallback su `_affiliate_url`.
 - Sincronizzazione tra `_alma_affiliate_url` e `_affiliate_url` per garantire backward compatibility con shortcode e tracking esistenti.
 - Nuova metabox tecnica nel singolo `affiliate_link` con metadati sorgente e readiness AI Agent.
+
+## Affiliate Sources (2.7.1)
+
+- CRUD base completo per le sorgenti: creazione e modifica dalla pagina `Affiliate Sources`.
+- Form admin con campi `name`, `provider`, `is_active`, `language`, `market`, `import_mode`, `destination_term_id`, `settings` JSON, `credentials` JSON.
+- Salvataggio sicuro con nonce, capability check e sanitizzazione lato server.
+- Rimozione della UI legacy `Importa Link` dal menu admin (classi backend mantenute per compatibilità).
+- Associazione visibile `Source -> Affiliate Link` nel CPT con campo “Provenienza” (fallback “Manuale”).
+- Hardening tracking: il frontend continua a usare `_affiliate_url`; se manca, viene riallineato automaticamente da `_alma_affiliate_url`.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.7
+ * Version: 2.7.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.7');
+define('ALMA_VERSION', '2.7.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -668,41 +668,12 @@ class AffiliateManagerAI {
                 ));
             }
 
-            if ($hook === 'affiliate_link_page_affiliate-link-import' || $hook === 'affiliate_link_page_alma-affiliate-sources') {
-                if ($hook === 'affiliate_link_page_alma-affiliate-sources' && file_exists(ALMA_PLUGIN_DIR . 'assets/affiliate-sources.css')) {
+            if ($hook === 'affiliate_link_page_alma-affiliate-sources') {
+                if (file_exists(ALMA_PLUGIN_DIR . 'assets/affiliate-sources.css')) {
                     wp_enqueue_style('alma-affiliate-sources', ALMA_PLUGIN_URL . 'assets/affiliate-sources.css', array(), ALMA_VERSION);
                 }
-                if ($hook === 'affiliate_link_page_alma-affiliate-sources' && file_exists(ALMA_PLUGIN_DIR . 'assets/affiliate-sources.js')) {
+                if (file_exists(ALMA_PLUGIN_DIR . 'assets/affiliate-sources.js')) {
                     wp_enqueue_script('alma-affiliate-sources', ALMA_PLUGIN_URL . 'assets/affiliate-sources.js', array('jquery'), ALMA_VERSION, true);
-                }
-                if (file_exists(ALMA_PLUGIN_DIR . 'assets/import-wizard.css')) {
-                    wp_enqueue_style(
-                        'alma-import-wizard',
-                        ALMA_PLUGIN_URL . 'assets/import-wizard.css',
-                        array(),
-                        ALMA_VERSION
-                    );
-                }
-            if (file_exists(ALMA_PLUGIN_DIR . 'assets/import-wizard.js')) {
-                wp_enqueue_script(
-                    'alma-import-wizard',
-                    ALMA_PLUGIN_URL . 'assets/import-wizard.js',
-                    array('jquery'),
-                    ALMA_VERSION,
-                    true
-                );
-                wp_localize_script('alma-import-wizard', 'almaImport', array(
-                    'ajax_url' => admin_url('admin-ajax.php'),
-                    'nonce'    => wp_create_nonce('alma_import_links'),
-                    'msg_success' => __('Importato: %s', 'affiliate-link-manager-ai'),
-                    'msg_error' => __('Errore: %s', 'affiliate-link-manager-ai'),
-                    'msg_duplicate' => __('Duplicato: %s', 'affiliate-link-manager-ai'),
-                    'msg_no_title' => __('Titolo mancante', 'affiliate-link-manager-ai'),
-                        'msg_no_url' => __('URL mancante', 'affiliate-link-manager-ai'),
-                        'msg_bad_url' => __('URL non valido', 'affiliate-link-manager-ai'),
-                        'msg_ajax' => __('Errore di comunicazione', 'affiliate-link-manager-ai'),
-                        'msg_summary' => __('Totali: %total% | Importati: %success% | Duplicati: %dup% | Errori: %err%', 'affiliate-link-manager-ai'),
-                    ));
                 }
             }
 
@@ -809,6 +780,12 @@ class AffiliateManagerAI {
         $click_count = get_post_meta($post->ID, '_click_count', true) ?: 0;
         $last_click = get_post_meta($post->ID, '_last_click', true);
         $ai_score = get_post_meta($post->ID, '_ai_performance_score', true) ?: 0;
+        $source_id = (int)get_post_meta($post->ID, '_alma_source_id', true);
+        $source_name = 'Manuale';
+        if ($source_id > 0) {
+            global $wpdb;
+            $source_name = (string)$wpdb->get_var($wpdb->prepare("SELECT name FROM {$wpdb->prefix}alma_affiliate_sources WHERE id = %d", $source_id));
+        }
         
         echo '<table class="form-table">';
         
@@ -817,6 +794,11 @@ class AffiliateManagerAI {
         echo '<th><label for="affiliate_url">' . __('URL Affiliato', 'affiliate-link-manager-ai') . ' <span style="color:red;">*</span></label></th>';
         echo '<td><input type="url" id="affiliate_url" name="affiliate_url" value="' . esc_attr($affiliate_url) . '" class="large-text" required />';
         echo '<p class="description">' . __('L\'URL completo del link affiliato (es: https://www.amazon.it/dp/...?tag=...)', 'affiliate-link-manager-ai') . '</p></td>';
+        echo '</tr>';
+
+        echo '<tr>';
+        echo '<th><label>' . __('Provenienza', 'affiliate-link-manager-ai') . '</label></th>';
+        echo '<td>' . esc_html($source_name ?: 'Manuale') . '</td>';
         echo '</tr>';
         
         // Relazione Link
@@ -1009,6 +991,11 @@ class AffiliateManagerAI {
         if (isset($_POST['affiliate_url'])) {
             update_post_meta($post_id, '_affiliate_url', esc_url_raw($_POST['affiliate_url']));
         }
+        $legacy_url = get_post_meta($post_id, '_alma_affiliate_url', true);
+        $canonical_url = get_post_meta($post_id, '_affiliate_url', true);
+        if (empty($canonical_url) && !empty($legacy_url)) {
+            update_post_meta($post_id, '_affiliate_url', esc_url_raw($legacy_url));
+        }
         
         // Salva relazione link
         if (isset($_POST['link_rel'])) {
@@ -1031,6 +1018,9 @@ class AffiliateManagerAI {
             wp_set_object_terms($post_id, $types, 'link_type');
         }
 
+        if (!metadata_exists('post', $post_id, '_alma_provider')) { update_post_meta($post_id, '_alma_provider', 'manual'); }
+        if (!metadata_exists('post', $post_id, '_alma_source_id')) { update_post_meta($post_id, '_alma_source_id', 0); }
+        if (!metadata_exists('post', $post_id, '_alma_import_mode')) { update_post_meta($post_id, '_alma_import_mode', 'manual'); }
         // Calcola AI Performance Score iniziale
         $this->calculate_ai_performance_score($post_id);
     }
@@ -1152,16 +1142,6 @@ class AffiliateManagerAI {
             array($this, 'render_css_editor_page')
         );
 
-        // Importazione massiva
-        add_submenu_page(
-            'edit.php?post_type=affiliate_link',
-            __('Importa Link', 'affiliate-link-manager-ai'),
-            __('Importa Link', 'affiliate-link-manager-ai'),
-            'manage_options',
-            'affiliate-link-import',
-            array($this, 'render_import_page')
-        );
-
         // Tipologie Link
         add_submenu_page(
             'edit.php?post_type=affiliate_link',
@@ -1253,7 +1233,6 @@ class AffiliateManagerAI {
             'affiliate-link-widgets',
             'alma-bot-affiliate-settings',
             'affiliate-chat-ai',
-            'affiliate-link-import',
             'alma-affiliate-sources',
             'alma-prompt-ai-settings',
             'affiliate-link-manager-settings',
@@ -1288,9 +1267,6 @@ class AffiliateManagerAI {
                             break;
                         case 'affiliate-chat-ai':
                             $item[0] = __('Affiliate Chat AI', 'affiliate-link-manager-ai');
-                            break;
-                        case 'affiliate-link-import':
-                            $item[0] = __('Importa Link', 'affiliate-link-manager-ai');
                             break;
                         case 'alma-affiliate-sources':
                             $item[0] = __('Affiliate Sources', 'affiliate-link-manager-ai');

--- a/assets/affiliate-sources.css
+++ b/assets/affiliate-sources.css
@@ -1,1 +1,3 @@
-.alma-source-status{font-weight:600}
+.alma-source-form-wrap{margin:16px 0;padding:16px;background:#fff;border:1px solid #dcdcde;border-radius:6px}
+.alma-source-form-wrap h2{margin-top:0}
+.alma-source-form-wrap .form-table th{width:220px}

--- a/assets/affiliate-sources.js
+++ b/assets/affiliate-sources.js
@@ -1,1 +1,23 @@
-jQuery(function($){ $('.alma-source-status').each(function(){}); });
+jQuery(function($){
+  const $wrap = $('#alma-source-form-wrap');
+  $('.alma-toggle-source-form').on('click', function(){ $wrap.toggle(); });
+
+  $('#alma-source-form').on('submit', function(e){
+    const name = $('#name').val().trim();
+    const provider = $('#provider').val();
+    if (!name || !provider) {
+      e.preventDefault();
+      window.alert('Name e provider sono obbligatori.');
+      return;
+    }
+
+    ['settings', 'credentials'].forEach(function(id){
+      const raw = $('#' + id).val().trim();
+      if (!raw) return;
+      try { JSON.parse(raw); } catch (err) {
+        e.preventDefault();
+        window.alert('JSON non valido nel campo: ' + id);
+      }
+    });
+  });
+});

--- a/includes/class-affiliate-source-manager.php
+++ b/includes/class-affiliate-source-manager.php
@@ -27,14 +27,73 @@ class ALMA_Affiliate_Source_Manager {
 
     public function render_sources_page() {
         if (!current_user_can('manage_options')) { wp_die('Unauthorized'); }
+        $this->maybe_handle_source_form();
         global $wpdb;
+        $providers = $this->registry->get_registered_providers();
+        $terms = get_terms(array('taxonomy' => 'link_type', 'hide_empty' => false));
+        $editing_id = isset($_GET['edit_source']) ? absint($_GET['edit_source']) : 0;
+        $editing = array();
+        if ($editing_id > 0) {
+            $editing = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}alma_affiliate_sources WHERE id = %d", $editing_id), ARRAY_A);
+        }
         $rows = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}alma_affiliate_sources ORDER BY id DESC LIMIT 100", ARRAY_A);
-        echo '<div class="wrap"><h1>Affiliate Sources</h1><table class="widefat striped"><thead><tr><th>Nome</th><th>Provider</th><th>Stato</th><th>Lingua</th><th>Mercato</th><th>Ultimo Sync</th><th>Stato Sync</th></tr></thead><tbody>';
+        echo '<div class="wrap"><h1>Affiliate Sources</h1>';
+        echo '<button type="button" class="button button-primary alma-toggle-source-form">Aggiungi nuova source</button>';
+        echo '<div id="alma-source-form-wrap" class="alma-source-form-wrap" style="' . ($editing ? '' : 'display:none;') . '">';
+        echo '<h2>' . ($editing ? 'Modifica source' : 'Nuova source') . '</h2>';
+        echo '<form method="post" id="alma-source-form">';
+        wp_nonce_field('alma_save_source', 'alma_source_nonce');
+        echo '<input type="hidden" name="action_type" value="save_source" />';
+        echo '<input type="hidden" name="source_id" value="' . esc_attr($editing['id'] ?? 0) . '" />';
+        echo '<table class="form-table"><tbody>';
+        $this->render_input_row('name', 'Name', $editing['name'] ?? '');
+        echo '<tr><th><label for="provider">Provider</label></th><td><select name="provider" id="provider" required>';
+        foreach ($providers as $key => $provider) { echo '<option value="' . esc_attr($key) . '"' . selected($editing['provider'] ?? '', $key, false) . '>' . esc_html($provider->get_name()) . '</option>'; }
+        echo '</select></td></tr>';
+        echo '<tr><th><label for="is_active">is_active</label></th><td><label><input type="checkbox" name="is_active" id="is_active" value="1" ' . checked((int)($editing['is_active'] ?? 1), 1, false) . '> Active</label></td></tr>';
+        $this->render_input_row('language', 'Language', $editing['language'] ?? '');
+        $this->render_input_row('market', 'Market', $editing['market'] ?? '');
+        echo '<tr><th><label for="import_mode">Import mode</label></th><td><select name="import_mode" id="import_mode">';
+        foreach (array('create_only','update_existing','create_update') as $mode) { echo '<option value="' . esc_attr($mode) . '"' . selected($editing['import_mode'] ?? 'create_update', $mode, false) . '>' . esc_html($mode) . '</option>'; }
+        echo '</select></td></tr>';
+        echo '<tr><th><label for="destination_term_id">Destination term</label></th><td><select name="destination_term_id" id="destination_term_id"><option value="0">—</option>';
+        foreach ($terms as $term) { echo '<option value="' . intval($term->term_id) . '"' . selected((int)($editing['destination_term_id'] ?? 0), (int)$term->term_id, false) . '>' . esc_html($term->name) . '</option>'; }
+        echo '</select></td></tr>';
+        echo '<tr><th><label for="settings">Settings JSON</label></th><td><textarea name="settings" id="settings" rows="5" class="large-text code">' . esc_textarea($editing['settings'] ?? '') . '</textarea></td></tr>';
+        echo '<tr><th><label for="credentials">Credentials JSON</label></th><td><textarea name="credentials" id="credentials" rows="5" class="large-text code">' . esc_textarea($editing['credentials'] ?? '') . '</textarea></td></tr>';
+        echo '</tbody></table><p><button type="submit" class="button button-primary">Salva source</button></p></form></div>';
+        echo '<table class="widefat striped"><thead><tr><th>Nome</th><th>Provider</th><th>Stato</th><th>Lingua</th><th>Mercato</th><th>Ultimo Sync</th><th>Stato Sync</th><th>Azioni</th></tr></thead><tbody>';
         if (empty($rows)) { echo '<tr><td colspan="7">Nessuna fonte configurata.</td></tr>'; }
         foreach ($rows as $r) {
-            echo '<tr><td>' . esc_html($r['name']) . '</td><td>' . esc_html($r['provider']) . '</td><td>' . ($r['is_active'] ? 'Attivo' : 'Disattivo') . '</td><td>' . esc_html($r['language']) . '</td><td>' . esc_html($r['market']) . '</td><td>' . esc_html($r['last_sync_at']) . '</td><td>' . esc_html($r['last_sync_status']) . '</td></tr>';
+            $edit_link = add_query_arg(array('post_type' => 'affiliate_link', 'page' => 'alma-affiliate-sources', 'edit_source' => (int)$r['id']), admin_url('edit.php'));
+            echo '<tr><td>' . esc_html($r['name']) . '</td><td>' . esc_html($r['provider']) . '</td><td>' . ($r['is_active'] ? 'Attivo' : 'Disattivo') . '</td><td>' . esc_html($r['language']) . '</td><td>' . esc_html($r['market']) . '</td><td>' . esc_html($r['last_sync_at']) . '</td><td>' . esc_html($r['last_sync_status']) . '</td><td><a class="button button-small" href="' . esc_url($edit_link) . '">Modifica</a></td></tr>';
         }
         echo '</tbody></table></div>';
+    }
+    private function render_input_row($name, $label, $value) { echo '<tr><th><label for="' . esc_attr($name) . '">' . esc_html($label) . '</label></th><td><input type="text" name="' . esc_attr($name) . '" id="' . esc_attr($name) . '" value="' . esc_attr($value) . '" class="regular-text" /></td></tr>'; }
+    private function decode_json_input($raw) { $raw = trim((string)$raw); if ($raw === '') { return ''; } $decoded = json_decode(wp_unslash($raw), true); if (!is_array($decoded)) { return ''; } return wp_json_encode($decoded); }
+    private function maybe_handle_source_form() {
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_POST['action_type']) || $_POST['action_type'] !== 'save_source') { return; }
+        if (!isset($_POST['alma_source_nonce']) || !wp_verify_nonce($_POST['alma_source_nonce'], 'alma_save_source')) { wp_die('Nonce non valido'); }
+        if (!current_user_can('manage_options')) { wp_die('Unauthorized'); }
+        global $wpdb;
+        $data = array(
+            'name' => sanitize_text_field(wp_unslash($_POST['name'] ?? '')),
+            'provider' => sanitize_text_field(wp_unslash($_POST['provider'] ?? 'manual')),
+            'is_active' => isset($_POST['is_active']) ? 1 : 0,
+            'language' => sanitize_text_field(wp_unslash($_POST['language'] ?? '')),
+            'market' => sanitize_text_field(wp_unslash($_POST['market'] ?? '')),
+            'import_mode' => sanitize_text_field(wp_unslash($_POST['import_mode'] ?? 'create_update')),
+            'destination_term_id' => absint($_POST['destination_term_id'] ?? 0),
+            'settings' => $this->decode_json_input($_POST['settings'] ?? ''),
+            'credentials' => $this->decode_json_input($_POST['credentials'] ?? ''),
+            'updated_at' => current_time('mysql'),
+        );
+        $source_id = absint($_POST['source_id'] ?? 0);
+        if ($source_id > 0) { $wpdb->update("{$wpdb->prefix}alma_affiliate_sources", $data, array('id' => $source_id)); }
+        else { $data['created_at'] = current_time('mysql'); $wpdb->insert("{$wpdb->prefix}alma_affiliate_sources", $data); }
+        wp_safe_redirect(add_query_arg(array('post_type' => 'affiliate_link', 'page' => 'alma-affiliate-sources'), admin_url('edit.php')));
+        exit;
     }
 
     public function register_technical_metabox() {
@@ -44,9 +103,15 @@ class ALMA_Affiliate_Source_Manager {
     public function render_technical_metabox($post) {
         if (!current_user_can('edit_post', $post->ID)) { return; }
         wp_nonce_field('alma_source_meta', 'alma_source_meta_nonce');
-        $keys = array('_alma_provider','_alma_source_id','_alma_external_id','_alma_original_url','_alma_last_sync_at','_alma_import_status','_alma_ai_visibility','_alma_ai_priority');
-        echo '<p><strong>Tipo origine:</strong> ' . esc_html(get_post_meta($post->ID, '_alma_import_status', true) ?: 'manual') . '</p>';
-        foreach($keys as $k){ echo '<p><strong>'.esc_html($k).':</strong> '.esc_html((string)get_post_meta($post->ID,$k,true)).'</p>'; }
+        global $wpdb;
+        $provider = get_post_meta($post->ID, '_alma_provider', true) ?: 'manual';
+        $source_id = (int)get_post_meta($post->ID, '_alma_source_id', true);
+        $source_name = 'Manuale';
+        if ($source_id > 0) { $source_name = (string)$wpdb->get_var($wpdb->prepare("SELECT name FROM {$wpdb->prefix}alma_affiliate_sources WHERE id = %d", $source_id)); }
+        echo '<p><strong>Provider:</strong> ' . esc_html($provider) . '</p>';
+        echo '<p><strong>Source name:</strong> ' . esc_html($source_name ?: 'Manuale') . '</p>';
+        echo '<p><strong>Import status:</strong> ' . esc_html(get_post_meta($post->ID, '_alma_import_status', true) ?: 'manual') . '</p>';
+        echo '<p><strong>AI visibility:</strong> ' . esc_html(get_post_meta($post->ID, '_alma_ai_visibility', true) ?: 'available') . '</p>';
     }
 
     public function save_technical_meta($post_id) {


### PR DESCRIPTION
### Motivation
- Provide a basic admin CRUD for Affiliate Sources so operators can create and edit import sources from the WordPress admin.
- Remove the legacy Import UI surface to simplify admin navigation while preserving backend import classes for backward compatibility.
- Ensure tracking integrity by guaranteeing the canonical frontend URL always uses `_affiliate_url` and adding a safe fallback from legacy `_alma_affiliate_url`.

### Description
- Added a source management UI and server handling inside `includes/class-affiliate-source-manager.php` with a toggleable form, edit flow (`edit_source`), nonce + capability checks, server-side sanitization and safe JSON decode/encode for `settings` and `credentials`.
- Added lightweight admin assets `assets/affiliate-sources.js` and `assets/affiliate-sources.css` to toggle the form and perform basic frontend validation for required fields and JSON inputs.
- Updated Affiliate Link metaboxes and save logic in `affiliate-link-manager-ai.php` to display a visible "Provenienza" (source name or fallback "Manuale"), and to populate `_affiliate_url` from `_alma_affiliate_url` when the canonical meta is empty.
- Removed legacy Import menu/submenu UI and the related menu reorder entry and import page submenu registration while keeping backend importer classes intact, and bumped plugin version to `2.7.1` with README/CHANGELOG updates.

### Testing
- Ran PHP syntax checks with `php -l affiliate-link-manager-ai.php` which returned no syntax errors.
- Ran PHP syntax checks with `php -l includes/class-affiliate-source-manager.php` which returned no syntax errors.
- Confirmed that the new admin assets file(s) are present and enqueued conditionally for the `Affiliate Sources` admin page (manual verification during local test load).</body> } PMID: 0.048.  Indices: 0.  Not a commitment to runtime.  Please review in staging before production.  (Note: last parenthetical line will not be included.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30a7096c083328dd3bd0d9ed59e40)