### PR TITLE
PR 4 — AI Content Agent Cumulative Selection Session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 
+## 2.21.0
+
+- PR 4 — AI Content Agent Cumulative Selection Session.
+- Sessione cumulativa di selezione con Aggiungi nuova ricerca, deduplicazione, Salva selezione, Svuota sessione e riepilogo sessione.
+- Limite massimo 3 Post validato lato UI e server-side.
+- Preparazione context package interno per PR future.
+- Nessuna chiamata OpenAI, nessuna creazione bozza articolo, nessuna programmazione.
+
 ## 2.20.0
 - PR 3 — AI Content Agent Knowledge Base Search Engine: motore ricerca interno Knowledge Base.
 - Ricerca ibrida WordPress + tabelle custom (knowledge_items/content_chunks) + Documenti TXT + Fonti online AI + Media Index.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 
+## 2.21.0
+
+- PR 4 — AI Content Agent Cumulative Selection Session.
+- Sessione cumulativa di selezione con Aggiungi nuova ricerca, deduplicazione, Salva selezione, Svuota sessione e riepilogo sessione.
+- Limite massimo 3 Post validato lato UI e server-side.
+- Preparazione context package interno per PR future.
+- Nessuna chiamata OpenAI, nessuna creazione bozza articolo, nessuna programmazione.
+
 ## 2.20.0
 - PR 3 — AI Content Agent Knowledge Base Search Engine: motore ricerca interno Knowledge Base.
 - Ricerca ibrida WordPress + tabelle custom (knowledge_items/content_chunks) + Documenti TXT + Fonti online AI + Media Index.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.20.0
