### PR TITLE
PR 4.1 — Fix media search ordering and TXT dedupe, bump to 2.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 
+## 2.21.1
+
+- PR 4.1 — AI Content Agent Knowledge Search Review Fixes.
+- Fix Media Search: ordinamento su `indexed_at` (tabella `media_index`).
+- Fix deduplica Documenti TXT con `source_id=0` (chiave distinta per knowledge item).
+- Hardening Media Search: fallback a array vuoto se query non iterabile/errore.
+- Nessuna nuova chiamata OpenAI, nessuna creazione bozza articolo.
+- Nessuna modifica scheduler, nessun crawling/scraping.
+
 ## 2.21.0
 
 - PR 4 — AI Content Agent Cumulative Selection Session.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 
-## 2.21.0
+## 2.21.1
 
-- PR 4 — AI Content Agent Cumulative Selection Session.
-- Sessione cumulativa di selezione con Aggiungi nuova ricerca, deduplicazione, Salva selezione, Svuota sessione e riepilogo sessione.
-- Limite massimo 3 Post validato lato UI e server-side.
-- Preparazione context package interno per PR future.
-- Nessuna chiamata OpenAI, nessuna creazione bozza articolo, nessuna programmazione.
+- Nota manutenzione PR 4.1: stabilizzata la ricerca Media nel Knowledge Base (ordinamento su `indexed_at`).
+- Corretta la deduplica dei Documenti TXT per evitare collisioni quando `source_id=0`.
+- Nessuna nuova funzionalità AI e nessuna modifica alla creazione bozze articolo.
 
 ## 2.20.0
 - PR 3 — AI Content Agent Knowledge Base Search Engine: motore ricerca interno Knowledge Base.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.21.0
+ * Version: 2.21.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.21.0');
+define('ALMA_VERSION', '2.21.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-knowledge-search.php
+++ b/includes/class-ai-content-agent-knowledge-search.php
@@ -92,7 +92,7 @@ class ALMA_AI_Content_Agent_Knowledge_Search {
                 'score' => $score,
                 'reason' => !empty($chunk_map[(int)$r['id']]) ? 'Match su knowledge e chunk' : 'Match su knowledge item',
                 'edit_url' => '',
-                'dedupe_ref' => $stype . ':' . (int)$r['source_id'],
+                'dedupe_ref' => self::build_dedupe_ref($stype, $r),
             ));
         }
         return $items;
