### PR TITLE
AI Content Agent Step 3.5.1: Admin Regression Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.18.1
+- Step 3.5.1 Admin Regression Fix: ripristinate tab operative Step 1/2 (Overview, Documenti, Fonti, Knowledge Base, Media Library, Reindicizzazione, Stato/Log).
+- Ripristinate action admin Step 2 (reindex_knowledge, reindex_media, index_document, save_note, save_source) con nonce/capability/sanitizzazione e notice post-action.
+- Ripristinata tab Idee contenuto con azioni Approva/Scarta/Archivia/Genera brief e dettagli brief esistente.
+- Migliorata tab Istruzioni AI con gestione profili multipli (lista, modifica, creazione, attivazione/disattivazione).
+- Fix fallback JSON (`extract_first_json`) per evitare fatal con output AI non pulito.
+- Fix `save_ideas()`: conta solo insert riusciti e restituisce errori DB sanitizzati.
+- Aggiunte diagnostiche `required_tables()` / `missing_tables()` e hardening Context Builder sui chunk ammessi.
+- Nessuna bozza/pubblicazione/scheduler in questa release.
+
 ## 2.18.0
 - Step 3.5 AI Content Agent: rimossa area legacy "PROMPT PER AI DEVELOPER" e relativi asset/menu.
 - Aggiunta tab "Istruzioni AI" con profili editoriali e profilo default.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## 2.18.1
+- Step 3.5.1 Admin Regression Fix: ripristinate tab operative Step 1/2 (Overview, Documenti, Fonti, Knowledge Base, Media Library, Reindicizzazione, Stato/Log).
+- Ripristinate action admin Step 2 (reindex_knowledge, reindex_media, index_document, save_note, save_source) con nonce/capability/sanitizzazione e notice post-action.
+- Ripristinata tab Idee contenuto con azioni Approva/Scarta/Archivia/Genera brief e dettagli brief esistente.
+- Migliorata tab Istruzioni AI con gestione profili multipli (lista, modifica, creazione, attivazione/disattivazione).
+- Fix fallback JSON (`extract_first_json`) per evitare fatal con output AI non pulito.
+- Fix `save_ideas()`: conta solo insert riusciti e restituisce errori DB sanitizzati.
+- Aggiunte diagnostiche `required_tables()` / `missing_tables()` e hardening Context Builder sui chunk ammessi.
+- Nessuna bozza/pubblicazione/scheduler in questa release.
+
 ## 2.14.3
 - Pagina **Importa contenuti**: aggiunta sezione **Filtri risultati** con checkbox `Solo nuovi nel plugin`, `Mostra anche già importati` e `Riempi automaticamente preview con nuovi item`.
 - Nella tabella anteprima aggiunta colonna **Link affiliato** (usa `productUrl` originale): link `Apri` in nuova tab con `rel="noopener noreferrer"`, tooltip URL completo e fallback `N/D` se assente.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.18.0
