### PR TITLE
Hotfix 2.10.2: guard su discovery Viator in Campi importabili + normalizzazione sort_order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.10.2 - Hotfix robustezza Campi importabili Viator
+- fix fatal in `Campi importabili` quando discovery Viator restituisce `WP_Error` o valore inatteso: rendering sempre sicuro con notice e fallback `n/d`
+- la tabella runtime resta renderizzata anche con discovery fallita; empty state esplicito quando non ci sono campi nel campione API
+- catalogo Viator documentato reso robusto (guard su classe/metodo/output array, fallback chiavi mancanti, skip righe non valide)
+- fix `sort_order` nel client Viator: priorità a `sort_order`, fallback legacy `order`, cache transient aggiornata includendo `sort_order`
+- normalizzazione backward-compatible `ASC/DESC` -> `ASCENDING/DESCENDING`; `order` inviato solo quando `sort` è valorizzato e non `DEFAULT`
+- nessun impatto su frontend, tracking click, shortcode e widget
+- versione plugin aggiornata a `2.10.2`
+
 ## 2.10.1 - Hotfix Viator importable fields discovery
 - fix fatal nella pagina Campi importabili quando discovery Viator fallisce o catalogo non è disponibile
 - discovery Viator aggiornata: POST JSON body corretto per /products/search e /search/freetext, query string limitata a campaign-value/target-lander

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # Affiliate Link Manager AI
 
-Versione 2.10.1
+Versione 2.10.2
 
 Questo plugin gestisce e ottimizza i link affiliati all'interno di WordPress.
+
+## Hotfix 2.10.2 (Viator)
+
+- Fix fatal nella pagina admin **Campi importabili** quando la discovery Viator fallisce: ora viene mostrata una notice e il rendering continua.
+- Discovery error-safe con fallback robusti per endpoint/ultimo aggiornamento/campi runtime.
+- Catalogo campi Viator documentati mostrato anche quando la chiamata runtime fallisce.
+- Correzione `sort_order` Viator con retrocompatibilità `order` legacy e normalizzazione `ASC/DESC` verso `ASCENDING/DESCENDING`.
+- Nessun impatto su frontend, tracking click, shortcode e widget.
 
 ## Funzionalità principali
 
@@ -134,4 +142,3 @@ Miglioramenti principali:
 - Aggiunta conferma eliminazione dedicata e blocchi per test connessione/discovery su Source eliminate.
 - Aggiunti snapshot source sui link (`_alma_source_name`, `_alma_source_provider`, `_alma_source_provider_label`, `_alma_source_deleted_at`).
 - Filtro Sources nei Link Affiliati aggiornato con etichetta `(eliminata)` e compatibilità retroattiva.
-

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.10.1
+ * Version: 2.10.2
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.10.1');
+define('ALMA_VERSION', '2.10.2');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-affiliate-source-manager.php
+++ b/includes/class-affiliate-source-manager.php
@@ -179,13 +179,23 @@ class ALMA_Affiliate_Source_Manager {
         $source=$wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}alma_affiliate_sources WHERE id=%d",$source_id),ARRAY_A); if(!is_array($source)) wp_die('Source non trovata'); if(!empty($source['deleted_at'])){ echo '<div class="wrap"><h1>Campi importabili</h1><div class="notice notice-warning"><p>Source eliminata: ripristinala prima di eseguire discovery.</p></div></div>'; return; }
         $force = isset($_GET['refresh']) && $_GET['refresh']==='1';
         $svc=new ALMA_Affiliate_Source_Field_Discovery_Service(); $result=$svc->discover($source,$force);
+        $discovery_endpoint='n/d'; $generated_at='n/d'; $fields=array(); $discovery_info=''; $discovery_error='';
+        if(is_array($result)){
+            $discovery_endpoint = (string)($result['endpoint'] ?? 'n/d');
+            $generated_at = (string)($result['generated_at'] ?? 'n/d');
+            $fields = is_array($result['fields'] ?? null) ? $result['fields'] : array();
+            $discovery_info = (string)($result['message'] ?? '');
+        }elseif(is_wp_error($result)){
+            $discovery_error = $this->map_error($result->get_error_code(),$result->get_error_message());
+        }else{
+            $discovery_error = $this->map_error('internal_error','Risultato discovery non valido.');
+        }
         $storage = new ALMA_Affiliate_Source_Connection_Test_Storage(); $storage->maybe_migrate_legacy((int)$source_id); $last_test=$storage->get((int)$source_id);
         echo '<div class="wrap"><h1>Campi importabili</h1><p><a class="button" href="'.esc_url(add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-affiliate-sources'),admin_url('edit.php'))).'">Torna alle Affiliate Sources</a> <a class="button button-primary" href="'.esc_url(add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-importable-fields','source_id'=>$source_id,'refresh'=>'1'),admin_url('edit.php'))).'">Aggiorna campi</a></p>';
