### PR TITLE
PR 7 — AI Content Agent Persistent Ideas & 3-Column Workflow UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.24.0
+- Introduzione entità persistente Idee contenuto come CPT interno (`alma_content_idea`).
+- Nuova UI a 3 colonne (Idee salvate, Cerca/Risultati, Sessione contenuto).
+- Prompt editoriale per OpenAI salvato per singola idea.
+- Azioni Aggiungi selezionati e gestione contenuti associati per idea.
+- Rimozione flusso Duplica/Proposta di sviluppo e mantenimento single-call OpenAI in creazione bozza.
+
 ## 2.23.1 — PR 6.1 — Search Session UX & Payload Refinement
 - fix selezione persa in dedupe preservando selected=true.
 - fix collegamento reale query di ricerca locale (campo unico).

--- a/README.md
+++ b/README.md
@@ -316,3 +316,7 @@ Workflow base completo: genera idee → genera brief → genera bozza → apri i
 - Documenti TXT: upload operativo solo `.txt`, salvataggio nel Knowledge Base e chunking/indexing locale.
 - Fonti online AI: CRUD operativo con URL validation, tecnologia da lista consentita e stato active/inactive.
 - Questa PR non introduce crawling/scraping né nuove chiamate AI/OpenAI.
+
+
+## AI Content Agent 2.24.0
+La tab Idee contenuto ora usa idee persistenti (CPT), layout operativo in 3 colonne, prompt OpenAI per idea, sessione contenuto associata all'idea e creazione bozza con una sola chiamata OpenAI.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.23.1
+ * Version: 2.24.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.23.1');
+define('ALMA_VERSION', '2.24.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -32,6 +32,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-text-utils.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-knowledge-indexer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-knowledge-search.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-selection-session.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-ideas.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-media-indexer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-source-tech-registry.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-source-manager.php';

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -46,9 +46,11 @@ class ALMA_AI_Content_Agent_Admin {
             $payload = array('max_ideas'=>absint($_POST['max_ideas'] ?? 1),'content_search_query'=>sanitize_text_field($_POST['content_search_query'] ?? ($_POST['search_terms'] ?? '')),'search_terms'=>sanitize_text_field($_POST['search_terms'] ?? ($_POST['content_search_query'] ?? '')),'theme'=>sanitize_text_field($_POST['theme'] ?? ''),'destination'=>sanitize_text_field($_POST['destination'] ?? ''),'temporary_instructions'=>sanitize_textarea_field($_POST['temporary_instructions'] ?? ''),'instruction_profile_id'=>$profile_id,'instruction_profile_name'=>sanitize_text_field($profile['profile_name'] ?? ''),'instruction_snapshot_hash'=>sanitize_text_field($profile ? ALMA_AI_Content_Agent_Instructions_Manager::snapshot_hash(wp_json_encode($profile)) : ''));
             $search = ALMA_AI_Content_Agent_Knowledge_Search::search($payload);
             $stats = ALMA_AI_Content_Agent_Selection_Session::add_search_results($payload, $search);
+            $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true)); if ($active_idea_id > 0) { ALMA_AI_Content_Agent_Selection_Session::persist_to_idea($active_idea_id); }
             $result = array('success' => true, 'message' => sprintf('Ricerca completata. Trovati: %d, aggiunti: %d, duplicati ignorati: %d.', (int)$stats['found'], (int)$stats['added'], (int)$stats['duplicates']));
         } elseif ($do === 'save_selection') {
             $result = ALMA_AI_Content_Agent_Selection_Session::save_selection($_POST['selected_result_keys'] ?? array());
+            $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true)); if ($active_idea_id > 0) { ALMA_AI_Content_Agent_Selection_Session::persist_to_idea($active_idea_id); }
         } elseif ($do === 'clear_selection_session') {
             ALMA_AI_Content_Agent_Selection_Session::clear();
             $result = array('success' => true, 'message' => 'Sessione contenuto svuotata.');
@@ -67,6 +69,30 @@ class ALMA_AI_Content_Agent_Admin {
                 $result['message'] = empty($result['success']) ? ($result['error'] ?? 'Errore creazione bozza da sessione.') : 'Bozza articolo creata.';
                 set_transient(self::RESULT_TRANSIENT_KEY . get_current_user_id(), $result, 120);
             }
+        } elseif ($do === 'new_content_idea') {
+            $idea_id = ALMA_AI_Content_Agent_Ideas::create('Nuova idea');
+            if ($idea_id > 0) { update_user_meta(get_current_user_id(), '_alma_active_idea_id', $idea_id); ALMA_AI_Content_Agent_Selection_Session::clear(); }
+            $result = array('success' => $idea_id > 0, 'message' => $idea_id > 0 ? 'Nuova idea creata.' : 'Errore creazione idea.');
+        } elseif ($do === 'load_content_idea') {
+            $idea_id = absint($_POST['idea_id'] ?? 0);
+            update_user_meta(get_current_user_id(), '_alma_active_idea_id', $idea_id);
+            $idea = ALMA_AI_Content_Agent_Ideas::get($idea_id);
+            ALMA_AI_Content_Agent_Selection_Session::load_from_idea($idea);
+            $result = array('success' => !empty($idea), 'message' => !empty($idea) ? 'Idea caricata.' : 'Idea non trovata.');
+        } elseif ($do === 'save_content_idea') {
+            $idea_id = absint($_POST['idea_id'] ?? 0);
+            $ok = ALMA_AI_Content_Agent_Ideas::save_from_request($idea_id, $_POST);
+            if ($ok) { ALMA_AI_Content_Agent_Selection_Session::persist_to_idea($idea_id); }
+            $result = array('success' => $ok, 'message' => $ok ? 'Idea salvata.' : 'Errore salvataggio idea.');
+        } elseif ($do === 'delete_content_idea') {
+            $idea_id = absint($_POST['idea_id'] ?? 0); $ok = $idea_id > 0 ? (bool)wp_delete_post($idea_id, true) : false;
+            if ($ok) { delete_user_meta(get_current_user_id(), '_alma_active_idea_id'); ALMA_AI_Content_Agent_Selection_Session::clear(); }
+            $result = array('success' => $ok, 'message' => $ok ? 'Idea eliminata.' : 'Impossibile eliminare idea.');
+        } elseif ($do === 'remove_selected_item') {
+            $k = sanitize_text_field($_POST['result_key'] ?? '');
+            $result = ALMA_AI_Content_Agent_Selection_Session::remove_selected_item($k);
+            $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true)); if ($active_idea_id > 0) { ALMA_AI_Content_Agent_Selection_Session::persist_to_idea($active_idea_id); }
+
         } elseif ($do === 'upload_txt_document') {
             $result = ALMA_AI_Content_Agent_Document_Manager::handle_upload(sanitize_text_field($_POST['document_name'] ?? ''), $_FILES['document_file'] ?? array());
         } elseif ($do === 'rename_txt_document') {
@@ -189,39 +215,35 @@ class ALMA_AI_Content_Agent_Admin {
     }
 
     private static function render_ideas_tab() {
-        echo '<h2>Idee contenuto</h2>';
-        $profiles = ALMA_AI_Content_Agent_Instructions_Manager::get_profiles(100,0);
-        $active = ALMA_AI_Content_Agent_Instructions_Manager::get_active_profile();
-        $profile_options = '<option value="0">Seleziona Profilo Istruzioni AI</option>';
-        foreach($profiles as $pp){ if((int)($pp['is_active']??0)!==1){ continue; } $profile_options .= '<option value="'.(int)$pp['id'].'" '.selected((int)($active['id']??0),(int)$pp['id'],false).'>'.esc_html($pp['profile_name']).'</option>'; }
-        self::action_form('search_knowledge_base','Cerca contenuti','<p><label><strong>Cerca contenuti per la bozza</strong><br><input class="large-text" name="content_search_query" placeholder="Es. tour Lecce barocco, itinerario Salento, museo ebraico, spiagge Otranto..."></label></p><p><label><strong>Profilo Istruzioni AI</strong> <select name="instruction_profile_id">'.$profile_options.'</select></label> <a class="button" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=istruzioni-ai')).'">Gestisci Profili Istruzioni AI</a></p><p><textarea name="temporary_instructions" class="large-text" rows="2" placeholder="Istruzioni temporanee per questa bozza"></textarea></p><p><button type="submit" class="button button-secondary" name="do" value="search_knowledge_base">Cerca contenuti</button> <button type="submit" class="button" name="do" value="add_new_search">Aggiungi nuova ricerca</button></p>');
+        $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true));
+        $ideas = get_posts(array('post_type'=>ALMA_AI_Content_Agent_Ideas::CPT,'post_status'=>'publish','numberposts'=>50,'orderby'=>'modified','order'=>'DESC','author'=>get_current_user_id()));
+        if ($active_idea_id < 1 && !empty($ideas)) { $active_idea_id = (int)$ideas[0]->ID; update_user_meta(get_current_user_id(), '_alma_active_idea_id', $active_idea_id); }
+        $active_idea = $active_idea_id ? ALMA_AI_Content_Agent_Ideas::get($active_idea_id) : array();
+        ALMA_AI_Content_Agent_Selection_Session::load_from_idea($active_idea);
 