+ * Version: 2.18.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.18.0');
+define('ALMA_VERSION', '2.18.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -1,36 +1,134 @@
 <?php
 if (!defined('ABSPATH')) { exit; }
 class ALMA_AI_Content_Agent_Admin {
-    public static function init() { add_action('admin_post_alma_ai_agent_action', array(__CLASS__,'handle_action')); }
-    public static function handle_action(){ if(!current_user_can('manage_options')) wp_die('forbidden'); check_admin_referer('alma_ai_agent_action'); $do=sanitize_key($_POST['do']??'');
-        if($do==='generate_ideas'){ ALMA_AI_Content_Agent_Planner::generate_ideas(array('max_ideas'=>absint($_POST['max_ideas']??3),'theme'=>sanitize_text_field($_POST['theme']??''),'destination'=>sanitize_text_field($_POST['destination']??''),'temporary_instructions'=>sanitize_textarea_field($_POST['temporary_instructions']??''))); }
-        if($do==='set_idea_status'){ ALMA_AI_Content_Agent_Store::update_idea_status(absint($_POST['idea_id']??0), sanitize_key($_POST['status']??'')); }
-        if($do==='generate_brief'){ ALMA_AI_Content_Agent_Brief_Builder::generate_for_idea(absint($_POST['idea_id']??0)); }
-        if($do==='save_instruction_profile'){ $id=absint($_POST['profile_id']??0); ALMA_AI_Content_Agent_Instructions_Manager::save_profile($_POST,$id); }
-        if($do==='activate_instruction_profile'){ ALMA_AI_Content_Agent_Instructions_Manager::set_active(absint($_POST['profile_id']??0)); }
-        if($do==='deactivate_instruction_profile'){ ALMA_AI_Content_Agent_Instructions_Manager::set_inactive(absint($_POST['profile_id']??0)); }
+    const NOTICE_TRANSIENT_KEY = 'alma_ai_agent_admin_notice_';
+
+    public static function init() { add_action('admin_post_alma_ai_agent_action', array(__CLASS__, 'handle_action')); }
+
+    public static function handle_action() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_ai_agent_action');
+        $do = sanitize_key($_POST['do'] ?? '');
+        $result = array('success' => true, 'message' => 'Azione completata.');
+
+        if ($do === 'generate_ideas') {
+            $result = ALMA_AI_Content_Agent_Planner::generate_ideas(array('max_ideas'=>absint($_POST['max_ideas'] ?? 3),'theme'=>sanitize_text_field($_POST['theme'] ?? ''),'destination'=>sanitize_text_field($_POST['destination'] ?? ''),'temporary_instructions'=>sanitize_textarea_field($_POST['temporary_instructions'] ?? '')));
+            $result['message'] = empty($result['success']) ? ($result['error'] ?? 'Errore generazione idee.') : sprintf('Idee generate e salvate: %d', (int)($result['saved'] ?? 0));
+        } elseif ($do === 'set_idea_status') {
+            $idea_id = absint($_POST['idea_id'] ?? 0); $status = sanitize_key($_POST['status'] ?? '');
+            $ok = ($idea_id > 0) && in_array($status, ALMA_AI_Content_Agent_Store::allowed_idea_statuses(), true) && ALMA_AI_Content_Agent_Store::update_idea_status($idea_id, $status);
+            $result = array('success' => $ok, 'message' => $ok ? 'Stato idea aggiornato.' : 'Impossibile aggiornare lo stato idea.');
+        } elseif ($do === 'generate_brief') {
+            $result = ALMA_AI_Content_Agent_Brief_Builder::generate_for_idea(absint($_POST['idea_id'] ?? 0));
+            $result['message'] = empty($result['success']) ? ($result['error'] ?? 'Errore generazione brief.') : 'Brief generato.';
+        } elseif ($do === 'save_instruction_profile') {
+            $id = absint($_POST['profile_id'] ?? 0);
+            $new_id = ALMA_AI_Content_Agent_Instructions_Manager::save_profile($_POST, $id);
+            if (!empty($_POST['activate_profile'])) { ALMA_AI_Content_Agent_Instructions_Manager::set_active($new_id); }
+            $result = array('success' => $new_id > 0, 'message' => $new_id > 0 ? 'Profilo istruzioni salvato.' : 'Errore salvataggio profilo.');
+        } elseif ($do === 'activate_instruction_profile') {
+            $ok = ALMA_AI_Content_Agent_Instructions_Manager::set_active(absint($_POST['profile_id'] ?? 0));
+            $result = array('success' => (bool)$ok, 'message' => $ok ? 'Profilo attivato.' : 'Impossibile attivare profilo.');
+        } elseif ($do === 'deactivate_instruction_profile') {
+            $ok = ALMA_AI_Content_Agent_Instructions_Manager::set_inactive(absint($_POST['profile_id'] ?? 0));
+            $result = array('success' => (bool)$ok, 'message' => $ok ? 'Profilo disattivato.' : 'Impossibile disattivare profilo.');
+        } elseif ($do === 'reindex_knowledge') {
+            $count = ALMA_AI_Content_Agent_Knowledge_Indexer::reindex_batch();
+            $result = array('success' => true, 'message' => sprintf('Reindex knowledge completato: %d elementi.', (int)$count));
+        } elseif ($do === 'reindex_media') {
+            $count = ALMA_AI_Content_Agent_Media_Indexer::reindex_batch(30);
+            $result = array('success' => true, 'message' => sprintf('Reindex media completato: %d elementi.', (int)$count));
+        } elseif ($do === 'index_document') {
+            ALMA_AI_Content_Agent_Document_Manager::index_attachment(absint($_POST['attachment_id'] ?? 0), sanitize_textarea_field($_POST['manual_text'] ?? ''), sanitize_key($_POST['usage_mode'] ?? 'knowledge'), sanitize_text_field($_POST['language_code'] ?? ''));
+            $result = array('success' => true, 'message' => 'Documento indicizzato.');
+        } elseif ($do === 'save_note') {
+            ALMA_AI_Content_Agent_Document_Manager::save_manual_note($_POST);
+            $result = array('success' => true, 'message' => 'Nota salvata.');
+        } elseif ($do === 'save_source') {
+            $url = esc_url_raw($_POST['source_url'] ?? '');
+            if (empty($url) || !wp_http_validate_url($url)) { $result = array('success' => false, 'message' => 'URL fonte non valido.'); }
+            else { ALMA_AI_Content_Agent_Source_Manager::save_source($_POST); $result = array('success' => true, 'message' => 'Fonte salvata.'); }
+        }
+
+        self::set_notice($result);
         wp_safe_redirect(wp_get_referer()); exit;
     }
-    public static function render_page(){ if(!current_user_can('manage_options')) return;
-        $tabs=array('overview'=>'Overview','istruzioni-ai'=>'Istruzioni AI','documenti'=>'Documenti','fonti'=>'Fonti','knowledge'=>'Knowledge Base','media'=>'Media Library','reindex'=>'Reindicizzazione','log'=>'Stato/Log','idee'=>'Idee contenuto','bozze'=>'Bozze','programmazione'=>'Programmazione');
-        $tab=sanitize_key($_GET['tab']??'overview'); if(!isset($tabs[$tab])) $tab='overview';
-        echo '<div class="wrap"><h1>AI Content Agent</h1><h2 class="nav-tab-wrapper">'; foreach($tabs as $tk=>$tl){ echo '<a class="nav-tab '.($tk===$tab?'nav-tab-active':'').'" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab='.$tk)).'">'.esc_html($tl).'</a>'; } echo '</h2>';
-        if($tab==='istruzioni-ai'){ self::render_instructions_tab(); echo '</div>'; return; }
-        if($tab==='idee'){ self::render_ideas_tab(); echo '</div>'; return; }
-        if(in_array($tab,array('bozze','programmazione'),true)){ echo '<p>Tab futura: non operativa in questo step.</p></div>'; return; }
-        echo '<p>Sezioni Step 1/2 invariate.</p></div>';
+
+    private static function set_notice($result) {
+        set_transient(self::NOTICE_TRANSIENT_KEY . get_current_user_id(), array('type' => !empty($result['success']) ? 'success' : 'error', 'message' => sanitize_text_field($result['message'] ?? 'Operazione completata.')), 120);
     }
-    private static function render_instructions_tab(){ $p=ALMA_AI_Content_Agent_Instructions_Manager::get_active_profile(); if(!$p){ ALMA_AI_Content_Agent_Instructions_Manager::ensure_default_profile(); $p=ALMA_AI_Content_Agent_Instructions_Manager::get_active_profile(); }
-        echo '<h2>Istruzioni AI</h2><p>Queste istruzioni influenzano Planner, Brief e Draft futuri. Non configurano API OpenAI.</p><p><strong>Profilo attivo:</strong> '.esc_html($p['profile_name']??'Nessuno').'</p>';
-        echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_ai_agent_action'); echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_instruction_profile"><input type="hidden" name="profile_id" value="'.(int)($p['id']??0).'">';
+    private static function render_notice() {
+        $n = get_transient(self::NOTICE_TRANSIENT_KEY . get_current_user_id()); if (!$n) { return; }
+        delete_transient(self::NOTICE_TRANSIENT_KEY . get_current_user_id());
+        echo '<div class="notice notice-' . esc_attr($n['type']) . ' is-dismissible"><p>' . esc_html($n['message']) . '</p></div>';
+    }
+
+    public static function render_page() {
+        if (!current_user_can('manage_options')) { return; }
+        $tabs = array('overview'=>'Overview','istruzioni-ai'=>'Istruzioni AI','documenti'=>'Documenti','fonti'=>'Fonti','knowledge'=>'Knowledge Base','media'=>'Media Library','reindex'=>'Reindicizzazione','log'=>'Stato/Log','idee'=>'Idee contenuto','bozze'=>'Bozze','programmazione'=>'Programmazione');
+        $tab = sanitize_key($_GET['tab'] ?? 'overview'); if (!isset($tabs[$tab])) { $tab = 'overview'; }
+        echo '<div class="wrap"><h1>AI Content Agent</h1>'; self::render_notice();
+        echo '<h2 class="nav-tab-wrapper">'; foreach ($tabs as $tk=>$tl) { echo '<a class="nav-tab '.($tk===$tab?'nav-tab-active':'').'" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab='.$tk)).'">'.esc_html($tl).'</a>'; } echo '</h2>';
+        if ($tab === 'overview') { self::render_overview_tab(); }
+        elseif ($tab === 'istruzioni-ai') { self::render_instructions_tab(); }
+        elseif ($tab === 'documenti') { self::render_documents_tab(); }
+        elseif ($tab === 'fonti') { self::render_sources_tab(); }
+        elseif ($tab === 'knowledge') { self::render_knowledge_tab(); }
+        elseif ($tab === 'media') { self::render_media_tab(); }
+        elseif ($tab === 'reindex') { self::render_reindex_tab(); }
+        elseif ($tab === 'log') { self::render_log_tab(); }
+        elseif ($tab === 'idee') { self::render_ideas_tab(); }
+        else { echo '<p>Tab futura: non operativa in questo step.</p>'; }
+        echo '</div>';
+    }
+
+    private static function render_overview_tab() { global $wpdb;
+        $missing = ALMA_AI_Content_Agent_Store::missing_tables();
+        echo '<h2>Overview</h2><ul>';
+        echo '<li>Knowledge items: '.(int)$wpdb->get_var("SELECT COUNT(*) FROM ".ALMA_AI_Content_Agent_Store::table('knowledge_items')).'</li>';
+        echo '<li>Chunks: '.(int)$wpdb->get_var("SELECT COUNT(*) FROM ".ALMA_AI_Content_Agent_Store::table('content_chunks')).'</li>';
+        echo '<li>Fonti: '.(int)$wpdb->get_var("SELECT COUNT(*) FROM ".ALMA_AI_Content_Agent_Store::table('sources')).'</li>';
+        echo '<li>Immagini indicizzate: '.(int)$wpdb->get_var("SELECT COUNT(*) FROM ".ALMA_AI_Content_Agent_Store::table('media_index')).'</li>';
+        echo '<li>OpenAI: '.(empty(get_option('alma_openai_api_key',''))?'Non configurato':'Configurato').'</li>';
+        echo '<li>Tabelle mancanti: '.(empty($missing)?'Nessuna':esc_html(implode(', ', $missing))).'</li></ul>';
+    }
+
+    private static function render_documents_tab() { global $wpdb; echo '<h2>Documenti</h2>'; self::action_form('index_document','Indicizza attachment','<input type="number" name="attachment_id" placeholder="Attachment ID" required> <input type="text" name="language_code" placeholder="Lingua (it/en)"> <input type="text" name="usage_mode" value="knowledge"><br><textarea name="manual_text" rows="2" class="large-text" placeholder="Note manuali"></textarea>'); self::action_form('save_note','Salva nota manuale','<input type="text" name="title" placeholder="Titolo nota" required> <input type="text" name="language_code" placeholder="Lingua"> <input type="text" name="usage_mode" value="knowledge"><input type="text" name="status" value="active"><br><textarea name="content" rows="2" class="large-text" placeholder="Contenuto nota"></textarea>');
+        $rows = $wpdb->get_results("SELECT id,source_type,title,indexed_at FROM ".ALMA_AI_Content_Agent_Store::table('knowledge_items')." WHERE source_type IN ('document_attachment','manual_note') ORDER BY id DESC LIMIT 20", ARRAY_A);
+        echo '<h3>Ultimi documenti/note</h3><table class="widefat"><thead><tr><th>ID</th><th>Tipo</th><th>Titolo</th><th>Indicizzato</th></tr></thead><tbody>';
+        foreach ($rows as $r) { echo '<tr><td>'.(int)$r['id'].'</td><td>'.esc_html($r['source_type']).'</td><td>'.esc_html($r['title']).'</td><td>'.esc_html($r['indexed_at']).'</td></tr>'; }
+        echo '</tbody></table>';
+    }
+    private static function render_sources_tab(){ global $wpdb; echo '<h2>Fonti</h2>'; self::action_form('save_source','Salva fonte','<input type="text" name="name" placeholder="Nome" required> <input type="url" name="source_url" placeholder="https://..." required><input type="text" name="source_type" value="manual"><input type="text" name="language_code" placeholder="Lingua"><input type="text" name="market" placeholder="Mercato"><input type="text" name="usage_mode" value="knowledge"><label><input type="checkbox" name="is_active" value="1" checked> Attiva</label><textarea name="notes" class="large-text" rows="2" placeholder="Note"></textarea>');
+        $rows = $wpdb->get_results("SELECT id,name,source_type,source_url,is_active,updated_at FROM ".ALMA_AI_Content_Agent_Store::table('sources')." ORDER BY id DESC LIMIT 20", ARRAY_A);
+        echo '<h3>Fonti recenti</h3><table class="widefat"><thead><tr><th>ID</th><th>Nome</th><th>Tipo</th><th>URL</th><th>Stato</th><th>Aggiornata</th></tr></thead><tbody>';
+        foreach($rows as $r){ echo '<tr><td>'.(int)$r['id'].'</td><td>'.esc_html($r['name']).'</td><td>'.esc_html($r['source_type']).'</td><td><a href="'.esc_url($r['source_url']).'" target="_blank" rel="noopener">'.esc_html($r['source_url']).'</a></td><td>'.((int)$r['is_active']?'attiva':'disattiva').'</td><td>'.esc_html($r['updated_at']).'</td></tr>'; }
+        echo '</tbody></table>';
+    }
+    private static function render_knowledge_tab(){ global $wpdb; $rows=$wpdb->get_results("SELECT id,source_type,title,usage_mode,status FROM ".ALMA_AI_Content_Agent_Store::table('knowledge_items')." ORDER BY id DESC LIMIT 30",ARRAY_A); echo '<h2>Knowledge Base</h2><table class="widefat"><thead><tr><th>ID</th><th>Tipo Fonte</th><th>Titolo</th><th>Usage mode</th><th>Stato</th></tr></thead><tbody>'; foreach($rows as $r){ echo '<tr><td>'.(int)$r['id'].'</td><td>'.esc_html($r['source_type']).'</td><td>'.esc_html($r['title']).'</td><td>'.esc_html($r['usage_mode']).'</td><td>'.esc_html($r['status']).'</td></tr>'; } echo '</tbody></table>'; }
+    private static function render_media_tab(){ global $wpdb; $rows=$wpdb->get_results("SELECT id,attachment_id,filename,alt_text FROM ".ALMA_AI_Content_Agent_Store::table('media_index')." ORDER BY id DESC LIMIT 20",ARRAY_A); echo '<h2>Media Library</h2><table class="widefat"><thead><tr><th>ID</th><th>Attachment ID</th><th>Filename</th><th>Alt text</th><th>Preview</th></tr></thead><tbody>'; foreach($rows as $r){ $thumb=wp_get_attachment_image((int)$r['attachment_id'],array(60,60)); echo '<tr><td>'.(int)$r['id'].'</td><td>'.(int)$r['attachment_id'].'</td><td>'.esc_html($r['filename']).'</td><td>'.esc_html($r['alt_text']).'</td><td>'.($thumb?$thumb:'-').'</td></tr>'; } echo '</tbody></table>'; }
+    private static function render_reindex_tab(){ echo '<h2>Reindicizzazione</h2>'; self::action_form('reindex_knowledge','Reindex knowledge'); self::action_form('reindex_media','Reindex media'); }
+    private static function render_log_tab(){ global $wpdb; $missing=ALMA_AI_Content_Agent_Store::missing_tables(); $jobs=$wpdb->get_results("SELECT id,job_type,status,last_error,updated_at FROM ".ALMA_AI_Content_Agent_Store::table('jobs')." ORDER BY id DESC LIMIT 20",ARRAY_A); $logs=ALMA_AI_Usage_Logger::get_recent_logs(20); echo '<h2>Stato/Log</h2><p><strong>Tabelle mancanti:</strong> '.(empty($missing)?'Nessuna':esc_html(implode(', ',$missing))).'</p>'; echo '<h3>Ultimi job/errori</h3><table class="widefat"><thead><tr><th>ID</th><th>Tipo</th><th>Stato</th><th>Errore</th><th>Aggiornato</th></tr></thead><tbody>'; foreach($jobs as $j){ echo '<tr><td>'.(int)$j['id'].'</td><td>'.esc_html($j['job_type']).'</td><td>'.esc_html($j['status']).'</td><td>'.esc_html($j['last_error']).'</td><td>'.esc_html($j['updated_at']).'</td></tr>'; } echo '</tbody></table>'; echo '<h3>Ultimi log AI</h3><table class="widefat"><thead><tr><th>Data</th><th>Task</th><th>Model</th><th>Successo</th><th>Errore</th></tr></thead><tbody>'; foreach($logs as $l){ echo '<tr><td>'.esc_html($l['created_at']).'</td><td>'.esc_html($l['task']).'</td><td>'.esc_html($l['model']).'</td><td>'.((int)$l['success']?'si':'no').'</td><td>'.esc_html($l['error_message']).'</td></tr>'; } echo '</tbody></table>'; }
+
+    private static function render_instructions_tab() { $profiles = ALMA_AI_Content_Agent_Instructions_Manager::get_profiles(50,0); $active = ALMA_AI_Content_Agent_Instructions_Manager::get_active_profile(); $edit_id=absint($_GET['profile_id'] ?? ($active['id'] ?? 0)); $current=$edit_id?ALMA_AI_Content_Agent_Instructions_Manager::get_profile($edit_id):array(); echo '<h2>Istruzioni AI</h2><h3>Profili</h3><table class="widefat"><thead><tr><th>ID</th><th>Nome</th><th>Attivo</th><th>Default</th><th>Azioni</th></tr></thead><tbody>'; foreach($profiles as $p){ echo '<tr><td>'.(int)$p['id'].'</td><td>'.esc_html($p['profile_name']).'</td><td>'.((int)$p['is_active']?'Sì':'No').'</td><td>'.((int)$p['is_default']?'Sì':'No').'</td><td><a class="button" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=istruzioni-ai&profile_id='.(int)$p['id'])).'">Modifica</a> '.self::inline_profile_action_form('activate_instruction_profile','Attiva',(int)$p['id']).' '.self::inline_profile_action_form('deactivate_instruction_profile','Disattiva',(int)$p['id']).'</td></tr>'; } echo '</tbody></table><p><a class="button" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=istruzioni-ai&profile_id=0')).'">Crea nuovo profilo</a></p>';
+        echo '<h3>'.($edit_id>0?'Modifica profilo':'Nuovo profilo').'</h3><form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_ai_agent_action'); echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_instruction_profile"><input type="hidden" name="profile_id" value="'.(int)$edit_id.'">';
         $fields=['profile_name'=>'Nome profilo','language_code'=>'Lingua','tone_of_voice'=>'Tono di voce','target_audience'=>'Pubblico target','editorial_style'=>'Stile editoriale','seo_rules'=>'Regole SEO','affiliate_rules'=>'Regole affiliate','image_rules'=>'Regole immagini','source_rules'=>'Regole fonti','anti_duplication_rules'=>'Regole anti-duplicazione','avoid_rules'=>'Cose da evitare','disclosure_policy'=>'Disclosure policy','custom_prompt'=>'Prompt libero personalizzato','internal_notes'=>'Note interne'];
