### PR TITLE
PR 6.1 — AI Content Agent: Search Session UX & Payload Refinement (v2.23.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
+## 2.23.1 — PR 6.1 — Search Session UX & Payload Refinement
+- fix selezione persa in dedupe preservando selected=true.
+- fix collegamento reale query di ricerca locale (campo unico).
+- ordinamento gruppi risultati: Link Affiliati, Post, File TXT, Fonti online, Pagine, Media.
+- nuovi limiti selezionabili: 20/3/5/5/2/5 con warning admin per gruppo.
+- Sessione contenuto persistente separata da Risultati ricerca.
+- rimossa dalla UI principale la tabella legacy idee/brief.
+- payload JSON basato sulla Sessione contenuto reale (single-call OpenAI solo su Crea Bozza).
 
-## 2.23.0 — PR 6 — AI Content Agent Single OpenAI Draft Workflow
+
+## 2.23.1 — PR 6 — AI Content Agent Single OpenAI Draft Workflow
 - Workflow idee contenuto semplificato: ricerca locale, selezione manuale, profilo istruzioni AI e creazione bozza.
 - Unica chiamata OpenAI al click su Crea Bozza; nessuna chiamata AI in ricerca/selezione/download JSON payload AI.
 - Aggiunto download “Scarica JSON payload AI” dalla sessione contenuto.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Versione 2.23.0
+## Versione 2.23.1
 - Nuovo workflow AI Content Agent: ricerca locale contenuti, selezione manuale, profilo Istruzioni AI, download JSON payload AI e creazione bozza WordPress in stato draft.
 - Unica chiamata OpenAI: solo su click esplicito “Crea Bozza con OpenAI”.
 - Nessuna chiamata AI durante ricerca contenuti, selezione risultati, salvataggio sessione o download JSON payload AI.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.23.0
+ * Version: 2.23.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.23.0');
+define('ALMA_VERSION', '2.23.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -43,7 +43,7 @@ class ALMA_AI_Content_Agent_Admin {
         } elseif ($do === 'search_knowledge_base' || $do === 'add_new_search') {
             $profile_id = absint($_POST['instruction_profile_id'] ?? 0);
             $profile = $profile_id ? ALMA_AI_Content_Agent_Instructions_Manager::get_profile($profile_id) : array();
-            $payload = array('max_ideas'=>absint($_POST['max_ideas'] ?? 1),'theme'=>sanitize_text_field($_POST['theme'] ?? ''),'destination'=>sanitize_text_field($_POST['destination'] ?? ''),'temporary_instructions'=>sanitize_textarea_field($_POST['temporary_instructions'] ?? ''),'instruction_profile_id'=>$profile_id,'instruction_profile_name'=>sanitize_text_field($profile['profile_name'] ?? ''),'instruction_snapshot_hash'=>sanitize_text_field($profile ? ALMA_AI_Content_Agent_Instructions_Manager::snapshot_hash(wp_json_encode($profile)) : ''));
+            $payload = array('max_ideas'=>absint($_POST['max_ideas'] ?? 1),'content_search_query'=>sanitize_text_field($_POST['content_search_query'] ?? ($_POST['search_terms'] ?? '')),'search_terms'=>sanitize_text_field($_POST['search_terms'] ?? ($_POST['content_search_query'] ?? '')),'theme'=>sanitize_text_field($_POST['theme'] ?? ''),'destination'=>sanitize_text_field($_POST['destination'] ?? ''),'temporary_instructions'=>sanitize_textarea_field($_POST['temporary_instructions'] ?? ''),'instruction_profile_id'=>$profile_id,'instruction_profile_name'=>sanitize_text_field($profile['profile_name'] ?? ''),'instruction_snapshot_hash'=>sanitize_text_field($profile ? ALMA_AI_Content_Agent_Instructions_Manager::snapshot_hash(wp_json_encode($profile)) : ''));
             $search = ALMA_AI_Content_Agent_Knowledge_Search::search($payload);
             $stats = ALMA_AI_Content_Agent_Selection_Session::add_search_results($payload, $search);
             $result = array('success' => true, 'message' => sprintf('Ricerca completata. Trovati: %d, aggiunti: %d, duplicati ignorati: %d.', (int)$stats['found'], (int)$stats['added'], (int)$stats['duplicates']));
@@ -188,55 +188,44 @@ class ALMA_AI_Content_Agent_Admin {
         echo '<p><label><input type="checkbox" name="activate_profile" value="1"> Attiva questo profilo dopo il salvataggio</label></p><p><button class="button button-primary">Salva profilo</button></p></form>';
     }
 
-    private static function render_ideas_tab() { $status = sanitize_key($_GET['idea_status'] ?? ''); echo '<h2>Idee contenuto</h2>'; $profiles = ALMA_AI_Content_Agent_Instructions_Manager::get_profiles(100,0);
+    private static function render_ideas_tab() {
+        echo '<h2>Idee contenuto</h2>';
+        $profiles = ALMA_AI_Content_Agent_Instructions_Manager::get_profiles(100,0);
         $active = ALMA_AI_Content_Agent_Instructions_Manager::get_active_profile();
         $profile_options = '<option value="0">Seleziona Profilo Istruzioni AI</option>';
         foreach($profiles as $pp){ if((int)($pp['is_active']??0)!==1){ continue; } $profile_options .= '<option value="'.(int)$pp['id'].'" '.selected((int)($active['id']??0),(int)$pp['id'],false).'>'.esc_html($pp['profile_name']).'</option>'; }
-        self::action_form('search_knowledge_base','Cerca contenuti per la bozza','<input name="theme" placeholder="Tema / argomento"> <input name="destination" placeholder="Destinazione"> <input name="search_terms" placeholder="Termini di ricerca"><br><textarea name="temporary_instructions" class="large-text" rows="2" placeholder="Istruzioni temporanee per questa bozza"></textarea><p><label><strong>Profilo Istruzioni AI</strong> <select name="instruction_profile_id">'.$profile_options.'</select></label> <a class="button" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=istruzioni-ai')).'">Gestisci Profili Istruzioni AI</a> <button type="submit" class="button button-secondary" name="do" value="search_knowledge_base">Cerca contenuti</button> <button type="submit" class="button" name="do" value="add_new_search">Aggiungi nuova ricerca</button></p>');
-        echo '<form method="get"><input type="hidden" name="post_type" value="affiliate_link"><input type="hidden" name="page" value="alma-ai-content-agent"><input type="hidden" name="tab" value="idee"><select name="idea_status"><option value="">Tutti gli stati</option>'; foreach(ALMA_AI_Content_Agent_Store::allowed_idea_statuses() as $st){ echo '<option '.selected($status,$st,false).' value="'.esc_attr($st).'">'.esc_html($st).'</option>'; } echo '</select> <button class="button">Filtra</button></form>';
-        $ideas = ALMA_AI_Content_Agent_Store::get_ideas($status); echo '<table class="widefat striped"><thead><tr><th>ID</th><th>Titolo</th><th>Motivazione</th><th>Stato</th><th>SEO</th><th>Priority</th><th>Affiliati</th><th>Immagini</th><th>Model</th><th>Profile</th><th>Snapshot</th><th>Warning</th><th>Azioni</th></tr></thead><tbody>';
-        foreach($ideas as $i){ $warnings=implode(', ',(array)json_decode((string)($i['warnings']??'[]'),true)); echo '<tr><td>'.(int)$i['id'].'</td><td>'.esc_html($i['proposed_title']).'</td><td>'.esc_html($i['rationale']).'</td><td>'.esc_html($i['status']).'</td><td>'.esc_html($i['seo_score']).'</td><td>'.esc_html($i['priority_score']).'</td><td>'.count((array)json_decode((string)$i['affiliate_candidates'],true)).'</td><td>'.count((array)json_decode((string)$i['image_candidates'],true)).'</td><td>'.esc_html($i['ai_model']).'</td><td>'.(int)$i['instruction_profile_id'].'</td><td>'.esc_html(substr((string)$i['instruction_snapshot_hash'],0,12)).'</td><td>'.esc_html($warnings).'</td><td>'.self::inline_status_form((int)$i['id'],'approved','Approva').' '.self::inline_status_form((int)$i['id'],'rejected','Scarta').' '.self::inline_status_form((int)$i['id'],'archived','Archivia').' '.self::inline_brief_form((int)$i['id']).' '.self::inline_draft_form((int)$i['id'], (string)$i['status']).'</td></tr>';
-            $brief=ALMA_AI_Content_Agent_Store::get_brief_by_idea((int)$i['id']); if($brief){ echo '<tr><td colspan="13"><details><summary>Brief esistente per idea #'.(int)$i['id'].'</summary><pre style="white-space:pre-wrap;">'.esc_html(wp_json_encode($brief, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)).'</pre></details></td></tr>'; }
-        }
-        echo '</tbody></table>';
+        self::action_form('search_knowledge_base','Cerca contenuti','<p><label><strong>Cerca contenuti per la bozza</strong><br><input class="large-text" name="content_search_query" placeholder="Es. tour Lecce barocco, itinerario Salento, museo ebraico, spiagge Otranto..."></label></p><p><label><strong>Profilo Istruzioni AI</strong> <select name="instruction_profile_id">'.$profile_options.'</select></label> <a class="button" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=istruzioni-ai')).'">Gestisci Profili Istruzioni AI</a></p><p><textarea name="temporary_instructions" class="large-text" rows="2" placeholder="Istruzioni temporanee per questa bozza"></textarea></p><p><button type="submit" class="button button-secondary" name="do" value="search_knowledge_base">Cerca contenuti</button> <button type="submit" class="button" name="do" value="add_new_search">Aggiungi nuova ricerca</button></p>');
 
         $summary = ALMA_AI_Content_Agent_Selection_Session::summary();