+        $profiles = ALMA_AI_Content_Agent_Instructions_Manager::get_profiles(100,0);
         $summary = ALMA_AI_Content_Agent_Selection_Session::summary();
         $results_groups = ALMA_AI_Content_Agent_Selection_Session::grouped_results(false);
         $selected_groups = ALMA_AI_Content_Agent_Selection_Session::grouped_results(true);
-        $labels = array('affiliate_link'=>'Link Affiliati','post'=>'Post','document_txt'=>'File TXT','source_online'=>'Fonti online','page'=>'Pagine','media'=>'Media');
-        $limits = array('affiliate_link'=>ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_AFFILIATE_LINKS,'post'=>ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_POSTS,'document_txt'=>ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_DOCUMENT_TXT,'source_online'=>ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_SOURCE_ONLINE,'page'=>ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_PAGES,'media'=>ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_MEDIA);
+        $labels = array('affiliate_link'=>'Link Affiliati','post'=>'Post','document_txt'=>'File TXT / Documenti TXT','source_online'=>'Fonti online','page'=>'Pagine','media'=>'Media');
+        echo '<div class="alma-ideas-layout" style="display:grid;grid-template-columns:22% 50% 28%;gap:16px;">';
+        echo '<div><h3>Idee salvate</h3>'; self::action_form('new_content_idea','+ Nuova idea'); foreach($ideas as $i){ $st=get_post_meta($i->ID, ALMA_AI_Content_Agent_Ideas::META_STATUS,true) ?: 'bozza'; echo '<div style="padding:8px;border:1px solid #ddd;margin-bottom:8px;'.($active_idea_id===$i->ID?'background:#eef6ff;':'').'">'; echo '<strong>'.esc_html($i->post_title).'</strong><br><small>'.esc_html($st).' · '.esc_html($i->post_modified).'</small>'; echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="load_content_idea"><input type="hidden" name="idea_id" value="'.(int)$i->ID.'"><p><button class="button button-small">Apri</button></p></form></div>'; } echo '</div>';
 
+        echo '<div><h3>2. Cerca contenuti</h3><form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_ai_agent_action');
+        echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="search_knowledge_base"><p><input class="large-text" name="content_search_query" value="'.esc_attr($active_idea['last_query']['content_search_query'] ?? '').'" placeholder="Cerca contenuti"></p><p><select name="instruction_profile_id">';
+        foreach($profiles as $pp){ echo '<option value="'.(int)$pp['id'].'" '.selected((int)($active_idea['profile_id']??0),(int)$pp['id'],false).'>'.esc_html($pp['profile_name']).'</option>'; }
+        echo '</select></p><p><label><strong>Prompt per OpenAI</strong></label><textarea class="large-text" rows="3" name="temporary_instructions">'.esc_textarea($active_idea['prompt'] ?? '').'</textarea></p><p><button class="button button-secondary">Cerca contenuti</button></p></form>';
         echo '<h3>Risultati ricerca</h3><form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_ai_agent_action');
         echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_selection">';