@@ -106,9 +106,18 @@ class ALMA_AI_Content_Agent_Knowledge_Search {
 
     private static function search_media($query) { global $wpdb; if (in_array(ALMA_AI_Content_Agent_Store::table('media_index'), ALMA_AI_Content_Agent_Store::missing_tables(), true)) { return array(); }
         $table = ALMA_AI_Content_Agent_Store::table('media_index'); $like = '%' . $wpdb->esc_like($query['text']) . '%';
-        $rows = $wpdb->get_results($wpdb->prepare("SELECT id,attachment_id,filename,title,alt_text,caption,description,keywords,destinations,manual_notes FROM $table WHERE filename LIKE %s OR title LIKE %s OR alt_text LIKE %s OR caption LIKE %s OR description LIKE %s OR keywords LIKE %s OR destinations LIKE %s OR manual_notes LIKE %s ORDER BY updated_at DESC LIMIT 30",$like,$like,$like,$like,$like,$like,$like,$like), ARRAY_A);
+        $rows = $wpdb->get_results($wpdb->prepare("SELECT id,attachment_id,filename,title,alt_text,caption,description,keywords,destinations,manual_notes FROM $table WHERE filename LIKE %s OR title LIKE %s OR alt_text LIKE %s OR caption LIKE %s OR description LIKE %s OR keywords LIKE %s OR destinations LIKE %s OR manual_notes LIKE %s ORDER BY indexed_at DESC LIMIT 30",$like,$like,$like,$like,$like,$like,$like,$like), ARRAY_A);
+        if (!is_array($rows)) { return array(); }
         $items=array(); foreach($rows as $r){ $score=self::score_text($query, implode(' ', $r)) + 6; $items[]=self::result(array('key'=>'media:'.$r['id'],'source_type'=>'media','source_id'=>(int)$r['attachment_id'],'title'=>sanitize_text_field($r['title']?:$r['filename']),'excerpt'=>wp_trim_words((string)($r['alt_text']?:$r['caption']),16),'score'=>$score,'reason'=>'Match su metadata media','edit_url'=>get_edit_post_link((int)$r['attachment_id'], 'raw'))); }
         return $items; }
+
+    private static function build_dedupe_ref($stype, $row) {
+        $source_id = isset($row['source_id']) ? (int)$row['source_id'] : 0;
+        if (($stype === 'document_txt' || $stype === 'document_attachment') && !empty($row['id'])) {
+            return $stype . ':kb:' . (int)$row['id'];
+        }
+        return $stype . ':' . $source_id;
+    }
 
     private static function score_text($query, $text) {
         $text = strtolower((string)$text); $score = 0;


### PR DESCRIPTION
### Motivation
- Correggere due regressioni segnalate nella review di PR 4: la ricerca Media che ordinava su una colonna inesistente (`updated_at`) e la deduplicazione dei `document_txt` che collassava documenti diversi quando `source_id=0`.
- Applicare gli aggiustamenti minimi necessari senza introdurre nuove funzionalità AI, cambi di DB o modifiche al workflow esistente.

### Description
- Modificata `search_media()` in `includes/class-ai-content-agent-knowledge-search.php` per usare `ORDER BY indexed_at DESC` (tabella `media_index`) al posto di `updated_at`, mantenendo tutti i campi cercati e il limite risultati invariati, e aggiunto hardening che restituisce `[]` se il risultato della query non è iterabile.
- Introdotta la funzione privata `build_dedupe_ref($stype, $row)` e aggiornata la costruzione di `dedupe_ref` per i risultati knowledge in modo che per `document_txt` e `document_attachment` venga usata una chiave stabile basata su `knowledge_items.id` (`<type>:kb:<id>`), evitando collisioni quando `source_id=0`; per gli altri tipi la logica di dedupe resta invariata.
- Aggiornata la versione plugin a `2.21.1` aggiornando header (`Version`), costante `ALMA_VERSION`, `README.md` (nota di manutenzione) e `CHANGELOG.md` (entry 2.21.1); non sono state introdotte nuove tabelle, migration o file aggiuntivi.

### Testing
- Eseguiti controlli automatici di sintassi e ricerca testuale: `php -l includes/class-ai-content-agent-knowledge-search.php` (successo), `php -l affiliate-link-manager-ai.php` (successo), e varie ricerche con `rg` per verificare la sostituzione di `updated_at` → `indexed_at` e l'aggiunta di `build_dedupe_ref` (tutte riuscite).
- Verificato che `search_media()` ora contiene `ORDER BY indexed_at` e che è presente il fallback `if (!is_array($rows)) { return array(); }`; verificato che la nuova funzione `build_dedupe_ref` è usata per i knowledge items (tutti i check testuali eseguiti con successo).
- Limite del testing runtime: non è stato possibile eseguire test funzionali nell'ambiente WordPress/admin in questo ambiente CLI, quindi i seguenti test manuali sono raccomandati in ambiente di staging: aprire WP admin → AI Content Agent → Idee contenuto; eseguire ricerca con media indicizzati e verificare assenza di errori SQL e presenza dei media; creare o caricare almeno due Documenti TXT (anche con `source_id=0`) e verificare che compaiano come risultati distinti; aggiungere risultati alla sessione cumulativa, salvare la selezione e verificare che la sessione mantenga i risultati; verificare che il limite a 3 Post sia rispettato; confermare assenza di errori PHP/JS e che la versione plugin mostrata sia `2.21.1`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f71f65d064833282b79cd670e63333)