-        $groups = ALMA_AI_Content_Agent_Selection_Session::grouped_results();
-        $labels = array('post'=>'Post','page'=>'Pagine','affiliate_link'=>'Affiliate Links','document_txt'=>'Documenti TXT','source_online'=>'Fonti online AI','media'=>'Media','other'=>'Altro');
-        echo '<div class="alma-agent-card"><h3>Sessione contenuto</h3>';
-        echo '<p>Puoi effettuare più ricerche: i nuovi risultati verranno aggiunti a questa sessione. Le selezioni saranno usate nella prossima fase per creare la bozza articolo. Puoi selezionare massimo 3 Post.</p>';
-        if (($summary['status'] ?? 'empty') === 'empty') { echo '<p><em>Sessione vuota.</em></p>'; }
-        echo '<ul><li>Stato sessione: <strong>'.esc_html($summary['status'] ?? 'empty').'</strong></li><li>Numero ricerche: '.(int)($summary['search_count'] ?? 0).'</li><li>Ultimo aggiornamento: '.esc_html($summary['updated_at'] ?? '-').'</li><li>Risultati totali: '.(int)($summary['total_results'] ?? 0).'</li><li>Risultati selezionati: '.(int)($summary['selected_total'] ?? 0).'</li><li>Post selezionati: <strong id="alma-post-counter">'.(int)($summary['selected_post'] ?? 0).'/3</strong></li><li>Documenti TXT selezionati: '.(int)($summary['selected_document_txt'] ?? 0).'</li><li>Fonti online AI selezionate: '.(int)($summary['selected_source_online'] ?? 0).'</li><li>Affiliate Links selezionati: '.(int)($summary['selected_affiliate_link'] ?? 0).'</li><li>Media selezionati: '.(int)($summary['selected_media'] ?? 0).'</li><li>Pagine selezionate: '.(int)($summary['selected_page'] ?? 0).'</li></ul></div>';
+        $results_groups = ALMA_AI_Content_Agent_Selection_Session::grouped_results(false);
+        $selected_groups = ALMA_AI_Content_Agent_Selection_Session::grouped_results(true);
+        $labels = array('affiliate_link'=>'Link Affiliati','post'=>'Post','document_txt'=>'File TXT','source_online'=>'Fonti online','page'=>'Pagine','media'=>'Media');
+        $limits = array('affiliate_link'=>ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_AFFILIATE_LINKS,'post'=>ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_POSTS,'document_txt'=>ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_DOCUMENT_TXT,'source_online'=>ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_SOURCE_ONLINE,'page'=>ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_PAGES,'media'=>ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_MEDIA);
 