-        foreach ($labels as $groupKey => $groupLabel) { $rows = (array)($results_groups[$groupKey] ?? array()); if (empty($rows)) { continue; } $sel=0; foreach($rows as $r){ if(!empty($r['selected'])){$sel++;}}
-            echo '<h4>' . esc_html($groupLabel) . ' (' . count($rows) . ') — max selezionabili '.(int)$limits[$groupKey].' — selezionati '.$sel.'</h4><table class="widefat striped"><tbody>';
-            foreach ($rows as $r) { $checked = !empty($r['selected']) ? 'checked' : '';
-                echo '<tr><td style="width:40px;"><input name="selected_result_keys[]" type="checkbox" value="' . esc_attr($r['result_key']) . '" ' . $checked . '></td><td><strong>' . esc_html($r['title']) . '</strong><br><small>' . esc_html($r['excerpt']) . '</small><br><span class="alma-badge is-pending">Score ' . (int)$r['score'] . '</span> <small>' . esc_html($r['reason']) . '</small>' . (!empty($r['admin_url']) ? ' <a href="'.esc_url($r['admin_url']).'" target="_blank" rel="noopener">Apri</a>' : '') . '</td></tr>'; }
-            echo '</tbody></table>'; }
-        echo '<p><button type="submit" class="button button-primary">Salva selezione</button></p></form>';
+        foreach($labels as $k=>$label){ $rows=(array)($results_groups[$k]??array()); if(!$rows)continue; echo '<h4>'.esc_html($label).' ('.count($rows).')</h4>'; foreach($rows as $r){ echo '<div style="border:1px solid #ddd;padding:8px;margin:6px 0;"><input type="checkbox" name="selected_result_keys[]" value="'.esc_attr($r['result_key']).'" '.(!empty($r['selected'])?'checked':'').'> <strong>'.esc_html($r['title']).'</strong> <span>score '.(int)$r['score'].'</span><br><small>'.esc_html($r['excerpt']).'</small><br><em>'.esc_html($r['reason']).'</em></div>'; }}
+        echo '<p><button class="button button-primary">Aggiungi selezionati</button></p></form></div>';
 
