### PR TITLE
Hotfix 2.8.2: make guided source settings authoritative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.8.2 - Guided settings authoritative hotfix
+- guided `settings_fields` resi autoritativi: applicati per ultimi e non sovrascrivibili da JSON avanzato/legacy
+- rimossa la textarea precompilata con JSON completo `settings` dalla UI standard Affiliate Sources
+- mantenuta backward compatibility: preservazione chiavi `settings` legacy/custom non renderizzate nel preset
+- merge settings in edit: DB esistente -> advanced extra espliciti -> guided fields
+
 ## 2.8.1 - Stabilizzazione salvataggio Affiliate Sources
 - preservazione `settings` esistenti in edit con merge sicuro tra DB, `settings_fields` e JSON avanzato valido
 - preservazione `credentials` esistenti: campi password vuoti non sovrascrivono, overwrite solo su nuovo valore non vuoto

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Affiliate Link Manager AI
 
-Versione 2.8.1
+Versione 2.8.2
 
 Questo plugin gestisce e ottimizza i link affiliati all'interno di WordPress.
 
@@ -77,3 +77,10 @@ Miglioramenti principali:
 - Le `credentials` esistenti restano salvate quando i campi password restano vuoti; i valori segreti non vengono mai precompilati o localizzati in JavaScript.
 - Lo stato `Attivo/Disattivo` è ora gestito in UI e persistito correttamente in salvataggio (checkbox reale).
 - Flusso Post/Redirect/Get dopo create/update con notice native WordPress (`created`, `updated`, `error`, `invalid_json`) e ritorno alla lista sorgenti.