-        echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_ai_agent_action');
+        echo '<h3>Risultati ricerca</h3><form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_ai_agent_action');
         echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_selection">';
-        foreach ($labels as $groupKey => $groupLabel) {
-            $rows = (array)($groups[$groupKey] ?? array());
-            if (empty($rows)) { continue; }
-            $sel=0; foreach($rows as $r){ if(!empty($r['selected'])){$sel++;}}
-            echo '<h4>' . esc_html($groupLabel) . ' (' . count($rows) . ') - selezionati '.$sel.'</h4><table class="widefat striped"><tbody>';
-            foreach ($rows as $r) {
-                $isPost = $groupKey === 'post';
-                $checked = !empty($r['selected']) ? 'checked' : '';
-                echo '<tr><td style="width:40px;"><input name="selected_result_keys[]" class="alma-kb-check ' . ($isPost ? 'alma-kb-post-check' : '') . '" type="checkbox" value="' . esc_attr($r['result_key']) . '" ' . $checked . '></td><td><strong>' . esc_html($r['title']) . '</strong><br><small>' . esc_html($r['excerpt']) . '</small><br><span class="alma-badge is-pending">Score ' . (int)$r['score'] . '</span> <small>' . esc_html($r['reason']) . '</small>' . (!empty($r['admin_url']) ? ' <a href="'.esc_url($r['admin_url']).'" target="_blank" rel="noopener">Apri</a>' : '') . '</td></tr>';
-            }
-            echo '</tbody></table>';
-        }
+        foreach ($labels as $groupKey => $groupLabel) { $rows = (array)($results_groups[$groupKey] ?? array()); if (empty($rows)) { continue; } $sel=0; foreach($rows as $r){ if(!empty($r['selected'])){$sel++;}}
+            echo '<h4>' . esc_html($groupLabel) . ' (' . count($rows) . ') — max selezionabili '.(int)$limits[$groupKey].' — selezionati '.$sel.'</h4><table class="widefat striped"><tbody>';
+            foreach ($rows as $r) { $checked = !empty($r['selected']) ? 'checked' : '';
+                echo '<tr><td style="width:40px;"><input name="selected_result_keys[]" type="checkbox" value="' . esc_attr($r['result_key']) . '" ' . $checked . '></td><td><strong>' . esc_html($r['title']) . '</strong><br><small>' . esc_html($r['excerpt']) . '</small><br><span class="alma-badge is-pending">Score ' . (int)$r['score'] . '</span> <small>' . esc_html($r['reason']) . '</small>' . (!empty($r['admin_url']) ? ' <a href="'.esc_url($r['admin_url']).'" target="_blank" rel="noopener">Apri</a>' : '') . '</td></tr>'; }
+            echo '</tbody></table>'; }
         echo '<p><button type="submit" class="button button-primary">Salva selezione</button></p></form>';