-        echo '<h3>Sessione contenuto</h3><p>Elementi selezionati persistenti usati per JSON payload e Crea Bozza.</p>';
-        if ((int)($summary['selected_total'] ?? 0) < 1) { echo '<p><em>Nessun elemento selezionato.</em></p>'; }
-        foreach ($labels as $groupKey => $groupLabel) { $rows = (array)($selected_groups[$groupKey] ?? array()); if (empty($rows)) { continue; }
-            echo '<h4>'.esc_html($groupLabel).' ('.count($rows).')</h4><ul>';
-            foreach($rows as $r){ echo '<li><strong>'.esc_html($r['title']).'</strong> — score '.(int)$r['score'].' — '.esc_html($r['reason']).'</li>'; }
-            echo '</ul>'; }
-
-        echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_ai_agent_action');
-        echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="download_ai_payload_json"><p><button type="submit" class="button">Scarica JSON payload AI</button></p></form>';
-        echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_ai_agent_action');
-        echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="create_draft_from_selection"><p><button type="submit" class="button button-primary">Crea Bozza con OpenAI</button></p></form>';
+        echo '<div><h3>3. Sessione contenuto</h3><p>Totale: '.(int)($summary['selected_total']??0).'</p>';
+        foreach($labels as $k=>$label){ $rows=(array)($selected_groups[$k]??array()); if(!$rows)continue; echo '<h4>'.esc_html($label).' ('.count($rows).')</h4>'; foreach($rows as $r){ echo '<div style="border:1px solid #ddd;padding:6px;margin:4px 0;"><strong>'.esc_html($r['title']).'</strong><br><small>Score '.(int)$r['score'].' - '.esc_html($r['reason']).'</small><form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="remove_selected_item"><input type="hidden" name="result_key" value="'.esc_attr($r['result_key']).'"><button class="button button-small">Rimuovi</button></form></div>'; }}
+        if($active_idea_id){ echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_content_idea"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><p><input name="idea_title" value="'.esc_attr($active_idea['title'] ?? '').'" class="regular-text"></p><p><select name="idea_status">'; foreach(ALMA_AI_Content_Agent_Ideas::statuses() as $sv=>$sl){ echo '<option value="'.esc_attr($sv).'" '.selected(($active_idea['status']??'bozza'),$sv,false).'>'.esc_html($sl).'</option>'; } echo '</select></p><input type="hidden" name="instruction_profile_id" value="'.(int)($active_idea['profile_id']??0).'"><input type="hidden" name="openai_prompt" value="'.esc_attr($active_idea['prompt']??'').'"><p><button class="button button-primary">Salva idea</button></p></form>'; }
+        self::action_form('download_ai_payload_json','Scarica JSON payload AI'); self::action_form('create_draft_from_selection','Crea Bozza con OpenAI');
+        if($active_idea_id){ echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="delete_content_idea"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><p><button class="button">Elimina</button></p></form>'; }
+        echo '</div></div>';
     }
 
     private static function inline_status_form($idea_id,$status,$label){ return '<form style="display:inline-block" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="set_idea_status"><input type="hidden" name="idea_id" value="'.(int)$idea_id.'"><input type="hidden" name="status" value="'.esc_attr($status).'"><button class="button button-small">'.esc_html($label).'</button></form>'; }

--- a/includes/class-ai-content-agent-ideas.php
+++ b/includes/class-ai-content-agent-ideas.php
@@ -1,0 +1,58 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_AI_Content_Agent_Ideas {
+    const CPT = 'alma_content_idea';
+    const META_STATUS = '_alma_idea_status';
+    const META_PROFILE_ID = '_alma_idea_profile_id';
+    const META_PROMPT = '_alma_idea_openai_prompt';
+    const META_LAST_QUERY = '_alma_idea_last_query';
+    const META_RESULTS = '_alma_idea_search_results';
+    const META_SELECTION = '_alma_idea_selected_results';
+
+    public static function init() {
+        add_action('init', array(__CLASS__, 'register_cpt'));
+    }
+
+    public static function register_cpt() {
+        register_post_type(self::CPT, array(
+            'label' => 'Idee contenuto',
+            'public' => false,
+            'show_ui' => false,
+            'supports' => array('title', 'author'),
+            'capability_type' => 'post',
+            'map_meta_cap' => true,
+        ));
+    }
+
+    public static function statuses() { return array('bozza'=>'Bozza','in_lavorazione'=>'In lavorazione','pronta'=>'Pronta','archiviata'=>'Archiviata'); }
+
+    public static function create($title = 'Nuova idea') {
+        $id = wp_insert_post(array('post_type'=>self::CPT,'post_status'=>'publish','post_title'=>sanitize_text_field($title),'post_author'=>get_current_user_id()), true);
+        if (is_wp_error($id) || !$id) { return 0; }
+        update_post_meta($id, self::META_STATUS, 'bozza');
+        update_post_meta($id, self::META_PROFILE_ID, 0);
+        update_post_meta($id, self::META_PROMPT, '');
+        update_post_meta($id, self::META_LAST_QUERY, array());
+        update_post_meta($id, self::META_RESULTS, array());
+        update_post_meta($id, self::META_SELECTION, array());
+        return (int)$id;
+    }
+
+    public static function get($id) {
+        $p = get_post(absint($id)); if (!$p || $p->post_type !== self::CPT) { return array(); }
+        return array('ID'=>$p->ID,'title'=>$p->post_title,'status'=>get_post_meta($p->ID,self::META_STATUS,true) ?: 'bozza','profile_id'=>absint(get_post_meta($p->ID,self::META_PROFILE_ID,true)),'prompt'=>get_post_meta($p->ID,self::META_PROMPT,true),'last_query'=>get_post_meta($p->ID,self::META_LAST_QUERY,true),'results'=>(array)get_post_meta($p->ID,self::META_RESULTS,true),'selection'=>(array)get_post_meta($p->ID,self::META_SELECTION,true),'modified'=>$p->post_modified);
+    }
+
+    public static function save_from_request($idea_id, $data) {
+        $idea_id = absint($idea_id); if ($idea_id < 1) { return false; }
+        $status = sanitize_key($data['idea_status'] ?? 'bozza');
+        if (!isset(self::statuses()[$status])) { $status = 'bozza'; }
+        wp_update_post(array('ID'=>$idea_id,'post_title'=>sanitize_text_field($data['idea_title'] ?? 'Nuova idea')));
+        update_post_meta($idea_id, self::META_STATUS, $status);
+        update_post_meta($idea_id, self::META_PROFILE_ID, absint($data['instruction_profile_id'] ?? 0));
+        update_post_meta($idea_id, self::META_PROMPT, sanitize_textarea_field($data['openai_prompt'] ?? ''));
+        return true;
+    }
+}
+ALMA_AI_Content_Agent_Ideas::init();

--- a/includes/class-ai-content-agent-selection-session.php
+++ b/includes/class-ai-content-agent-selection-session.php
@@ -201,6 +201,36 @@ class ALMA_AI_Content_Agent_Selection_Session {
         return $c;
     }
 
+
+    public static function persist_to_idea($idea_id) {
+        $idea_id = absint($idea_id); if ($idea_id < 1) { return; }
+        $session = self::get_session();
+        update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_LAST_QUERY, (array)$session['last_query']);
+        update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_RESULTS, (array)$session['results']);
+        update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_SELECTION, array_values(array_filter((array)$session['results'], function($r){ return !empty($r['selected']); })));
+    }
+
+    public static function load_from_idea($idea) {
+        if (empty($idea['ID'])) { self::clear(); return; }
+        $results = (array)($idea['results'] ?? array());
+        $session = self::empty_session();
+        $session['status'] = empty($results) ? 'empty' : 'active';
+        $session['last_query'] = (array)($idea['last_query'] ?? array());
+        $session['results'] = $results;
+        $session['instruction_profile_id'] = absint($idea['profile_id'] ?? 0);
+        $session['updated_at'] = current_time('mysql');
+        $session['counts'] = self::count_summary($results);
+        set_transient(self::key(), $session, self::TTL);
+    }
+
+    public static function remove_selected_item($result_key) {
+        $session = self::get_session();
+        $result_key = sanitize_text_field($result_key);
+        if (isset($session['results'][$result_key])) { $session['results'][$result_key]['selected'] = false; }
+        $session['counts'] = self::count_summary($session['results']);
+        set_transient(self::key(), $session, self::TTL);
+        return array('success'=>true,'message'=>'Elemento rimosso dalla sessione contenuto.');
+    }
     public static function build_context_package() {
         $s = self::get_session();
         $selected = array_values(array_filter($s['results'], function($r){ return !empty($r['selected']); }));


### PR DESCRIPTION
### Motivation
- Replace fragile transient/session-only idea storage with a first-class, persistent "Idea contenuto" entity to ensure durable UX and clear ownership/state. 
- Redesign the admin Ideas screen into a clear 3-column operational workflow (Saved ideas, Search+Results, Content session) to separate persistent idea state from ephemeral search results. 
- Enable per-idea OpenAI editorial prompts and keep the OpenAI draft generation as a single explicit call from the active idea. 

### Description
- Added a new internal CPT and helper class `ALMA_AI_Content_Agent_Ideas` in `includes/class-ai-content-agent-ideas.php` to persist ideas and their metadata (`status`, `profile_id`, `prompt`, `last_query`, `results`, `selection`).
- Bootstrapped the ideas module by requiring the new file in `affiliate-link-manager-ai.php` and bumped plugin version to `2.24.0` (header and `ALMA_VERSION`).
- Extended admin action handlers in `includes/class-ai-content-agent-admin.php` with new flows: `new_content_idea`, `load_content_idea`, `save_content_idea`, `delete_content_idea`, and `remove_selected_item`, and persisted selection session to the active idea after search/save/remove operations.
- Reworked the Ideas admin UI in `render_ideas_tab()` to a 3-column layout showing saved ideas (left), search + results (center) and the content session/cart (right), added `+ Nuova idea`, explicit bulk `Aggiungi selezionati` flow and per-item removal action in the session column, and renamed the temporary instructions field to the `Prompt per OpenAI` prompt saved per idea.
- Extended `ALMA_AI_Content_Agent_Selection_Session` (`includes/class-ai-content-agent-selection-session.php`) with `persist_to_idea()`, `load_from_idea()` and `remove_selected_item()` to map transient session state to/from the persistent idea entity.
- Updated documentation: `CHANGELOG.md` and `README.md` to describe the new persistent-idea model and the 3-column UI and confirmed single-call OpenAI draft creation is unchanged.

### Testing
- Ran PHP syntax checks with `php -l` against modified files `affiliate-link-manager-ai.php`, `includes/class-ai-content-agent-ideas.php`, `includes/class-ai-content-agent-selection-session.php`, and `includes/class-ai-content-agent-admin.php`, and all returned no syntax errors. 
- No automated browser E2E tests were run in this change; runtime/admin render and OpenAI integration should be validated in an admin environment (manual checks recommended).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f847f86b1083329a32fe9257b12bc8)