### PR TITLE
PR 5.1.1 — AI Content Agent Review Fixes: TXT Documents & Instruction Profiles CTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.22.2 — PR 5.1.1 — AI Content Agent Review Fixes
+- Fix P1 Documenti TXT: gestione `knowledge_item_id` stabile dalla ricerca alla Selection Session e resolver difensivo nel Draft Builder per key normalizzate (`document_txt:kb_document_txt_123`, `kb:document_txt:123`, `kb_document_txt_123`).
+- Fix P2 tab/CTA Istruzioni AI: rimosso remap verso Idee, tab dedicata visibile e routing diretto a `render_instructions_tab()`.
+- Migliorata notice risultato creazione bozza da Selection Session con dettagli completi (stato draft, link azione, profilo, modello, conteggi fonti, warning QA).
+- Confermato: nessuno scheduler, nessuna pubblicazione automatica, nessun crawling/scraping/web search.
+
 ## 2.22.1 — PR 5.1 — AI Content Agent Draft Creation from Selection Session
 - Pulsante **Crea bozza articolo** operativo nella tab Idee contenuto.
 - Generazione bozza da Selection Session con uso dei soli risultati selezionati.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 
+## 2.22.2
+
+- PR 5.1.1 — patch di stabilizzazione post-review workflow AI Content Agent → Selection Session → Draft Builder.
+- Fix Documenti TXT con `result_key` normalizzati (es. `document_txt:kb_document_txt_123`) con propagazione/risoluzione stabile `knowledge_item_id`.
+- Tab admin **Istruzioni AI** resa raggiungibile dalla navigazione e CTA “Gestisci Profili Istruzioni AI” corretta.
+- Migliorata la card risultato bozza con stato, CTA Modifica/Anteprima, profilo istruzioni, modello AI, conteggi fonti e warning QA.
+- Nessuno scheduler nuovo, nessuna pubblicazione automatica, nessun crawling/scraping/web search.
+
 ## 2.22.1
 
 - PR 5 — Crea bozza articolo da Selection Session con uso esclusivo delle fonti selezionate.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.22.1