+
+        echo '<h3>Sessione contenuto</h3><p>Elementi selezionati persistenti usati per JSON payload e Crea Bozza.</p>';
+        if ((int)($summary['selected_total'] ?? 0) < 1) { echo '<p><em>Nessun elemento selezionato.</em></p>'; }
+        foreach ($labels as $groupKey => $groupLabel) { $rows = (array)($selected_groups[$groupKey] ?? array()); if (empty($rows)) { continue; }
+            echo '<h4>'.esc_html($groupLabel).' ('.count($rows).')</h4><ul>';
+            foreach($rows as $r){ echo '<li><strong>'.esc_html($r['title']).'</strong> — score '.(int)$r['score'].' — '.esc_html($r['reason']).'</li>'; }
+            echo '</ul>'; }
+
         echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_ai_agent_action');
         echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="download_ai_payload_json"><p><button type="submit" class="button">Scarica JSON payload AI</button></p></form>';
         echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_ai_agent_action');
         echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="create_draft_from_selection"><p><button type="submit" class="button button-primary">Crea Bozza con OpenAI</button></p></form>';
-
-        echo "<form method='post' action='".esc_url(admin_url('admin-post.php'))."' onsubmit=\"return confirm('Svuotare la sessione corrente?');\">"; wp_nonce_field('alma_ai_agent_action');
-        echo "<input type='hidden' name='action' value='alma_ai_agent_action'><input type='hidden' name='do' value='clear_selection_session'><p><button class='button'>Svuota sessione</button></p></form>";
-        echo "<script>(function(){var checks=document.querySelectorAll('.alma-kb-post-check');var c=document.getElementById('alma-post-counter');function u(){var n=0;checks.forEach(function(x){if(x.checked){n++;}});if(c){c.textContent=n+'/3';}checks.forEach(function(x){if(!x.checked){x.disabled=n>=3;}else{x.disabled=false;}});}checks.forEach(function(x){x.addEventListener('change',function(e){var n=[].filter.call(checks,function(i){return i.checked;}).length;if(n>3){e.target.checked=false;alert('Puoi selezionare massimo 3 Post.');}u();});});u();})();</script>";
-
-
     }
 
     private static function inline_status_form($idea_id,$status,$label){ return '<form style="display:inline-block" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="set_idea_status"><input type="hidden" name="idea_id" value="'.(int)$idea_id.'"><input type="hidden" name="status" value="'.esc_attr($status).'"><button class="button button-small">'.esc_html($label).'</button></form>'; }
