### PR TITLE
Add Viator Partner API v2 client, Viator preset, and guided-fields UX enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.10.0 - Integrazione Viator Partner API v2 (Affiliate Sources)
+- aggiunto client dedicato `ALMA_Affiliate_Source_Provider_Client_Viator` con gestione environment sandbox/production e header Viator
+- preset Viator aggiornato: supporto test connessione + field discovery, provider type `commercial_api`, sola credenziale `api_key`
+- UI guided fields estesa in backward compatibility con metadati (`label`, `type`, `options`, `default`, `help`, `required`, `placeholder`)
+- rimossi dalla UI Viator i campi `base_url_production` e `base_url_sandbox` (gestione interna client)
+- test connessione Viator su `/products/tags` con mapping errori (`missing_credentials`, `invalid_environment`, `invalid_api_version`, `unauthorized`, `forbidden`, `rate_limited`, `timeout`, `api_error`, `invalid_json`, `internal_error`)
+- field discovery Viator su `/products/search` o `/search/freetext` con criteri minimi, count limitato e transient cache senza segreti
+- normalizzazione aggiornata per fallback Viator (`productUrl`, `productCode`) e mapping hint per product summary
+- versione plugin aggiornata a `2.10.0`
+
 ## 2.9.2 - Conferma post-save Affiliate Sources (UX + PRG hardening)
 - aggiunta vista GET di conferma dopo create/update con flusso Post/Redirect/Get completo (nessun rendering diretto dopo POST)
 - schermata di conferma con messaggio esplicito, riepilogo source (nome, provider, preset, stato) e azioni rapide

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Affiliate Link Manager AI
 
-Versione 2.9.2
+Versione 2.10.0
 
 Questo plugin gestisce e ottimizza i link affiliati all'interno di WordPress.
 
@@ -115,6 +115,19 @@ Miglioramenti principali:
 - Nuovo filtro **Sources** nell'elenco admin Link Affiliati (`edit.php?post_type=affiliate_link`) basato su meta key `_alma_source_id`.
 - Compatibilità mantenuta per link manuali/legacy e nessun impatto su frontend/tracking click.
 
+
+
+## Affiliate Sources 2.10.0 — Viator Partner API v2
+
+- Integrazione dedicata Viator con **unica credenziale API key** (nessun OAuth, client_id/client_secret, username/password).
+- API key trattata come segreta e inviata solo via header `exp-api-key`.
+- Header `Accept` versionato (`application/json;version=2.0`) e `Accept-Language` configurabile.
+- Ambiente `sandbox/production` gestito internamente dal client, senza esporre base URL nella UI guidata.
+- `Testa connessione` su endpoint leggero `/products/tags` con errori mappati e messaggi chiari.
+- `Campi importabili` con discovery Viator su `/products/search` o `/search/freetext` e mapping suggerito.
+- Differenza esplicita tra destination term WordPress e `default_destination_id` Viator (ID Viator).
+- Uso di `productUrl` completo senza ricostruzioni o alterazioni dei parametri affiliati.
+- Booking/checkout/pagamenti/cancellation **non inclusi** in questa release.
 ## 2026-04 Hotfix Affiliate Sources
 - Fix: gestione POST create/update Source spostata su hook pre-render `load-<page_hook>` con redirect PRG sicuro.
 - Aggiunta archiviazione Source (soft-delete) con `deleted_at`/`deleted_by`, pulizia credenziali e mantenimento link importati.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.9.2