-        echo '<ul><li><strong>Source:</strong> '.esc_html($source['name']).'</li><li><strong>Provider:</strong> '.esc_html($source['provider_label']).'</li><li><strong>Preset:</strong> '.esc_html(($source['provider_preset'] ?? '') !== '' ? $source['provider_preset'] : (($source['provider'] ?? '') !== '' ? $source['provider'] : '—')).'</li><li><strong>Stato:</strong> '.(((int)$source['is_active'])?'Attivo':'Disattivo').'</li><li><strong>Endpoint discovery:</strong> '.esc_html($result['endpoint']??'n/d').'</li><li><strong>Ultimo aggiornamento:</strong> '.esc_html($result['generated_at']??'n/d').'</li><li><strong>Ultimo test connessione:</strong> '.esc_html(is_array($last_test)?(($last_test['tested_at']??'n/d').' ('.(($last_test['status']??'')==='success'?'ok':'ko').')'):'n/d').'</li></ul>';
+        echo '<ul><li><strong>Source:</strong> '.esc_html($source['name']).'</li><li><strong>Provider:</strong> '.esc_html($source['provider_label']).'</li><li><strong>Preset:</strong> '.esc_html(($source['provider_preset'] ?? '') !== '' ? $source['provider_preset'] : (($source['provider'] ?? '') !== '' ? $source['provider'] : '—')).'</li><li><strong>Stato:</strong> '.(((int)$source['is_active'])?'Attivo':'Disattivo').'</li><li><strong>Endpoint discovery:</strong> '.esc_html($discovery_endpoint).'</li><li><strong>Ultimo aggiornamento:</strong> '.esc_html($generated_at).'</li><li><strong>Ultimo test connessione:</strong> '.esc_html(is_array($last_test)?(($last_test['tested_at']??'n/d').' ('.(($last_test['status']??'')==='success'?'ok':'ko').')'):'n/d').'</li></ul>';
         echo '<div class="notice notice-info"><p><strong>Compliance Viator:</strong> productUrl va salvato completo e non modificato; recensioni solo come campi disponibili; booking/checkout/pagamenti/cancellazioni non implementati in questa PR.</p></div>';