+ * Version: 2.22.2
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.22.1');
+define('ALMA_VERSION', '2.22.2');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -106,25 +106,38 @@ class ALMA_AI_Content_Agent_Admin {
         $r = get_transient(self::RESULT_TRANSIENT_KEY . get_current_user_id());
         if (!empty($r) && !empty($r['success'])) {
             delete_transient(self::RESULT_TRANSIENT_KEY . get_current_user_id());
-            echo '<div class="notice notice-success"><p><strong>Bozza articolo creata</strong>: '.esc_html($r['title'] ?? '').' (Bozza) ';
-            if (!empty($r['edit_url'])) { echo '<a class="button button-small" href="'.esc_url($r['edit_url']).'">Modifica articolo</a> '; }
-            if (!empty($r['preview_url'])) { echo '<a class="button button-small" href="'.esc_url($r['preview_url']).'" target="_blank" rel="noopener">Anteprima articolo</a>'; }
-            echo '</p>';
+            $summary = (array)($r['summary'] ?? array());
+            $counts = (array)($summary['source_counts'] ?? array());
+            echo '<div class="notice notice-success"><h3 style="margin-top:0;">Bozza articolo creata</h3>';
+            echo '<p><strong>Titolo:</strong> '.esc_html($r['title'] ?? '').'<br><strong>Stato:</strong> Bozza</p><p>';
+            if (!empty($r['edit_url'])) { echo '<a class="button button-primary" href="'.esc_url($r['edit_url']).'">Modifica articolo</a> '; }
+            if (!empty($r['preview_url'])) { echo '<a class="button" href="'.esc_url($r['preview_url']).'" target="_blank" rel="noopener">Anteprima articolo</a>'; }
+            echo '</p><ul>';
+            if (!empty($summary['instruction_profile_name'])) { echo '<li><strong>Profilo istruzioni:</strong> '.esc_html($summary['instruction_profile_name']).'</li>'; }
+            if (!empty($r['model'])) { echo '<li><strong>Modello AI:</strong> '.esc_html($r['model']).'</li>'; }
+            echo '<li><strong>Post:</strong> '.(int)($counts['post'] ?? 0).'</li>';
+            echo '<li><strong>Pagine:</strong> '.(int)($counts['page'] ?? 0).'</li>';
+            echo '<li><strong>Affiliate Links:</strong> '.(int)($counts['affiliate_link'] ?? 0).'</li>';
+            echo '<li><strong>Documenti TXT:</strong> '.(int)($counts['document_txt'] ?? 0).'</li>';
+            echo '<li><strong>Fonti online AI:</strong> '.(int)($counts['source_online'] ?? 0).'</li>';
+            echo '<li><strong>Media:</strong> '.(int)($counts['media'] ?? 0).'</li>';
+            echo '</ul>';
             if (!empty($r['warnings'])) { echo '<p><strong>Warning QA:</strong> '.esc_html(implode(' | ', array_map('sanitize_text_field', (array)$r['warnings']))).'</p>'; }
-            echo '<p>Puoi conservare la sessione per creare una nuova bozza o svuotarla manualmente.</p></div>';
+            echo '<p>Puoi revisionare l’articolo in WordPress prima della pubblicazione.</p></div>';
         }
     }
 
     public static function render_page() {
         if (!current_user_can('manage_options')) { return; }
-        $tabs = array('dashboard'=>'Dashboard','idee'=>'Idee contenuto','documenti'=>'Documenti TXT','fonti'=>'Fonti online AI','reindex'=>'Reindicizza','log'=>'Stato/log');
-        $legacy_map = array('overview'=>'dashboard','reindirizza'=>'reindex','knowledge'=>'dashboard','media'=>'dashboard','bozze'=>'log','programmazione'=>'log','istruzioni-ai'=>'idee');
+        $tabs = array('dashboard'=>'Dashboard','idee'=>'Idee contenuto','istruzioni-ai'=>'Istruzioni AI','documenti'=>'Documenti TXT','fonti'=>'Fonti online AI','reindex'=>'Reindicizza','log'=>'Stato/log');
+        $legacy_map = array('overview'=>'dashboard','reindirizza'=>'reindex','knowledge'=>'dashboard','media'=>'dashboard','bozze'=>'log','programmazione'=>'log',);
         $tab = sanitize_key($_GET['tab'] ?? 'dashboard');
         if (isset($legacy_map[$tab])) { $tab = $legacy_map[$tab]; }
         if (!isset($tabs[$tab])) { $tab = 'dashboard'; }
         echo '<div class="wrap alma-ai-agent-admin"><h1>AI Content Agent</h1>'; self::render_notice();
         echo '<h2 class="nav-tab-wrapper">'; foreach ($tabs as $tk=>$tl) { echo '<a class="nav-tab '.($tk===$tab?'nav-tab-active':'').'" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab='.$tk)).'">'.esc_html($tl).'</a>'; } echo '</h2>';
         if ($tab === 'dashboard') { self::render_overview_tab(); }