-    private static function inline_brief_form($idea_id){ return '<form style="display:inline-block" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="generate_brief"><input type="hidden" name="idea_id" value="'.(int)$idea_id.'"><button class="button button-small button-primary">Genera brief</button></form>'; }
+    private static function inline_brief_form($idea_id){ return '<form style="display:inline-block" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="generate_brief"><input type="hidden" name="idea_id" value="'.(int)$idea_id.'"><button class="button button-small button-primary">Brief legacy</button></form>'; }
     private static function inline_draft_form($idea_id, $idea_status){
         $idea_id = absint($idea_id); $idea_status = sanitize_key($idea_status);
         if (in_array($idea_status, array('rejected', 'archived'), true)) { return ''; }

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -38,7 +38,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
     private static function build_payload_from_selection_session($user_id = 0) {
         $user_id = absint($user_id ?: get_current_user_id());
         $session = ALMA_AI_Content_Agent_Selection_Session::build_context_package();
-        return array('task'=>'create_article_draft_from_selected_sources','site_context'=>array('site_name'=>get_bloginfo('name'),'language'=>get_bloginfo('language'),'generated_at'=>current_time('mysql')),'user_inputs'=>array('theme'=>sanitize_text_field($session['last_query']['theme'] ?? ''),'destination'=>sanitize_text_field($session['last_query']['destination'] ?? ''),'search_terms'=>sanitize_text_field($session['last_query']['search_terms'] ?? '')),'temporary_instructions'=>sanitize_textarea_field($session['last_query']['temporary_instructions'] ?? ''),'instruction_profile'=>$session['instruction_profile_name'] ?? '','selection_context'=>$session['selected_results'] ?? array(),'output_contract'=>array('title','slug','excerpt','content','seo_title','seo_description','affiliate_shortcodes_used','media_used','warnings'));
+        return array('task'=>'create_article_draft_from_selected_sources','site_context'=>array('site_name'=>get_bloginfo('name'),'language'=>get_bloginfo('language'),'generated_at'=>current_time('mysql')),'user_inputs'=>array('content_search_query'=>sanitize_text_field($session['last_query']['content_search_query'] ?? ($session['last_query']['search_terms'] ?? '')),'theme'=>sanitize_text_field($session['last_query']['theme'] ?? ''),'destination'=>sanitize_text_field($session['last_query']['destination'] ?? ''),'temporary_instructions'=>sanitize_textarea_field($session['last_query']['temporary_instructions'] ?? '')),'instruction_profile'=>$session['instruction_profile_name'] ?? '','temporary_instructions'=>sanitize_textarea_field($session['last_query']['temporary_instructions'] ?? ''),'rules'=>array('output_json'=>true,'title_required'=>true,'content_required'=>true,'slug_optional'=>true,'no_raw_affiliate_urls'=>true),'selection_context'=>array(),'affiliate_links'=>array(),'posts'=>array(),'documents'=>array(),'sources_online'=>array(),'pages'=>array(),'media'=>array(),'affiliate_rules'=>array(),'seo_rules'=>array(),'media_rules'=>array(),'output_contract'=>array('title','slug','excerpt','content','seo_title','seo_description','affiliate_shortcodes_used','media_used','warnings'),'warnings'=>array());
     }
 
     public static function download_payload_json_from_selection_session($user_id = 0) {
@@ -113,7 +113,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
                 if (!$item || ($item['status'] ?? '') !== 'active') { $warnings[] = 'Documento TXT non disponibile: #'.$kid; continue; }
                 $chunks = self::fetch_document_chunks($kid, 3);
                 if (empty($chunks)) { $warnings[] = 'Documento TXT senza chunk validi: #'.$kid; }
-                $ctx['documents'][] = array('id'=>(int)$item['id'],'title'=>sanitize_text_field($item['title']),'status'=>sanitize_text_field($item['status']),'chunks'=>array_map(function($c){ return mb_substr(wp_strip_all_tags((string)$c),0,500); }, (array)$chunks));
+                $ctx['documents'][] = array('id'=>(int)$item['id'],'title'=>sanitize_text_field($item['title']),'status'=>sanitize_text_field($item['status']),'normalized_text'=>implode("\n", array_map(function($c){ return mb_substr(wp_strip_all_tags((string)$c),0,500); }, (array)$chunks)));
             } elseif ($group === 'source_online') {
                 $src = $wpdb->get_row($wpdb->prepare("SELECT id,name,source_url,source_type,is_active FROM ".ALMA_AI_Content_Agent_Store::table('sources')." WHERE id=%d", $sid), ARRAY_A);
                 if (!$src || (int)$src['is_active'] !== 1) { $warnings[] = 'Fonte online non disponibile: #'.$sid; continue; }
@@ -132,7 +132,12 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         $payload = self::build_payload_from_selection_session($user_id);
         $payload['instruction_profile'] = $profile;
         $payload['selection_context'] = $ctx;
-        $payload['rules'] = array('output_json'=>true,'title_required'=>true,'content_required'=>true,'slug_optional'=>true,'no_raw_affiliate_urls'=>true);
+        $payload['affiliate_links'] = $ctx['affiliate_links'];
+        $payload['posts'] = $ctx['posts'];
+        $payload['documents'] = $ctx['documents'];
+        $payload['sources_online'] = $ctx['sources_online'];
+        $payload['pages'] = $ctx['pages'];
+        $payload['media'] = $ctx['media'];
         $prompt = 'Genera solo JSON con chiavi: title,content,slug,warnings. Usa solo shortcode affiliati autorizzati.';
         $res = ALMA_OpenAI_Service::request(array('system_prompt'=>'Sei un content editor WordPress. Output solo JSON valido.', 'user_prompt'=>$prompt.' CONTEXT: '.wp_json_encode($payload), 'json_output'=>true, 'max_output_tokens'=>1800));
         if (empty($res['success'])) { return self::fail($res['error'] ?? 'Risposta OpenAI fallita.', $res['model'] ?? '', 'session:user:'.$user_id); }

--- a/includes/class-ai-content-agent-knowledge-search.php
+++ b/includes/class-ai-content-agent-knowledge-search.php
@@ -20,11 +20,12 @@ class ALMA_AI_Content_Agent_Knowledge_Search {
     }
 
     private static function normalize_input($input) {
+        $content_search_query = sanitize_text_field($input['content_search_query'] ?? ($input['search_terms'] ?? ''));
         $theme = sanitize_text_field($input['theme'] ?? '');
         $destination = sanitize_text_field($input['destination'] ?? '');
         $instructions = sanitize_textarea_field($input['temporary_instructions'] ?? '');
-        $text = trim($theme . ' ' . $destination . ' ' . $instructions);
-        return array('theme'=>$theme,'destination'=>$destination,'temporary_instructions'=>$instructions,'text'=>$text,'terms'=>self::extract_terms($text));
+        $text = trim($content_search_query !== '' ? $content_search_query : trim($theme . ' ' . $destination . ' ' . $instructions));
+        return array('content_search_query'=>$content_search_query,'theme'=>$theme,'destination'=>$destination,'temporary_instructions'=>$instructions,'text'=>$text,'terms'=>self::extract_terms($text));
     }
 
     private static function extract_terms($text) {
@@ -122,8 +123,9 @@ class ALMA_AI_Content_Agent_Knowledge_Search {
 
     private static function score_text($query, $text) {
         $text = strtolower((string)$text); $score = 0;
-        if (!empty($query['destination']) && strpos($text, strtolower($query['destination'])) !== false) { $score += 30; }
-        if (!empty($query['theme']) && strpos($text, strtolower($query['theme'])) !== false) { $score += 25; }
+        if (!empty($query['content_search_query']) && strpos($text, strtolower($query['content_search_query'])) !== false) { $score += 35; }
+        if (!empty($query['destination']) && strpos($text, strtolower($query['destination'])) !== false) { $score += 15; }
+        if (!empty($query['theme']) && strpos($text, strtolower($query['theme'])) !== false) { $score += 10; }
         foreach ($query['terms'] as $t) { if (strpos($text, $t) !== false) { $score += 6; } }
         return min(100, $score);
     }

--- a/includes/class-ai-content-agent-selection-session.php
+++ b/includes/class-ai-content-agent-selection-session.php
@@ -3,11 +3,11 @@ if (!defined('ABSPATH')) { exit; }
 
 class ALMA_AI_Content_Agent_Selection_Session {
     const MAX_SELECTED_POSTS = 3;
-    const MAX_SELECTED_PAGES = 3;
-    const MAX_SELECTED_AFFILIATE_LINKS = 6;
+    const MAX_SELECTED_PAGES = 2;
+    const MAX_SELECTED_AFFILIATE_LINKS = 20;
     const MAX_SELECTED_DOCUMENT_TXT = 5;
     const MAX_SELECTED_SOURCE_ONLINE = 5;
-    const MAX_SELECTED_MEDIA = 6;
+    const MAX_SELECTED_MEDIA = 5;
     const TTL = DAY_IN_SECONDS;
     const MAX_RESULTS = 250;
 
@@ -39,13 +39,15 @@ class ALMA_AI_Content_Agent_Selection_Session {
                 $k = $normalized['result_key'];
                 if (isset($session['results'][$k])) {
                     $duplicates++;
-                    if ((int)($normalized['score'] ?? 0) > (int)($session['results'][$k]['score'] ?? 0)) {
-                        $session['results'][$k] = $normalized;
-                    } elseif (!empty($normalized['reason'])) {
-                        $old_reason = (string)($session['results'][$k]['reason'] ?? '');
-                        if ($old_reason === '') { $session['results'][$k]['reason'] = $normalized['reason']; }
-                        elseif (strpos($old_reason, $normalized['reason']) === false) { $session['results'][$k]['reason'] = $old_reason . ' | ' . $normalized['reason']; }
-                    }
+                    $existing = $session['results'][$k];
+                    $merged = ((int)($normalized['score'] ?? 0) > (int)($existing['score'] ?? 0)) ? $normalized : $existing;
+                    $merged['selected'] = !empty($existing['selected']) || !empty($normalized['selected']);
+                    $merged['origin_key'] = sanitize_text_field($merged['origin_key'] ?? ($existing['origin_key'] ?? ($normalized['origin_key'] ?? '')));
+                    $merged['raw_key'] = sanitize_text_field($existing['raw_key'] ?? ($normalized['raw_key'] ?? ''));
+                    $old_reason = array_filter(array_map('trim', explode('|', (string)($existing['reason'] ?? ''))));
+                    $new_reason = array_filter(array_map('trim', explode('|', (string)($normalized['reason'] ?? ''))));
+                    $merged['reason'] = implode(' | ', array_values(array_unique(array_merge($old_reason, $new_reason))));
+                    $session['results'][$k] = $merged;
                     continue;
                 }
                 $session['results'][$k] = $normalized;
@@ -55,9 +57,9 @@ class ALMA_AI_Content_Agent_Selection_Session {
         if (count($session['results']) > self::MAX_RESULTS) {
             $session['results'] = array_slice($session['results'], -self::MAX_RESULTS, null, true);
         }
-        $query = array('theme'=>sanitize_text_field($payload['theme'] ?? ''),'destination'=>sanitize_text_field($payload['destination'] ?? ''),'search_terms'=>sanitize_text_field($payload['search_terms'] ?? ''),'temporary_instructions'=>sanitize_textarea_field($payload['temporary_instructions'] ?? ''));
+        $query = array('content_search_query'=>sanitize_text_field($payload['content_search_query'] ?? ($payload['search_terms'] ?? '')),'theme'=>sanitize_text_field($payload['theme'] ?? ''),'destination'=>sanitize_text_field($payload['destination'] ?? ''),'search_terms'=>sanitize_text_field($payload['search_terms'] ?? ''),'temporary_instructions'=>sanitize_textarea_field($payload['temporary_instructions'] ?? ''));
         $session['last_query'] = $query;
-        $session['query_history'][] = array('at'=>current_time('mysql'),'theme'=>$query['theme'],'destination'=>$query['destination']);
+        $session['query_history'][] = array('at'=>current_time('mysql'),'content_search_query'=>$query['content_search_query']);
         if (count($session['query_history']) > 20) { $session['query_history'] = array_slice($session['query_history'], -20); }
         $session['status'] = empty($session['results']) ? 'empty' : 'active';
         $session['updated_at'] = current_time('mysql');
@@ -83,7 +85,8 @@ class ALMA_AI_Content_Agent_Selection_Session {
         $warnings = array();
         foreach ($limits as $g => $max) {
             if (($counts[$g] ?? 0) <= $max) { continue; }
-            $warnings[] = sprintf('%s: massimo %d elementi, ridotti automaticamente.', $g, $max);
+            $labels = array('affiliate_link'=>'Link Affiliati','post'=>'Post','document_txt'=>'File TXT','source_online'=>'Fonti online','page'=>'Pagine','media'=>'Media');
+            $warnings[] = sprintf('Hai selezionato %d %s: ne sono stati mantenuti %d.', (int)($counts[$g] ?? 0), $labels[$g] ?? $g, $max);
             $kept = 0;
             foreach ($next as $k => $row) {
                 if (($row['source_group'] ?? '') !== $g || empty($next[$k]['selected'])) { continue; }
@@ -145,6 +148,7 @@ class ALMA_AI_Content_Agent_Selection_Session {
         return array(
             'result_key' => sanitize_text_field($result_key),
             'origin_key' => $origin_key,
+            'raw_key' => sanitize_text_field($row['result_key'] ?? ''),
             'source_group' => $source_group,
             'source_type' => $source_type,
             'source_id' => $source_id,
@@ -160,9 +164,23 @@ class ALMA_AI_Content_Agent_Selection_Session {
         );
     }
 
-    public static function grouped_results() {
-        $session = self::get_session(); $groups = array();
-        foreach ($session['results'] as $row) { $groups[$row['source_group']][] = $row; }
+    public static function grouped_results($selected_only = false) {
+        $session = self::get_session();
+        $order = array('affiliate_link','post','document_txt','source_online','page','media','other');
+        $groups = array_fill_keys($order, array());
+        foreach ($session['results'] as $row) {
+            if ($selected_only && empty($row['selected'])) { continue; }
+            $k = isset($groups[$row['source_group']]) ? $row['source_group'] : 'other';
+            $groups[$k][] = $row;
+        }
+        foreach ($groups as $k => $rows) {
+            usort($rows, function($a, $b){
+                $score = ((int)($b['score'] ?? 0)) <=> ((int)($a['score'] ?? 0));
+                if ($score !== 0) { return $score; }
+                return strcasecmp((string)($a['title'] ?? ''), (string)($b['title'] ?? ''));
+            });
+            $groups[$k] = $rows;
+        }
         return $groups;
     }
 


### PR DESCRIPTION
### Motivation
- Stabilizzare e rifinire il nuovo workflow introdotto in 2.23.0 per evitare perdita di selezione nella deduplica e per far sì che la query di ricerca mostrata in UI venga effettivamente usata nelle ricerche e nel payload AI. 
- Semplificare l'UX con un unico campo di ricerca e separare chiaramente i `Risultati ricerca` dalla `Sessione contenuto`, mantenendo singola chiamata OpenAI solo su `Crea Bozza` e senza riattivare generation/brief AI operativi o Claude.

### Description
- Preservata la selezione durante la deduplica in `ALMA_AI_Content_Agent_Selection_Session::add_search_results()` facendo il merge conservativo che mantiene `selected=true` se presente in una delle versioni e unisce le motivazioni senza duplicati; conservati `origin_key`/`raw_key` quando disponibili.
- Introdotto e collegato un unico campo di ricerca `content_search_query` (con fallback legacy `search_terms`) passando il valore dall'action admin → `ALMA_AI_Content_Agent_Knowledge_Search::normalize_input()` → `Selection_Session` → `Draft_Builder` e mostrando la query nella sessione; sanitizzazione applicata ovunque.
- Riorganizzati i gruppi e l'ordinamento in priorità editoriale: `affiliate_link`, `post`, `document_txt`, `source_online`, `page`, `media`; ogni gruppo è ordinato `score DESC` con tiebreak alfabetico su `title` e limiti per group slice rispettati.
- Aggiornati i limiti selezionabili server-side a: Link Affiliati = `20`, Post = `3`, File TXT = `5`, Fonti online = `5`, Pagine = `2`, Media = `5`, con messaggi di warning chiari che indicano il gruppo limitato quando si supera il massimo.
- Separata l'UI della tab `Idee contenuto` in blocchi `Risultati ricerca` (ultima ricerca, sostituiti a ogni nuova ricerca) e `Sessione contenuto` (elementi salvati/persistenti), rifattura dei pulsanti (Cerca contenuti / Aggiungi nuova ricerca / Salva selezione / Scarica JSON payload AI / Crea Bozza con OpenAI) e rimozione della tabella legacy idee/brief dalla UI principale di quel tab.
- Rifatturato il payload costruito da sessione: `Draft_Builder` ora costruisce payload raggruppato e utilmente strutturato (top-level `task`, `site_context`, `user_inputs` includendo `content_search_query`, `temporary_instructions`, `instruction_profile`, `selection_context` e sezioni raggruppate `affiliate_links`, `posts`, `documents` (con `normalized_text`), `sources_online`, `pages`, `media`, regole e `output_contract`) evitando l'uso di `content_chunks.content` e rendendo il download JSON indipendente da chiamate OpenAI.
- Confermato e mantenuto la regola single-call OpenAI: chiamata a OpenAI solo in `generate_from_selection_session()` (pulsante `Crea Bozza con OpenAI`), nessuna chiamata su ricerca, salvataggio o download payload; nessuno scheduler/crawling/scraping/web-search introdotto.
- Aggiornati `Version` e `ALMA_VERSION` a `2.23.1` e documentazione (`README.md`, `CHANGELOG.md`).

### Testing
- Eseguiti i controlli di sintassi PHP: `php -l includes/class-ai-content-agent-admin.php`, `php -l includes/class-ai-content-agent-selection-session.php`, `php -l includes/class-ai-content-agent-knowledge-search.php`, `php -l includes/class-ai-content-agent-draft-builder.php`, `php -l affiliate-link-manager-ai.php` — tutti senza errori.
- Eseguiti grep/ricerche per verificare wiring della query e assenza di uso di `content_chunks.content`, presenza di `content_search_query`, aggiornamento limiti e rimozione testi operativi di generation brief; tutti i check automatizzati eseguiti in CI/CLI sono passati.
- Nota limitazione: i test manuali UI end‑to‑end nella dashboard WordPress (interazioni visuali, comportamento JavaScript di disabling/contatori, verifica visiva tabella legacy rimossa) non sono stati eseguiti in questo ambiente CLI e richiedono validazione manuale in ambiente WordPress come indicato nella checklist funzionale.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7758fa9d48332baba9b52f0330be6)