-        foreach($fields as $k=>$l){ echo '<p><label><strong>'.esc_html($l).'</strong><br>'; if(in_array($k,['profile_name','language_code'],true)){ echo '<input class="regular-text" name="'.esc_attr($k).'" value="'.esc_attr($p[$k]??'').'"></label></p>'; } else { echo '<textarea class="large-text" rows="3" name="'.esc_attr($k).'">'.esc_textarea($p[$k]??'').'</textarea></label></p>'; }}
-        echo '<p><button class="button button-primary">Salva profilo</button></p></form>';
+        foreach($fields as $k=>$l){ echo '<p><label><strong>'.esc_html($l).'</strong><br>'; if(in_array($k,['profile_name','language_code'],true)){ echo '<input class="regular-text" name="'.esc_attr($k).'" value="'.esc_attr($current[$k]??'').'">'; } else { echo '<textarea class="large-text" rows="3" name="'.esc_attr($k).'">'.esc_textarea($current[$k]??'').'</textarea>'; } echo '</label></p>'; }
+        echo '<p><label><input type="checkbox" name="activate_profile" value="1"> Attiva questo profilo dopo il salvataggio</label></p><p><button class="button button-primary">Salva profilo</button></p></form>';
     }
-    private static function render_ideas_tab(){ $status = sanitize_key($_GET['idea_status'] ?? ''); echo '<h2>Genera idee</h2>'; self::action_form('generate_ideas','Genera idee','<input type="number" min="1" max="10" name="max_ideas" value="3"/> <input name="theme" placeholder="Tema"> <input name="destination" placeholder="Destinazione"><br><textarea name="temporary_instructions" class="large-text" rows="2" placeholder="Istruzioni aggiuntive per questa generazione (opzionale)"></textarea>');
+
+    private static function render_ideas_tab() { $status = sanitize_key($_GET['idea_status'] ?? ''); echo '<h2>Genera idee</h2>'; self::action_form('generate_ideas','Genera idee','<input type="number" min="1" max="10" name="max_ideas" value="3"/> <input name="theme" placeholder="Tema"> <input name="destination" placeholder="Destinazione"><br><textarea name="temporary_instructions" class="large-text" rows="2" placeholder="Istruzioni aggiuntive per questa generazione (opzionale)"></textarea>');
         echo '<form method="get"><input type="hidden" name="post_type" value="affiliate_link"><input type="hidden" name="page" value="alma-ai-content-agent"><input type="hidden" name="tab" value="idee"><select name="idea_status"><option value="">Tutti gli stati</option>'; foreach(ALMA_AI_Content_Agent_Store::allowed_idea_statuses() as $st){ echo '<option '.selected($status,$st,false).' value="'.esc_attr($st).'">'.esc_html($st).'</option>'; } echo '</select> <button class="button">Filtra</button></form>';
-        foreach(ALMA_AI_Content_Agent_Store::get_ideas($status) as $i){ echo '<div><strong>#'.(int)$i['id'].' '.esc_html($i['proposed_title']).'</strong> - '.esc_html($i['status']).' - Profile ID: '.esc_html($i['instruction_profile_id']??'n/a').' - Snapshot: '.esc_html(substr((string)($i['instruction_snapshot_hash']??''),0,12)).'</div>'; }
+        $ideas = ALMA_AI_Content_Agent_Store::get_ideas($status); echo '<table class="widefat striped"><thead><tr><th>ID</th><th>Titolo</th><th>Motivazione</th><th>Stato</th><th>SEO</th><th>Priority</th><th>Affiliati</th><th>Immagini</th><th>Model</th><th>Profile</th><th>Snapshot</th><th>Warning</th><th>Azioni</th></tr></thead><tbody>';
+        foreach($ideas as $i){ $warnings=implode(', ',(array)json_decode((string)($i['warnings']??'[]'),true)); echo '<tr><td>'.(int)$i['id'].'</td><td>'.esc_html($i['proposed_title']).'</td><td>'.esc_html($i['rationale']).'</td><td>'.esc_html($i['status']).'</td><td>'.esc_html($i['seo_score']).'</td><td>'.esc_html($i['priority_score']).'</td><td>'.count((array)json_decode((string)$i['affiliate_candidates'],true)).'</td><td>'.count((array)json_decode((string)$i['image_candidates'],true)).'</td><td>'.esc_html($i['ai_model']).'</td><td>'.(int)$i['instruction_profile_id'].'</td><td>'.esc_html(substr((string)$i['instruction_snapshot_hash'],0,12)).'</td><td>'.esc_html($warnings).'</td><td>'.self::inline_status_form((int)$i['id'],'approved','Approva').' '.self::inline_status_form((int)$i['id'],'rejected','Scarta').' '.self::inline_status_form((int)$i['id'],'archived','Archivia').' '.self::inline_brief_form((int)$i['id']).'</td></tr>';
+            $brief=ALMA_AI_Content_Agent_Store::get_brief_by_idea((int)$i['id']); if($brief){ echo '<tr><td colspan="13"><details><summary>Brief esistente per idea #'.(int)$i['id'].'</summary><pre style="white-space:pre-wrap;">'.esc_html(wp_json_encode($brief, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)).'</pre></details></td></tr>'; }
+        }
+        echo '</tbody></table>';
     }
+
+    private static function inline_status_form($idea_id,$status,$label){ return '<form style="display:inline-block" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="set_idea_status"><input type="hidden" name="idea_id" value="'.(int)$idea_id.'"><input type="hidden" name="status" value="'.esc_attr($status).'"><button class="button button-small">'.esc_html($label).'</button></form>'; }
+    private static function inline_brief_form($idea_id){ return '<form style="display:inline-block" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="generate_brief"><input type="hidden" name="idea_id" value="'.(int)$idea_id.'"><button class="button button-small button-primary">Genera brief</button></form>'; }
+    private static function inline_profile_action_form($do,$label,$profile_id){ return '<form style="display:inline-block" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="'.esc_attr($do).'"><input type="hidden" name="profile_id" value="'.(int)$profile_id.'"><button class="button button-small">'.esc_html($label).'</button></form>'; }
     private static function action_form($do,$label,$extra=''){ echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_ai_agent_action'); echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="'.esc_attr($do).'">'.$extra.'<p><button class="button">'.esc_html($label).'</button></p></form>'; }
 }
 ALMA_AI_Content_Agent_Admin::init();