+        elseif ($tab === 'istruzioni-ai') { self::render_instructions_tab(); }
         elseif ($tab === 'documenti') { self::render_documents_tab(); }
         elseif ($tab === 'fonti') { self::render_sources_tab(); }
         elseif ($tab === 'reindex') { self::render_reindex_tab(); }

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -8,10 +8,23 @@ class ALMA_AI_Content_Agent_Draft_Builder {
     }
 
     private static function resolve_document_knowledge_item_id($row) {
-        $kid = absint($row['knowledge_item_id'] ?? 0);
-        if ($kid > 0) { return $kid; }
-        $rkey = sanitize_text_field($row['result_key'] ?? '');
-        if (preg_match('/(?:^|:)(\d+)$/', $rkey, $m)) { return absint($m[1]); }
+        $candidates = array(
+            $row['knowledge_item_id'] ?? '',
+            $row['result_key'] ?? '',
+            $row['result_id'] ?? '',
+            $row['key'] ?? '',
+        );
+        foreach ($candidates as $candidate) {
+            if (is_numeric($candidate)) {
+                $kid = absint($candidate);
+                if ($kid > 0) { return $kid; }
+            }
+            $value = sanitize_text_field((string)$candidate);
+            if ($value === '') { continue; }
+            if (preg_match('/^(?:kb:)?document_txt:(\d+)$/', $value, $m)) { return absint($m[1]); }
+            if (preg_match('/^(?:document_txt:)?kb_document_txt_(\d+)$/', $value, $m)) { return absint($m[1]); }
+            if (preg_match('/^kb:document_txt:kb_document_txt_(\d+)$/', $value, $m)) { return absint($m[1]); }
+        }
         return 0;
     }
     private static function fetch_document_chunks($knowledge_item_id, $limit = 3) {
@@ -128,6 +141,6 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         update_post_meta($post_id, '_alma_ai_agent_qa_warnings', wp_json_encode(array_values(array_unique(array_merge($warnings, (array)$clean['warnings'], (array)($parsed['warnings'] ?? array()))))));
         update_post_meta($post_id, '_alma_ai_generated_at', current_time('mysql'));
         ALMA_AI_Usage_Logger::log(array('task'=>self::TASK_SELECTION,'success'=>true,'model'=>$res['model'] ?? '','response_time'=>$res['response_time'] ?? null,'input_tokens'=>$res['usage']['input_tokens'] ?? null,'output_tokens'=>$res['usage']['output_tokens'] ?? null,'reference_id'=>'post:'.$post_id));
-        return array('success'=>true,'post_id'=>$post_id,'title'=>$clean['title'],'edit_url'=>get_edit_post_link($post_id, 'raw'),'preview_url'=>get_preview_post_link($post_id),'warnings'=>array_values(array_unique(array_merge($warnings, (array)$clean['warnings'], (array)($parsed['warnings'] ?? array())))),'model'=>$res['model'] ?? '','usage'=>$res['usage'] ?? array());
+        return array('success'=>true,'post_id'=>$post_id,'title'=>$clean['title'],'edit_url'=>get_edit_post_link($post_id, 'raw'),'preview_url'=>get_preview_post_link($post_id),'warnings'=>array_values(array_unique(array_merge($warnings, (array)$clean['warnings'], (array)($parsed['warnings'] ?? array())))),'model'=>$res['model'] ?? '','usage'=>$res['usage'] ?? array(),'summary'=>array('status'=>'draft','instruction_profile_name'=>sanitize_text_field($profile['profile_name'] ?? ($session['instruction_profile_name'] ?? '')),'source_counts'=>array('post'=>count((array)$ctx['posts']),'page'=>count((array)$ctx['pages']),'affiliate_link'=>count((array)$ctx['affiliate_links']),'document_txt'=>count((array)$ctx['documents']),'source_online'=>count((array)$ctx['sources_online']),'media'=>count((array)$ctx['media']))));
     }
 }

