### PR TITLE
Restore admin Source JS and add criteria_token transient for import preview (2.14.2)

### DIFF
--- a/assets/affiliate-sources.css
+++ b/assets/affiliate-sources.css
@@ -1,7 +1,11 @@
-.alma-import-page .postbox{max-width:1200px}
-.alma-grid-3{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:8px 16px}
-.alma-import-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:10px 16px}
-.alma-import-grid p{margin:0}
-.alma-badge-warning{background:#fff3cd;color:#664d03;padding:2px 8px;border-radius:10px;font-weight:600}
-.alma-advanced-filters{grid-column:1/-1;border:1px solid #dcdcde;padding:8px;border-radius:4px}
-.alma-import-preview td{vertical-align:middle}
+.alma-import-page .postbox{border-radius:8px}
+.alma-import-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}
+.alma-preview-summary,.alma-pagination-box{background:#fff;border:1px solid #dcdcde;padding:12px;border-radius:8px;margin:10px 0}
+.alma-badge-new,.alma-badge-existing,.alma-badge-error,.alma-link-type-badge{display:inline-block;padding:2px 8px;border-radius:20px;font-size:12px}
+.alma-badge-new{background:#e8f7ed;color:#0a5c2f}.alma-badge-existing{background:#fff3cd;color:#664d03}.alma-badge-error{background:#f8d7da;color:#842029}
+.alma-link-type-badge{background:#eef2ff;color:#2d3a8c;margin-right:4px}
+.alma-time-reference{white-space:nowrap}
+.alma-empty-state{padding:16px;border:1px dashed #c3c4c7;background:#fcfcfc}
+.alma-load-more-wrap{display:flex;gap:10px;align-items:center}
+.alma-row-existing{background:#fffdf4}
+.alma-inline-result.ok{color:#0a5c2f}.alma-inline-result.err{color:#842029}

--- a/assets/affiliate-sources.js
+++ b/assets/affiliate-sources.js
@@ -1,11 +1,55 @@
 jQuery(function($){
+  function parseJson(id){ try { return JSON.parse($(id).val() || '{}'); } catch(e){ return {}; } }
   function updateSelected(){ $('.alma-selected-counter').text($('.alma-select-item:checked').length+' selezionati'); }
-  $(document).on('click','.alma-select-all',function(){ $('.alma-select-item').prop('checked',true); updateSelected();});
+  function toggleSearchHints(){
+    var m = $('#import_search_model').val();
+    $('.alma-search-term-wrap').toggle(m === 'freetext_search');
+    $('.alma-destination-wrap').toggle(m !== 'freetext_search');
+  }
+  function renderProviderFields(){
+    var existingSettings = parseJson('#alma-existing-settings');
+    var existingCredFlags = parseJson('#alma-existing-credentials-flags');
+    var preset = $('#provider_preset').val();
+    var $settings = $('#alma-guided-settings');
+    var $creds = $('#alma-guided-credentials');
+    var isViator = preset === 'viator';
+    $('#alma-advanced-credentials').toggle(!isViator);
+    $('#alma-viator-credentials-note').toggle(isViator);
+    $settings.html(''); $creds.html('');
+    if(isViator){
+      $settings.append('<p><label>Modalità <select name="settings_fields[mode]"><option value="create_update">create_update</option><option value="create_only">create_only</option></select></label></p>');
+      $creds.append('<p><label><strong>Viator API key *</strong><br/><input type="password" name="credentials_fields[api_key]" class="regular-text" '+(existingCredFlags.api_key ? '' : 'required')+' placeholder="'+(existingCredFlags.api_key ? 'già salvata' : '')+'" autocomplete="off"></label></p>');
+    }
+    if(existingSettings.mode){ $settings.find('select[name="settings_fields[mode]"]').val(existingSettings.mode); }
+  }
+
+  $(document).on('click','.alma-toggle-source-form',function(){
+    $('#alma-source-form-wrap').slideToggle(150, function(){ if($(this).is(':visible')) $('#name').trigger('focus'); });
+  });
+  $(document).on('change','#provider_preset', renderProviderFields);
+  $(document).on('submit','#alma-source-form',function(){
+    if(!$('#name').val().trim() || !$('#provider_label').val().trim()){ alert('Name e Provider sono obbligatori.'); return false; }
+  });
+  $(document).on('click','.alma-test-connection',function(e){
+    e.preventDefault();
+    var $btn=$(this), $row=$btn.closest('td, .alma-test-connection-wrap'), $res=$row.find('.alma-inline-result').first();
+    $res.removeClass('ok err').text('Test in corso...');
+    $.post(ajaxurl,{action:'alma_test_source_connection', nonce:(window.almaSources&&almaSources.testNonce)||'', source_id:$btn.data('source-id')})
+      .done(function(r){ $res.addClass(r&&r.success?'ok':'err').text((r&&r.data&&r.data.message)||'Risposta non valida'); })
+      .fail(function(){ $res.addClass('err').text('Errore di rete'); });
+  });
+
+  $(document).on('click','.alma-select-all',function(){ $('.alma-select-item:visible').prop('checked',true); updateSelected();});
   $(document).on('click','.alma-deselect-all',function(){ $('.alma-select-item').prop('checked',false); updateSelected();});
   $(document).on('change','.alma-select-item',updateSelected);
-  $(document).on('change','#import_search_model',function(){
-    var m=$(this).val();
-    $('input[name="import_search_term"]').closest('p').toggle(m==='freetext_search');
-  }).trigger('change');
+  $(document).on('change','#import_search_model',toggleSearchHints);
+  $(document).on('change','input[name="import_availability_range"]',function(){ $('.alma-date-custom-wrap').toggle($(this).val()==='custom'); });
+  $(document).on('change','input[name="hide_existing"]',function(){ $('.alma-show-existing-wrap').toggle($(this).is(':checked')); });
+  $(document).on('change','input[name="show_existing"]',function(){ $('.alma-row-existing').toggle($(this).is(':checked')); });
+  $(document).on('change','input[name="auto_fill_new_items"]',function(){ $('.alma-auto-fill-note').toggle($(this).is(':checked')); });
+  $(document).on('click','.alma-toggle-advanced-filters',function(e){ e.preventDefault(); $('.alma-advanced-filters').toggleClass('is-open'); });
+
+  renderProviderFields();
+  toggleSearchHints();
   updateSelected();
 });

--- a/includes/class-affiliate-source-manager.php
+++ b/includes/class-affiliate-source-manager.php
@@ -3,6 +3,8 @@ if (!defined('ABSPATH')) { exit; }
 
 class ALMA_Affiliate_Source_Manager {
     private $registry; private $table_error = '';
+    private function make_criteria_token($source_id){ return wp_generate_password(24,false,false).dechex((int)$source_id); }
+    private function criteria_transient_key($user_id,$source_id,$token){ return 'alma_import_criteria_'.absint($user_id).'_'.absint($source_id).'_'.sanitize_key($token); }
     public function __construct() {
         $this->registry = new ALMA_Affiliate_Source_Provider_Registry();
         $this->registry->bootstrap_native_providers();
@@ -134,12 +136,17 @@ class ALMA_Affiliate_Source_Manager {
         echo '<details class="alma-advanced-filters"><summary>Filtri avanzati Viator</summary><div class="alma-grid-3"><p><label>Rating minimo <input type="number" step="0.1" min="0" max="5" name="import_rating_from" value="'.esc_attr((string)$criteria['import_rating_from']).'"/></label></p><p><label>Rating massimo <input type="number" step="0.1" min="0" max="5" name="import_rating_to" value="'.esc_attr((string)$criteria['import_rating_to']).'"/></label></p><p><label>Tag Viator IDs <input type="text" name="import_tag_ids" value="'.esc_attr($criteria['import_tag_ids']).'"/></label></p></div></details>';
         echo '<p><button class="button button-primary">Carica anteprima</button></p></div></form>';
         if($load_preview){
+            $criteria_token = sanitize_key($_GET['criteria_token'] ?? '');
+            if($criteria_token===''){
+                $criteria_token = $this->make_criteria_token($source_id);
+                set_transient($this->criteria_transient_key(get_current_user_id(),$source_id,$criteria_token), array('criteria'=>$criteria,'source_id'=>$source_id,'user_id'=>get_current_user_id(),'created_at'=>time()), 15*MINUTE_IN_SECONDS);
+            }
             $preview_service=new ALMA_Affiliate_Source_Import_Preview_Service(); $items=$preview_service->get_preview_items($source,$criteria); if(is_wp_error($items)){ echo '<div class="notice notice-error"><p>'.esc_html($items->get_error_message()).'</p></div></div>'; return; }
             $dup=sanitize_key($settings['duplicate_policy']??'skip_existing'); $dedupe_map=$preview_service->build_dedupe_map($source,$items,$dup); $new=array(); $existing=array(); foreach((array)$items as $it){$eid=(string)($it['productCode']??''); if($eid==='' )continue; if(!empty($dedupe_map[$eid]['post_id'])) $existing[]=$it; else $new[]=$it;}
             $visible = $criteria['hide_existing']==='1' ? $new : $items;
             echo '<div class="postbox"><h2 class="hndle"><span>Criteri applicati</span></h2><div class="inside"><p>Modello: '.esc_html($criteria['import_search_model']).' · Keyword: '.esc_html($criteria['import_search_term']).' · Destination: '.esc_html($criteria['import_destination_id']).' · Quantità: '.(int)$criteria['import_limit'].' · Mostra solo nuovi: '.($criteria['hide_existing']==='1'?'Sì':'No').'</p></div></div>';
             echo '<div class="postbox"><h2 class="hndle"><span>Risultati anteprima</span></h2><div class="inside"><p>Recuperati API: '.count((array)$items).' · Nuovi mostrati: '.count($visible).' · Già importati nascosti: '.count($existing).'</p>';
-            echo '<form method="post">'; wp_nonce_field('alma_import_selected','alma_import_selected_nonce'); echo '<input type="hidden" name="action_type" value="import_selected_items"/><input type="hidden" name="source_id" value="'.(int)$source_id.'"/><input type="hidden" name="import_search_model" value="'.esc_attr($criteria['import_search_model']).'"/><input type="hidden" name="import_search_term" value="'.esc_attr($criteria['import_search_term']).'"/><input type="hidden" name="import_destination_id" value="'.esc_attr($criteria['import_destination_id']).'"/><input type="hidden" name="import_limit" value="'.(int)$criteria['import_limit'].'"/>';
+            echo '<form method="post">'; wp_nonce_field('alma_import_selected','alma_import_selected_nonce'); echo '<input type="hidden" name="action_type" value="import_selected_items"/><input type="hidden" name="source_id" value="'.(int)$source_id.'"/><input type="hidden" name="criteria_token" value="'.esc_attr($criteria_token).'"/><input type="hidden" name="import_search_model" value="'.esc_attr($criteria['import_search_model']).'"/><input type="hidden" name="import_search_term" value="'.esc_attr($criteria['import_search_term']).'"/><input type="hidden" name="import_destination_id" value="'.esc_attr($criteria['import_destination_id']).'"/><input type="hidden" name="import_limit" value="'.(int)$criteria['import_limit'].'"/><input type="hidden" name="import_start" value="'.(int)$criteria['import_start'].'"/><input type="hidden" name="next_start" value="'.(int)$criteria['next_start'].'"/><input type="hidden" name="show_existing" value="'.esc_attr($criteria['show_existing']).'"/><input type="hidden" name="auto_fill_new_items" value="'.esc_attr($criteria['auto_fill_new_items']).'"/>';
             echo '<p><button type="button" class="button alma-select-all">Seleziona tutti</button> <button type="button" class="button alma-deselect-all">Deseleziona tutti</button> <span class="alma-selected-counter">0 selezionati</span></p><table class="widefat striped alma-import-preview"><thead><tr><th></th><th>Titolo</th><th>External ID</th><th>Azione</th></tr></thead><tbody>';
             foreach((array)$visible as $it){$eid=(string)($it['productCode']??''); if($eid==='')continue; $exists=!empty($dedupe_map[$eid]['post_id']); echo '<tr><td><input class="alma-select-item" type="checkbox" name="selected_external_ids[]" value="'.esc_attr($eid).'" '.checked(!$exists,true,false).'></td><td>'.esc_html($it['title']??$it['name']??'—').'</td><td>'.esc_html($eid).'</td><td>'.($exists?'salta':'crea').'</td></tr>';}
             echo '</tbody></table><p><button class="button button-primary" '.(empty($term_ids)?'disabled':'').'>Importa selezionati</button></p></form></div></div>';
@@ -148,11 +155,12 @@ class ALMA_Affiliate_Source_Manager {
     }
     private function handle_import_selected_items(){
         if(!wp_verify_nonce($_POST['alma_import_selected_nonce']??'','alma_import_selected')) wp_die('Nonce non valido');
-        $source_id=absint($_POST['source_id']??0); $selected=array_values(array_unique(array_filter(array_map('sanitize_text_field',(array)($_POST['selected_external_ids']??array())))));
+        $source_id=absint($_POST['source_id']??0); $selected=array_values(array_unique(array_filter(array_map('sanitize_text_field',(array)($_POST['selected_external_ids']??array()))))); $criteria_token=sanitize_key($_POST['criteria_token']??'');
         global $wpdb; $source=$wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}alma_affiliate_sources WHERE id=%d",$source_id),ARRAY_A); if(!is_array($source)) wp_die('Source non valida');
         if(!empty($source['deleted_at'])){ $result = new WP_Error('source_archived', __('Source archiviata: import bloccato.', 'affiliate-link-manager-ai')); } else {
-            $criteria_service=new ALMA_Affiliate_Source_Import_Criteria_Service(); $criteria=$criteria_service->sanitize($_POST);
-            $service=new ALMA_Affiliate_Source_Manual_Import_Service(); $result=$service->import_selected($source,array('ids'=>$selected,'criteria'=>$criteria));
+            $stored=get_transient($this->criteria_transient_key(get_current_user_id(),$source_id,$criteria_token));
+            if(empty($criteria_token) || !is_array($stored) || empty($stored['criteria'])){ $result = new WP_Error('criteria_token_expired', __('Sessione criteri scaduta o non valida. Ricarica anteprima.', 'affiliate-link-manager-ai')); }
+            else { $service=new ALMA_Affiliate_Source_Manual_Import_Service(); $result=$service->import_selected($source,array('ids'=>$selected,'criteria'=>$stored['criteria'])); }
         }
         set_transient('alma_import_result_'.get_current_user_id(),array('source_id'=>$source_id,'selected'=>count($selected),'result'=>$result),5*MINUTE_IN_SECONDS);
         wp_safe_redirect(add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-affiliate-sources','alma_view'=>'import_result','source_id'=>$source_id),admin_url('edit.php'))); exit;


### PR DESCRIPTION
### Motivation
- Restore admin JavaScript handlers removed in a prior rewrite and fix the import preview → import flow so advanced criteria are preserved and selected items do not disappear when importing from a filtered preview. 
- Ensure the runtime criteria are stored securely server-side (no API keys/raw payloads persisted), tied to user+source and time-limited to prevent replay and leakage.

### Description
- Restored and extended admin JS in `assets/affiliate-sources.js` to bring back Source form toggling and focus, guided provider field rendering, Viator credential behavior, Source form validation, AJAX connection test feedback, and import selection helpers (select/deselect/counter and import-related toggles). 
- Updated `assets/affiliate-sources.css` to style import cards, preview summary, pagination/load-more area, badges (new/existing/error), time-reference column placeholders, link-type badges and empty states. 
- Added criteria token + transient support in `includes/class-affiliate-source-manager.php` by introducing `make_criteria_token()` and `criteria_transient_key()`, saving sanitized criteria to a transient on preview (TTL 15 minutes) keyed by `user_id + source_id + token`, embedding `criteria_token` and related safe hidden fields in the import form, and changing the import handler to read criteria from the transient and return a clear error when the token is missing/expired. 
- Files modified: `assets/affiliate-sources.js`, `assets/affiliate-sources.css`, `includes/class-affiliate-source-manager.php`; plugin version left at `2.14.2`; branch `work`, commit `06a53ee`.

### Testing
- Static syntax checks: ran `php -l` on `includes/class-affiliate-source-manager.php`, `includes/class-affiliate-source-import-criteria-service.php` and `includes/class-affiliate-source-provider-client-viator.php`, and all returned "No syntax errors detected.". 
- Development commit details: branch `work`, commit `06a53ee`, files changed `assets/affiliate-sources.js`, `assets/affiliate-sources.css`, `includes/class-affiliate-source-manager.php` and the changes were committed.
- Known limits: this change restores admin JS and implements secure `criteria_token` persistence but does not yet complete multi-page "Carica altri risultati" accumulation, automatic extra-page fill, full Viator incremental fetch loop, temporal column population from detail fetches, or complete link-type humanization in preview; additional work is required to finalize those features and to reconcile the AJAX nonce variable name in JS localization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4cad094088332b9d706d76481a214)