-        $fields=array();
-        if(is_wp_error($result)){ echo '<div class="notice notice-warning"><p>'.esc_html($this->map_error($result->get_error_code(),$result->get_error_message())).'</p></div>'; }
-        else { $fields=(array)($result['fields']??array()); if(!empty($result['message'])){ echo '<div class="notice notice-info"><p>'.esc_html($result['message']).'</p></div>'; } }
+        if($discovery_error!==''){ echo '<div class="notice notice-warning"><p>'.esc_html($discovery_error).'</p></div>'; }
+        if($discovery_info!==''){ echo '<div class="notice notice-info"><p>'.esc_html($discovery_info).'</p></div>'; }
         $catalog=array();
         if(class_exists('ALMA_Affiliate_Source_Viator_Field_Catalog') && is_callable(array('ALMA_Affiliate_Source_Viator_Field_Catalog','get_catalog'))){
             $catalog = ALMA_Affiliate_Source_Viator_Field_Catalog::get_catalog();
@@ -193,9 +203,10 @@ class ALMA_Affiliate_Source_Manager {
         } else {
             echo '<div class="notice notice-warning"><p>'.$this->map_error('catalog_unavailable','').'</p></div>';
         }
-        $detected_paths = array(); foreach($fields as $f){ $path=(string)($f['path']??''); if($path!==''){$detected_paths[$path]=true;} }
+        $detected_paths = array(); foreach($fields as $f){ if(!is_array($f)) continue; $path=(string)($f['path']??''); if($path!==''){$detected_paths[$path]=true;} }
         echo '<h2>Campi rilevati nel campione API</h2><table class="widefat striped"><thead><tr><th>Campo/path</th><th>Gruppo</th><th>Endpoint/origine</th><th>Tipo</th><th>Descrizione</th><th>Esempio</th><th>Mapping</th><th>Stato</th></tr></thead><tbody>';
-        foreach($fields as $f){ echo '<tr><td>'.esc_html($f['path']??'').'</td><td>'.esc_html($f['group']??'Campione API').'</td><td>'.esc_html($f['origin']??($result['endpoint']??'')).'</td><td>'.esc_html($f['type']??'').'</td><td>'.esc_html($f['description']??'Campo rilevato dal payload API.').'</td><td>'.esc_html($f['example']??'—').'</td><td>'.esc_html($f['mapping_hint']??'—').'</td><td>rilevato nel campione</td></tr>'; }
+        foreach($fields as $f){ if(!is_array($f)) continue; echo '<tr><td>'.esc_html($f['path']??'').'</td><td>'.esc_html($f['group']??'Campione API').'</td><td>'.esc_html($f['origin']??$discovery_endpoint).'</td><td>'.esc_html($f['type']??'').'</td><td>'.esc_html($f['description']??'Campo rilevato dal payload API.').'</td><td>'.esc_html($f['example']??'—').'</td><td>'.esc_html($f['mapping_hint']??'—').'</td><td>rilevato nel campione</td></tr>'; }
+        if(empty($fields)){ echo '<tr><td colspan=\"8\">Nessun campo rilevato dal campione API. Verifica i criteri di ricerca oppure consulta il catalogo documentato.</td></tr>'; }
         echo '</tbody></table>';
         echo '<h2>Catalogo campi Viator documentati</h2><table class="widefat striped"><thead><tr><th>Campo/path</th><th>Gruppo</th><th>Endpoint/origine</th><th>Tipo</th><th>Descrizione</th><th>Esempio</th><th>Mapping</th><th>Stato</th></tr></thead><tbody>';
         foreach((array)$catalog as $c){ if(!is_array($c)) continue; $path=(string)($c['path']??''); $status = !empty($detected_paths[$path]) ? 'rilevato nel campione' : (((string)($c['status']??'')==='protected')?'protetto/compliance':'documentato ma non rilevato'); $desc=(string)($c['description']??'Campo documentato Viator.'); $note=(string)($c['compliance_note']??''); echo '<tr><td>'.esc_html($path).'</td><td>'.esc_html($c['group']??'Viator').'</td><td>'.esc_html($c['endpoint']??'').'</td><td>'.esc_html($c['type']??'').'</td><td>'.esc_html($desc).($note!==''?' — '.esc_html($note):'').'</td><td>'.esc_html($c['example']??'—').'</td><td>'.esc_html($c['mapping_hint']??'—').'</td><td>'.esc_html($status).'</td></tr>'; }

--- a/includes/class-affiliate-source-provider-client-viator.php
+++ b/includes/class-affiliate-source-provider-client-viator.php
@@ -39,6 +39,20 @@ class ALMA_Affiliate_Source_Provider_Client_Viator {
         return $query;
     }
 
+    private function normalize_sort_order($settings) {
+        $raw = strtoupper(sanitize_text_field($settings['sort_order'] ?? ''));
+        if ($raw === '' && isset($settings['order'])) $raw = strtoupper(sanitize_text_field($settings['order']));
+        if ($raw === 'ASC') return 'ASCENDING';
+        if ($raw === 'DESC') return 'DESCENDING';
+        if (in_array($raw, array('ASCENDING', 'DESCENDING'), true)) return $raw;
+        return '';
+    }
+
+    private function sort_supports_custom_order($sort) {
+        $sort = strtoupper((string) $sort);
+        return $sort !== '' && $sort !== 'DEFAULT';
+    }
+
     private function build_products_search_body($settings) {
         $destination_id = sanitize_text_field($settings['default_destination_id'] ?? '');
         if ($destination_id === '') return new WP_Error('missing_destination_id', __('Destination ID mancante per products_search.', 'affiliate-link-manager-ai'));
@@ -46,10 +60,10 @@ class ALMA_Affiliate_Source_Provider_Client_Viator {
         $currency = sanitize_text_field($settings['currency'] ?? 'EUR');
         $body = array('filtering' => array('destination' => (string) $destination_id), 'pagination' => array('start' => 1, 'count' => $result_count), 'currency' => $currency);
         $sort = strtoupper(sanitize_text_field($settings['sort'] ?? 'DEFAULT'));
-        $order = strtoupper(sanitize_text_field($settings['order'] ?? ''));
+        $sort_order = $this->normalize_sort_order($settings);
         if ($sort !== '' && $sort !== 'DEFAULT') {
             $body['sorting'] = array('sort' => $sort);
-            if (in_array($order, array('ASC', 'DESC'), true)) $body['sorting']['order'] = $order;
+            if ($this->sort_supports_custom_order($sort) && $sort_order !== '') $body['sorting']['order'] = $sort_order;
         }
         return $body;
     }
@@ -63,10 +77,10 @@ class ALMA_Affiliate_Source_Provider_Client_Viator {
         $destination_id = sanitize_text_field($settings['default_destination_id'] ?? '');
         if ($destination_id !== '') $body['productFiltering'] = array('destination' => (string) $destination_id);
         $sort = strtoupper(sanitize_text_field($settings['sort'] ?? 'DEFAULT'));
-        $order = strtoupper(sanitize_text_field($settings['order'] ?? ''));
+        $sort_order = $this->normalize_sort_order($settings);
         if ($sort !== '' && $sort !== 'DEFAULT') {
             $body['productSorting'] = array('sort' => $sort);
-            if (in_array($order, array('ASC', 'DESC'), true)) $body['productSorting']['order'] = $order;
+            if ($this->sort_supports_custom_order($sort) && $sort_order !== '') $body['productSorting']['order'] = $sort_order;
         }
         return $body;
     }
@@ -114,7 +128,7 @@ class ALMA_Affiliate_Source_Provider_Client_Viator {
         $search_model = sanitize_key($settings['search_model'] ?? 'products_search');
         if (!in_array($search_model, array('products_search', 'freetext_search'), true)) return new WP_Error('missing_minimum_criteria', __('Modello di ricerca Viator non supportato.', 'affiliate-link-manager-ai'));
 
-        $cache_basis = array('id' => (int) ($source['id'] ?? 0), 'env' => $environment, 'model' => $search_model, 'destination' => sanitize_text_field($settings['default_destination_id'] ?? ''), 'term' => sanitize_text_field($settings['default_search_term'] ?? ''), 'currency' => sanitize_text_field($settings['currency'] ?? 'EUR'), 'count' => (int) ($settings['result_count'] ?? 5), 'sort' => sanitize_text_field($settings['sort'] ?? ''), 'order' => sanitize_text_field($settings['order'] ?? ''));
+        $cache_basis = array('id' => (int) ($source['id'] ?? 0), 'env' => $environment, 'model' => $search_model, 'destination' => sanitize_text_field($settings['default_destination_id'] ?? ''), 'term' => sanitize_text_field($settings['default_search_term'] ?? ''), 'currency' => sanitize_text_field($settings['currency'] ?? 'EUR'), 'count' => (int) ($settings['result_count'] ?? 5), 'sort' => sanitize_text_field($settings['sort'] ?? ''), 'sort_order' => sanitize_text_field($settings['sort_order'] ?? ($settings['order'] ?? '')), 'legacy_order' => sanitize_text_field($settings['order'] ?? ''));
         $cache_key = 'alma_viator_fields_' . md5(wp_json_encode($cache_basis));
         if (!$force_refresh) { $cached = get_transient($cache_key); if (is_array($cached)) return $cached; }
 

--- a/includes/class-affiliate-source-provider-presets.php
+++ b/includes/class-affiliate-source-provider-presets.php
@@ -35,7 +35,11 @@ class ALMA_Affiliate_Source_Provider_Presets {
         array('key'=>'default_search_term','label'=>'Default search term','type'=>'text','placeholder'=>'es. Colosseo Roma','help'=>'Termine usato da /search/freetext.'),
         array('key'=>'result_count','label'=>'Result count','type'=>'number','default'=>'5','placeholder'=>'5'),
         array('key'=>'sort','label'=>'Sort','type'=>'text','default'=>'DEFAULT','placeholder'=>'DEFAULT'),
-        array('key'=>'sort_order','label'=>'Sort order','type'=>'text','placeholder'=>'ASC o DESC'),
+        array('key'=>'sort_order','label'=>'Sort order','type'=>'select','default'=>'','options'=>array(
+            array('value'=>'','label'=>'Automatico (default Viator)'),
+            array('value'=>'ASCENDING','label'=>'ASCENDING'),
+            array('value'=>'DESCENDING','label'=>'DESCENDING'),
+        ),'help'=>'Usato solo per sort che supportano ordinamento custom. Lascia vuoto per comportamento predefinito Viator.'),
         array('key'=>'campaign_value','label'=>'Campaign value','type'=>'text','placeholder'=>'opzionale'),
         array('key'=>'target_lander','label'=>'Target lander','type'=>'text','default'=>'','placeholder'=>'opzionale','help'=>'Parametro opzionale. Lascia vuoto per usare la landing affiliate ottimizzata da Viator.'),
         array('key'=>'partner_access_level','label'=>'Partner access level','type'=>'select','default'=>'basic_affiliate','options'=>array(


### PR DESCRIPTION
### Motivation
- Evitare il fatal nella pagina admin "Campi importabili" causato dall'accesso a `$result[...]` quando `discover` ritorna un `WP_Error` o un valore inatteso. 
- Rendere il rendering della pagina resiliente a errori runtime Viator mostrando notice informative e continuando a mostrare il catalogo documentato. 
- Allineare il comportamento del client Viator al preset salvato (`sort_order`) con fallback legacy e normalizzazione verso i valori accettati dall'API.

### Description
- Gestione sicura in `render_importable_fields_page()` con tre casi espliciti: risultato `array` valido, `WP_Error` e valore inatteso, e introduzione di variabili per `endpoint`, `generated_at`, `fields`, `discovery_info` e `discovery_error` usate nel rendering; evitati accessi diretti a `$result[...]`. (branch `work`, commit `d7ff00b`).
- Hardening dei loop runtime e catalogo: skip di righe non array, fallback sicuri per chiavi mancanti e empty state esplicito nella tabella runtime quando non ci sono campi rilevati; il catalogo resta renderizzato anche se la discovery fallisce. (file: `includes/class-affiliate-source-manager.php`).
- Fix client Viator: lettura prioritaria di `sort_order` con funzione di `normalize_sort_order()` che converte `ASC`/`DESC` in `ASCENDING`/`DESCENDING`, fallback legacy a `order` solo se `sort_order` assente, invio di `order` solo quando `sort` è valorizzato e diverso da `DEFAULT`, e aggiornamento del basis del transient includendo `sort_order`. (file: `includes/class-affiliate-source-provider-client-viator.php`).
- Aggiornamento preset Viator per trasformare `sort_order` da campo testo a `select` con opzioni "Automatico", `ASCENDING` e `DESCENDING` e relativo help text; bump versione plugin a `2.10.2` e aggiornamento documentazione (`README.md`, `CHANGELOG.md`, `affiliate-link-manager-ai.php`). (files: `includes/class-affiliate-source-provider-presets.php`, `README.md`, `CHANGELOG.md`, `affiliate-link-manager-ai.php`).
- Manual test checklist inclusa nella PR per convalida funzionale in ambiente WordPress (apertura Source Viator con/ senza destination/search term, verifica notice vs fatal, controllo normalizzazione `sort_order`, verifica transient key, controllo assenza di esposizione API key). Modified files: `includes/class-affiliate-source-manager.php`, `includes/class-affiliate-source-provider-client-viator.php`, `includes/class-affiliate-source-provider-presets.php`, `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`.
- Causa reale del fatal: accesso a chiavi di `$result` come array prima di verificarne il tipo quando `discover` ritorna `WP_Error`.

### Testing
- Eseguiti i check di sintassi PHP con `php -l` su tutti i file modificati e sul plugin bootstrap: tutti i controlli hanno passato (`includes/class-affiliate-source-manager.php`, `includes/class-affiliate-source-provider-client-viator.php`, `includes/class-affiliate-source-provider-presets.php`, `includes/class-affiliate-source-viator-field-catalog.php`, `affiliate-link-manager-ai.php`).
- Eseguita verifica statica della rimozione di accessi diretti a `$result[...]` con `rg` e confermato che non rimangono accessi indicizzati non protetti in `includes/class-affiliate-source-manager.php`.
- Tutti i check automatici eseguiti sono passati (lint + grep) e il commit è stato creato con esito positivo; i test manuali richiesti sono elencati nella checklist della PR per essere eseguiti in un ambiente WordPress con credenziali/API Viator.

Known limits: non sono stati eseguiti test end-to-end in wp-admin con API Viator reali in questo ambiente CI, quindi la checklist manuale va eseguita localmente o su staging con API key valide; nessuna modifica è stata fatta a frontend, tracking, shortcode, widget o salvataggio raw delle risposte.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f467f11e608332a34a25319cb8a923)