### PR TITLE
OpenAI-only AI Core + Settings + AI Content Agent shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.15.0
+- OpenAI-only core: rimosse chiamate operative Claude/Anthropic, introdotto servizio unico OpenAI Responses API via `wp_remote_post`.
+- Nuove impostazioni OpenAI in pagina Impostazioni con test connessione dedicato, stato configurazione, model selector (gpt-5.4-mini default).
+- Aggiunto logging utilizzo AI su tabella dedicata `*_alma_ai_usage`.
+- Aggiunto shell admin `AI Content Agent` con tab preparatorie non operative.
+
 ## 2.14.3
 - Pagina **Importa contenuti**: aggiunta sezione **Filtri risultati** con checkbox `Solo nuovi nel plugin`, `Mostra anche già importati` e `Riempi automaticamente preview con nuovi item`.
 - Nella tabella anteprima aggiunta colonna **Link affiliato** (usa `productUrl` originale): link `Apri` in nuova tab con `rel="noopener noreferrer"`, tooltip URL completo e fallback `N/D` se assente.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.12.1
+Versione 2.15.0
 
 
 ## Novità 2.12.1 — Pagina Importa contenuti + fix import
@@ -213,3 +213,10 @@ Miglioramenti principali:
 
 ## Versione 2.13.0
 - Nuova UX Importa contenuti con criteri ricerca runtime (max 100).