+ * Version: 2.10.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.9.2');
+define('ALMA_VERSION', '2.10.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -34,6 +34,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-registr
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-presets.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-client-fallback.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-client-custom-api.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-client-viator.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-client-factory.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-connection-test-storage.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-connection-service.php';

--- a/assets/affiliate-sources.js
+++ b/assets/affiliate-sources.js
@@ -2,34 +2,33 @@ jQuery(function($){
   const $wrap = $('#alma-source-form-wrap');
   $('.alma-toggle-source-form').on('click', function(){ $wrap.toggle(); });
   function parseHidden(id){ const raw=$(id).val(); if(!raw) return {}; try{return JSON.parse(raw);}catch(e){return{};} }
+  function normalizeField(field){ return typeof field === 'string' ? {key:field,label:field,type:'text'} : (field||{}); }
+  function esc(v){ return $('<div/>').text(v||'').html(); }
+  function renderSelect(name, meta, value){
+    const options = Array.isArray(meta.options) ? meta.options : [];
+    let html = '<select class="regular-text" name="'+name+'">';
+    options.forEach(opt => { const val = (opt&&opt.value)||''; const label=(opt&&opt.label)||val; html += '<option value="'+esc(val)+'"'+(String(value)===String(val)?' selected':'')+'>'+esc(label)+'</option>'; });
+    html += '</select>';
+    return html;
+  }
   function renderGuided(){
     const presets=(window.almaSourcePresets&&almaSourcePresets.presets)||{}; const key=$('#provider_preset').val(); const preset=presets[key]||null;
     const existingSettings=parseHidden('#alma-existing-settings'); const credentialFlags=parseHidden('#alma-existing-credentials-flags');
     const $s=$('#alma-guided-settings').empty(); const $c=$('#alma-guided-credentials').empty(); if(!preset) return;
-    (preset.settings_fields||[]).forEach(f=>{ const value=typeof existingSettings[f]==='string'?existingSettings[f]:''; $s.append('<p><label><strong>'+f+'</strong><br/><input class="regular-text" type="text" name="settings_fields['+f+']" value="'+$('<div/>').text(value).html()+'"></label></p>'); });
-    (preset.credentials_fields||[]).forEach(f=>{ const placeholder=credentialFlags[f]?'già salvato':''; $c.append('<p><label><strong>'+f+'</strong><br/><input class="regular-text" type="password" name="credentials_fields['+f+']" value="" placeholder="'+placeholder+'" autocomplete="off"></label></p>'); });
-    if(preset.help_text){ $s.append('<p class="description">'+preset.help_text+'</p>'); }
+    (preset.settings_fields||[]).map(normalizeField).forEach(meta=>{
+      const k=meta.key||''; if(!k) return;
+      const value=typeof existingSettings[k]==='string'?existingSettings[k]:(meta.default||'');
+      const req = meta.required ? ' required' : '';
+      const type = meta.type==='number'?'number':'text';
+      let input = '<input class="regular-text" type="'+type+'" name="settings_fields['+k+']" value="'+esc(value)+'" placeholder="'+esc(meta.placeholder||'')+'"'+req+'>';
+      if(meta.type==='select'){ input = renderSelect('settings_fields['+k+']', meta, value); }
+      $s.append('<p><label><strong>'+esc(meta.label||k)+'</strong><br/>'+input+'</label>'+(meta.help?'<br/><span class="description">'+esc(meta.help)+'</span>':'')+'</p>');
+    });
+    (preset.credentials_fields||[]).map(normalizeField).forEach(meta=>{ const k=meta.key||''; if(!k) return; const placeholder=credentialFlags[k]?'già salvato':(meta.placeholder||''); const req = meta.required ? ' required' : ''; $c.append('<p><label><strong>'+esc(meta.label||k)+'</strong><br/><input class="regular-text" type="password" name="credentials_fields['+k+']" value="" placeholder="'+esc(placeholder)+'" autocomplete="off"'+req+'></label>'+(meta.help?'<br/><span class="description">'+esc(meta.help)+'</span>':'')+'</p>'); });
+    if(preset.help_text){ $s.append('<p class="description">'+esc(preset.help_text)+'</p>'); }
   }
   $('#provider_preset').on('change', renderGuided); renderGuided();
   $('#alma-source-form').on('submit', function(e){ const name=$('#name').val().trim(); const provider=$('#provider_label').val().trim(); if(!name||!provider){ e.preventDefault(); alert('Name e provider sono obbligatori.'); }});
-  function getInlineResultTarget($btn){
-    const $context=$btn.closest('tr, .alma-source-actions, .alma-test-connection-wrap');
-    if($context.length){
-      const $contextResult=$context.find('.alma-inline-result').first();
-      if($contextResult.length){ return $contextResult; }
-    }
-    const $siblings=$btn.siblings('.alma-inline-result').first();
-    if($siblings.length){ return $siblings; }
-    const $nearest=$btn.parent().find('.alma-inline-result').first();
-    if($nearest.length){ return $nearest; }
-    return $('<span class=\"alma-inline-result\" aria-live=\"polite\"></span>').insertAfter($btn);
-  }
-  $(document).on('click','.alma-test-connection', function(){
-    const $btn=$(this); const sourceId=$btn.data('source-id'); const $res=getInlineResultTarget($btn);
-    $btn.prop('disabled',true).addClass('updating-message'); $res.removeClass('error success').text('Test in corso...');
-    $.post(almaSourcePresets.ajax_url,{action:'alma_test_source_connection',nonce:almaSourcePresets.nonce,source_id:sourceId})
-      .done(function(resp){ if(resp&&resp.success){$res.addClass('success').text(resp.data.message||'Connessione riuscita');} else {$res.addClass('error').text(resp?.data?.message||'Errore interno');} })
-      .fail(function(){ $res.addClass('error').text('Errore interno'); })
-      .always(function(){ $btn.prop('disabled',false).removeClass('updating-message'); });
-  });
+  function getInlineResultTarget($btn){ const $context=$btn.closest('tr, .alma-source-actions, .alma-test-connection-wrap'); if($context.length){ const $contextResult=$context.find('.alma-inline-result').first(); if($contextResult.length){ return $contextResult; } } const $siblings=$btn.siblings('.alma-inline-result').first(); if($siblings.length){ return $siblings; } const $nearest=$btn.parent().find('.alma-inline-result').first(); if($nearest.length){ return $nearest; } return $('<span class="alma-inline-result" aria-live="polite"></span>').insertAfter($btn); }
+  $(document).on('click','.alma-test-connection', function(){ const $btn=$(this); const sourceId=$btn.data('source-id'); const $res=getInlineResultTarget($btn); $btn.prop('disabled',true).addClass('updating-message'); $res.removeClass('error success').text('Test in corso...'); $.post(almaSourcePresets.ajax_url,{action:'alma_test_source_connection',nonce:almaSourcePresets.nonce,source_id:sourceId}).done(function(resp){ if(resp&&resp.success){$res.addClass('success').text(resp.data.message||'Connessione riuscita');} else {$res.addClass('error').text(resp?.data?.message||'Errore interno');} }).fail(function(){ $res.addClass('error').text('Errore interno'); }).always(function(){ $btn.prop('disabled',false).removeClass('updating-message'); }); });
 });

--- a/includes/class-affiliate-source-normalizer.php
+++ b/includes/class-affiliate-source-normalizer.php
@@ -4,16 +4,16 @@ if (!defined('ABSPATH')) { exit; }
 class ALMA_Affiliate_Source_Normalizer {
     public static function normalize($item, $source) {
         $normalized = array(
-            'post_title' => sanitize_text_field($item['title'] ?? ''),
+            'post_title' => sanitize_text_field($item['title'] ?? ($item['name'] ?? '')),
             'post_content' => wp_kses_post($item['description'] ?? ''),
             'featured_image_url' => esc_url_raw($item['image'] ?? ''),
-            'affiliate_url' => esc_url_raw($item['affiliate_url'] ?? ''),
-            'original_url' => esc_url_raw($item['original_url'] ?? ''),
+            'affiliate_url' => esc_url_raw($item['affiliate_url'] ?? ($item['productUrl'] ?? '')),
+            'original_url' => esc_url_raw($item['original_url'] ?? ($item['productUrl'] ?? '')),
             'provider_category' => sanitize_text_field($item['category'] ?? ''),
             'meta' => array(
                 '_alma_provider' => sanitize_key($source['provider'] ?? 'manual'),
                 '_alma_source_id' => (string) ($source['id'] ?? ''),
-                '_alma_external_id' => sanitize_text_field($item['external_id'] ?? ''),
+                '_alma_external_id' => sanitize_text_field($item['external_id'] ?? ($item['productCode'] ?? '')),
                 '_alma_brand' => sanitize_text_field($item['brand'] ?? ''),
                 '_alma_destination' => sanitize_text_field($item['destination'] ?? ''),
                 '_alma_country' => sanitize_text_field($item['country'] ?? ($source['market'] ?? '')),

--- a/includes/class-affiliate-source-provider-client-factory.php
+++ b/includes/class-affiliate-source-provider-client-factory.php
@@ -3,12 +3,17 @@ if (!defined('ABSPATH')) { exit; }
 
 class ALMA_Affiliate_Source_Provider_Client_Factory {
     const PROVIDER_CUSTOM_API = 'custom_api';
+    const PROVIDER_VIATOR = 'viator';
 
     public static function make($source) {
         $provider = self::resolve_provider_key($source);
 
         if ($provider === self::PROVIDER_CUSTOM_API) {
             return new ALMA_Affiliate_Source_Provider_Client_Custom_API();
+        }
+
+        if ($provider === self::PROVIDER_VIATOR) {
+            return new ALMA_Affiliate_Source_Provider_Client_Viator();
         }
 
         return new ALMA_Affiliate_Source_Provider_Client_Fallback();

--- a/includes/class-affiliate-source-provider-client-viator.php
+++ b/includes/class-affiliate-source-provider-client-viator.php
@@ -1,0 +1,206 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_Affiliate_Source_Provider_Client_Viator {
+    const ENV_SANDBOX = 'sandbox';
+    const ENV_PRODUCTION = 'production';
+
+    private function source_settings($source){ return json_decode((string)($source['settings'] ?? '{}'), true) ?: array(); }
+    private function source_credentials($source){ return json_decode((string)($source['credentials'] ?? '{}'), true) ?: array(); }
+
+    private function resolve_environment($settings) {
+        $env = sanitize_key($settings['environment'] ?? self::ENV_SANDBOX);
+        if (!in_array($env, array(self::ENV_SANDBOX, self::ENV_PRODUCTION), true)) {
+            return '';
+        }
+        return $env;
+    }
+
+    private function base_url_for_environment($environment) {
+        if ($environment === self::ENV_PRODUCTION) {
+            return 'https://api.viator.com/partner';
+        }
+        return 'https://api.sandbox.viator.com/partner';
+    }
+
+    private function build_headers($settings, $credentials, $include_content_type = false) {
+        $api_key = sanitize_text_field($credentials['api_key'] ?? '');
+        if ($api_key === '') {
+            return new WP_Error('missing_credentials', __('API key Viator mancante.', 'affiliate-link-manager-ai'));
+        }
+
+        $api_version = sanitize_text_field($settings['api_version'] ?? '2.0');
+        if ($api_version === '') {
+            return new WP_Error('invalid_api_version', __('Versione API Viator non valida.', 'affiliate-link-manager-ai'));
+        }
+
+        $headers = array(
+            'exp-api-key' => $api_key,
+            'Accept' => 'application/json;version=' . $api_version,
+        );
+
+        $language = sanitize_text_field($settings['accept_language'] ?? 'it');
+        if ($language !== '') {
+            $headers['Accept-Language'] = $language;
+        }
+
+        if ($include_content_type) {
+            $headers['Content-Type'] = 'application/json';
+        }
+
+        return $headers;
+    }
+
+    private function sanitize_example($value) {
+        $text = is_scalar($value) ? (string)$value : wp_json_encode($value);
+        return mb_substr(sanitize_text_field($text), 0, 120);
+    }
+
+    private function flatten($value, $path, &$fields) {
+        if (is_array($value)) {
+            foreach ($value as $k => $v) {
+                $seg = is_int($k) ? '[]' : (string)$k;
+                $next = $path === '' ? $seg : $path . (is_int($k) ? '' : '.') . $seg;
+                $this->flatten($v, $next, $fields);
+            }
+            return;
+        }
+
+        $fields[] = array(
+            'path' => $path,
+            'label' => ucwords(str_replace(array('.', '_', '[', ']'), ' ', $path)),
+            'type' => gettype($value),
+            'example' => $this->sanitize_example($value),
+            'mapping_hint' => $this->mapping_hint($path),
+        );
+    }
+
+    private function mapping_hint($path) {
+        $normalized = strtolower(str_replace('[]', '', $path));
+        $map = array(
+            'productcode' => 'provider ID / external_id',
+            'title' => 'titolo',
+            'description' => 'descrizione',
+            'producturl' => 'URL affiliato',
+            'images.variants.url' => 'immagine',
+            'pricing.summary.fromprice' => 'prezzo',
+            'pricing.currency' => 'valuta',
+            'reviews.combinedaveragerating' => 'rating',
+            'destinations.ref' => 'destinazione',
+            'tags' => 'categoria/tag',
+            'flags' => 'metadata',
+            'duration' => 'durata',
+            'itinerarytype' => 'tipo itinerario',
+        );
+
+        foreach ($map as $needle => $hint) {
+            if (strpos($normalized, $needle) !== false) {
+                return $hint;
+            }
+        }
+
+        return '—';
+    }
+
+    public function test_connection($source) {
+        $settings = $this->source_settings($source);
+        $credentials = $this->source_credentials($source);
+        $environment = $this->resolve_environment($settings);
+
+        if ($environment === '') {
+            return new WP_Error('invalid_environment', __('Environment Viator non valido.', 'affiliate-link-manager-ai'));
+        }
+
+        $headers = $this->build_headers($settings, $credentials, false);
+        if (is_wp_error($headers)) { return $headers; }
+
+        $endpoint = $this->base_url_for_environment($environment) . '/products/tags';
+        $response = wp_remote_get($endpoint, array('timeout' => 8, 'redirection' => 1, 'headers' => $headers));
+
+        if (is_wp_error($response)) {
+            return new WP_Error('timeout', __('Timeout o errore di rete verso Viator.', 'affiliate-link-manager-ai'));
+        }
+
+        $code = (int) wp_remote_retrieve_response_code($response);
+        if ($code >= 200 && $code < 300) {
+            return array('success' => true, 'http_status' => $code, 'message' => __('Connessione Viator riuscita.', 'affiliate-link-manager-ai'));
+        }
+        if ($code === 401) { return new WP_Error('unauthorized', __('API key Viator non autorizzata.', 'affiliate-link-manager-ai')); }
+        if ($code === 403) { return new WP_Error('forbidden', __('Accesso Viator negato per questo account.', 'affiliate-link-manager-ai')); }
+        if ($code === 429) { return new WP_Error('rate_limited', __('Rate limit Viator raggiunto.', 'affiliate-link-manager-ai')); }
+
+        $body = json_decode((string) wp_remote_retrieve_body($response), true);
+        if (!empty(wp_remote_retrieve_body($response)) && !is_array($body)) {
+            return new WP_Error('invalid_json', __('Risposta Viator non valida.', 'affiliate-link-manager-ai'));
+        }
+
+        return new WP_Error('api_error', sprintf(__('Errore API Viator (HTTP %d).', 'affiliate-link-manager-ai'), $code));
+    }
+
+    public function discover_fields($source, $force_refresh = false) {
+        $settings = $this->source_settings($source);
+        $credentials = $this->source_credentials($source);
+        $environment = $this->resolve_environment($settings);
+        if ($environment === '') {
+            return new WP_Error('invalid_environment', __('Environment Viator non valido.', 'affiliate-link-manager-ai'));
+        }
+
+        $search_model = sanitize_key($settings['search_model'] ?? 'products_search');
+        $query = array(
+            'count' => max(1, min(10, (int)($settings['result_count'] ?? 5))),
+            'currency' => sanitize_text_field($settings['currency'] ?? 'EUR'),
+        );
+
+        if (!empty($settings['campaign_value'])) { $query['campaignValue'] = sanitize_text_field($settings['campaign_value']); }
+        if (!empty($settings['target_lander'])) { $query['targetLander'] = sanitize_text_field($settings['target_lander']); }
+
+        if ($search_model === 'freetext_search') {
+            $term = sanitize_text_field($settings['default_search_term'] ?? '');
+            if ($term === '') {
+                return new WP_Error('missing_minimum_criteria', __('Inserisci default_search_term per la discovery freetext.', 'affiliate-link-manager-ai'));
+            }
+            $endpoint = $this->base_url_for_environment($environment) . '/search/freetext';
+            $query['searchTerm'] = $term;
+        } else {
+            $destination_id = sanitize_text_field($settings['default_destination_id'] ?? '');
+            if ($destination_id === '') {
+                return new WP_Error('missing_minimum_criteria', __('Inserisci default_destination_id per la discovery products/search.', 'affiliate-link-manager-ai'));
+            }
+            $endpoint = $this->base_url_for_environment($environment) . '/products/search';
+            $query['destId'] = $destination_id;
+        }
+
+        $cache_key = 'alma_viator_fields_' . md5((int)($source['id'] ?? 0) . '|' . $environment . '|' . $search_model . '|' . wp_json_encode($query));
+        if (!$force_refresh) {
+            $cached = get_transient($cache_key);
+            if (is_array($cached)) { return $cached; }
+        }
+
+        $headers = $this->build_headers($settings, $credentials, true);
+        if (is_wp_error($headers)) { return $headers; }
+
+        $response = wp_remote_post(add_query_arg($query, $endpoint), array('timeout' => 10, 'redirection' => 1, 'headers' => $headers, 'body' => wp_json_encode(array())));
+        if (is_wp_error($response)) {
+            return new WP_Error('timeout', __('Timeout o errore di rete verso Viator.', 'affiliate-link-manager-ai'));
+        }
+
+        $code = (int) wp_remote_retrieve_response_code($response);
+        if ($code < 200 || $code >= 300) {
+            if ($code === 401) { return new WP_Error('unauthorized', __('API key Viator non autorizzata.', 'affiliate-link-manager-ai')); }
+            if ($code === 403) { return new WP_Error('forbidden', __('Accesso Viator negato per questo account.', 'affiliate-link-manager-ai')); }
+            if ($code === 429) { return new WP_Error('rate_limited', __('Rate limit Viator raggiunto.', 'affiliate-link-manager-ai')); }
+            return new WP_Error('api_error', sprintf(__('Errore API Viator (HTTP %d).', 'affiliate-link-manager-ai'), $code));
+        }
+
+        $data = json_decode((string) wp_remote_retrieve_body($response), true);
+        if (!is_array($data)) {
+            return new WP_Error('invalid_json', __('Risposta Viator non JSON o non interpretabile.', 'affiliate-link-manager-ai'));
+        }
+
+        $fields = array();
+        $this->flatten($data, '', $fields);
+        $result = array('fields' => array_slice($fields, 0, 300), 'origin' => parse_url($endpoint, PHP_URL_HOST));
+        set_transient($cache_key, $result, 10 * MINUTE_IN_SECONDS);
+        return $result;
+    }
+}

--- a/includes/class-affiliate-source-provider-presets.php
+++ b/includes/class-affiliate-source-provider-presets.php
@@ -6,7 +6,7 @@ class ALMA_Affiliate_Source_Provider_Presets {
         return array(
             'manual' => array('supports_connection_test'=>false,'supports_field_discovery'=>false,'provider_type'=>'manual','unsupported_message'=>'Provider non ancora supportato per test/discovery.','label'=>'Manual','provider_key'=>'manual','description'=>'Gestione manuale senza API.','modes'=>array('manual'),'settings_fields'=>array(),'credentials_fields'=>array(),'required_fields'=>array(),'optional_fields'=>array(),'help_text'=>'Usa questa modalità per inserimenti manuali.','commercial_notes'=>''),
             'custom_api' => array('supports_connection_test'=>true,'supports_field_discovery'=>true,'provider_type'=>'api','unsupported_message'=>'','label'=>'Custom API','provider_key'=>'custom_api','description'=>'Provider API personalizzato.','modes'=>array('api','deeplink','widget','xml_api','manual'),'settings_fields'=>self::common_settings(),'credentials_fields'=>self::common_credentials(),'required_fields'=>array(),'optional_fields'=>array(),'help_text'=>'Configura endpoint e credenziali del provider custom.','commercial_notes'=>''),
-            'viator' => array('supports_connection_test'=>false,'supports_field_discovery'=>false,'provider_type'=>'commercial_api','unsupported_message'=>'Supporto non ancora disponibile in questa versione.','label'=>'Viator','provider_key'=>'viator','description'=>'Viator affiliate API.','modes'=>array('api','deeplink'),'settings_fields'=>array('environment','base_url_production','base_url_sandbox','accept_language','api_version','currency','campaign_value','target_lander','partner_type'),'credentials_fields'=>array('api_key'),'required_fields'=>array('environment','accept_language','api_version','api_key'),'optional_fields'=>array('currency','campaign_value'),'help_text'=>'Header exp-api-key; Accept-Language e API version da impostare.','commercial_notes'=>'Richiede accesso commerciale partner Viator.'),
+            'viator' => array('supports_connection_test'=>true,'supports_field_discovery'=>true,'provider_type'=>'commercial_api','unsupported_message'=>'','label'=>'Viator','provider_key'=>'viator','description'=>'Viator Partner API v2 (solo flusso affiliate base).','modes'=>array('api','deeplink'),'settings_fields'=>self::viator_settings(),'credentials_fields'=>self::viator_credentials(),'required_fields'=>array('environment','accept_language','api_version','search_model','api_key'),'optional_fields'=>array('currency','default_destination_id','default_search_term','result_count','sort','sort_order','campaign_value','target_lander','partner_access_level'),'help_text'=>'La API key è una credenziale segreta: inviata solo come header exp-api-key e mai esposta in HTML/JS/URL/log.','commercial_notes'=>'Basic Affiliate supportato; booking/checkout/pagamenti esclusi in questa release.'),
             'getyourguide' => array('supports_connection_test'=>false,'supports_field_discovery'=>false,'provider_type'=>'commercial_api','unsupported_message'=>'Supporto non ancora disponibile in questa versione.','label'=>'GetYourGuide','provider_key'=>'getyourguide','description'=>'Marketplace Partner API o Connectivity.','modes'=>array('api','deeplink','widget'),'settings_fields'=>array('integration_type','base_url','currency','cnt_language','locale','mode'),'credentials_fields'=>array('access_token','username','password'),'required_fields'=>array('integration_type'),'optional_fields'=>array('access_token','username','password'),'help_text'=>'Partner API usa X-ACCESS-TOKEN; Connectivity usa Basic Auth.','commercial_notes'=>'Accesso dipende dall’approvazione partnership.'),
             'tiqets' => array('supports_connection_test'=>false,'supports_field_discovery'=>false,'provider_type'=>'commercial_api','unsupported_message'=>'Supporto non ancora disponibile in questa versione.','label'=>'Tiqets','provider_key'=>'tiqets','description'=>'Distributor API Tiqets.','modes'=>array('api','deeplink','widget'),'settings_fields'=>array('environment','base_url','user_agent','sitebrand','mode','api_version'),'credentials_fields'=>array('api_key','jwt_signing_key','jwt_key_id'),'required_fields'=>array('base_url','user_agent','api_key'),'optional_fields'=>array('jwt_signing_key','jwt_key_id'),'help_text'=>'Authorization: Token; User-Agent richiesto.','commercial_notes'=>''),
             'booking_com' => array('supports_connection_test'=>false,'supports_field_discovery'=>false,'provider_type'=>'commercial_api','unsupported_message'=>'Supporto non ancora disponibile in questa versione.','label'=>'Booking.com','provider_key'=>'booking_com','description'=>'Demand API e deeplink.','modes'=>array('demand_api','deeplink'),'settings_fields'=>array('environment','api_version','base_url','currency','language','booker_country','platform','mode'),'credentials_fields'=>array('api_key','affiliate_id'),'required_fields'=>array('mode'),'optional_fields'=>array('api_key','affiliate_id'),'help_text'=>'Bearer API key e X-Affiliate-Id per Demand API.','commercial_notes'=>'Può richiedere approvazione account partner.'),
@@ -19,5 +19,36 @@ class ALMA_Affiliate_Source_Provider_Presets {
         );
     }
     private static function common_settings(){ return array('environment','base_url','language','locale','currency','market','campaign','integration_mode','endpoint_path','user_agent','api_version'); }
+    private static function viator_settings(){ return array(
+        array('key'=>'environment','label'=>'Environment','type'=>'select','default'=>'sandbox','required'=>true,'options'=>array(
+            array('value'=>'sandbox','label'=>'Sandbox'),
+            array('value'=>'production','label'=>'Production'),
+        )),
+        array('key'=>'accept_language','label'=>'Accept-Language','type'=>'text','default'=>'it','required'=>true,'placeholder'=>'it','help'=>'Lingua di risposta Viator (es. it, en-US).'),
+        array('key'=>'api_version','label'=>'API version','type'=>'text','default'=>'2.0','required'=>true,'placeholder'=>'2.0'),
+        array('key'=>'currency','label'=>'Currency','type'=>'text','default'=>'EUR','placeholder'=>'EUR'),
+        array('key'=>'search_model','label'=>'Search model','type'=>'select','default'=>'products_search','required'=>true,'options'=>array(
+            array('value'=>'products_search','label'=>'Products Search (/products/search)'),
+            array('value'=>'freetext_search','label'=>'Freetext Search (/search/freetext)'),
+        )),
+        array('key'=>'default_destination_id','label'=>'Default destination ID (Viator)','type'=>'text','placeholder'=>'es. d57','help'=>'Usato da /products/search. È l\'ID destinazione Viator, non il termine WP.'),
+        array('key'=>'default_search_term','label'=>'Default search term','type'=>'text','placeholder'=>'es. Colosseo Roma','help'=>'Usato da /search/freetext.'),
+        array('key'=>'result_count','label'=>'Result count','type'=>'number','default'=>'5','placeholder'=>'5'),
+        array('key'=>'sort','label'=>'Sort','type'=>'text','default'=>'DEFAULT','placeholder'=>'DEFAULT'),
+        array('key'=>'sort_order','label'=>'Sort order','type'=>'text','placeholder'=>'ASC o DESC'),
+        array('key'=>'campaign_value','label'=>'Campaign value','type'=>'text','placeholder'=>'opzionale'),
+        array('key'=>'target_lander','label'=>'Target lander','type'=>'text','default'=>'','placeholder'=>'opzionale'),
+        array('key'=>'partner_access_level','label'=>'Partner access level','type'=>'select','default'=>'basic_affiliate','options'=>array(
+            array('value'=>'basic_affiliate','label'=>'Basic Affiliate'),
+            array('value'=>'full_affiliate','label'=>'Full Affiliate'),
+            array('value'=>'full_affiliate_booking','label'=>'Full Affiliate Booking'),
+            array('value'=>'merchant','label'=>'Merchant'),
+        ),'help'=>'Informativo: non è una credenziale.'),
+    ); }
+
+    private static function viator_credentials(){ return array(
+        array('key'=>'api_key','label'=>'Viator API key','type'=>'password','required'=>true,'placeholder'=>'già salvato','help'=>'Credenziale segreta inviata come header exp-api-key. Non verrà mai mostrata in chiaro.'),
+    ); }
+
     private static function common_credentials(){ return array('api_key','access_token','bearer_token','affiliate_id','site_id','client_id','client_secret','username','password','partner_id','referral_url','tracking_code','xml_api_key'); }
 }


### PR DESCRIPTION
### Motivation
- Provide a first-class integration for Viator Partner API v2 that uses the single API key credential model and follows Viator docs (headers, versioning, sandbox/production). 
- Expose safe connection test and field discovery for affiliate workflows while keeping backward compatibility with existing sources and presets. 
- Improve guided-settings UX to support richer metadata for fields while preserving legacy simple presets and not leaking secrets.

### Description
- Added a dedicated client `ALMA_Affiliate_Source_Provider_Client_Viator` in `includes/class-affiliate-source-provider-client-viator.php` implementing environment-aware base URLs, required headers (`exp-api-key`, `Accept: application/json;version=...`, `Accept-Language`, `Content-Type` for JSON POST), `test_connection` (using `/products/tags`) and `discover_fields` (using `/products/search` or `/search/freetext`), result flattening and mapping hints, transient caching and error mapping. 
- Updated `includes/class-affiliate-source-provider-presets.php` to set the `viator` preset to `supports_connection_test=true`, `supports_field_discovery=true`, `provider_type='commercial_api'`, remove UI base URL fields, provide a metadata-driven `settings_fields` list with defaults (`environment: sandbox`, `accept_language: it`, `api_version: 2.0`, `currency: EUR`, `search_model: products_search`, `result_count: 5`, `sort: DEFAULT`, empty `target_lander`) and a single secret credential `api_key` (password type). 
- Extended guided field renderer in `assets/affiliate-sources.js` to accept both legacy string lists and richer field metadata (`key`, `label`, `type`, `options`, `default`, `help`, `required`, `placeholder`) while maintaining backward compatibility. 
- Updated `includes/class-affiliate-source-provider-client-factory.php` to instantiate the new Viator client when `provider_preset` or `provider` resolves to `viator`. 
- Updated `includes/class-affiliate-source-normalizer.php` to prefer Viator-specific fallbacks (`productUrl` → `affiliate_url`, `productCode` → external id) without rebuilding or altering `productUrl`. 
- Bootstrapped the new client by including it in `affiliate-link-manager-ai.php` and bumped plugin version to `2.10.0`; updated `README.md` and `CHANGELOG.md` with Viator integration notes. 

### Testing
- Ran PHP lint checks: `php -l` on `affiliate-link-manager-ai.php`, `includes/class-affiliate-source-provider-presets.php`, `includes/class-affiliate-source-provider-client-factory.php`, `includes/class-affiliate-source-field-discovery-service.php`, `includes/class-affiliate-source-connection-service.php`, `includes/class-affiliate-source-normalizer.php`, and `includes/class-affiliate-source-provider-client-viator.php`; final run reported no syntax errors. 
- Fixed an initial parse issue caused by an unescaped apostrophe in a help string, after which all `php -l` checks passed. 
- All automated lint checks completed successfully; integration with live Viator backend (API key validation, rate-limit behavior) requires manual tests with real credentials per the included checklist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36e9660308332995e72829ea04cda)