--- a/includes/class-ai-content-agent-context-builder.php
+++ b/includes/class-ai-content-agent-context-builder.php
@@ -3,11 +3,16 @@ if (!defined('ABSPATH')) { exit; }
 class ALMA_AI_Content_Agent_Context_Builder {
     public static function build($args = array()) {
         global $wpdb; $usage_mode=sanitize_key($args['usage_mode'] ?? 'knowledge');
-        $items=$wpdb->get_results($wpdb->prepare("SELECT id,title,normalized_excerpt FROM ".ALMA_AI_Content_Agent_Store::table('knowledge_items')." WHERE status='active' AND usage_mode IN (%s,'knowledge') AND usage_mode <> 'exclude_from_generation' ORDER BY indexed_at DESC LIMIT %d",$usage_mode,max(1,min(20,absint($args['limit_items']??8)))),ARRAY_A);
-        $chunks=$wpdb->get_results($wpdb->prepare("SELECT knowledge_item_id,normalized_text FROM ".ALMA_AI_Content_Agent_Store::table('content_chunks')." ORDER BY id DESC LIMIT %d",max(1,min(30,absint($args['limit_chunks']??12)))),ARRAY_A);
+        $limit_items=max(1,min(20,absint($args['limit_items']??8))); $limit_chunks=max(1,min(30,absint($args['limit_chunks']??12)));
+        $items=$wpdb->get_results($wpdb->prepare("SELECT id,title,normalized_excerpt FROM ".ALMA_AI_Content_Agent_Store::table('knowledge_items')." WHERE status='active' AND usage_mode <> 'exclude_from_generation' AND usage_mode IN (%s,'knowledge') ORDER BY indexed_at DESC LIMIT %d",$usage_mode,$limit_items),ARRAY_A);
+        $chunks=array();
+        if (!empty($items)) {
+            $ids = array_map('absint', wp_list_pluck($items, 'id'));
+            $in = implode(',', $ids);
+            $chunks=$wpdb->get_results("SELECT knowledge_item_id,normalized_text FROM ".ALMA_AI_Content_Agent_Store::table('content_chunks')." WHERE knowledge_item_id IN ($in) ORDER BY id DESC LIMIT ".(int)$limit_chunks,ARRAY_A);
+        }
         $links=ALMA_AI_Content_Agent_Affiliate_Selector::select_candidates($args); $media=ALMA_AI_Content_Agent_Media_Selector::select_candidates($args);
-        $profile = ALMA_AI_Content_Agent_Instructions_Manager::get_active_profile();
-        $temporary = sanitize_textarea_field($args['temporary_instructions'] ?? '');
+        $profile = ALMA_AI_Content_Agent_Instructions_Manager::get_active_profile(); $temporary = sanitize_textarea_field($args['temporary_instructions'] ?? '');
         $instruction_block = ALMA_AI_Content_Agent_Instructions_Manager::build_compact_instruction_block($profile, $temporary);
         return array('context'=>array('knowledge_items'=>$items,'chunks'=>$chunks,'affiliate_links'=>$links['items'],'media'=>$media['items'],'instruction_block'=>$instruction_block),'diagnostics'=>array('knowledge_items'=>count($items),'chunks'=>count($chunks),'affiliate_links'=>count($links['items']),'images'=>count($media['items']),'instruction_profile_id'=>$profile['id']??null,'has_active_instruction_profile'=>!empty($profile),'instruction_snapshot_hash'=>ALMA_AI_Content_Agent_Instructions_Manager::snapshot_hash($instruction_block),'instruction_snapshot'=>$instruction_block,'warnings'=>array_merge($links['warnings'],$media['warnings'])));
     }

--- a/includes/class-ai-content-agent-planner.php
+++ b/includes/class-ai-content-agent-planner.php
@@ -13,8 +13,10 @@ class ALMA_AI_Content_Agent_Planner {
         $parsed = json_decode($res['response'], true);
         if (!is_array($parsed)) { $parsed = json_decode(ALMA_AI_Content_Agent_Text_Utils::extract_first_json($res['response']), true); }
         if (!is_array($parsed) || empty($parsed['ideas']) || !is_array($parsed['ideas'])) { return array('success'=>false,'error'=>'JSON idee non valido'); }
-        $saved = ALMA_AI_Content_Agent_Store::save_ideas($parsed['ideas'], $res['model'], $ctx['diagnostics']);
+        $save_result = ALMA_AI_Content_Agent_Store::save_ideas($parsed['ideas'], $res['model'], $ctx['diagnostics']);
+        $saved = (int)($save_result['saved'] ?? 0);
         ALMA_AI_Usage_Logger::log(array('task'=>'content_idea_generation','success'=>true,'model'=>$res['model'],'response_time'=>$res['response_time'] ?? null,'input_tokens'=>$res['usage']['input_tokens'] ?? null,'output_tokens'=>$res['usage']['output_tokens'] ?? null,'estimated_cost'=>$res['usage']['total_tokens'] ?? null));
-        return array('success'=>true,'saved'=>$saved,'diagnostics'=>$ctx['diagnostics']);
+        if ($saved < 1) { return array('success'=>false,'error'=>'Nessuna idea salvata (verificare database).','saved'=>0,'diagnostics'=>$ctx['diagnostics'],'db_errors'=>$save_result['errors'] ?? array()); }
+        return array('success'=>true,'saved'=>$saved,'diagnostics'=>$ctx['diagnostics'],'warnings'=>$save_result['errors'] ?? array());
     }
 }