+ * Version: 2.21.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.20.0');
+define('ALMA_VERSION', '2.21.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -31,6 +31,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-store.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-text-utils.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-knowledge-indexer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-knowledge-search.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-selection-session.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-media-indexer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-source-tech-registry.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-source-manager.php';

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -41,11 +41,16 @@ class ALMA_AI_Content_Agent_Admin {
         } elseif ($do === 'reindex_media') {
             $count = ALMA_AI_Content_Agent_Media_Indexer::reindex_batch(30);
             $result = array('success' => true, 'message' => sprintf('Reindex media completato: %d elementi.', (int)$count));
-        } elseif ($do === 'search_knowledge_base') {
+        } elseif ($do === 'search_knowledge_base' || $do === 'add_new_search') {
             $payload = array('max_ideas'=>absint($_POST['max_ideas'] ?? 1),'theme'=>sanitize_text_field($_POST['theme'] ?? ''),'destination'=>sanitize_text_field($_POST['destination'] ?? ''),'temporary_instructions'=>sanitize_textarea_field($_POST['temporary_instructions'] ?? ''));
             $search = ALMA_AI_Content_Agent_Knowledge_Search::search($payload);
-            set_transient('alma_ai_agent_search_results_' . get_current_user_id(), $search, 300);
-            $result = array('success' => true, 'message' => 'Ricerca Knowledge Base completata.');
+            $stats = ALMA_AI_Content_Agent_Selection_Session::add_search_results($payload, $search);
+            $result = array('success' => true, 'message' => sprintf('Ricerca completata. Trovati: %d, aggiunti: %d, duplicati ignorati: %d.', (int)$stats['found'], (int)$stats['added'], (int)$stats['duplicates']));
+        } elseif ($do === 'save_selection') {
+            $result = ALMA_AI_Content_Agent_Selection_Session::save_selection($_POST['selected_result_keys'] ?? array());
+        } elseif ($do === 'clear_selection_session') {
+            ALMA_AI_Content_Agent_Selection_Session::clear();
+            $result = array('success' => true, 'message' => 'Sessione contenuto svuotata.');
         } elseif ($do === 'upload_txt_document') {
             $result = ALMA_AI_Content_Agent_Document_Manager::handle_upload(sanitize_text_field($_POST['document_name'] ?? ''), $_FILES['document_file'] ?? array());
         } elseif ($do === 'rename_txt_document') {
@@ -144,33 +149,42 @@ class ALMA_AI_Content_Agent_Admin {
         echo '<p><label><input type="checkbox" name="activate_profile" value="1"> Attiva questo profilo dopo il salvataggio</label></p><p><button class="button button-primary">Salva profilo</button></p></form>';
     }
 
-    private static function render_ideas_tab() { $status = sanitize_key($_GET['idea_status'] ?? ''); echo '<h2>Idee contenuto</h2>'; self::action_form('generate_ideas','Genera idee','<input type="number" min="1" max="10" name="max_ideas" value="1"/> <input name="theme" placeholder="Tema"> <input name="destination" placeholder="Destinazione"><br><textarea name="temporary_instructions" class="large-text" rows="2" placeholder="Istruzioni per questa generazione"></textarea><p><select><option>Profilo Istruzioni AI</option></select> <button type="submit" class="button button-secondary" name="do" value="search_knowledge_base">Cerca nel Knowledge Base</button> <button type="button" class="button" disabled>Aggiungi nuova ricerca</button> <button type="button" class="button" disabled>Crea bozza articolo</button> <button type="button" class="button" disabled>Programma creazione bozza articolo</button> <em>La selezione dei risultati sarà collegata alla generazione nelle prossime fasi del workflow.</em></p>');
+    private static function render_ideas_tab() { $status = sanitize_key($_GET['idea_status'] ?? ''); echo '<h2>Idee contenuto</h2>'; self::action_form('generate_ideas','Genera idee','<input type="number" min="1" max="10" name="max_ideas" value="1"/> <input name="theme" placeholder="Tema"> <input name="destination" placeholder="Destinazione"><br><textarea name="temporary_instructions" class="large-text" rows="2" placeholder="Istruzioni per questa generazione"></textarea><p><select><option>Profilo Istruzioni AI</option></select> <button type="submit" class="button button-secondary" name="do" value="search_knowledge_base">Cerca nel Knowledge Base</button> <button type="submit" class="button" name="do" value="add_new_search">Aggiungi nuova ricerca</button> <button type="button" class="button" disabled>Crea bozza articolo</button> <button type="button" class="button" disabled>Programma creazione bozza articolo</button> <em>La selezione dei risultati sarà collegata alla generazione nelle prossime fasi del workflow.</em></p>');
         echo '<form method="get"><input type="hidden" name="post_type" value="affiliate_link"><input type="hidden" name="page" value="alma-ai-content-agent"><input type="hidden" name="tab" value="idee"><select name="idea_status"><option value="">Tutti gli stati</option>'; foreach(ALMA_AI_Content_Agent_Store::allowed_idea_statuses() as $st){ echo '<option '.selected($status,$st,false).' value="'.esc_attr($st).'">'.esc_html($st).'</option>'; } echo '</select> <button class="button">Filtra</button></form>';
         $ideas = ALMA_AI_Content_Agent_Store::get_ideas($status); echo '<table class="widefat striped"><thead><tr><th>ID</th><th>Titolo</th><th>Motivazione</th><th>Stato</th><th>SEO</th><th>Priority</th><th>Affiliati</th><th>Immagini</th><th>Model</th><th>Profile</th><th>Snapshot</th><th>Warning</th><th>Azioni</th></tr></thead><tbody>';
         foreach($ideas as $i){ $warnings=implode(', ',(array)json_decode((string)($i['warnings']??'[]'),true)); echo '<tr><td>'.(int)$i['id'].'</td><td>'.esc_html($i['proposed_title']).'</td><td>'.esc_html($i['rationale']).'</td><td>'.esc_html($i['status']).'</td><td>'.esc_html($i['seo_score']).'</td><td>'.esc_html($i['priority_score']).'</td><td>'.count((array)json_decode((string)$i['affiliate_candidates'],true)).'</td><td>'.count((array)json_decode((string)$i['image_candidates'],true)).'</td><td>'.esc_html($i['ai_model']).'</td><td>'.(int)$i['instruction_profile_id'].'</td><td>'.esc_html(substr((string)$i['instruction_snapshot_hash'],0,12)).'</td><td>'.esc_html($warnings).'</td><td>'.self::inline_status_form((int)$i['id'],'approved','Approva').' '.self::inline_status_form((int)$i['id'],'rejected','Scarta').' '.self::inline_status_form((int)$i['id'],'archived','Archivia').' '.self::inline_brief_form((int)$i['id']).' '.self::inline_draft_form((int)$i['id'], (string)$i['status']).'</td></tr>';
             $brief=ALMA_AI_Content_Agent_Store::get_brief_by_idea((int)$i['id']); if($brief){ echo '<tr><td colspan="13"><details><summary>Brief esistente per idea #'.(int)$i['id'].'</summary><pre style="white-space:pre-wrap;">'.esc_html(wp_json_encode($brief, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)).'</pre></details></td></tr>'; }
         }
         echo '</tbody></table>';
-        $search = get_transient('alma_ai_agent_search_results_' . get_current_user_id());
-        if (!empty($search['groups']) && is_array($search['groups'])) {
-            $labels = array('post'=>'Post','page'=>'Pagine','affiliate_link'=>'Affiliate Links','document_txt'=>'Documenti TXT','source_online'=>'Fonti online AI','media'=>'Media','other'=>'Altro');
-            echo '<div class="alma-agent-card"><h3>Risultati Knowledge Base</h3><p>Query: <strong>' . esc_html(($search['query']['theme'] ?? '') . ' / ' . ($search['query']['destination'] ?? '')) . '</strong></p>';
-            echo '<p id="alma-post-counter"><strong>Post selezionati: 0/3</strong></p>';
-            foreach ($labels as $groupKey => $groupLabel) {
-                $rows = (array)($search['groups'][$groupKey] ?? array());
-                echo '<h4>' . esc_html($groupLabel) . ' (' . count($rows) . ')</h4>';
-                if (empty($rows)) { echo '<p><em>Nessun risultato.</em></p>'; continue; }
-                echo '<table class="widefat striped"><tbody>';
-                foreach ($rows as $r) {
-                    $isPost = $groupKey === 'post';
-                    $checked = !empty($r['preselected']) ? 'checked' : '';
-                    $level = esc_html($r['score_level'] ?? 'Bassa');
-                    echo '<tr><td style="width:40px;"><input class="alma-kb-check ' . ($isPost ? 'alma-kb-post-check' : '') . '" type="checkbox" value="' . esc_attr($r['result_id']) . '" ' . $checked . '></td><td><strong>' . esc_html($r['title']) . '</strong><br><small>' . esc_html($r['excerpt']) . '</small><br><span class="alma-badge is-pending">Score ' . (int)$r['score'] . ' - ' . $level . '</span> <small>' . esc_html($r['reason']) . '</small></td></tr>';
-                }
-                echo '</tbody></table>';
+
+        $summary = ALMA_AI_Content_Agent_Selection_Session::summary();
+        $groups = ALMA_AI_Content_Agent_Selection_Session::grouped_results();
+        $labels = array('post'=>'Post','page'=>'Pagine','affiliate_link'=>'Affiliate Links','document_txt'=>'Documenti TXT','source_online'=>'Fonti online AI','media'=>'Media','other'=>'Altro');
+        echo '<div class="alma-agent-card"><h3>Sessione contenuto</h3>';
+        echo '<p>Puoi effettuare più ricerche: i nuovi risultati verranno aggiunti a questa sessione. Le selezioni saranno usate nella prossima fase per creare la bozza articolo. Puoi selezionare massimo 3 Post.</p>';
+        if (($summary['status'] ?? 'empty') === 'empty') { echo '<p><em>Sessione vuota.</em></p>'; }
+        echo '<ul><li>Stato sessione: <strong>'.esc_html($summary['status'] ?? 'empty').'</strong></li><li>Numero ricerche: '.(int)($summary['search_count'] ?? 0).'</li><li>Ultimo aggiornamento: '.esc_html($summary['updated_at'] ?? '-').'</li><li>Risultati totali: '.(int)($summary['total_results'] ?? 0).'</li><li>Risultati selezionati: '.(int)($summary['selected_total'] ?? 0).'</li><li>Post selezionati: <strong id="alma-post-counter">'.(int)($summary['selected_post'] ?? 0).'/3</strong></li><li>Documenti TXT selezionati: '.(int)($summary['selected_document_txt'] ?? 0).'</li><li>Fonti online AI selezionate: '.(int)($summary['selected_source_online'] ?? 0).'</li><li>Affiliate Links selezionati: '.(int)($summary['selected_affiliate_link'] ?? 0).'</li><li>Media selezionati: '.(int)($summary['selected_media'] ?? 0).'</li><li>Pagine selezionate: '.(int)($summary['selected_page'] ?? 0).'</li></ul></div>';
+
+        echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_ai_agent_action');
+        echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_selection">';
+        foreach ($labels as $groupKey => $groupLabel) {
+            $rows = (array)($groups[$groupKey] ?? array());
+            if (empty($rows)) { continue; }
+            $sel=0; foreach($rows as $r){ if(!empty($r['selected'])){$sel++;}}
+            echo '<h4>' . esc_html($groupLabel) . ' (' . count($rows) . ') - selezionati '.$sel.'</h4><table class="widefat striped"><tbody>';
+            foreach ($rows as $r) {
+                $isPost = $groupKey === 'post';
+                $checked = !empty($r['selected']) ? 'checked' : '';
+                echo '<tr><td style="width:40px;"><input name="selected_result_keys[]" class="alma-kb-check ' . ($isPost ? 'alma-kb-post-check' : '') . '" type="checkbox" value="' . esc_attr($r['result_key']) . '" ' . $checked . '></td><td><strong>' . esc_html($r['title']) . '</strong><br><small>' . esc_html($r['excerpt']) . '</small><br><span class="alma-badge is-pending">Score ' . (int)$r['score'] . '</span> <small>' . esc_html($r['reason']) . '</small>' . (!empty($r['admin_url']) ? ' <a href="'.esc_url($r['admin_url']).'" target="_blank" rel="noopener">Apri</a>' : '') . '</td></tr>';
             }
-            echo "</div><script>(function(){var checks=document.querySelectorAll('\.alma-kb-post-check');var c=document.getElementById('alma-post-counter');function u(){var n=0;checks.forEach(function(x){if(x.checked){n++;}});c.innerHTML='<strong>Post selezionati: '+n+'/3</strong>';checks.forEach(function(x){if(!x.checked){x.disabled=n>=3;}else{x.disabled=false;}});}checks.forEach(function(x){x.addEventListener('change',function(e){var n=[].filter.call(checks,function(i){return i.checked;}).length;if(n>3){e.target.checked=false;alert('Puoi selezionare massimo 3 Post.');}u();});});u();})();</script>";
+            echo '</tbody></table>';
         }
+        echo '<p><button type="submit" class="button button-primary">Salva selezione</button></p></form>';
+
+        echo "<form method='post' action='".esc_url(admin_url('admin-post.php'))."' onsubmit=\"return confirm('Svuotare la sessione corrente?');\">"; wp_nonce_field('alma_ai_agent_action');
+        echo "<input type='hidden' name='action' value='alma_ai_agent_action'><input type='hidden' name='do' value='clear_selection_session'><p><button class='button'>Svuota sessione</button></p></form>";
+        echo "<script>(function(){var checks=document.querySelectorAll('.alma-kb-post-check');var c=document.getElementById('alma-post-counter');function u(){var n=0;checks.forEach(function(x){if(x.checked){n++;}});if(c){c.textContent=n+'/3';}checks.forEach(function(x){if(!x.checked){x.disabled=n>=3;}else{x.disabled=false;}});}checks.forEach(function(x){x.addEventListener('change',function(e){var n=[].filter.call(checks,function(i){return i.checked;}).length;if(n>3){e.target.checked=false;alert('Puoi selezionare massimo 3 Post.');}u();});});u();})();</script>";
+
 
     }
 

--- a/includes/class-ai-content-agent-selection-session.php
+++ b/includes/class-ai-content-agent-selection-session.php
@@ -1,0 +1,129 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_AI_Content_Agent_Selection_Session {
+    const MAX_SELECTED_POSTS = 3;
+    const TTL = DAY_IN_SECONDS;
+    const MAX_RESULTS = 250;
+
+    private static function key() { return 'alma_ai_agent_selection_session_' . get_current_user_id(); }
+
+    public static function get_session() {
+        $s = get_transient(self::key());
+        if (!is_array($s)) { return self::empty_session(); }
+        $s = wp_parse_args($s, self::empty_session());
+        if (!is_array($s['results'])) { $s['results'] = array(); }
+        if (!is_array($s['query_history'])) { $s['query_history'] = array(); }
+        return $s;
+    }
+
+    public static function clear() { delete_transient(self::key()); }
+
+    private static function empty_session() {
+        return array('status'=>'empty','last_query'=>array(),'query_history'=>array(),'results'=>array(),'counts'=>array(),'updated_at'=>'','instruction_profile_id'=>0);
+    }
+
+    public static function add_search_results($payload, $search_results) {
+        $session = self::get_session();
+        $added = 0; $duplicates = 0; $found = 0;
+        foreach ((array)($search_results['groups'] ?? array()) as $group => $rows) {
+            foreach ((array)$rows as $row) {
+                $found++;
+                $normalized = self::normalize_result($group, $row);
+                if (empty($normalized['result_key'])) { continue; }
+                $k = $normalized['result_key'];
+                if (isset($session['results'][$k])) {
+                    $duplicates++;
+                    continue;
+                }
+                $session['results'][$k] = $normalized;
+                $added++;
+            }
+        }
+        if (count($session['results']) > self::MAX_RESULTS) {
+            $session['results'] = array_slice($session['results'], -self::MAX_RESULTS, null, true);
+        }
+        $query = array('theme'=>sanitize_text_field($payload['theme'] ?? ''),'destination'=>sanitize_text_field($payload['destination'] ?? ''),'temporary_instructions'=>sanitize_textarea_field($payload['temporary_instructions'] ?? ''));
+        $session['last_query'] = $query;
+        $session['query_history'][] = array('at'=>current_time('mysql'),'theme'=>$query['theme'],'destination'=>$query['destination']);
+        if (count($session['query_history']) > 20) { $session['query_history'] = array_slice($session['query_history'], -20); }
+        $session['status'] = empty($session['results']) ? 'empty' : 'active';
+        $session['updated_at'] = current_time('mysql');
+        $session['instruction_profile_id'] = absint($payload['instruction_profile_id'] ?? 0);
+        $session['counts'] = self::count_summary($session['results']);
+        set_transient(self::key(), $session, self::TTL);
+        return array('found'=>$found,'added'=>$added,'duplicates'=>$duplicates,'total'=>count($session['results']));
+    }
+
+    public static function save_selection($selected_keys) {
+        $session = self::get_session();
+        $selected = array_fill_keys(array_map('sanitize_text_field', (array)$selected_keys), true);
+        $next = $session['results'];
+        $post_count = 0;
+        foreach ($next as $k => $row) {
+            $is_selected = isset($selected[$k]);
+            if ($is_selected && ($row['source_group'] ?? '') === 'post') { $post_count++; }
+            $next[$k]['selected'] = $is_selected;
+        }
+        if ($post_count > self::MAX_SELECTED_POSTS) {
+            return array('success'=>false,'message'=>'Puoi selezionare massimo 3 Post. Salvataggio bloccato.');
+        }
+        $session['results'] = $next;
+        $session['updated_at'] = current_time('mysql');
+        $session['counts'] = self::count_summary($session['results']);
+        $session['status'] = empty($session['results']) ? 'empty' : 'active';
+        set_transient(self::key(), $session, self::TTL);
+        return array('success'=>true,'message'=>'Selezione salvata.');
+    }
+
+    private static function normalize_result($group, $row) {
+        $source_id = absint($row['source_id'] ?? 0);
+        $wp_id = absint($row['wp_id'] ?? 0);
+        $result_id = sanitize_text_field($row['result_id'] ?? '');
+        $result_key = sanitize_key($group) . ':' . ($source_id ?: ($wp_id ?: $result_id));
+        if (empty($result_key)) { $result_key = sanitize_key($group) . ':' . substr(md5(wp_json_encode($row)), 0, 12); }
+        return array(
+            'result_key' => $result_key,
+            'source_group' => sanitize_key($group),
+            'source_type' => sanitize_text_field($row['source_type'] ?? $group),
+            'source_id' => $source_id,
+            'wp_id' => $wp_id,
+            'title' => sanitize_text_field($row['title'] ?? ''),
+            'excerpt' => sanitize_text_field($row['excerpt'] ?? ''),
+            'score' => (int)($row['score'] ?? 0),
+            'reason' => sanitize_text_field($row['reason'] ?? ''),
+            'admin_url' => esc_url_raw($row['admin_url'] ?? ''),
+            'selectable' => true,
+            'selected' => !empty($row['preselected']),
+        );
+    }
+
+    public static function grouped_results() {
+        $session = self::get_session(); $groups = array();
+        foreach ($session['results'] as $row) { $groups[$row['source_group']][] = $row; }
+        return $groups;
+    }
+
+    public static function summary() {
+        $session = self::get_session();
+        return array_merge(array('status'=>$session['status'],'search_count'=>count($session['query_history']),'updated_at'=>$session['updated_at']), $session['counts']);
+    }
+
+    private static function count_summary($rows) {
+        $c = array('total_results'=>0,'selected_total'=>0,'selected_post'=>0,'selected_page'=>0,'selected_affiliate_link'=>0,'selected_document_txt'=>0,'selected_source_online'=>0,'selected_media'=>0);
+        foreach ($rows as $r) {
+            $c['total_results']++;
+            if (empty($r['selected'])) { continue; }
+            $c['selected_total']++;
+            $key = 'selected_' . sanitize_key($r['source_group']);
+            if (isset($c[$key])) { $c[$key]++; }
+        }
+        return $c;
+    }
+
+    public static function build_context_package() {
+        $s = self::get_session();
+        $selected = array_values(array_filter($s['results'], function($r){ return !empty($r['selected']); }));
+        return array('last_query'=>$s['last_query'],'query_history'=>$s['query_history'],'selected_results'=>$selected,'counts'=>$s['counts'],'updated_at'=>$s['updated_at'],'instruction_profile_id'=>$s['instruction_profile_id']);
+    }
+}


### PR DESCRIPTION
### Motivation
- Implementare una sessione cumulativa user-scoped per l’area AI Content Agent → Idee contenuto in modo che più ricerche possano essere sommate senza perdere le selezioni precedenti.
- Rinforzare la business rule esistente: massimo 3 Post selezionabili con validazione sia lato UI che server-side.
- Preparare un context package interno leggero per la fase successiva senza introdurre chiamate OpenAI o creazione bozze in questa PR.

### Description
- Aggiunta classe modulare `ALMA_AI_Content_Agent_Selection_Session` in `includes/class-ai-content-agent-selection-session.php` che gestisce transient user-scoped, aggiunta cumulativa, deduplicazione, stato `selected`, conteggi, svuotamento e `build_context_package()`.
- Integrata la sessione nel flusso admin: aggiornati i handler in `includes/class-ai-content-agent-admin.php` per `search_knowledge_base`/`add_new_search` (append + dedupe), `save_selection` (persistenza con validazione server-side) e `clear_selection_session` (svuota sessione utente).
- Aggiornata UI tab `Idee contenuto` (render in `includes/class-ai-content-agent-admin.php`) per mostrare il box `Sessione contenuto`, i risultati cumulativi raggruppati, il form `Salva selezione`, il pulsante `Svuota sessione` con conferma e il contatore JS che blocca la selezione del quarto Post; i pulsanti di creazione bozza/scheduler restano disabilitati come placeholder.
- Aggiornata versione plugin a `2.21.0` (header `affiliate-link-manager-ai.php`, costante `ALMA_VERSION`, `README.md` e `CHANGELOG.md`) e aggiunta require della nuova classe nel bootstrap del plugin.

### Testing
- Eseguiti controlli di sintassi PHP con `php -l` su `includes/class-ai-content-agent-selection-session.php`, `includes/class-ai-content-agent-admin.php` e `affiliate-link-manager-ai.php` e tutti i file modificati sono risultati validi: successo.
- Verificata presenza delle nuove azioni e stringhe con `rg` e stato git con `git status --short`; commit eseguito con successo: successo.
- Controlli funzionali automatizzati eseguiti in locale: parsing/integrazione delle nuove funzioni senza errori fatali e JavaScript in pagina `Idee contenuto` include il blocco client-side per il limite `3/3`: successo.
- Nota: nessuna chiamata OpenAI, nessuna creazione bozza, nessun scheduler/crawling/scraping è stata aggiunta in questa PR (verificato a livello di codice).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f71cdecf588332bb1bef4c161e4d26)