### PR TITLE
PR 5 — AI Content Agent: Crea bozza da Selection Session (v2.22.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.22.0 — PR 5 — AI Content Agent Draft Creation from Selection Session
+- Pulsante **Crea bozza articolo** operativo nella tab Idee contenuto.
+- Generazione bozza da Selection Session con uso dei soli risultati selezionati.
+- Content Budget applicato con limite massimo 3 Post e contesto compatto strutturato.
+- Payload AI strutturato e richiesta output JSON (`title`, `content`, `slug`) con validazione robusta.
+- Creazione post WordPress in stato `draft` con permalink/preview generati da WordPress.
+- Salvataggio meta provenance AI, warning QA locali e logging AI usage.
+- Nessuna pubblicazione automatica, nessuna programmazione/scheduler.
+- Nessun crawling/scraping e nessuna web search.
+
+
 
 ## 2.21.1
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 
-## 2.21.1
+## 2.22.0
+
+- PR 5 — Crea bozza articolo da Selection Session con uso esclusivo delle fonti selezionate.
+- Output OpenAI richiesto in JSON validato (`title`, `content`, `slug`) e creazione articolo WordPress in stato bozza.
+- Permalink/anteprima generati da WordPress, QA locale applicata, meta provenance salvati.
+- Nessuna pubblicazione automatica, nessuna programmazione scheduler in questa PR.
 
 - Nota manutenzione PR 4.1: stabilizzata la ricerca Media nel Knowledge Base (ordinamento su `indexed_at`).
 - Corretta la deduplica dei Documenti TXT per evitare collisioni quando `source_id=0`.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.21.1
+ * Version: 2.22.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.21.1');
+define('ALMA_VERSION', '2.22.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -2,6 +2,7 @@
 if (!defined('ABSPATH')) { exit; }
 class ALMA_AI_Content_Agent_Admin {
     const NOTICE_TRANSIENT_KEY = 'alma_ai_agent_admin_notice_';
+    const RESULT_TRANSIENT_KEY = 'alma_ai_agent_admin_result_';
 
     public static function init() { add_action('admin_post_alma_ai_agent_action', array(__CLASS__, 'handle_action')); }
 
@@ -51,6 +52,17 @@ class ALMA_AI_Content_Agent_Admin {
         } elseif ($do === 'clear_selection_session') {
             ALMA_AI_Content_Agent_Selection_Session::clear();
             $result = array('success' => true, 'message' => 'Sessione contenuto svuotata.');
+        } elseif ($do === 'create_draft_from_selection') {
+            $summary = ALMA_AI_Content_Agent_Selection_Session::summary();
+            if (($summary['status'] ?? 'empty') === 'empty') { $result = array('success'=>false,'message'=>'Nessuna sessione contenuto attiva.'); }
+            elseif ((int)($summary['selected_total'] ?? 0) < 1) { $result = array('success'=>false,'message'=>'Seleziona almeno una fonte prima di creare la bozza.'); }
+            elseif ((int)($summary['selected_post'] ?? 0) > ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_POSTS) { $result = array('success'=>false,'message'=>'Puoi selezionare massimo 3 Post.'); }
+            elseif (empty(get_option('alma_openai_api_key', ''))) { $result = array('success'=>false,'message'=>'OpenAI non è configurata.'); }
+            else {
+                $result = ALMA_AI_Content_Agent_Draft_Builder::generate_from_selection_session(get_current_user_id());
+                $result['message'] = empty($result['success']) ? ($result['error'] ?? 'Errore creazione bozza da sessione.') : 'Bozza articolo creata.';
+                set_transient(self::RESULT_TRANSIENT_KEY . get_current_user_id(), $result, 120);
+            }
         } elseif ($do === 'upload_txt_document') {
             $result = ALMA_AI_Content_Agent_Document_Manager::handle_upload(sanitize_text_field($_POST['document_name'] ?? ''), $_FILES['document_file'] ?? array());
         } elseif ($do === 'rename_txt_document') {
@@ -89,6 +101,16 @@ class ALMA_AI_Content_Agent_Admin {
         $n = get_transient(self::NOTICE_TRANSIENT_KEY . get_current_user_id()); if (!$n) { return; }
         delete_transient(self::NOTICE_TRANSIENT_KEY . get_current_user_id());
         echo '<div class="notice notice-' . esc_attr($n['type']) . ' is-dismissible"><p>' . esc_html($n['message']) . '</p></div>';
+        $r = get_transient(self::RESULT_TRANSIENT_KEY . get_current_user_id());
+        if (!empty($r) && !empty($r['success'])) {
+            delete_transient(self::RESULT_TRANSIENT_KEY . get_current_user_id());
+            echo '<div class="notice notice-success"><p><strong>Bozza articolo creata</strong>: '.esc_html($r['title'] ?? '').' (Bozza) ';
+            if (!empty($r['edit_url'])) { echo '<a class="button button-small" href="'.esc_url($r['edit_url']).'">Modifica articolo</a> '; }
+            if (!empty($r['preview_url'])) { echo '<a class="button button-small" href="'.esc_url($r['preview_url']).'" target="_blank" rel="noopener">Anteprima articolo</a>'; }
+            echo '</p>';
+            if (!empty($r['warnings'])) { echo '<p><strong>Warning QA:</strong> '.esc_html(implode(' | ', array_map('sanitize_text_field', (array)$r['warnings']))).'</p>'; }
+            echo '<p>Puoi conservare la sessione per creare una nuova bozza o svuotarla manualmente.</p></div>';
+        }
     }
 
     public static function render_page() {
@@ -149,7 +171,7 @@ class ALMA_AI_Content_Agent_Admin {
         echo '<p><label><input type="checkbox" name="activate_profile" value="1"> Attiva questo profilo dopo il salvataggio</label></p><p><button class="button button-primary">Salva profilo</button></p></form>';
     }
 
-    private static function render_ideas_tab() { $status = sanitize_key($_GET['idea_status'] ?? ''); echo '<h2>Idee contenuto</h2>'; self::action_form('generate_ideas','Genera idee','<input type="number" min="1" max="10" name="max_ideas" value="1"/> <input name="theme" placeholder="Tema"> <input name="destination" placeholder="Destinazione"><br><textarea name="temporary_instructions" class="large-text" rows="2" placeholder="Istruzioni per questa generazione"></textarea><p><select><option>Profilo Istruzioni AI</option></select> <button type="submit" class="button button-secondary" name="do" value="search_knowledge_base">Cerca nel Knowledge Base</button> <button type="submit" class="button" name="do" value="add_new_search">Aggiungi nuova ricerca</button> <button type="button" class="button" disabled>Crea bozza articolo</button> <button type="button" class="button" disabled>Programma creazione bozza articolo</button> <em>La selezione dei risultati sarà collegata alla generazione nelle prossime fasi del workflow.</em></p>');
+    private static function render_ideas_tab() { $status = sanitize_key($_GET['idea_status'] ?? ''); echo '<h2>Idee contenuto</h2>'; self::action_form('generate_ideas','Genera idee','<input type="number" min="1" max="10" name="max_ideas" value="1"/> <input name="theme" placeholder="Tema"> <input name="destination" placeholder="Destinazione"><br><textarea name="temporary_instructions" class="large-text" rows="2" placeholder="Istruzioni per questa generazione"></textarea><p><select><option>Profilo Istruzioni AI</option></select> <button type="submit" class="button button-secondary" name="do" value="search_knowledge_base">Cerca nel Knowledge Base</button> <button type="submit" class="button" name="do" value="add_new_search">Aggiungi nuova ricerca</button> <button type="button" class="button" disabled>Programma creazione bozza articolo</button> <em>Programma creazione bozza articolo: Disponibile nella prossima fase.</em></p>');
         echo '<form method="get"><input type="hidden" name="post_type" value="affiliate_link"><input type="hidden" name="page" value="alma-ai-content-agent"><input type="hidden" name="tab" value="idee"><select name="idea_status"><option value="">Tutti gli stati</option>'; foreach(ALMA_AI_Content_Agent_Store::allowed_idea_statuses() as $st){ echo '<option '.selected($status,$st,false).' value="'.esc_attr($st).'">'.esc_html($st).'</option>'; } echo '</select> <button class="button">Filtra</button></form>';
         $ideas = ALMA_AI_Content_Agent_Store::get_ideas($status); echo '<table class="widefat striped"><thead><tr><th>ID</th><th>Titolo</th><th>Motivazione</th><th>Stato</th><th>SEO</th><th>Priority</th><th>Affiliati</th><th>Immagini</th><th>Model</th><th>Profile</th><th>Snapshot</th><th>Warning</th><th>Azioni</th></tr></thead><tbody>';
         foreach($ideas as $i){ $warnings=implode(', ',(array)json_decode((string)($i['warnings']??'[]'),true)); echo '<tr><td>'.(int)$i['id'].'</td><td>'.esc_html($i['proposed_title']).'</td><td>'.esc_html($i['rationale']).'</td><td>'.esc_html($i['status']).'</td><td>'.esc_html($i['seo_score']).'</td><td>'.esc_html($i['priority_score']).'</td><td>'.count((array)json_decode((string)$i['affiliate_candidates'],true)).'</td><td>'.count((array)json_decode((string)$i['image_candidates'],true)).'</td><td>'.esc_html($i['ai_model']).'</td><td>'.(int)$i['instruction_profile_id'].'</td><td>'.esc_html(substr((string)$i['instruction_snapshot_hash'],0,12)).'</td><td>'.esc_html($warnings).'</td><td>'.self::inline_status_form((int)$i['id'],'approved','Approva').' '.self::inline_status_form((int)$i['id'],'rejected','Scarta').' '.self::inline_status_form((int)$i['id'],'archived','Archivia').' '.self::inline_brief_form((int)$i['id']).' '.self::inline_draft_form((int)$i['id'], (string)$i['status']).'</td></tr>';
@@ -180,6 +202,8 @@ class ALMA_AI_Content_Agent_Admin {
             echo '</tbody></table>';
         }
         echo '<p><button type="submit" class="button button-primary">Salva selezione</button></p></form>';
+        echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_ai_agent_action');
+        echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="create_draft_from_selection"><p><button type="submit" class="button button-primary">Crea bozza articolo</button></p></form>';
 
         echo "<form method='post' action='".esc_url(admin_url('admin-post.php'))."' onsubmit=\"return confirm('Svuotare la sessione corrente?');\">"; wp_nonce_field('alma_ai_agent_action');
         echo "<input type='hidden' name='action' value='alma_ai_agent_action'><input type='hidden' name='do' value='clear_selection_session'><p><button class='button'>Svuota sessione</button></p></form>";

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -1,6 +1,7 @@
 <?php
 if (!defined('ABSPATH')) { exit; }
 class ALMA_AI_Content_Agent_Draft_Builder {
+    const TASK_SELECTION = 'content_agent_draft_from_selection';
     private static function fail($message, $model = '', $reference_id = '', $extra = array()) {
         ALMA_AI_Usage_Logger::log(array('task'=>'content_draft_generation','success'=>false,'error'=>sanitize_text_field($message),'model'=>sanitize_text_field($model),'reference_id'=>sanitize_text_field($reference_id)));
         return array_merge(array('success'=>false,'error'=>sanitize_text_field($message),'warnings'=>array()), $extra);
@@ -29,5 +30,75 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         update_post_meta($post_id, '_alma_ai_agent_generated', 1); update_post_meta($post_id, '_alma_ai_agent_idea_id', $idea_id); update_post_meta($post_id, '_alma_ai_agent_brief_id', absint($brief['id'] ?? 0)); update_post_meta($post_id, '_alma_ai_agent_task', 'content_draft_generation'); update_post_meta($post_id, '_alma_ai_agent_model', sanitize_text_field($res['model'] ?? '')); update_post_meta($post_id, '_alma_ai_agent_instruction_profile_id', absint($brief['instruction_profile_id'] ?? $idea['instruction_profile_id'] ?? 0)); update_post_meta($post_id, '_alma_ai_agent_instruction_snapshot_hash', sanitize_text_field($brief['instruction_snapshot_hash'] ?? $idea['instruction_snapshot_hash'] ?? '')); update_post_meta($post_id, '_alma_ai_agent_affiliate_links_used', wp_json_encode($clean['affiliate_links_used'])); update_post_meta($post_id, '_alma_ai_agent_image_ids_used', wp_json_encode($clean['inline_image_ids'])); update_post_meta($post_id, '_alma_ai_agent_featured_image_id', absint($clean['featured_image_id'])); update_post_meta($post_id, '_alma_ai_agent_qa_warnings', wp_json_encode(array_merge((array)$clean['warnings'], (array)($parsed['warnings'] ?? array())))); update_post_meta($post_id, '_alma_ai_seo_title', sanitize_text_field($parsed['seo_title'] ?? '')); update_post_meta($post_id, '_alma_ai_meta_description', sanitize_text_field($parsed['meta_description'] ?? '')); update_post_meta($post_id, '_alma_ai_focus_keyword', sanitize_text_field($parsed['focus_keyword'] ?? '')); update_post_meta($post_id, '_alma_ai_generated_at', current_time('mysql')); update_post_meta($post_id, '_alma_ai_suggested_tags', wp_json_encode((array)($parsed['suggested_tags'] ?? array())));
         ALMA_AI_Usage_Logger::log(array('task'=>'content_draft_generation','success'=>true,'model'=>$res['model'] ?? '','response_time'=>$res['response_time'] ?? null,'input_tokens'=>$res['usage']['input_tokens'] ?? null,'output_tokens'=>$res['usage']['output_tokens'] ?? null,'estimated_cost'=>$res['usage']['total_tokens'] ?? null,'reference_id'=>'post:'.$post_id));
         return array('success'=>true,'post_id'=>$post_id,'edit_url'=>get_edit_post_link($post_id, 'raw'),'warnings'=>array_values(array_merge((array)$clean['warnings'], (array)($parsed['warnings'] ?? array()))));
+    }
+
+    public static function generate_from_selection_session($user_id = 0) {
+        global $wpdb;
+        $user_id = absint($user_id ?: get_current_user_id());
+        $session = ALMA_AI_Content_Agent_Selection_Session::build_context_package();
+        $selected = array_values(array_filter((array)($session['selected_results'] ?? array()), function($r){ return !empty($r['selected']); }));
+        if (empty($selected)) { return self::fail('Seleziona almeno una fonte prima di creare la bozza.'); }
+        $selected_posts = array_values(array_filter($selected, function($r){ return ($r['source_group'] ?? '') === 'post'; }));
+        if (count($selected_posts) > ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_POSTS) { return self::fail('Puoi selezionare massimo 3 Post.'); }
+        if (empty(get_option('alma_openai_api_key', ''))) { return self::fail('OpenAI non è configurata.'); }
+
+        $ctx = array('posts'=>array(),'pages'=>array(),'affiliate_links'=>array(),'documents'=>array(),'sources_online'=>array(),'media'=>array());
+        $warnings = array();
+        foreach ($selected as $row) {
+            $group = sanitize_key($row['source_group'] ?? '');
+            $sid = absint($row['source_id'] ?? 0);
+            if ($group === 'post' || $group === 'page') {
+                $p = get_post($sid);
+                if (!$p || $p->post_type !== $group) { $warnings[] = 'Elemento selezionato non più disponibile: '.$group.'#'.$sid; continue; }
+                $ctx[$group === 'post' ? 'posts' : 'pages'][] = array('id'=>$p->ID,'title'=>sanitize_text_field($p->post_title),'excerpt'=>wp_trim_words(wp_strip_all_tags($p->post_excerpt ?: $p->post_content), 40),'content'=>mb_substr(wp_strip_all_tags($p->post_content),0,1200),'permalink'=>get_permalink($p->ID));
+            } elseif ($group === 'affiliate_link') {
+                $p = get_post($sid);
+                if (!$p || $p->post_type !== 'affiliate_link') { $warnings[] = 'Affiliate link non disponibile: #'.$sid; continue; }
+                $ctx['affiliate_links'][] = array('id'=>$p->ID,'title'=>sanitize_text_field($p->post_title),'description'=>sanitize_text_field($p->post_excerpt),'affiliate_url'=>esc_url_raw((string)get_post_meta($p->ID,'affiliate_url',true)),'shortcode'=>'[affiliate_link id="'.$p->ID.'"]','ai_context'=>sanitize_textarea_field((string)get_post_meta($p->ID,'affiliate_ai_context',true)));
+            } elseif ($group === 'document_txt') {
+                $item = $wpdb->get_row($wpdb->prepare("SELECT id,title,status FROM ".ALMA_AI_Content_Agent_Store::table('knowledge_items')." WHERE id=%d AND source_type='document_txt'", $sid), ARRAY_A);
+                if (!$item || ($item['status'] ?? '') !== 'active') { $warnings[] = 'Documento TXT non disponibile: #'.$sid; continue; }
+                $chunks = $wpdb->get_col($wpdb->prepare("SELECT content FROM ".ALMA_AI_Content_Agent_Store::table('content_chunks')." WHERE knowledge_item_id=%d ORDER BY id ASC LIMIT 3", $sid));
+                $ctx['documents'][] = array('id'=>(int)$item['id'],'title'=>sanitize_text_field($item['title']),'status'=>sanitize_text_field($item['status']),'chunks'=>array_map(function($c){ return mb_substr(wp_strip_all_tags((string)$c),0,500); }, (array)$chunks));
+            } elseif ($group === 'source_online') {
+                $src = $wpdb->get_row($wpdb->prepare("SELECT id,name,source_url,source_type,is_active FROM ".ALMA_AI_Content_Agent_Store::table('sources')." WHERE id=%d", $sid), ARRAY_A);
+                if (!$src || (int)$src['is_active'] !== 1) { $warnings[] = 'Fonte online non disponibile: #'.$sid; continue; }
+                $ctx['sources_online'][] = array('id'=>(int)$src['id'],'name'=>sanitize_text_field($src['name']),'url'=>esc_url_raw($src['source_url']),'technology'=>sanitize_text_field($src['source_type']),'status'=>'active');
+            } elseif ($group === 'media') {
+                $att = get_post($sid);
+                if (!$att || $att->post_type !== 'attachment') { $warnings[] = 'Media non disponibile: #'.$sid; continue; }
+                $ctx['media'][] = array('attachment_id'=>$att->ID,'title'=>sanitize_text_field($att->post_title),'alt_text'=>sanitize_text_field(get_post_meta($att->ID,'_wp_attachment_image_alt',true)),'caption'=>sanitize_text_field($att->post_excerpt),'description'=>sanitize_textarea_field($att->post_content),'url'=>wp_get_attachment_url($att->ID));
+            }
+        }
+        if (empty($ctx['posts']) && empty($ctx['pages']) && empty($ctx['documents']) && empty($ctx['affiliate_links']) && empty($ctx['sources_online']) && empty($ctx['media'])) {
+            return self::fail('Nessuna fonte valida disponibile nella sessione selezionata.');
+        }
+        $profile = ALMA_AI_Content_Agent_Instructions_Manager::get_active_profile();
+        $payload = array('task'=>'creazione bozza articolo','rules'=>array('output_json'=>true,'title_required'=>true,'content_required'=>true,'slug_optional'=>true,'no_raw_affiliate_urls'=>true),'instruction_profile'=>$profile,'selection_context'=>$ctx);
+        $prompt = 'Genera solo JSON con chiavi: title,content,slug,warnings. Usa solo shortcode affiliati autorizzati.';
+        $res = ALMA_OpenAI_Service::request(array('system_prompt'=>'Sei un content editor WordPress. Output solo JSON valido.', 'user_prompt'=>$prompt.' CONTEXT: '.wp_json_encode($payload), 'json_output'=>true, 'max_output_tokens'=>1800));
+        if (empty($res['success'])) { return self::fail($res['error'] ?? 'Risposta OpenAI fallita.', $res['model'] ?? '', 'session:user:'.$user_id); }
+        $parsed = json_decode((string)$res['response'], true); if (!is_array($parsed)) { $parsed = json_decode(ALMA_AI_Content_Agent_Text_Utils::extract_first_json((string)$res['response']), true); }
+        if (!is_array($parsed)) { return self::fail('Draft JSON non valido', $res['model'] ?? '', 'session:user:'.$user_id); }
+        $parsed['content_html'] = (string)($parsed['content'] ?? '');
+        $candidate_affiliate_ids = array_values(array_map('absint', wp_list_pluck((array)$ctx['affiliate_links'], 'id')));
+        $candidate_image_ids = array_values(array_map('absint', wp_list_pluck((array)$ctx['media'], 'attachment_id')));
+        $clean = ALMA_AI_Content_Agent_Draft_Quality_Checker::validate_payload($parsed, $candidate_affiliate_ids, $candidate_image_ids);
+        if ($clean['title'] === '' || trim(wp_strip_all_tags($clean['content'])) === '') { return self::fail('Titolo o contenuto non validi dopo QA.', $res['model'] ?? '', 'session:user:'.$user_id); }
+        $post_id = wp_insert_post(array('post_type'=>'post','post_status'=>'draft','post_author'=>$user_id,'post_title'=>$clean['title'],'post_name'=>$clean['slug'],'post_excerpt'=>$clean['excerpt'],'post_content'=>$clean['content']), true);
+        if (is_wp_error($post_id) || !$post_id) { return self::fail('Errore creazione bozza.', $res['model'] ?? '', 'session:user:'.$user_id); }
+        update_post_meta($post_id, '_alma_ai_agent_generated', 1);
+        update_post_meta($post_id, '_alma_ai_agent_task', self::TASK_SELECTION);
+        update_post_meta($post_id, '_alma_ai_agent_model', sanitize_text_field($res['model'] ?? ''));
+        update_post_meta($post_id, '_alma_ai_agent_selected_post_ids', wp_json_encode(wp_list_pluck($ctx['posts'], 'id')));
+        update_post_meta($post_id, '_alma_ai_agent_selected_affiliate_link_ids', wp_json_encode(wp_list_pluck($ctx['affiliate_links'], 'id')));
+        update_post_meta($post_id, '_alma_ai_agent_selected_document_txt_ids', wp_json_encode(wp_list_pluck($ctx['documents'], 'id')));
+        update_post_meta($post_id, '_alma_ai_agent_selected_source_online_ids', wp_json_encode(wp_list_pluck($ctx['sources_online'], 'id')));
+        update_post_meta($post_id, '_alma_ai_agent_selected_media_ids', wp_json_encode(wp_list_pluck($ctx['media'], 'attachment_id')));
+        update_post_meta($post_id, '_alma_ai_agent_instruction_profile_id', absint($session['instruction_profile_id'] ?? ($profile['id'] ?? 0)));
+        update_post_meta($post_id, '_alma_ai_agent_qa_warnings', wp_json_encode(array_values(array_unique(array_merge($warnings, (array)$clean['warnings'], (array)($parsed['warnings'] ?? array()))))));
+        update_post_meta($post_id, '_alma_ai_generated_at', current_time('mysql'));
+        ALMA_AI_Usage_Logger::log(array('task'=>self::TASK_SELECTION,'success'=>true,'model'=>$res['model'] ?? '','response_time'=>$res['response_time'] ?? null,'input_tokens'=>$res['usage']['input_tokens'] ?? null,'output_tokens'=>$res['usage']['output_tokens'] ?? null,'reference_id'=>'post:'.$post_id));
+        return array('success'=>true,'post_id'=>$post_id,'title'=>$clean['title'],'edit_url'=>get_edit_post_link($post_id, 'raw'),'preview_url'=>get_preview_post_link($post_id),'warnings'=>array_values(array_unique(array_merge($warnings, (array)$clean['warnings'], (array)($parsed['warnings'] ?? array())))),'model'=>$res['model'] ?? '','usage'=>$res['usage'] ?? array());
     }
 }


### PR DESCRIPTION
### Motivation
- Implementare il primo flusso operativo reale del workflow AI: usare la Selection Session esistente per inviare solo le fonti selezionate a OpenAI e creare una bozza WordPress validata in stato `draft` con meta di provenance e QA locale.
- Garantire controlli di sicurezza e vincoli richiesti: massimo 3 Post selezionati, capability/nonce, validazione sessione, nessuna pubblicazione automatica, nessuno scheduler, nessun crawling/scraping o web search.

### Description
- Aggiunto metodo `generate_from_selection_session()` in `includes/class-ai-content-agent-draft-builder.php` che risolve i risultati selezionati (post, page, affiliate_link, document_txt con chunks, source_online, media), costruisce un payload compatto, chiama `ALMA_OpenAI_Service`, richiede/valida output JSON e crea il post in `post_status='draft'` salvando meta di provenance e log tramite `ALMA_AI_Usage_Logger`.
- Aggiunta action admin sicura `create_draft_from_selection` in `includes/class-ai-content-agent-admin.php` con controlli server-side (sessione attiva, selected items, max 3 post, OpenAI configurata), salvataggio del risultato in transient e rendering di notice con link `Modifica articolo` e `Anteprima articolo` e warning QA; il pulsante `Crea bozza articolo` è stato reso operativo nella tab `Idee contenuto` mentre `Programma creazione bozza articolo` resta placeholder disabilitato.
- Riutilizzo dei componenti esistenti: chiamata al servizio OpenAI esistente (`ALMA_OpenAI_Service`), validazione QA con `ALMA_AI_Content_Agent_Draft_Quality_Checker`, uso della Selection Session (`ALMA_AI_Content_Agent_Selection_Session::build_context_package()`), e logging con `ALMA_AI_Usage_Logger`.
- Aggiornata versione plugin a `2.22.0` (`affiliate-link-manager-ai.php` header e `ALMA_VERSION`) e aggiornati `README.md` e `CHANGELOG.md` con voce `2.22.0 — PR 5`.

### Testing
- Eseguiti controlli sintattici PHP con `php -l` su `includes/class-ai-content-agent-draft-builder.php`, `includes/class-ai-content-agent-admin.php` e `affiliate-link-manager-ai.php`, tutti passati con esito "No syntax errors detected".
- Verificata integrazione locale con commit Git (`git commit`) creato correttamente per i file modificati: `includes/class-ai-content-agent-draft-builder.php`, `includes/class-ai-content-agent-admin.php`, `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`.
- Non sono stati eseguiti test end-to-end WordPress/OpenAI in ambiente remoto in questa sessione; indicati i test manuali raccomandati in admin per validare comportamento OpenAI on/off, sessione vuota, selezioni non esistenti, oltre/<=3 post e creazione bozza con meta e link.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75c3f91048332aed957ae794e290a)