--- a/includes/class-ai-content-agent-store.php
+++ b/includes/class-ai-content-agent-store.php
@@ -15,7 +15,39 @@ class ALMA_AI_Content_Agent_Store {
         ALMA_AI_Content_Agent_Instructions_Manager::ensure_default_profile();
     }
     public static function allowed_idea_statuses(){ return array('new','reviewed','approved','rejected','brief_ready','archived'); }
-    public static function save_ideas($ideas,$model,$diag=array()){ global $wpdb; $saved=0; foreach((array)$ideas as $idea){ $score=ALMA_AI_Content_Agent_Opportunity_Scorer::score(array('primary_keyword'=>$idea['primary_keyword']??'','secondary_keywords'=>$idea['secondary_keywords']??array(),'affiliate_candidates'=>$idea['affiliate_candidates']??array(),'image_candidates'=>$idea['image_candidates']??array(),'knowledge_count'=>$diag['knowledge_items']??0)); $wpdb->insert(self::table('content_ideas'), array('proposed_title'=>sanitize_text_field($idea['title']??''),'suggested_slug'=>sanitize_title($idea['suggested_slug']??($idea['title']??'')),'destination'=>sanitize_text_field($idea['destination']??''),'travel_theme'=>sanitize_text_field($idea['theme']??''),'primary_keyword'=>sanitize_text_field($idea['primary_keyword']??''),'secondary_keywords'=>wp_json_encode((array)($idea['secondary_keywords']??array())),'seo_intent'=>sanitize_text_field($idea['seo_intent']??''),'rationale'=>sanitize_textarea_field($idea['rationale']??''),'seo_score'=>$score['seo_score'],'monetization_score'=>$score['monetization_score'],'media_score'=>$score['media_score'],'knowledge_score'=>$score['knowledge_score'],'duplication_risk'=>$score['duplication_risk'],'priority_score'=>$score['priority_score'],'status'=>'new','affiliate_candidates'=>wp_json_encode((array)($idea['affiliate_candidates']??array())),'image_candidates'=>wp_json_encode((array)($idea['image_candidates']??array())),'knowledge_suggestions'=>wp_json_encode((array)($idea['knowledge_suggestions']??array())),'warnings'=>wp_json_encode((array)($idea['warnings']??array())),'instruction_profile_id'=>isset($diag['instruction_profile_id'])?absint($diag['instruction_profile_id']):null,'instruction_snapshot_hash'=>sanitize_text_field($diag['instruction_snapshot_hash']??''),'instruction_snapshot'=>sanitize_textarea_field($diag['instruction_snapshot']??''),'ai_model'=>sanitize_text_field($model),'created_at'=>current_time('mysql'),'updated_at'=>current_time('mysql'))); $saved++; } return $saved; }
+
+    public static function required_tables() {
+        return array(
+            ALMA_AI_Usage_Logger::table_name(),
+            self::table('knowledge_items'),
+            self::table('content_chunks'),
+            self::table('media_index'),
+            self::table('sources'),
+            self::table('jobs'),
+            self::table('content_ideas'),
+            self::table('editorial_briefs'),
+            self::table('instruction_profiles'),
+        );
+    }
+
+    public static function missing_tables() {
+        global $wpdb;
+        $missing = array();
+        foreach (self::required_tables() as $table_name) {
+            $exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table_name));
+            if ($exists !== $table_name) { $missing[] = $table_name; }
+        }
+        return $missing;
+    }
+    public static function save_ideas($ideas,$model,$diag=array()){
+        global $wpdb; $saved=0; $errors=array();
+        foreach((array)$ideas as $idea){
+            $score=ALMA_AI_Content_Agent_Opportunity_Scorer::score(array('primary_keyword'=>$idea['primary_keyword']??'','secondary_keywords'=>$idea['secondary_keywords']??array(),'affiliate_candidates'=>$idea['affiliate_candidates']??array(),'image_candidates'=>$idea['image_candidates']??array(),'knowledge_count'=>$diag['knowledge_items']??0));
+            $ok=$wpdb->insert(self::table('content_ideas'), array('proposed_title'=>sanitize_text_field($idea['title']??''),'suggested_slug'=>sanitize_title($idea['suggested_slug']??($idea['title']??'')),'destination'=>sanitize_text_field($idea['destination']??''),'travel_theme'=>sanitize_text_field($idea['theme']??''),'primary_keyword'=>sanitize_text_field($idea['primary_keyword']??''),'secondary_keywords'=>wp_json_encode((array)($idea['secondary_keywords']??array())),'seo_intent'=>sanitize_text_field($idea['seo_intent']??''),'rationale'=>sanitize_textarea_field($idea['rationale']??''),'seo_score'=>$score['seo_score'],'monetization_score'=>$score['monetization_score'],'media_score'=>$score['media_score'],'knowledge_score'=>$score['knowledge_score'],'duplication_risk'=>$score['duplication_risk'],'priority_score'=>$score['priority_score'],'status'=>'new','affiliate_candidates'=>wp_json_encode((array)($idea['affiliate_candidates']??array())),'image_candidates'=>wp_json_encode((array)($idea['image_candidates']??array())),'knowledge_suggestions'=>wp_json_encode((array)($idea['knowledge_suggestions']??array())),'warnings'=>wp_json_encode((array)($idea['warnings']??array())),'instruction_profile_id'=>isset($diag['instruction_profile_id'])?absint($diag['instruction_profile_id']):null,'instruction_snapshot_hash'=>sanitize_text_field($diag['instruction_snapshot_hash']??''),'instruction_snapshot'=>sanitize_textarea_field($diag['instruction_snapshot']??''),'ai_model'=>sanitize_text_field($model),'created_at'=>current_time('mysql'),'updated_at'=>current_time('mysql')));
+            if($ok){ $saved++; } else { $errors[] = sanitize_text_field($wpdb->last_error ?: 'insert_failed'); }
+        }
+        return array('saved'=>$saved,'errors'=>$errors);
+    }
     public static function get_ideas($status=''){ global $wpdb; $t=self::table('content_ideas'); if($status!=='' && in_array($status,self::allowed_idea_statuses(),true)){ return $wpdb->get_results($wpdb->prepare("SELECT * FROM $t WHERE status=%s ORDER BY id DESC",$status),ARRAY_A);} return $wpdb->get_results("SELECT * FROM $t ORDER BY id DESC LIMIT 100",ARRAY_A); }
     public static function get_idea($id){ global $wpdb; return $wpdb->get_row($wpdb->prepare("SELECT * FROM ".self::table('content_ideas')." WHERE id=%d",absint($id)),ARRAY_A); }
     public static function update_idea_status($id,$status){ if(!in_array($status,self::allowed_idea_statuses(),true)){ return false;} global $wpdb; return (bool)$wpdb->update(self::table('content_ideas'),array('status'=>$status,'updated_at'=>current_time('mysql')),array('id'=>absint($id))); }

