### PR TITLE
Hotfix 2.7.2: Fix Affiliate Sources admin fatal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.7.2 - Affiliate Sources admin fatal hotfix
+- fix fatal nella pagina admin `Affiliate Sources` quando la tabella `alma_affiliate_sources` manca o la source in edit non esiste
+- aggiunte guard clauses su provider registry, query DB e rendering metabox tecnica per evitare errori critici in admin
+- aggiunto controllo update-version per creare/riparare le tabelle anche sugli aggiornamenti plugin (non solo su prima attivazione)
+
 ## 2.7.1 - Affiliate Sources CRUD & hardening
 - aggiunto CRUD base per `Affiliate Sources` (creazione/modifica) con form admin dedicato
 - aggiunti controlli sicurezza su salvataggio source (nonce, capability, sanitizzazione, JSON safe encode/decode)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Affiliate Link Manager AI
 
-Versione 2.7.1
+Versione 2.7.2
 
 Questo plugin gestisce e ottimizza i link affiliati all'interno di WordPress.
 
@@ -54,3 +54,8 @@ Miglioramenti principali:
 - Rimozione della UI legacy `Importa Link` dal menu admin (classi backend mantenute per compatibilità).
 - Associazione visibile `Source -> Affiliate Link` nel CPT con campo “Provenienza” (fallback “Manuale”).
 - Hardening tracking: il frontend continua a usare `_affiliate_url`; se manca, viene riallineato automaticamente da `_alma_affiliate_url`.