--- a/includes/class-ai-content-agent-knowledge-search.php
+++ b/includes/class-ai-content-agent-knowledge-search.php
@@ -87,6 +87,7 @@ class ALMA_AI_Content_Agent_Knowledge_Search {
                 'key' => 'kb:' . $stype . ':' . (int)$r['id'],
                 'source_type' => $group,
                 'source_id' => (int)$r['source_id'],
+                'knowledge_item_id' => (int)$r['id'],
                 'title' => sanitize_text_field($r['title']),
                 'excerpt' => wp_trim_words(wp_strip_all_tags((string)$r['normalized_excerpt']), 20),
                 'score' => $score,
@@ -153,6 +154,6 @@ class ALMA_AI_Content_Agent_Knowledge_Search {
     private static function result($data) {
         $labels = array('post'=>'Post','page'=>'Pagine','affiliate_link'=>'Affiliate Links','document_txt'=>'Documenti TXT','source_online'=>'Fonti online AI','media'=>'Media','other'=>'Altro');
         $safe_key = sanitize_key(str_replace(':','_', (string)$data['key']));
-        return array('result_id'=>$safe_key,'key'=>$data['key'],'source_type'=>$data['source_type'],'source_label'=>$labels[$data['source_type']] ?? 'Altro','source_id'=>(int)($data['source_id'] ?? 0),'title'=>sanitize_text_field($data['title'] ?? ''),'excerpt'=>sanitize_textarea_field($data['excerpt'] ?? ''),'score'=>(int)($data['score'] ?? 0),'reason'=>sanitize_text_field($data['reason'] ?? ''),'edit_url'=>esc_url_raw($data['edit_url'] ?? ''),'selectable'=>true,'preselected'=>false,'dedupe_ref'=>sanitize_text_field($data['dedupe_ref'] ?? ''));
+        return array('result_id'=>$safe_key,'key'=>$data['key'],'source_type'=>$data['source_type'],'source_label'=>$labels[$data['source_type']] ?? 'Altro','source_id'=>(int)($data['source_id'] ?? 0),'knowledge_item_id'=>(int)($data['knowledge_item_id'] ?? 0),'title'=>sanitize_text_field($data['title'] ?? ''),'excerpt'=>sanitize_textarea_field($data['excerpt'] ?? ''),'score'=>(int)($data['score'] ?? 0),'reason'=>sanitize_text_field($data['reason'] ?? ''),'edit_url'=>esc_url_raw($data['edit_url'] ?? ''),'selectable'=>true,'preselected'=>false,'dedupe_ref'=>sanitize_text_field($data['dedupe_ref'] ?? ''));
     }
 }

--- a/includes/class-ai-content-agent-selection-session.php
+++ b/includes/class-ai-content-agent-selection-session.php
@@ -78,12 +78,38 @@ class ALMA_AI_Content_Agent_Selection_Session {
         return array('success'=>true,'message'=>'Selezione salvata.');
     }
 
+
+    private static function infer_knowledge_item_id($group, $row, $fallback_result_id = '') {
+        $group = sanitize_key((string)$group);
+        $candidates = array(
+            $row['knowledge_item_id'] ?? '',
+            $row['result_key'] ?? '',
+            $row['key'] ?? '',
+            $row['result_id'] ?? $fallback_result_id,
+        );
+        foreach ($candidates as $candidate) {
+            if (is_numeric($candidate)) {
+                $id = absint($candidate);
+                if ($id > 0) { return $id; }
+            }
+            $value = sanitize_text_field((string)$candidate);
+            if ($value === '') { continue; }
+            if ($group === 'document_txt') {
+                if (preg_match('/(?:^|:)(?:kb_document_txt_)(\d+)$/', $value, $m)) { return absint($m[1]); }
+                if (preg_match('/^(?:kb:)?document_txt:(\d+)$/', $value, $m)) { return absint($m[1]); }
+            }
+            if (preg_match('/(?:^|:)kb:[a-z_]+:(\d+)$/', $value, $m)) { return absint($m[1]); }
+        }
+        return 0;
+    }
+
     private static function normalize_result($group, $row) {
         $source_id = absint($row['source_id'] ?? 0);
         $wp_id = absint($row['wp_id'] ?? 0);
         $result_id = sanitize_text_field($row['result_id'] ?? '');
-        $knowledge_item_id = absint($row['knowledge_item_id'] ?? 0);
-        $result_key = sanitize_key($group) . ':' . ($knowledge_item_id ?: ($source_id ?: ($wp_id ?: $result_id)));
+        $knowledge_item_id = self::infer_knowledge_item_id($group, $row, $result_id);
+        $incoming_key = sanitize_text_field($row['key'] ?? ($row['result_key'] ?? ''));
+        $result_key = $incoming_key !== '' ? $incoming_key : (sanitize_key($group) . ':' . ($knowledge_item_id ?: ($source_id ?: ($wp_id ?: $result_id))));
         if (empty($result_key)) { $result_key = sanitize_key($group) . ':' . substr(md5(wp_json_encode($row)), 0, 12); }
         return array(
             'result_key' => $result_key,


### PR DESCRIPTION
### Motivation
- Risolvere regressioni P1/P2 emerse in review: Documenti TXT con `result_key` normalizzati venivano scartati in fase di Draft Builder, e la CTA "Gestisci Profili Istruzioni AI" apriva la tab sbagliata; migliorare inoltre la UX della notice di risultato bozza.
- Assicurare propagazione stabile di `knowledge_item_id` dal flusso Knowledge Search → Selection Session e fornire un resolver difensivo nel Draft Builder per supportare formati `kb_document_txt_*` senza rompere la compatibilità.

### Description
- Propagazione ID: `includes/class-ai-content-agent-knowledge-search.php` ora include `knowledge_item_id` nei risultati generati da `search_knowledge_items()` per preservare l`'id` della row knowledge_items. 
- Normalizzazione sessione: `includes/class-ai-content-agent-selection-session.php` introduce `infer_knowledge_item_id()` ed estende `normalize_result()` per salvare/derivare `knowledge_item_id` da `knowledge_item_id`, `result_key`, `key` o `result_id`, preservando la `result_key` in ingresso quando presente.
- Resolver difensivo: `includes/class-ai-content-agent-draft-builder.php` aggiorna `resolve_document_knowledge_item_id()` per riconoscere e estrarre ID da valori come `document_txt:123`, `document_txt:kb_document_txt_123`, `kb:document_txt:123`, `kb_document_txt_123` e ritorna solo interi positivi chiaramente deducibili.
- Admin routing e notice: `includes/class-ai-content-agent-admin.php` rende la tab `istruzioni-ai` visibile nella nav senza remapping legacy e rende raggiungibile `render_instructions_tab()`; inoltre la `render_notice()` mostra una card/notice migliorata con titolo bozza, stato, pulsanti Modifica/Anteprima, profilo istruzioni, modello AI, conteggi fonti e warning QA.
- Summary e output: `generate_from_selection_session()` è esteso a restituire un blocco `summary` (stato + `instruction_profile_name` + `source_counts`) usato dalla notice senza salvare nuovi dati o chiamare AI aggiuntiva.
- Versioning e documentazione: aggiornati header plugin e costante `ALMA_VERSION` in `affiliate-link-manager-ai.php` a `2.22.2`, e aggiornati `README.md` e `CHANGELOG.md` con la descrizione della patch.
- Vincoli rispettati: non sono state introdotte nuove tabelle, scheduler, crawling/scraping, pubblicazione automatica o web search; non è stata reintrodotta lettura di `content_chunks.content` (si usa solo `normalized_text`) e sono mantenuti nonce/capability/sanitizzazione esistenti.

### Testing
- Lint PHP: eseguiti con successo `php -l` su `includes/class-ai-content-agent-draft-builder.php`, `includes/class-ai-content-agent-selection-session.php`, `includes/class-ai-content-agent-knowledge-search.php`, `includes/class-ai-content-agent-admin.php` e `affiliate-link-manager-ai.php` (tutti senza errori).
- Verifiche testuali automatiche: controllata l'assenza di query su `content_chunks.content`, la presenza di gestione `kb_document_txt_` e la rimozione del remap `istruzioni-ai => idee`, nonché la raggiungibilità di `render_instructions_tab()` e la presenza della versione `2.22.2` in header/const/README/CHANGELOG (tutte positive).
- Commit/PR: le modifiche sono state committate e raccolte in PR con titolo richiesto; il diff tocca solo i file indicati e non introduce nuovi file o strutture.
- Raccomandazione test manuali in WordPress: aprire `AI Content Agent → Idee contenuto`, cliccare `Gestisci Profili Istruzioni AI` per verificare apertura della tab `Istruzioni AI`, eseguire una ricerca KB che ritorni Documenti TXT con `result_key` normalizzato, selezionare il Documento TXT, creare bozza e verificare che la bozza sia in `draft` e che la card risultante mostri Modifica/Anteprima, profilo, modello, conteggi fonti e warning QA (eseguire questi test in ambiente WP con DB reale per validazione end-to-end).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f762d41f5c8332af6210f2d5686cbf)