--- a/includes/class-ai-content-agent-text-utils.php
+++ b/includes/class-ai-content-agent-text-utils.php
@@ -19,6 +19,10 @@ class ALMA_AI_Content_Agent_Text_Utils {
         return '';
     }
 
+    public static function extract_first_json($text) {
+        return ALMA_AI_Utils::extract_first_json((string) $text);
+    }
+
     public static function extract_keywords($text, $limit = 15) {
         $stop = array('the','and','for','with','this','that','from','your','you','sono','come','della','delle','degli','dallo','alla','alle','per','con','nel','nella','dove','quando','sulla','sulle','una','uno','gli','dei','del','che','non','tra');
         $text = mb_strtolower(self::normalize_text($text));


### PR DESCRIPTION
### Motivation
- Risolvere regressioni introdotte in Step 3.5 che hanno reso non operative le tab admin e le azioni correlate dell'AI Content Agent e garantire stabilità prima dello Step 4 Draft Builder.
- Ripristinare workflow admin (Step 1/2) senza introdurre nuove feature non richieste (nessun Draft Builder, scheduler, Claude o provider-router).

### Description
- Ripristinato rendering reale delle tab operative Step 1/2 e reintrodotto notice post-action: `Overview`, `Documenti`, `Fonti`, `Knowledge Base`, `Media Library`, `Reindicizzazione`, `Stato/Log` con conteggi/diagnostica e liste recenti; aggiunta visualizzazione diagnostica tabelle mancanti. (file: `includes/class-ai-content-agent-admin.php`)
- Ripristinate e hardenate le azioni admin Step 2 in `handle_action()` con controlli `manage_options`, nonce e sanitizzazione degli input per: `reindex_knowledge`, `reindex_media`, `index_document`, `save_note`, `save_source` e azioni idee/brief (`generate_ideas`, `set_idea_status`, `generate_brief`, `save_instruction_profile`, `activate_instruction_profile`, `deactivate_instruction_profile`). (file: `includes/class-ai-content-agent-admin.php`)
- Ripristinata la tab `Idee contenuto` con tabella leggibile, metadati Step 3.5 (profile/snapshot/model/warnings), inline helper-forms (`inline_status_form`, `inline_brief_form`) che inviano a `admin-post.php` con `alma_ai_agent_action`, e visualizzazione del brief esistente in sezione espandibile. (file: `includes/class-ai-content-agent-admin.php`)
- Migliorata la tab `Istruzioni AI` per supportare profili multipli: lista profili, indicazione attivo/default, modifica, creazione (`profile_id=0`), attivazione/disattivazione e opzione "attiva dopo salvataggio"; modulo di salvataggio riusa il flusso nonce/capability (file: `includes/class-ai-content-agent-admin.php`, `includes/class-ai-content-agent-instructions-manager.php` unchanged for DB logic).
- Ripristinate diagnostiche store: aggiunte `required_tables()` e `missing_tables()` che includono la `ALMA_AI_Usage_Logger::table_name()` e usano query sicure `prepare('SHOW TABLES LIKE %s', ...)`. (file: `includes/class-ai-content-agent-store.php`)
- Corretto `save_ideas()` per incrementare il contatore solo quando `$wpdb->insert()` ha successo e per restituire array con `saved` e `errors` (non generare fatal su insert fallito). (file: `includes/class-ai-content-agent-store.php`)
- Aggiornato `Planner` per gestire il nuovo risultato di `save_ideas()` e ritornare errore leggibile se nessuna idea è stata salvata. (file: `includes/class-ai-content-agent-planner.php`)
- Ripristinato helper JSON fallback: aggiunta `ALMA_AI_Content_Agent_Text_Utils::extract_first_json()` che delega a `ALMA_AI_Utils::extract_first_json()` per evitare fatal con output AI contenente markdown/code-fence o testo extra. (file: `includes/class-ai-content-agent-text-utils.php`, `includes/class-ai-utils.php` already has parser)
- Hardened Context Builder: i `chunks` vengono ora recuperati solo per i `knowledge_items` selezionati/ammessi; se non ci sono item non viene fatto fetch generico di chunk. (file: `includes/class-ai-content-agent-context-builder.php`)
- Bumped plugin version a `2.18.1` e aggiornati `README.md` / `CHANGELOG.md` con il changelog della micro-release; nessuna funzionalità non richiesta è stata introdotta.
- File modificati: `includes/class-ai-content-agent-admin.php`, `includes/class-ai-content-agent-store.php`, `includes/class-ai-content-agent-context-builder.php`, `includes/class-ai-content-agent-text-utils.php`, `includes/class-ai-content-agent-planner.php`, `affiliate-link-manager-ai.php`, `CHANGELOG.md`, `README.md`.

### Testing
- Eseguito PHP lint su file principali modificati con `php -l` for: `includes/class-ai-content-agent-admin.php`, `includes/class-ai-content-agent-store.php`, `includes/class-ai-content-agent-context-builder.php`, `includes/class-ai-content-agent-text-utils.php`, `includes/class-ai-content-agent-planner.php` e `affiliate-link-manager-ai.php`; tutti i file sono risultati senza errori di sintassi (successo).
- Nessun test automatico unitario/integration suite disponibile nel repository; le modifiche sono state verificate localmente tramite linting e ispezione del flusso admin ripristinato.
- Raccomandazione: eseguire i test manuali di integrazione admin (come da istruzioni fornite) in ambiente WordPress reale per verificare transizioni notice, salvataggi DB e comportamento Planner/Brief con OpenAI configurato e con casi di output AI non pulito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c2df43a083329f4aa2d3ed43eef9)