+
+## Affiliate Sources hotfix (2.7.2)
+
+- Fix fatal error nella pagina admin `Affiliate Sources` con gestione resiliente di tabella mancante, source non trovata, provider/registry non disponibili e JSON non valido.
+- Aggiunto tentativo sicuro di repair/creazione tabella `alma_affiliate_sources` quando la pagina viene aperta.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.7.1
+ * Version: 2.7.2
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.7.1');
+define('ALMA_VERSION', '2.7.2');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -49,6 +49,7 @@ class AffiliateManagerAI {
         add_action('init', array($this, 'init'));
         register_activation_hook(__FILE__, array($this, 'activate'));
         register_deactivation_hook(__FILE__, array($this, 'deactivate'));
+        add_action('plugins_loaded', array($this, 'maybe_run_update_tasks'));
         
         // Hook per gestire eliminazione link
         add_action('before_delete_post', array($this, 'before_delete_link'));
@@ -630,7 +631,7 @@ class AffiliateManagerAI {
      */
     public function admin_enqueue_scripts($hook) {
         // Solo nelle pagine del plugin
-        $screen = get_current_screen();
+        $screen = function_exists('get_current_screen') ? get_current_screen() : null;
         $allowed_types = get_option('alma_link_post_types', array('post', 'page'));
         
         if ($screen && ($screen->post_type === 'affiliate_link' || 
@@ -3510,6 +3511,7 @@ class AffiliateManagerAI {
         $this->create_analytics_table();
         ALMA_Affiliate_Source_Manager::create_tables();
         $this->create_default_categories();
+        update_option('alma_plugin_version', ALMA_VERSION);
         flush_rewrite_rules();
     }
     
@@ -3517,6 +3519,15 @@ class AffiliateManagerAI {
         // Rimuovi cron jobs
         wp_clear_scheduled_hook('alma_daily_optimization');
         flush_rewrite_rules();
+    }
+
+    public function maybe_run_update_tasks() {
+        $installed_version = get_option('alma_plugin_version', '0.0.0');
+        if (version_compare($installed_version, ALMA_VERSION, '<')) {
+            $this->create_analytics_table();
+            ALMA_Affiliate_Source_Manager::create_tables();
+            update_option('alma_plugin_version', ALMA_VERSION);
+        }
     }
     
     private function create_analytics_table() {

--- a/includes/class-affiliate-source-manager.php
+++ b/includes/class-affiliate-source-manager.php
@@ -3,6 +3,7 @@ if (!defined('ABSPATH')) { exit; }
 
 class ALMA_Affiliate_Source_Manager {
     private $registry;
+    private $table_error = '';
 
     public function __construct() {
         $this->registry = new ALMA_Affiliate_Source_Provider_Registry();
@@ -27,17 +28,37 @@ class ALMA_Affiliate_Source_Manager {
 
     public function render_sources_page() {
         if (!current_user_can('manage_options')) { wp_die('Unauthorized'); }
+        $this->maybe_ensure_sources_table();
         $this->maybe_handle_source_form();
         global $wpdb;
-        $providers = $this->registry->get_registered_providers();
+        $providers = array();
+        if ($this->registry && method_exists($this->registry, 'get_registered_providers')) {
+            $providers = (array) $this->registry->get_registered_providers();
+        }
         $terms = get_terms(array('taxonomy' => 'link_type', 'hide_empty' => false));
+        if (is_wp_error($terms) || !is_array($terms)) {
+            $terms = array();
+        }
         $editing_id = isset($_GET['edit_source']) ? absint($_GET['edit_source']) : 0;
         $editing = array();
-        if ($editing_id > 0) {
+        if ($editing_id > 0 && $this->sources_table_exists()) {
             $editing = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}alma_affiliate_sources WHERE id = %d", $editing_id), ARRAY_A);
+            if (!is_array($editing) || empty($editing)) {
+                $editing = array();
+                echo '<div class="notice notice-warning"><p>La source richiesta non esiste più. Modalità creazione attivata.</p></div>';
+            }
         }
-        $rows = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}alma_affiliate_sources ORDER BY id DESC LIMIT 100", ARRAY_A);
+        $rows = array();
+        if ($this->sources_table_exists()) {
+            $rows = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}alma_affiliate_sources ORDER BY id DESC LIMIT 100", ARRAY_A);
+            if (!is_array($rows)) {
+                $rows = array();
+            }
+        }
         echo '<div class="wrap"><h1>Affiliate Sources</h1>';
+        if ($this->table_error !== '') {
+            echo '<div class="notice notice-error"><p>' . esc_html($this->table_error) . '</p></div>';
+        }
         echo '<button type="button" class="button button-primary alma-toggle-source-form">Aggiungi nuova source</button>';
         echo '<div id="alma-source-form-wrap" class="alma-source-form-wrap" style="' . ($editing ? '' : 'display:none;') . '">';
         echo '<h2>' . ($editing ? 'Modifica source' : 'Nuova source') . '</h2>';
@@ -48,7 +69,10 @@ class ALMA_Affiliate_Source_Manager {
         echo '<table class="form-table"><tbody>';
         $this->render_input_row('name', 'Name', $editing['name'] ?? '');
         echo '<tr><th><label for="provider">Provider</label></th><td><select name="provider" id="provider" required>';
-        foreach ($providers as $key => $provider) { echo '<option value="' . esc_attr($key) . '"' . selected($editing['provider'] ?? '', $key, false) . '>' . esc_html($provider->get_name()) . '</option>'; }
+        foreach ($providers as $key => $provider) {
+            if (!is_object($provider) || !method_exists($provider, 'get_name')) { continue; }
+            echo '<option value="' . esc_attr($key) . '"' . selected($editing['provider'] ?? '', $key, false) . '>' . esc_html($provider->get_name()) . '</option>';
+        }
         echo '</select></td></tr>';
         echo '<tr><th><label for="is_active">is_active</label></th><td><label><input type="checkbox" name="is_active" id="is_active" value="1" ' . checked((int)($editing['is_active'] ?? 1), 1, false) . '> Active</label></td></tr>';
         $this->render_input_row('language', 'Language', $editing['language'] ?? '');
@@ -74,6 +98,8 @@ class ALMA_Affiliate_Source_Manager {
     private function decode_json_input($raw) { $raw = trim((string)$raw); if ($raw === '') { return ''; } $decoded = json_decode(wp_unslash($raw), true); if (!is_array($decoded)) { return ''; } return wp_json_encode($decoded); }
     private function maybe_handle_source_form() {
         if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_POST['action_type']) || $_POST['action_type'] !== 'save_source') { return; }
+        $this->maybe_ensure_sources_table();
+        if (!$this->sources_table_exists()) { return; }
         if (!isset($_POST['alma_source_nonce']) || !wp_verify_nonce($_POST['alma_source_nonce'], 'alma_save_source')) { wp_die('Nonce non valido'); }
         if (!current_user_can('manage_options')) { wp_die('Unauthorized'); }
         global $wpdb;
@@ -107,7 +133,7 @@ class ALMA_Affiliate_Source_Manager {
         $provider = get_post_meta($post->ID, '_alma_provider', true) ?: 'manual';
         $source_id = (int)get_post_meta($post->ID, '_alma_source_id', true);
         $source_name = 'Manuale';
-        if ($source_id > 0) { $source_name = (string)$wpdb->get_var($wpdb->prepare("SELECT name FROM {$wpdb->prefix}alma_affiliate_sources WHERE id = %d", $source_id)); }
+        if ($source_id > 0 && $this->sources_table_exists()) { $source_name = (string)$wpdb->get_var($wpdb->prepare("SELECT name FROM {$wpdb->prefix}alma_affiliate_sources WHERE id = %d", $source_id)); }
         echo '<p><strong>Provider:</strong> ' . esc_html($provider) . '</p>';
         echo '<p><strong>Source name:</strong> ' . esc_html($source_name ?: 'Manuale') . '</p>';
         echo '<p><strong>Import status:</strong> ' . esc_html(get_post_meta($post->ID, '_alma_import_status', true) ?: 'manual') . '</p>';
@@ -120,5 +146,21 @@ class ALMA_Affiliate_Source_Manager {
         if (get_post_type($post_id) !== 'affiliate_link') { return; }
         if (!metadata_exists('post', $post_id, '_alma_ai_visibility')) { update_post_meta($post_id, '_alma_ai_visibility', 'available'); }
         if (!metadata_exists('post', $post_id, '_alma_import_status')) { update_post_meta($post_id, '_alma_import_status', 'manual'); }
+    }
+
+    private function sources_table_exists() {
+        global $wpdb;
+        $table_name = $wpdb->prefix . 'alma_affiliate_sources';
+        return $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table_name)) === $table_name;
+    }
+
+    private function maybe_ensure_sources_table() {
+        if ($this->sources_table_exists()) {
+            return;
+        }
+        self::create_tables();
+        if (!$this->sources_table_exists()) {
+            $this->table_error = 'Tabella Affiliate Sources non disponibile. Tentativo di creazione eseguito, controlla permessi DB.';
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- L'apice del problema era che la pagina admin `Affiliate Sources` assumeva sempre disponibile la tabella custom, le entry in edit e i provider registrati, causando un fatal in stati post-update o con DB mancante; la correzione interviene sulla causa primaria rendendo la pagina resiliente. 
- È necessario che la pagina e la metabox tecnica non esplodano quando la tabella `alma_affiliate_sources` non esiste, quando i dati JSON sono vuoti/invalidi, quando mancano provider o quando un `edit_source` è stale. 
- Inoltre va garantita la creazione/repair sicura delle tabelle anche su aggiornamento plugin, non solo in `activate`.

### Description
- Bumped plugin version e costante `ALMA_VERSION` a `2.7.2` e aggiornati header, `README.md` e `CHANGELOG.md` con nota hotfix. 
- Aggiunto `maybe_run_update_tasks()` eseguito su `plugins_loaded` per creare/riparare le tabelle anche durante update e salvata la versione installata con `update_option('alma_plugin_version', ALMA_VERSION)`. 
- Hardening di `admin_enqueue_scripts()` con `function_exists('get_current_screen')` per evitare assunzioni su uno screen non disponibile. 
- In `ALMA_Affiliate_Source_Manager` aggiunte funzioni `sources_table_exists()` e `maybe_ensure_sources_table()` più la proprietà `$table_error`, e reso `render_sources_page()` difensivo gestendo: registry/providers mancanti, `get_terms()` che ritorna `WP_Error`, assenza tabella (tentativo di creazione sicuro), fallback se `edit_source` non esiste (notice + modalità creazione) e protezione sul salvataggio se la tabella non è disponibile. 
- Reso sicura la `render_technical_metabox()` con controllo di esistenza tabella prima di leggere il nome source e mantenuto fallback “Manuale”. 

### Testing
- Eseguiti i check di sintassi PHP con `php -l affiliate-link-manager-ai.php` e `php -l includes/class-affiliate-source-manager.php`, entrambi restituiscono "No syntax errors detected". 
- Eseguita una ricerca delle occorrenze chiave con `rg -n "ALMA_Affiliate_Source_Manager|alma_affiliate_sources|affiliate-sources"` per verificare i punti di intervento, con risultati coerenti. 
- Le modifiche sono state committate in un commit del repository (messaggio: "Hotfix 2.7.2: fix Affiliate Sources admin fatal").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30e511d008332a38ed5d7165439d2)