+
+
+## OpenAI-only AI Core (2.15.0)
+- Provider AI attivo unico: OpenAI.
+- Configurazione API in Impostazioni con test connessione manuale.
+- Logging token/costi/tempi su storage dedicato.
+- AI Content Agent: pannello admin preparatorio (senza generazione automatica contenuti in questo step).

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.14.2
+ * Version: 2.15.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.14.2');
+define('ALMA_VERSION', '2.15.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -24,6 +24,9 @@ define('ALMA_PLUGIN_FILE', __FILE__);
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-utils.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-content-analysis-ai.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-dashboard-stats.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-openai-service.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-ai-usage-logger.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-admin.php';
 
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-interface.php';
 require_once ALMA_PLUGIN_DIR . 'includes/providers/class-affiliate-source-provider-manual.php';
@@ -443,7 +446,7 @@ class AffiliateManagerAI {
             "Non menzionare o generare link esterni alla lista. Se nessun link è adatto, segnala che non sono disponibili suggerimenti. " .
             "Spiega brevemente le tue scelte prima della lista.";
 
-        $result = ALMA_AI_Utils::call_claude_api($user_prompt, $system_prompt, $conversation);
+        $result = ALMA_AI_Utils::call_openai_api($user_prompt, $system_prompt, $conversation);
 
         if (!$result['success']) {
             wp_send_json_error($result['error']);
@@ -492,6 +495,7 @@ class AffiliateManagerAI {
         // Crea la tabella se non esiste
         if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table_name)) != $table_name) {
             $this->create_analytics_table();
+        ALMA_AI_Usage_Logger::create_table();
         ALMA_Affiliate_Source_Manager::create_tables();
         }
 
@@ -635,7 +639,7 @@ class AffiliateManagerAI {
         // AJAX handlers
         add_action('wp_ajax_alma_get_ai_suggestions', array($this, 'ajax_get_ai_suggestions'));
         add_action('wp_ajax_alma_ai_suggest_text', array($this, 'ajax_ai_suggest_text'));
-        add_action('wp_ajax_alma_test_claude_api', array($this, 'ajax_test_claude_api'));
+        add_action('wp_ajax_alma_test_openai_connection', array($this, 'ajax_test_openai_connection'));
         add_action('wp_ajax_alma_get_performance_predictions', array($this, 'ajax_get_performance_predictions'));
         add_action('wp_ajax_alma_get_link_types', array($this, 'ajax_get_link_types'));
         add_action('wp_ajax_alma_import_affiliate_link', array($this, 'ajax_import_affiliate_link'));
@@ -1213,6 +1217,16 @@ class AffiliateManagerAI {
             array($this, 'render_bot_affiliate_settings_page')
         );
 
+        // AI Content Agent
+        add_submenu_page(
+            'edit.php?post_type=affiliate_link',
+            __('AI Content Agent', 'affiliate-link-manager-ai'),
+            __('AI Content Agent', 'affiliate-link-manager-ai'),
+            'manage_options',
+            'alma-ai-content-agent',
+            array('ALMA_AI_Content_Agent_Admin', 'render_page')
+        );
+
         // Affiliate Chat AI
         add_submenu_page(
             'edit.php?post_type=affiliate_link',
@@ -1267,6 +1281,7 @@ class AffiliateManagerAI {
             'affiliate-chat-ai',
             'alma-affiliate-sources',
             'alma-prompt-ai-settings',
+            'alma-ai-content-agent',
             'affiliate-link-manager-settings',
             'alma-css-editor',
         );
@@ -1419,10 +1434,18 @@ class AffiliateManagerAI {
             $analysis_types = array_map('sanitize_text_field', $_POST['alma_content_analysis_post_types'] ?? array());
             update_option('alma_content_analysis_post_types', $analysis_types);
 
-            // Claude API settings
-            update_option('alma_claude_api_key', sanitize_text_field($_POST['claude_api_key'] ?? ''));
-            update_option('alma_claude_model', sanitize_text_field($_POST['claude_model'] ?? 'claude-3-haiku-20240307'));
-            update_option('alma_claude_temperature', floatval($_POST['claude_temperature'] ?? 0.7));
+            // OpenAI API settings
+            if (!empty($_POST['alma_clear_openai_api_key'])) {
+                delete_option('alma_openai_api_key');
+            } elseif (!empty($_POST['openai_api_key'])) {
+                update_option('alma_openai_api_key', sanitize_text_field($_POST['openai_api_key']));
+            }
+            $selected_model = sanitize_text_field($_POST['openai_model'] ?? 'gpt-5.4-mini');
+            $custom_model = sanitize_text_field($_POST['openai_model_custom'] ?? '');
+            update_option('alma_openai_model', $custom_model !== '' ? $custom_model : $selected_model);
+            update_option('alma_openai_max_output_tokens', absint($_POST['openai_max_output_tokens'] ?? 600));
+            update_option('alma_openai_timeout', absint($_POST['openai_timeout'] ?? 30));
+            update_option('alma_openai_temperature', floatval($_POST['openai_temperature'] ?? 0.7));
             
             echo '<div class="notice notice-success"><p>' . __('Impostazioni salvate!', 'affiliate-link-manager-ai') . '</p></div>';
         }
@@ -1430,9 +1453,9 @@ class AffiliateManagerAI {
         // Recupera impostazioni attuali
         $track_logged_out = get_option('alma_track_logged_out', 'yes');
         $enable_ai = get_option('alma_enable_ai', 'yes');
-        $claude_api_key = get_option('alma_claude_api_key', '');
-        $claude_model = get_option('alma_claude_model', 'claude-3-haiku-20240307');
-        $claude_temperature = get_option('alma_claude_temperature', 0.7);
+        $openai_api_key = get_option('alma_openai_api_key', '');
+        $openai_model = get_option('alma_openai_model', 'gpt-5.4-mini');
+        $openai_temperature = get_option('alma_openai_temperature', 0.7);
         $allowed_post_types = get_option('alma_link_post_types', array('post', 'page'));
 
         ?>
@@ -1449,7 +1472,7 @@ class AffiliateManagerAI {
                     <a href="#general" class="nav-tab nav-tab-active">Generale</a>
                     <a href="#tracking" class="nav-tab">Tracking</a>
                     <a href="#ai" class="nav-tab">AI Settings</a>
-                    <a href="#claude" class="nav-tab">Claude API</a>
+                    <a href="#openai" class="nav-tab">OpenAI API</a>
                     <a href="#content-analysis" class="nav-tab">Content Analysis AI</a>
                     <a href="#editor" class="nav-tab">Editor</a>
                     <a href="#cleanup" class="nav-tab">Pulizia</a>
@@ -1520,68 +1543,57 @@ class AffiliateManagerAI {
                     </table>
                 </div>
                 
-                <!-- Claude API Settings -->
-                <div id="claude" class="alma-settings-section" style="display:none;">
-                    <h2>🧠 Claude API Configuration</h2>
+                <!-- OpenAI API Settings -->
+                <div id="openai" class="alma-settings-section" style="display:none;">
+                    <h2>🧠 OpenAI API Configuration</h2>
                     <table class="form-table">
                         <tr>
                             <th scope="row">
-                                <label for="claude_api_key">API Key</label>
+                                <label for="openai_api_key">API Key</label>
                             </th>
                             <td>
                                 <input type="password" 
-                                       name="claude_api_key" 
-                                       id="claude_api_key" 
-                                       value="<?php echo esc_attr($claude_api_key); ?>" 
+                                       name="openai_api_key" 
+                                       id="openai_api_key" 
+                                       value="" 
                                        class="regular-text" />
                                 <button type="button" class="button alma-toggle-api-key">👁 Mostra</button>
-                                <p class="description">
-                                    Ottieni la tua API key da 
-                                    <a href="https://console.anthropic.com/" target="_blank">Anthropic Console</a>
+                                <label><input type="checkbox" name="alma_clear_openai_api_key" value="1" /> Cancella API key salvata</label><p class="description">Ottieni la tua API key da 
+                                    <a href="https://platform.openai.com/" target="_blank">OpenAI Platform</a>
                                 </p>
                             </td>
                         </tr>
                         <tr>
                             <th scope="row">
-                                <label for="claude_model">Modello</label>
+                                <label for="openai_model">Modello</label>
                             </th>
                             <td>
-                                <select name="claude_model" id="claude_model">
-                                    <option value="claude-3-haiku-20240307" <?php selected($claude_model, 'claude-3-haiku-20240307'); ?>>
-                                        Claude 3 Haiku (Veloce ed economico)
-                                    </option>
-                                    <option value="claude-3-sonnet-20240229" <?php selected($claude_model, 'claude-3-sonnet-20240229'); ?>>
-                                        Claude 3 Sonnet (Bilanciato)
-                                    </option>
-                                    <option value="claude-3-opus-20240229" <?php selected($claude_model, 'claude-3-opus-20240229'); ?>>
-                                        Claude 3 Opus (Più potente)
-                                    </option>
-                                </select>
+                                <select name="openai_model" id="openai_model"><option value="gpt-5.4-mini" <?php selected($openai_model, 'gpt-5.4-mini'); ?>>gpt-5.4-mini (consigliato)</option><option value="gpt-5.4" <?php selected($openai_model, 'gpt-5.4'); ?>>gpt-5.4</option><option value="gpt-5.5" <?php selected($openai_model, 'gpt-5.5'); ?>>gpt-5.5</option></select><p><input type="text" name="openai_model_custom" placeholder="Modello custom (opzionale)" /></p>
                             </td>
                         </tr>
                         <tr>
                             <th scope="row">
-                                <label for="claude_temperature">Temperature</label>
+                                <label for="openai_temperature">Temperature</label>
                             </th>
                             <td>
                                 <input type="number" 
-                                       name="claude_temperature" 
-                                       id="claude_temperature" 
-                                       value="<?php echo esc_attr($claude_temperature); ?>" 
+                                       name="openai_temperature" 
+                                       id="openai_temperature" 
+                                       value="<?php echo esc_attr($openai_temperature); ?>" 
                                        min="0" 
                                        max="1" 
                                        step="0.1" 
                                        style="width:80px;" />
                                 <p class="description">0 = Deterministico, 1 = Creativo (default: 0.7)</p>
                             </td>
-                        </tr>
+                        </tr><tr><th scope="row"><label for="openai_max_output_tokens">Max output tokens</label></th><td><input type="number" name="openai_max_output_tokens" id="openai_max_output_tokens" value="<?php echo esc_attr(get_option('alma_openai_max_output_tokens', 600)); ?>" min="1" /></td></tr><tr><th scope="row"><label for="openai_timeout">Timeout richiesta</label></th><td><input type="number" name="openai_timeout" id="openai_timeout" value="<?php echo esc_attr(get_option('alma_openai_timeout', 30)); ?>" min="5" /></td></tr><tr><th scope="row">Stato configurazione</th><td><?php echo empty($openai_api_key) ? 'Non configurato' : 'Configurato'; ?></td></tr>
                         <tr>
                             <th scope="row">Test Connessione</th>
                             <td>
-                                <button type="button" id="test-claude-connection" class="button">
+                                <button type="button" id="test-openai-connection" class="button">
                                     🧪 Testa Connessione
                                 </button>
-                                <div id="claude-test-result" style="margin-top:10px;"></div>
+                                <div id="openai-test-result" style="margin-top:10px;"></div>
                             </td>
                         </tr>
                     </table>
@@ -1683,23 +1695,23 @@ class AffiliateManagerAI {
 
             // Toggle API key visibility
             $('.alma-toggle-api-key').on('click', function() {
-                var $input = $('#claude_api_key');
+                var $input = $('#openai_api_key');
                 var type = $input.attr('type') === 'password' ? 'text' : 'password';
                 $input.attr('type', type);
                 $(this).text(type === 'password' ? '👁 Mostra' : '🙈 Nascondi');
             });
 
-            // Test Claude API connection
-            $('#test-claude-connection').on('click', function(e) {
+            // Test OpenAI API connection
+            $('#test-openai-connection').on('click', function(e) {
                 e.preventDefault();
-                var $result = $('#claude-test-result');
+                var $result = $('#openai-test-result');
                 $result.html('<span class="spinner is-active" style="float:none; margin-top:0;"></span> Test in corso...');
 
                 $.ajax({
                     url: ajaxurl,
                     method: 'POST',
                     data: {
-                        action: 'alma_test_claude_api',
+                        action: 'alma_test_openai_connection',
                         nonce: '<?php echo wp_create_nonce("alma_admin_nonce"); ?>'
                     },
                     success: function(response) {
@@ -2814,10 +2826,10 @@ class AffiliateManagerAI {
         }
         $prompt .= "\nRestituisci un array JSON con massimo 10 oggetti {\"id\": ID, \"score\": COERENZA}, dove COERENZA è un numero da 0 a 100 che indica quanto il link è coerente con l'articolo. Rispondi esclusivamente con JSON valido, senza testo aggiuntivo.\n";
 
-        $response = ALMA_AI_Utils::call_claude_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo');
+        $response = ALMA_AI_Utils::call_openai_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo');
         if (empty($response['success'])) {
-            $msg = $response['error'] ?? __('Impossibile generare suggerimenti con Claude.', 'affiliate-link-manager-ai');
-            error_log('Claude API error: ' . $msg);
+            $msg = $response['error'] ?? __('Impossibile generare suggerimenti con OpenAI.', 'affiliate-link-manager-ai');
+            error_log('OpenAI API error: ' . $msg);
             wp_send_json_error($msg);
         }
 
@@ -2872,13 +2884,13 @@ class AffiliateManagerAI {
 
         $link_id = intval($_POST['link_id']);
 
-        // Genera suggerimenti AI basati su Claude
+        // Genera suggerimenti AI basati su OpenAI
         $suggestions = $this->generate_ai_suggestions($link_id);
 
         if (is_wp_error($suggestions) || empty($suggestions)) {
             $msg = is_wp_error($suggestions)
                 ? $suggestions->get_error_message()
-                : __('Impossibile generare suggerimenti con Claude.', 'affiliate-link-manager-ai');
+                : __('Impossibile generare suggerimenti con OpenAI.', 'affiliate-link-manager-ai');
             wp_send_json_error($msg);
         }
 
@@ -2919,7 +2931,7 @@ class AffiliateManagerAI {
         if (is_wp_error($title_suggestions) || is_wp_error($content_suggestions) ||
             (empty($title_suggestions) && empty($content_suggestions))) {
             $error = is_wp_error($title_suggestions) ? $title_suggestions : $content_suggestions;
-            $msg   = $error ? $error->get_error_message() : __('Impossibile generare suggerimenti con Claude.', 'affiliate-link-manager-ai');
+            $msg   = $error ? $error->get_error_message() : __('Impossibile generare suggerimenti con OpenAI.', 'affiliate-link-manager-ai');
             wp_send_json_error($msg);
         }
 
@@ -2929,26 +2941,29 @@ class AffiliateManagerAI {
         ));
     }
     
-    public function ajax_test_claude_api() {
+    public function ajax_test_openai_connection() {
         if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'alma_admin_nonce')) {
             wp_send_json_error('Invalid nonce');
             return;
         }
         
-        $api_key = get_option('alma_claude_api_key');
+        $api_key = get_option('alma_openai_api_key');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(__('Permessi insufficienti', 'affiliate-link-manager-ai'));
+            return;
+        }
+
         if (empty($api_key)) {
-            wp_send_json_error('API Key non configurata');
+            wp_send_json_error('OpenAI API key non configurata');
             return;
         }
         
-        // Test semplice con Claude
-        $response = ALMA_AI_Utils::call_claude_api('Rispondi solo con: "Connessione OK"');
+        // Test semplice con OpenAI
+        $response = ALMA_AI_Utils::call_openai_api('Rispondi solo con: "Connessione OK"');
         
         if ($response['success']) {
-            wp_send_json_success(array(
-                'model' => $response['model'],
-                'response_time' => $response['response_time']
-            ));
+            update_option('alma_openai_last_test', array('date' => current_time('mysql'),'status' => 'ok','model' => $response['model']));
+            wp_send_json_success(array('esito'=>'ok','model' => $response['model'],'response_time' => $response['response_time'],'usage' => $response['usage'] ?? null));
         } else {
             wp_send_json_error($response['error']);
         }
@@ -3223,16 +3238,16 @@ class AffiliateManagerAI {
         }
         $prompt .= "\nRestituisci un array JSON con massimo 500 oggetti {\"id\": ID, \"score\": PERTINENZA}, dove PERTINENZA è un numero da 0 a 100 che indica quanto il link è coerente con il titolo. Ordina dal più pertinente al meno pertinente. Rispondi esclusivamente con JSON valido, senza testo aggiuntivo.";
 
-        $response = ALMA_AI_Utils::call_claude_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo');
+        $response = ALMA_AI_Utils::call_openai_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo');
         if (empty($response['success'])) {
-            return new \WP_Error('claude_error', $response['error'] ?? __('Errore nella richiesta AI', 'affiliate-link-manager-ai'));
+            return new \WP_Error('openai_error', $response['error'] ?? __('Errore nella richiesta AI', 'affiliate-link-manager-ai'));
         }
 
         $clean = ALMA_AI_Utils::extract_first_json($response['response']);
         $items = json_decode($clean, true);
         if (!is_array($items)) {
             error_log('JSON decode failed: ' . json_last_error_msg() . ' | Raw: ' . $response['response']);
-            return new \WP_Error('claude_parse_error', __('Risposta non valida dall\'AI', 'affiliate-link-manager-ai'));
+            return new \WP_Error('openai_parse_error', __('Risposta non valida dall\'AI', 'affiliate-link-manager-ai'));
         }
 
         usort($items, function ($a, $b) {
@@ -3289,10 +3304,10 @@ class AffiliateManagerAI {
             wp_strip_all_tags($post->post_content)
         );
 
-        $response = ALMA_AI_Utils::call_claude_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo');
+        $response = ALMA_AI_Utils::call_openai_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo');
 
         if (empty($response['success'])) {
-            return new \WP_Error('claude_error', $response['error'] ?? __('Errore sconosciuto', 'affiliate-link-manager-ai'));
+            return new \WP_Error('openai_error', $response['error'] ?? __('Errore sconosciuto', 'affiliate-link-manager-ai'));
         }
 
         $clean   = ALMA_AI_Utils::extract_first_json($response['response']);
@@ -3300,7 +3315,7 @@ class AffiliateManagerAI {
 
         if (!is_array($decoded)) {
             error_log('JSON decode failed: ' . json_last_error_msg() . ' | Raw: ' . $response['response']);
-            return new \WP_Error('claude_parse_error', __('Risposta non valida da Claude', 'affiliate-link-manager-ai'));
+            return new \WP_Error('openai_parse_error', __('Risposta non valida da OpenAI', 'affiliate-link-manager-ai'));
         }
 
         $suggestions = array();
@@ -3315,7 +3330,7 @@ class AffiliateManagerAI {
         }
 
         if (empty($suggestions)) {
-            return new \WP_Error('empty_suggestions', __('Risposta non valida da Claude', 'affiliate-link-manager-ai'));
+            return new \WP_Error('empty_suggestions', __('Risposta non valida da OpenAI', 'affiliate-link-manager-ai'));
         }
 
         return $suggestions;
@@ -3332,10 +3347,10 @@ class AffiliateManagerAI {
             $content_part
         );
 
-        $response = ALMA_AI_Utils::call_claude_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo');
+        $response = ALMA_AI_Utils::call_openai_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo');
 
         if (empty($response['success'])) {
-            return new \WP_Error('claude_error', $response['error'] ?? __('Errore sconosciuto', 'affiliate-link-manager-ai'));
+            return new \WP_Error('openai_error', $response['error'] ?? __('Errore sconosciuto', 'affiliate-link-manager-ai'));
         }
 
         $clean   = ALMA_AI_Utils::extract_first_json($response['response']);
@@ -3343,7 +3358,7 @@ class AffiliateManagerAI {
 
         if (!is_array($decoded)) {
             error_log('JSON decode failed: ' . json_last_error_msg() . ' | Raw: ' . $response['response']);
-            return new \WP_Error('claude_parse_error', __('Risposta non valida da Claude', 'affiliate-link-manager-ai'));
+            return new \WP_Error('openai_parse_error', __('Risposta non valida da OpenAI', 'affiliate-link-manager-ai'));
         }
 
         $suggestions = array();
@@ -3356,7 +3371,7 @@ class AffiliateManagerAI {
         }
 
         if (empty($suggestions)) {
-            return new \WP_Error('empty_suggestions', __('Risposta non valida da Claude', 'affiliate-link-manager-ai'));
+            return new \WP_Error('empty_suggestions', __('Risposta non valida da OpenAI', 'affiliate-link-manager-ai'));
         }
 
         return $suggestions;
@@ -3370,10 +3385,10 @@ class AffiliateManagerAI {
             $title
         );
 
-        $response = ALMA_AI_Utils::call_claude_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo');
+        $response = ALMA_AI_Utils::call_openai_api($prompt, 'Rispondi esclusivamente con JSON valido, senza testo aggiuntivo');
 
         if (empty($response['success'])) {
-            return new \WP_Error('claude_error', $response['error'] ?? __('Errore sconosciuto', 'affiliate-link-manager-ai'));
+            return new \WP_Error('openai_error', $response['error'] ?? __('Errore sconosciuto', 'affiliate-link-manager-ai'));
         }
 
         $clean   = ALMA_AI_Utils::extract_first_json($response['response']);
@@ -3381,7 +3396,7 @@ class AffiliateManagerAI {
 
         if (!is_array($decoded)) {
             error_log('JSON decode failed: ' . json_last_error_msg() . ' | Raw: ' . $response['response']);
-            return new \WP_Error('claude_parse_error', __('Risposta non valida da Claude', 'affiliate-link-manager-ai'));
+            return new \WP_Error('openai_parse_error', __('Risposta non valida da OpenAI', 'affiliate-link-manager-ai'));
         }
 
         $suggestions = array();
@@ -3396,7 +3411,7 @@ class AffiliateManagerAI {
         }
 
         if (empty($suggestions)) {
-            return new \WP_Error('empty_suggestions', __('Risposta non valida da Claude', 'affiliate-link-manager-ai'));
+            return new \WP_Error('empty_suggestions', __('Risposta non valida da OpenAI', 'affiliate-link-manager-ai'));
         }
 
         return $suggestions;
@@ -3540,6 +3555,7 @@ class AffiliateManagerAI {
      */
     public function activate() {
         $this->create_analytics_table();
+        ALMA_AI_Usage_Logger::create_table();
         ALMA_Affiliate_Source_Manager::create_tables();
         $this->create_default_categories();
         update_option('alma_plugin_version', ALMA_VERSION);
@@ -3556,6 +3572,7 @@ class AffiliateManagerAI {
         $installed_version = get_option('alma_plugin_version', '0.0.0');
         if (version_compare($installed_version, ALMA_VERSION, '<')) {
             $this->create_analytics_table();
+        ALMA_AI_Usage_Logger::create_table();
             ALMA_Affiliate_Source_Manager::create_tables();
             update_option('alma_plugin_version', ALMA_VERSION);
         }

--- a/assets/prompt-ai-admin.js
+++ b/assets/prompt-ai-admin.js
@@ -46,7 +46,7 @@ jQuery(document).ready(function($){
         });
     });
 
-    $('#alma-test-claude').on('click', function(e){
+    $('#alma-test-openai').on('click', function(e){
         e.preventDefault();
         var data = {
             action: 'alma_test_prompt',
@@ -54,12 +54,12 @@ jQuery(document).ready(function($){
             message: $('#alma-test-message').val(),
             context: $('#alma-test-context').val()
         };
-        $('#alma-test-claude').prop('disabled', true);
-        $('#alma-claude-response').text('...');
+        $('#alma-test-openai').prop('disabled', true);
+        $('#alma-openai-response').text('...');
         $('#alma-final-prompt').text('');
         $.post(alma_prompt_ai.ajax_url, data, function(resp){
             if(resp.success){
-                $('#alma-claude-response').text(resp.data.response);
+                $('#alma-openai-response').text(resp.data.response);
                 $('#alma-final-prompt').text(resp.data.prompt);
                 var links = resp.data.links || {};
                 var container = $('#alma-affiliate-links');
@@ -87,10 +87,10 @@ jQuery(document).ready(function($){
             } else {
                 alert(resp.data);
             }
-            $('#alma-test-claude').prop('disabled', false);
+            $('#alma-test-openai').prop('disabled', false);
         }).fail(function(){
             alert('Errore test');
-            $('#alma-test-claude').prop('disabled', false);
+            $('#alma-test-openai').prop('disabled', false);
         });
     });
 });

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -1,0 +1,12 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+class ALMA_AI_Content_Agent_Admin {
+    public static function render_page(){ if(!current_user_can('manage_options')) return; $configured = get_option('alma_openai_api_key','') !== ''; $model = get_option('alma_openai_model','gpt-5.4-mini'); $last = get_option('alma_openai_last_test', array()); $logs = class_exists('ALMA_AI_Usage_Logger') ? ALMA_AI_Usage_Logger::get_recent_logs(10):array();
+        $tabs=array('overview'=>'Overview','documenti'=>'Documenti','fonti'=>'Fonti','media'=>'Media Library','idee'=>'Idee contenuto','bozze'=>'Bozze','programmazione'=>'Programmazione','log'=>'Log'); $tab=sanitize_key($_GET['tab']??'overview'); if(!isset($tabs[$tab])) $tab='overview';
+        echo '<div class="wrap"><h1>AI Content Agent</h1><h2 class="nav-tab-wrapper">'; foreach($tabs as $k=>$l){$u=admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab='.$k); echo '<a class="nav-tab '.($k===$tab?'nav-tab-active':'').'" href="'.esc_url($u).'">'.esc_html($l).'</a>'; } echo '</h2>';
+        if($tab!=='overview'){ echo '<p>Funzionalità prevista nello step successivo.</p></div>'; return; }
+        echo '<p><strong>Stato OpenAI:</strong> '.($configured?'Configurato':'Non configurato').'</p><p><strong>Modello default:</strong> '.esc_html($model).'</p>';
+        if(!empty($last)){ echo '<p><strong>Ultimo test connessione:</strong> '.esc_html($last['date']??'').' - '.esc_html($last['status']??'').'</p>'; }
+        echo '<h3>Ultimi log AI</h3><ul>'; foreach($logs as $log){ echo '<li>'.esc_html($log['created_at'].' | '.$log['task'].' | '.$log['model'].' | '.($log['success']?'OK':'KO')).'</li>'; } echo '</ul>';
+        echo '<h3>Step successivi</h3><p>Knowledge Base, trend collector, document indexing, media intelligence e scheduler saranno implementati in PR successive.</p></div>'; }
+}

--- a/includes/class-ai-usage-logger.php
+++ b/includes/class-ai-usage-logger.php
@@ -1,0 +1,9 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+class ALMA_AI_Usage_Logger {
+    public static function table_name(){ global $wpdb; return $wpdb->prefix.'alma_ai_usage'; }
+    public static function create_table(){ global $wpdb; require_once ABSPATH.'wp-admin/includes/upgrade.php'; $t=self::table_name(); $c=$wpdb->get_charset_collate(); dbDelta("CREATE TABLE IF NOT EXISTS $t (id bigint unsigned NOT NULL AUTO_INCREMENT,created_at datetime NOT NULL,provider varchar(20) NOT NULL,model varchar(100) NOT NULL,task varchar(100) DEFAULT '' NOT NULL,input_tokens bigint NULL,output_tokens bigint NULL,estimated_cost decimal(12,6) NULL,response_time int NULL,success tinyint(1) NOT NULL DEFAULT 0,error_message text NULL,reference_id varchar(100) DEFAULT '' NOT NULL,PRIMARY KEY(id),KEY created_at(created_at)) $c;"); }
+    public static function log($d){ global $wpdb; $wpdb->insert(self::table_name(), array('created_at'=>current_time('mysql'),'provider'=>'openai','model'=>sanitize_text_field($d['model']??''),'task'=>sanitize_text_field($d['task']??''),'input_tokens'=>isset($d['input_tokens'])?(int)$d['input_tokens']:null,'output_tokens'=>isset($d['output_tokens'])?(int)$d['output_tokens']:null,'estimated_cost'=>isset($d['estimated_cost'])?(float)$d['estimated_cost']:null,'response_time'=>isset($d['response_time'])?(int)$d['response_time']:null,'success'=>!empty($d['success'])?1:0,'error_message'=>isset($d['error'])?sanitize_text_field($d['error']):null,'reference_id'=>sanitize_text_field($d['reference_id']??'')), array('%s','%s','%s','%s','%d','%d','%f','%d','%d','%s','%s')); }
+    public static function get_recent_logs($limit=20){ global $wpdb; return $wpdb->get_results($wpdb->prepare("SELECT * FROM ".self::table_name()." ORDER BY created_at DESC LIMIT %d", absint($limit)), ARRAY_A); }
+    public static function get_total_estimated_cost(){ global $wpdb; return (float)$wpdb->get_var("SELECT COALESCE(SUM(estimated_cost),0) FROM ".self::table_name()); }
+}

--- a/includes/class-ai-utils.php
+++ b/includes/class-ai-utils.php
@@ -1,153 +1,21 @@
 <?php
-// Previeni accesso diretto
-if (!defined('ABSPATH')) {
-    exit;
-}
-
-/**
- * Funzioni di utilità per interagire con i servizi AI
- */
+if (!defined('ABSPATH')) { exit; }
+require_once ALMA_PLUGIN_DIR . 'includes/class-openai-service.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-ai-usage-logger.php';
 class ALMA_AI_Utils {
-    /**
-     * Effettua una chiamata alla Claude API
-     *
-     * @param string $user_prompt   Messaggio dell'utente
-     * @param string $system_prompt Istruzioni di sistema opzionali
-     * @param array  $conversation  Array di messaggi precedenti per mantenere il contesto
-     * @return array Risultato con chiavi success, response, model, response_time
-     */
+    public static function call_openai_api($user_prompt, $system_prompt = '', $conversation = array(), $args = array()) {
+        $result = ALMA_OpenAI_Service::request(array_merge($args, array('user_prompt'=>$user_prompt,'system_prompt'=>$system_prompt,'conversation'=>$conversation)));
+        ALMA_AI_Usage_Logger::log(array('model'=>$result['model'] ?? ($args['model'] ?? ''),'task'=>$args['task'] ?? 'generic','input_tokens'=>$result['usage']['input_tokens'] ?? null,'output_tokens'=>$result['usage']['output_tokens'] ?? null,'response_time'=>$result['response_time'] ?? null,'success'=>!empty($result['success']),'error'=>$result['error'] ?? null,'reference_id'=>$args['reference_id'] ?? ''));
+        return $result;
+    }
     public static function call_claude_api($user_prompt, $system_prompt = '', $conversation = array()) {
-        $api_key = trim(get_option('alma_claude_api_key'));
-        if (empty($api_key)) {
-            return array('success' => false, 'error' => 'API Key non configurata');
-        }
-
-        $model       = get_option('alma_claude_model', 'claude-3-haiku-20240307');
-        $temperature = (float) get_option('alma_claude_temperature', 0.7);
-
-        $body = array(
-            'model'       => $model,
-            'max_tokens'  => 300,
-            'temperature' => $temperature,
-            'messages'    => array()
-        );
-
-        foreach ($conversation as $msg) {
-            $body['messages'][] = array(
-                'role'    => $msg['role'],
-                'content' => array(
-                    array(
-                        'type' => 'text',
-                        'text' => $msg['content'],
-                    )
-                )
-            );
-        }
-
-        $body['messages'][] = array(
-            'role'    => 'user',
-            'content' => array(
-                array(
-                    'type' => 'text',
-                    'text' => $user_prompt,
-                )
-            )
-        );
-
-        if (!empty($system_prompt)) {
-            $body['system'] = $system_prompt;
-        }
-        $start_time = microtime(true);
-        $response   = wp_remote_post('https://api.anthropic.com/v1/messages', array(
-            'headers' => array(
-                'Content-Type'      => 'application/json',
-                'Accept'            => 'application/json',
-                'x-api-key'         => $api_key,
-                'anthropic-version' => '2023-06-01',
-            ),
-            'body'    => wp_json_encode($body, JSON_UNESCAPED_UNICODE),
-            'timeout' => 30,
-        ));
-        $response_time = round((microtime(true) - $start_time) * 1000);
-
-        if (is_wp_error($response)) {
-            return array('success' => false, 'error' => $response->get_error_message(), 'response_time' => $response_time);
-        }
-
-        $code = wp_remote_retrieve_response_code($response);
-        $data = json_decode(wp_remote_retrieve_body($response), true);
-
-        if (200 !== $code) {
-            $error = $data['error']['message'] ?? 'Errore di connessione a Claude';
-            return array('success' => false, 'error' => $error, 'response_time' => $response_time);
-        }
-
-        if (empty($data['content'][0]['text'])) {
-            return array('success' => false, 'error' => 'Risposta non valida da Claude', 'response_time' => $response_time);
-        }
-
-        return array(
-            'success'       => true,
-            'response'      => $data['content'][0]['text'],
-            'model'         => $data['model'] ?? $model,
-            'response_time' => $response_time,
-        );
+        return self::call_openai_api($user_prompt, $system_prompt, $conversation, array('task' => 'legacy_claude_alias'));
     }
-
-    /**
-     * Estrae il primo blocco JSON valido da una stringa
-     *
-     * @param string $text Testo da analizzare
-     * @return string JSON individuato o stringa vuota
-     */
-    public static function extract_first_json($text) {
-        $text = preg_replace('/```json\s*(.+?)\s*```/is', '$1', $text);
-        $text = preg_replace('/```\s*(.+?)\s*```/is', '$1', $text);
-
-        $len = strlen($text);
-        for ($i = 0; $i < $len; $i++) {
-            $char = $text[$i];
-            if ($char !== '{' && $char !== '[') {
-                continue;
+    public static function extract_first_json($text) { /* unchanged */
+        $text = preg_replace('/```json\s*(.+?)\s*```/is', '$1', $text); $text = preg_replace('/```\s*(.+?)\s*```/is', '$1', $text); $len = strlen($text);
+        for ($i=0;$i<$len;$i++){ $char=$text[$i]; if($char!=='{'&&$char!=='[') continue; $open=$char; $close=$char==='{'?'}':']'; $depth=0; $in_string=false; $escape=false;
+            for($j=$i;$j<$len;$j++){ $c=$text[$j]; if($in_string){ if($c==='\\'&&!$escape){$escape=true;continue;} if($c==='"'&&!$escape){$in_string=false;} $escape=false; continue; }
+                if($c==='"'){ $in_string=true; continue; } if($c===$open){$depth++;} elseif($c===$close){$depth--; if($depth===0){return substr($text,$i,$j-$i+1);} }
             }
-
-            $open  = $char;
-            $close = $char === '{' ? '}' : ']';
-            $depth = 0;
-            $in_string = false;
-            $escape = false;
-
-            for ($j = $i; $j < $len; $j++) {
-                $c = $text[$j];
-
-                if ($in_string) {
-                    if ($c === '\\' && !$escape) {
-                        $escape = true;
-                        continue;
-                    }
-                    if ($c === '"' && !$escape) {
-                        $in_string = false;
-                    }
-                    $escape = false;
-                    continue;
-                }
-
-                if ($c === '"') {
-                    $in_string = true;
-                    continue;
-                }
-
-                if ($c === $open) {
-                    $depth++;
-                } elseif ($c === $close) {
-                    $depth--;
-                    if ($depth === 0) {
-                        return substr($text, $i, $j - $i + 1);
-                    }
-                }
-            }
-        }
-
-        return '';
-    }
+        } return ''; }
 }

--- a/includes/class-bot-affiliate.php
+++ b/includes/class-bot-affiliate.php
@@ -415,7 +415,7 @@ class ALMA_Bot_Affiliate {
             "Non generare o menzionare link esterni o non presenti nella lista. Rispondi in formato JSON: [{\\\"title\\\":\\\"Titolo\\\",\\\"url\\\":\\\"https://esempio.com\\\"}]\n" .
             "Link disponibili:\n{$list_text}\nContenuto:\n" . wp_strip_all_tags($content);
 
-        $result = ALMA_AI_Utils::call_claude_api($prompt);
+        $result = ALMA_AI_Utils::call_openai_api($prompt);
         if (!$result['success']) {
             return array();
         }

--- a/includes/class-openai-service.php
+++ b/includes/class-openai-service.php
@@ -1,0 +1,55 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_OpenAI_Service {
+    public static function request($args = array()) {
+        $api_key = trim((string) get_option('alma_openai_api_key', ''));
+        if ($api_key === '') {
+            return array('success'=>false,'error'=>__('OpenAI non configurato', 'affiliate-link-manager-ai'));
+        }
+
+        $model = sanitize_text_field($args['model'] ?? get_option('alma_openai_model', 'gpt-5.4-mini'));
+        $temperature = isset($args['temperature']) ? (float)$args['temperature'] : (float)get_option('alma_openai_temperature', 0.7);
+        $max_output_tokens = isset($args['max_output_tokens']) ? absint($args['max_output_tokens']) : absint(get_option('alma_openai_max_output_tokens', 600));
+        $timeout = isset($args['timeout']) ? absint($args['timeout']) : absint(get_option('alma_openai_timeout', 30));
+
+        $input = array();
+        if (!empty($args['system_prompt'])) {
+            $input[] = array('role'=>'system','content'=>array(array('type'=>'input_text','text'=>(string)$args['system_prompt'])));
+        }
+        foreach ((array)($args['conversation'] ?? array()) as $msg) {
+            if (empty($msg['role']) || !isset($msg['content'])) { continue; }
+            $input[] = array('role'=>sanitize_key($msg['role']),'content'=>array(array('type'=>'input_text','text'=>(string)$msg['content'])));
+        }
+        $input[] = array('role'=>'user','content'=>array(array('type'=>'input_text','text'=>(string)($args['user_prompt'] ?? ''))));
+
+        $body = array('model'=>$model,'input'=>$input,'max_output_tokens'=>$max_output_tokens);
+        if ($temperature >= 0 && $temperature <= 2) { $body['temperature'] = $temperature; }
+        if (!empty($args['json_output'])) { $body['text'] = array('format'=>array('type'=>'json_object')); }
+
+        $start = microtime(true);
+        $res = wp_remote_post('https://api.openai.com/v1/responses', array(
+            'headers'=>array('Authorization'=>'Bearer '.$api_key,'Content-Type'=>'application/json'),
+            'body'=>wp_json_encode($body),
+            'timeout'=>$timeout > 0 ? $timeout : 30,
+        ));
+        $rt = round((microtime(true)-$start)*1000);
+
+        if (is_wp_error($res)) return array('success'=>false,'error'=>__('Errore connessione AI', 'affiliate-link-manager-ai'),'response_time'=>$rt);
+        $code = wp_remote_retrieve_response_code($res);
+        $data = json_decode(wp_remote_retrieve_body($res), true);
+        if ($code < 200 || $code >= 300) {
+            $err = $data['error']['message'] ?? __('Errore OpenAI', 'affiliate-link-manager-ai');
+            return array('success'=>false,'error'=>sanitize_text_field($err),'response_time'=>$rt,'model'=>$model);
+        }
+        $text = '';
+        if (!empty($data['output_text'])) { $text = (string)$data['output_text']; }
+        if ($text === '' && !empty($data['output']) && is_array($data['output'])) {
+            foreach ($data['output'] as $out) {
+                foreach ((array)($out['content'] ?? array()) as $c) { if (($c['type'] ?? '') === 'output_text' && !empty($c['text'])) { $text .= $c['text']; } }
+            }
+        }
+        if (trim($text) === '') return array('success'=>false,'error'=>__('Risposta AI non valida', 'affiliate-link-manager-ai'),'response_time'=>$rt,'model'=>$data['model'] ?? $model);
+        return array('success'=>true,'response'=>$text,'model'=>$data['model'] ?? $model,'response_time'=>$rt,'usage'=>$data['usage'] ?? null);
+    }
+}

--- a/includes/class-prompt-ai-admin.php
+++ b/includes/class-prompt-ai-admin.php
@@ -7,7 +7,7 @@ if (!defined('ABSPATH')) {
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-utils.php';
 
 /**
- * Gestione impostazioni prompt AI per Claude
+ * Gestione impostazioni prompt AI per OpenAI
  */
 class ALMA_Prompt_AI_Admin {
     const OPTION_NAME = 'alma_prompt_ai_settings';
@@ -239,11 +239,11 @@ class ALMA_Prompt_AI_Admin {
                     </select>
                     <p class="description"><?php esc_html_e('Scegli il contesto da utilizzare nel test.', 'affiliate-link-manager-ai'); ?></p>
                 </div>
-                <p><button class="button" id="alma-test-claude"><?php esc_html_e('Testa comportamento AI', 'affiliate-link-manager-ai'); ?></button></p>
+                <p><button class="button" id="alma-test-openai"><?php esc_html_e('Testa comportamento AI', 'affiliate-link-manager-ai'); ?></button></p>
             </form>
             <div id="alma-test-result" style="display:none;">
-                <h3><?php esc_html_e('Risposta Claude', 'affiliate-link-manager-ai'); ?></h3>
-                <div id="alma-claude-response"></div>
+                <h3><?php esc_html_e('Risposta OpenAI', 'affiliate-link-manager-ai'); ?></h3>
+                <div id="alma-openai-response"></div>
                 <div id="alma-affiliate-links"></div>
                 <details>
                     <summary><?php esc_html_e('Prompt Finale', 'affiliate-link-manager-ai'); ?></summary>
@@ -320,7 +320,7 @@ class ALMA_Prompt_AI_Admin {
         $context = isset($_POST['context']) ? sanitize_text_field(wp_unslash($_POST['context'])) : 'general';
 
         $prompts  = self::build_prompt($message, $context);
-        $response = ALMA_AI_Utils::call_claude_api($prompts['user'], $prompts['system']);
+        $response = ALMA_AI_Utils::call_openai_api($prompts['user'], $prompts['system']);
 
         if (empty($response['success'])) {
             wp_send_json_error($response['error'] ?? __('Errore AI', 'affiliate-link-manager-ai'));
@@ -460,16 +460,16 @@ class ALMA_Prompt_AI_Admin {
         $message .= "\nRispondi esclusivamente con un oggetto JSON con i campi \"summary\" e \"results\". \"summary\" deve contenere una breve frase in italiano che spiega perché hai scelto i link. \"results\" è un array con massimo {$max_results} oggetti{\"id\":ID,\"description\":\"testo\",\"score\":COERENZA} dove COERENZA è 0-100. Rispondi esclusivamente con JSON valido, senza testo aggiuntivo.\n";
 
         $prompts  = self::build_prompt($message, 'search');
-        $response = ALMA_AI_Utils::call_claude_api($prompts['user'], $prompts['system']);
+        $response = ALMA_AI_Utils::call_openai_api($prompts['user'], $prompts['system']);
 
         if (empty($response['success'])) {
-            return new \WP_Error('claude_error', $response['error'] ?? __('Errore AI', 'affiliate-link-manager-ai'));
+            return new \WP_Error('openai_error', $response['error'] ?? __('Errore AI', 'affiliate-link-manager-ai'));
         }
 
         $clean = ALMA_AI_Utils::extract_first_json($response['response']);
         $items = json_decode($clean, true);
         if (!is_array($items) || !isset($items['results']) || !is_array($items['results'])) {
-            return new \WP_Error('claude_parse_error', __('Risposta non valida da Claude', 'affiliate-link-manager-ai'));
+            return new \WP_Error('openai_parse_error', __('Risposta non valida da OpenAI', 'affiliate-link-manager-ai'));
         }
 
         $summary = sanitize_text_field($items['summary']);


### PR DESCRIPTION
### Motivation
- Rimuovere l'integrazione operativa con Claude/Anthropic e preparare l'infrastruttura per un futuro “AI Content Agent” usando solo OpenAI come provider attivo. 
- Fornire una base sicura e compatibile per le chiamate AI (servizio centralizzato, logging, impostazioni) senza introdurre multi-provider, router o funzioni di generazione automatica in questa PR. 

### Description
- Aggiunti i servizi infrastrutturali: `includes/class-openai-service.php` (client OpenAI Responses API via `wp_remote_post` con risposta normalizzata) e `includes/class-ai-usage-logger.php` (logger con tabella `*_alma_ai_usage` e metodi `log`, `get_recent_logs`, `get_total_estimated_cost`).
- Aggiunto lo scheletro admin `AI Content Agent` in `includes/class-ai-content-agent-admin.php` e registrata la voce di sottomenu `alma-ai-content-agent` come pannello preparatorio con tabs non operative e overview dello stato OpenAI. 
- Aggiornato `ALMA_AI_Utils` in `includes/class-ai-utils.php` esponendo `call_openai_api()` e mantenendo `call_claude_api()` come alias legacy che delega internamente a OpenAI (quindi nessuna chiamata Anthropic/Claude). 
- Modificati punti di integrazione AI per usare OpenAI: sostituiti i riferimenti e le chiamate operative a Claude con `call_openai_api()` (file modificati principali: `affiliate-link-manager-ai.php`, `includes/class-bot-affiliate.php`, `includes/class-prompt-ai-admin.php`, `assets/prompt-ai-admin.js`). 
- Aggiornata la UI Impostazioni per gestire OpenAI: nuovo tab `OpenAI API` con campi `abilita AI`, `OpenAI API key` (non mostrata dopo il salvataggio), `modell0` (select con `gpt-5.4-mini` default + campo custom), `temperatura`, `max output tokens`, `timeout`, stato configurazione e pulsante `Test Connessione`; aggiunta azione AJAX `alma_test_openai_connection` con nonce e capability checks. 
- Creata logica di attivazione/aggiornamento per creare la tabella di log AI chiamando `ALMA_AI_Usage_Logger::create_table()` in `activate()` e in `maybe_run_update_tasks()`, e incrementata versione plugin a `2.15.0`. 
- Nota compatibilità: le opzioni storiche `alma_claude_*` possono rimanere nel DB ma non sono più usate dal flusso runtime; se necessario il metodo legacy `call_claude_api()` ora delega a OpenAI senza effettuare richieste Anthropic. 

Files aggiunti
- `includes/class-openai-service.php`
- `includes/class-ai-usage-logger.php`
- `includes/class-ai-content-agent-admin.php`

Files modificati (principali)
- `affiliate-link-manager-ai.php` (version bump, inclusione servizi OpenAI, settings UI, AJAX action, submenu AI Content Agent, migration chiamate AI)
- `includes/class-ai-utils.php` (nuovo `call_openai_api`, alias legacy per `call_claude_api`, `extract_first_json` mantenuto)
- `includes/class-bot-affiliate.php` (sostituzione chiamate a OpenAI)
- `includes/class-prompt-ai-admin.php` (UI/test prompt aggiornati per OpenAI)
- `assets/prompt-ai-admin.js` (button/id aggiornati per test OpenAI)
- `README.md` e `CHANGELOG.md` aggiornati per documentare il cambio.

### Testing
- Eseguito controllo sintassi PHP con `php -l` sui file modificati/aggiunti e tutti i check hanno restituito `No syntax errors detected`, per i file: `affiliate-link-manager-ai.php`, `includes/class-ai-utils.php`, `includes/class-openai-service.php`, `includes/class-ai-usage-logger.php`, `includes/class-ai-content-agent-admin.php` (successo). 
- Verificata la sostituzione operativa delle chiamate AI nel codice sorgente tramite ricerca, confermando che le chiamate runtime usano `call_openai_api()` e che non vengono effettuate chiamate ad endpoint Anthropic/Claude (static checks durante il rollout, successo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5a37a00288332ae1fb1c47507eedf)