+
+
+## Affiliate Sources hotfix 2.8.2
+
+- I campi guidati `settings_fields` sono ora autoritativi in salvataggio: nessun JSON avanzato/legacy può sovrascrivere un campo guidato inviato dall'utente.
+- Rimossa dalla UI standard la textarea JSON avanzata precompilata dei `settings`; restano preservate in DB eventuali chiavi legacy/custom non renderizzate nel form.
+- Merge order in edit: `settings` esistenti -> eventuale payload avanzato esplicito -> guided fields (priorità finale ai guided).

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.8.1
+ * Version: 2.8.2
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.8.1');
+define('ALMA_VERSION', '2.8.2');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/assets/affiliate-sources.js
+++ b/assets/affiliate-sources.js
@@ -36,7 +36,7 @@ jQuery(function($){
     const name = $('#name').val().trim();
     const provider = $('#provider_label').val().trim();
     if (!name || !provider) { e.preventDefault(); window.alert('Name e provider sono obbligatori.'); return; }
-    ['settings_advanced', 'credentials_advanced'].forEach(function(id){
+    ['credentials_advanced'].forEach(function(id){
       const raw = $('#' + id).val().trim(); if (!raw) return;
       try { JSON.parse(raw); } catch (err) { e.preventDefault(); window.alert('JSON non valido nel campo: ' + id); }
     });

--- a/includes/class-affiliate-source-manager.php
+++ b/includes/class-affiliate-source-manager.php
@@ -35,7 +35,7 @@ class ALMA_Affiliate_Source_Manager {
         echo '</div><div class="alma-section"><h3>Destination terms</h3><select multiple name="destination_term_ids[]" id="destination_term_ids" size="6">'; foreach($terms as $t){ echo '<option value="'.intval($t->term_id).'"'.(in_array((int)$t->term_id,$sel,true)?' selected':'').'>'.esc_html($t->name).'</option>'; } echo '</select></div>';
         echo '<div class="alma-section"><h3>Configurazione provider</h3><div id="alma-guided-settings"></div></div><div class="alma-section"><h3>Credenziali</h3><div id="alma-guided-credentials"></div>';
         foreach(array('api_key','access_token','bearer_token','affiliate_id','site_id','client_id','client_secret','username','password','marker','partner_id','referral_url','tracking_code','xml_api_key','xml_username','xml_password') as $f){ $this->render_field('credentials_extra_fields['.$f.']',$f,'',false,true,!empty($ec[$f])); }
-        echo '</div><div class="alma-section"><h3>Configurazione JSON avanzata</h3><textarea name="settings_advanced" id="settings_advanced" rows="4" class="large-text code">'.esc_textarea(wp_json_encode($es, JSON_PRETTY_PRINT)).'</textarea><textarea name="credentials_advanced" id="credentials_advanced" rows="4" class="large-text code"></textarea></div></div><p><button class="button button-primary">Salva source</button></p></form></div>';
+        echo '</div><div class="alma-section"><h3>Credenziali avanzate (opzionale)</h3><p class="description">Inserisci solo chiavi extra non coperte dai campi guidati.</p><textarea name="credentials_advanced" id="credentials_advanced" rows="4" class="large-text code"></textarea></div></div><p><button class="button button-primary">Salva source</button></p></form></div>';
         echo '<table class="widefat striped"><thead><tr><th>Nome</th><th>Provider</th><th>Destination</th><th>Mode</th><th>Stato</th><th>Lingua</th><th>Mercato</th><th>Ultimo Sync</th><th>Stato Sync</th><th>Azioni</th></tr></thead><tbody>';
         foreach((array)$rows as $r){ $s=$this->decode_db_json($r['settings']??''); $ids=json_decode($r['destination_term_ids']??'',true); if(!is_array($ids))$ids=array(); if(empty($ids)&&!empty($r['destination_term_id']))$ids=array((int)$r['destination_term_id']); $names=array(); foreach($ids as $tid){ $term=get_term((int)$tid,'link_type'); if($term&&!is_wp_error($term))$names[]=$term->name; }
             $provider_label=$r['provider_label']?:$r['provider']; $edit_link=add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-affiliate-sources','edit_source'=>(int)$r['id']),admin_url('edit.php'));
@@ -45,11 +45,26 @@ class ALMA_Affiliate_Source_Manager {
     private function maybe_handle_source_form(){ if(($_SERVER['REQUEST_METHOD']??'')!=='POST'||($_POST['action_type']??'')!=='save_source')return; if(!wp_verify_nonce($_POST['alma_source_nonce']??'','alma_save_source'))wp_die('Nonce non valido'); if(!current_user_can('manage_options'))wp_die('Unauthorized'); global $wpdb;
         $source_id=absint($_POST['source_id']??0); $existing=$source_id?$wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}alma_affiliate_sources WHERE id=%d",$source_id),ARRAY_A):array();
         $provider_label=sanitize_text_field(wp_unslash($_POST['provider_label']??'')); $provider=$this->norm_provider($provider_label);
-        $settings_existing=$this->decode_db_json($existing['settings']??''); $settings=$settings_existing; foreach((array)($_POST['settings_fields']??array()) as $k=>$v){ $settings[sanitize_key($k)]=sanitize_text_field(wp_unslash($v)); }
+        $settings_existing=$this->decode_db_json($existing['settings']??'');
+        $settings=$settings_existing;
+
+        // Backward compatibility: accept advanced settings JSON, but never let it override guided fields.
+        $sa=$this->parse_json($_POST['settings_advanced']??'');
+        $ca=$this->parse_json($_POST['credentials_advanced']??'');
+        if(isset($sa['__invalid'])||isset($ca['__invalid'])){ wp_safe_redirect(add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-affiliate-sources','alma_result'=>'invalid_json'),admin_url('edit.php'))); exit; }
+
+        foreach($sa as $k=>$v){
+            $kk=sanitize_key($k);
+            if($kk==='') continue;
+            $settings[$kk]=is_scalar($v)?sanitize_text_field((string)$v):wp_json_encode($v);
+        }
+        foreach((array)($_POST['settings_fields']??array()) as $k=>$v){
+            $settings[sanitize_key($k)]=sanitize_text_field(wp_unslash($v));
+        }
+
         $credentials_existing=$this->decode_db_json($existing['credentials']??''); $credentials=$credentials_existing; foreach((array)($_POST['credentials_fields']??array()) as $k=>$v){ $k=sanitize_key($k); $v=sanitize_text_field(wp_unslash($v)); if($v!=='')$credentials[$k]=$v; }
         foreach((array)($_POST['credentials_extra_fields']??array()) as $k=>$v){ $k=sanitize_key($k); $v=sanitize_text_field(wp_unslash($v)); if($v!=='')$credentials[$k]=$v; }
-        $sa=$this->parse_json($_POST['settings_advanced']??''); $ca=$this->parse_json($_POST['credentials_advanced']??''); if(isset($sa['__invalid'])||isset($ca['__invalid'])){ wp_safe_redirect(add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-affiliate-sources','alma_result'=>'invalid_json'),admin_url('edit.php'))); exit; }
-        $settings=array_replace($settings,$sa); foreach($ca as $k=>$v){ if($v!==''&&$v!==null){ $credentials[sanitize_key($k)]=is_scalar($v)?sanitize_text_field((string)$v):wp_json_encode($v); } }
+        foreach($ca as $k=>$v){ if($v!==''&&$v!==null){ $credentials[sanitize_key($k)]=is_scalar($v)?sanitize_text_field((string)$v):wp_json_encode($v); } }
         $term_ids=array_values(array_unique(array_filter(array_map('absint',(array)($_POST['destination_term_ids']??array())))));
         $data=array('name'=>sanitize_text_field(wp_unslash($_POST['name']??'')),'provider'=>$provider,'provider_label'=>$provider_label,'is_active'=>isset($_POST['is_active'])?1:0,'language'=>sanitize_text_field(wp_unslash($_POST['language']??'')),'market'=>sanitize_text_field(wp_unslash($_POST['market']??'')),'import_mode'=>sanitize_key($_POST['import_mode']??'create_update'),'destination_term_id'=>(int)($term_ids[0]??0),'destination_term_ids'=>!empty($term_ids)?wp_json_encode($term_ids):null,'settings'=>wp_json_encode($settings),'credentials'=>wp_json_encode($credentials),'updated_at'=>current_time('mysql'));
         $ok=false; $result='error';


### PR DESCRIPTION
### Motivation
- Fix a bug where editing an Affiliate Source could have guided fields overwritten by a prefilled advanced JSON textarea when the user updated a guided field but left the JSON untouched. 
- Ensure guided `settings_fields` are always authoritative at save time so user edits to guided inputs cannot be reverted by legacy/advanced JSON. 
- Simplify the standard UI by removing the prefilled full `settings` JSON textarea and keep an optional, non-prefilled channel only for explicit extra credentials.

### Description
- Changed save merge order in `includes/class-affiliate-source-manager.php` so `settings` are built as: existing DB settings -> explicit advanced settings payload (if present) -> guided `settings_fields` applied last and authoritative. 
- Removed the prefilled `settings_advanced` textarea from the standard form and replaced the advanced panel with an optional `credentials_advanced` textarea that is not prepopulated, and updated the form render accordingly. 
- Updated `assets/affiliate-sources.js` to stop validating `settings_advanced` (it no longer exists in the standard UI) and to keep credential handling masked; secrets are not localized or prefilled. 
- Bumped plugin version/docs/changelog to `2.8.2` and updated `README.md`, `CHANGELOG.md`, and plugin header; branch used: `work`, commit: `637ceaa`, files modified: `includes/class-affiliate-source-manager.php`, `assets/affiliate-sources.js`, `README.md`, `CHANGELOG.md`, `affiliate-link-manager-ai.php`. 
- Confirmations: guided fields are now authoritative and cannot be overwritten by advanced JSON, legacy/custom keys in DB are preserved when not rendered by the current preset, and credential logic from 2.8.1 (empty password fields preserve secrets) remains unchanged.

### Testing
- Ran `php -l includes/class-affiliate-source-manager.php` and it returned no syntax errors. 
- Ran `php -l affiliate-link-manager-ai.php` and it returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f322b92ca483329194f4bcc12474a7)