### PR TITLE
PR 7.7 — AI Content Agent Data Normalization Fatal Fix and Ideas Layout Hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.24.7 — PR 7.7 AI Content Agent Data Normalization Fatal Fix and Ideas Layout Hardening
+- Hardening runtime su meta/transient legacy o corrotti: normalizzazione difensiva di risultati/sessione e guard su rendering gruppi/conteggi.
+- Fix definitivo fatal PHP 8 su accessi offset stringa in Selection Session (`grouped_results`, `count_summary`, load/persist/build context).
+- Hardening tab Idee contenuto: validazione idea attiva, fallback profili/usage sicuri, stati vuoti espliciti e nessun fatal con tabelle usage mancanti.
+- Consolidato layout CSS Idee contenuto in una sola sezione scoped `.alma-ai-agent-admin` con 3 colonne leggibili e fallback responsive.
+- Verificato enqueue di `assets/admin.css` anche su `affiliate_link_page_alma-ai-content-agent`.
+
 ## 2.24.6 — PR 7.6 AI Content Agent Critical Error Hotfix and Ideas UI Optimization
 - Fix critical error in Selection Session: rimosse variabili non definite e normalizzazione difensiva della struttura sessione.
 - Stabilizzata persistenza `openai_prompt`, `status`, `counts` e `updated_at` anche con sessioni vuote/corrotte.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## 2.24.7 — PR 7.7 AI Content Agent Data Normalization Fatal Fix and Ideas Layout Hardening
+- Hardening runtime su meta/transient legacy o corrotti: normalizzazione difensiva di risultati/sessione e guard su rendering gruppi/conteggi.
+- Fix definitivo fatal PHP 8 su accessi offset stringa in Selection Session (`grouped_results`, `count_summary`, load/persist/build context).
+- Hardening tab Idee contenuto: validazione idea attiva, fallback profili/usage sicuri, stati vuoti espliciti e nessun fatal con tabelle usage mancanti.
+- Consolidato layout CSS Idee contenuto in una sola sezione scoped `.alma-ai-agent-admin` con 3 colonne leggibili e fallback responsive.
+- Verificato enqueue di `assets/admin.css` anche su `affiliate_link_page_alma-ai-content-agent`.
+
 ## 2.24.6 — PR 7.6 AI Content Agent Critical Error Hotfix and Ideas UI Optimization
 - Fix critical error in Selection Session: rimosse variabili non definite e normalizzazione difensiva della struttura sessione.
 - Stabilizzata persistenza `openai_prompt`, `status`, `counts` e `updated_at` anche con sessioni vuote/corrotte.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.24.6
+ * Version: 2.24.7
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.24.6');
+define('ALMA_VERSION', '2.24.7');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -679,6 +679,7 @@ class AffiliateManagerAI {
         
         if ($screen && ($screen->post_type === 'affiliate_link' || 
             strpos($hook, 'affiliate-link-manager') !== false ||
+            $hook === 'affiliate_link_page_alma-ai-content-agent' ||
             $hook === 'index.php')) {
             
             // Stili - verifica che il file esista

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -635,45 +635,21 @@ button:disabled {
 .alma-ai-agent-admin .alma-badge.is-success{background:#d1e7dd}
 .alma-ai-agent-admin .alma-badge.is-warning,.alma-ai-agent-admin .alma-badge.is-pending{background:#fff3cd}
 
-/* AI Content Agent - Idee contenuto 3 column restoration */
-.alma-ai-agent-admin .alma-ideas-layout{display:grid;grid-template-columns:minmax(220px,22%) minmax(560px,56%) minmax(260px,22%);gap:16px;align-items:start}
-.alma-ai-agent-admin .alma-ideas-card{background:#fff;border:1px solid #dcdcde;border-radius:8px;padding:14px;margin-bottom:14px}
-.alma-ai-agent-admin .alma-ideas-card-header{display:flex;justify-content:space-between;align-items:center;gap:10px}
-.alma-ai-agent-admin .alma-idea-card{border:1px solid #dcdcde;border-radius:6px;padding:10px;margin-bottom:10px;background:#fff}
-.alma-ai-agent-admin .alma-idea-card.is-active{border-color:#2271b1;box-shadow:inset 0 0 0 1px #2271b1}
-.alma-ai-agent-admin .alma-results-group{border:1px solid #e2e4e7;border-radius:6px;padding:10px;margin-bottom:10px;background:#fff}
-.alma-ai-agent-admin .alma-result-item{border-top:1px solid #f0f0f1;padding-top:8px;margin-top:8px}
-.alma-ai-agent-admin .alma-score-badge,.alma-ai-agent-admin .alma-count-badge{display:inline-block;background:#f6f7f7;border-radius:999px;padding:2px 8px;font-size:12px}
-.alma-ai-agent-admin .alma-excerpt{margin:6px 0;color:#50575e}
-.alma-ai-agent-admin .alma-session-sticky{position:sticky;top:46px;max-height:calc(100vh - 64px);overflow:auto}
-@media (max-width:1200px){.alma-ai-agent-admin .alma-ideas-layout{grid-template-columns:1fr}.alma-ai-agent-admin .alma-session-sticky{position:static;max-height:none}}
-.alma-ideas-actions-row{margin:12px 0;padding:12px;background:#fff;border:1px solid #dcdcde}
-.alma-actions-inline{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
-.alma-result-item.is-already-added{background:#eef8f0;border-left:4px solid #46b450}
-.alma-added-badge,.alma-usage-badge{display:inline-block;padding:2px 8px;border-radius:10px;background:#f0f6fc;font-size:12px}
-.alma-added-badge{background:#e7f5ea;color:#1e7e34}
-.alma-pagination{margin-top:8px;font-size:12px;color:#50575e}
-
-/* Ideas UI 2.24.5 */
-.alma-ideas-toolbar{display:flex;justify-content:space-between;gap:12px;align-items:flex-end;flex-wrap:wrap}
-.alma-idea-title-input{font-size:20px;font-weight:700;min-width:340px}
-.alma-ideas-layout{display:flex;gap:16px;align-items:flex-start}
-.alma-ideas-col-left{width:20%}.alma-ideas-col-main{width:56%}.alma-ideas-col-right{width:24%}
-.alma-ideas-card{background:#fff;border:1px solid #dcdcde;padding:14px;border-radius:6px;margin-bottom:12px}
-.alma-idea-title-lg{font-size:24px;font-weight:700;margin:8px 0}
-.alma-result-item{border:1px solid #e2e4e7;padding:10px;border-radius:6px;margin:8px 0}
-.alma-result-item.is-already-added{background:#f0f7ff;border-color:#72aee6}
-.alma-added-badge,.alma-usage-badge,.alma-count-badge{display:inline-block;padding:2px 8px;border-radius:999px;font-size:11px;margin-left:6px}
-.alma-added-badge{background:#dceffd;color:#135e96}.alma-usage-badge{background:#f0f0f1;color:#1d2327}.alma-count-badge{background:#eef2f7;color:#3c434a}
-@media (max-width: 1100px){.alma-ideas-layout{flex-direction:column}.alma-ideas-col-left,.alma-ideas-col-main,.alma-ideas-col-right{width:100%}}
-
 /* AI Content Agent Ideas layout */
-.alma-ai-agent-admin .alma-ideas-layout{display:grid;grid-template-columns:minmax(240px,1fr) minmax(520px,2.2fr) minmax(360px,1.4fr);gap:16px;align-items:start}
+.alma-ai-agent-admin .alma-ideas-toolbar{display:flex;justify-content:space-between;gap:12px;align-items:flex-end;flex-wrap:wrap}
+.alma-ai-agent-admin .alma-idea-title-input{font-size:20px;font-weight:700;min-width:320px}
+.alma-ai-agent-admin .alma-ideas-layout{display:grid;grid-template-columns:minmax(240px,320px) minmax(540px,1.9fr) minmax(320px,1.2fr);gap:16px;align-items:start;max-width:1600px}
 .alma-ai-agent-admin .alma-ideas-col{min-width:0}
-.alma-ai-agent-admin .alma-ideas-card{background:#fff;border:1px solid #dcdcde;border-radius:6px;padding:14px}
-.alma-ai-agent-admin .alma-idea-title-lg{font-size:18px;font-weight:600;margin:0 0 8px}
-.alma-ai-agent-admin .alma-results-scroll{max-height:70vh;overflow:auto;padding-right:4px}
+.alma-ai-agent-admin .alma-ideas-card{background:#fff;border:1px solid #dcdcde;border-radius:6px;padding:14px;margin-bottom:12px}
+.alma-ai-agent-admin .alma-idea-title-lg{font-size:22px;font-weight:700;margin:8px 0}
 .alma-ai-agent-admin .alma-results-group{margin:0 0 12px}
 .alma-ai-agent-admin .alma-result-item{padding:10px;border:1px solid #e2e4e7;border-radius:4px;margin:0 0 8px}
-@media (max-width: 1600px){.alma-ai-agent-admin .alma-ideas-layout{grid-template-columns:minmax(220px,1fr) minmax(460px,1.8fr) minmax(320px,1.3fr)}}
-@media (max-width: 1320px){.alma-ai-agent-admin .alma-ideas-layout{grid-template-columns:1fr;}.alma-ai-agent-admin .alma-results-scroll{max-height:none}}
+.alma-ai-agent-admin .alma-result-item.is-already-added{background:#eef8f0;border-color:#46b450}
+.alma-ai-agent-admin .alma-added-badge,.alma-ai-agent-admin .alma-usage-badge,.alma-ai-agent-admin .alma-count-badge{display:inline-block;padding:2px 8px;border-radius:999px;font-size:11px;margin-left:6px}
+.alma-ai-agent-admin .alma-added-badge{background:#e7f5ea;color:#1e7e34}
+.alma-ai-agent-admin .alma-usage-badge{background:#f0f0f1;color:#1d2327}
+.alma-ai-agent-admin .alma-count-badge{background:#eef2f7;color:#3c434a}
+.alma-ai-agent-admin .alma-excerpt{margin:6px 0;color:#50575e}
+.alma-ai-agent-admin .alma-actions-inline{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+@media (max-width: 1450px){.alma-ai-agent-admin .alma-ideas-layout{grid-template-columns:1fr}}
+@media (max-width: 782px){.alma-ai-agent-admin .alma-idea-title-input{min-width:100%}}

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -233,10 +233,19 @@ class ALMA_AI_Content_Agent_Admin {
     private static function render_ideas_tab() {
         $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true));
         $ideas = get_posts(array('post_type'=>ALMA_AI_Content_Agent_Ideas::CPT,'post_status'=>'publish','numberposts'=>50,'orderby'=>'modified','order'=>'DESC','author'=>get_current_user_id()));
+        if ($active_idea_id > 0) {
+            $active_post = get_post($active_idea_id);
+            if (!$active_post || $active_post->post_type !== ALMA_AI_Content_Agent_Ideas::CPT) {
+                delete_user_meta(get_current_user_id(), '_alma_active_idea_id');
+                $active_idea_id = 0;
+            }
+        }
         if ($active_idea_id < 1 && !empty($ideas)) { $active_idea_id = (int)$ideas[0]->ID; update_user_meta(get_current_user_id(), '_alma_active_idea_id', $active_idea_id); }
         $active_idea = $active_idea_id ? ALMA_AI_Content_Agent_Ideas::get($active_idea_id) : array();
-        ALMA_AI_Content_Agent_Selection_Session::load_from_idea($active_idea);
+        if (!empty($active_idea['ID'])) { ALMA_AI_Content_Agent_Selection_Session::load_from_idea($active_idea); }
+        else { ALMA_AI_Content_Agent_Selection_Session::clear(); }
         $profiles = ALMA_AI_Content_Agent_Instructions_Manager::get_profiles(100,0);
+        if (!is_array($profiles)) { $profiles = array(); }
         $session = ALMA_AI_Content_Agent_Selection_Session::get_session();
         $summary = ALMA_AI_Content_Agent_Selection_Session::summary();
         $results_groups = ALMA_AI_Content_Agent_Selection_Session::grouped_results(false);
@@ -249,8 +258,10 @@ class ALMA_AI_Content_Agent_Admin {
             }
         }
         $labels = array('affiliate_link'=>'Link Affiliati','post'=>'Post','document_txt'=>'File TXT','source_online'=>'Fonti online','page'=>'Pagine','media'=>'Media');
-        $usage_keys = array_unique(array_merge(array_keys((array)$session['search_results']), array_keys((array)$session['selected_results'])));
-        $usage_counts = ALMA_AI_Content_Agent_Result_Usage::get_counts($usage_keys);
+        $usage_keys = array();
+        foreach ((array)$session['search_results'] as $row) { if (!is_array($row)) { continue; } $rk = sanitize_text_field($row['result_key'] ?? ''); if ($rk !== '') { $usage_keys[] = $rk; } }
+        foreach ((array)$session['selected_results'] as $row) { if (!is_array($row)) { continue; } $rk = sanitize_text_field($row['result_key'] ?? ''); if ($rk !== '') { $usage_keys[] = $rk; } }
+        $usage_counts = ALMA_AI_Content_Agent_Result_Usage::get_counts(array_values(array_unique($usage_keys)));
 
         echo '<div class="alma-ideas-toolbar alma-ideas-card">';
         echo '<div><label for="alma-idea-title"><strong>Titolo idea</strong></label><input id="alma-idea-title" class="regular-text alma-idea-title-input" form="alma-save-idea-form" type="text" name="idea_title" value="'.esc_attr($active_idea['title'] ?? 'Nuova idea').'">';
@@ -276,8 +287,10 @@ class ALMA_AI_Content_Agent_Admin {
         echo '</select></p><p><label>Prompt per OpenAI</label><textarea class="widefat" rows="4" name="openai_prompt">'.esc_textarea($active_idea['prompt'] ?? ($session['openai_prompt'] ?? '')).'</textarea><span class="description">Questo prompt verrà inviato a OpenAI insieme ai contenuti raccolti e guiderà cosa scrivere nella bozza.</span></p><p><button class="button button-primary">Cerca contenuti</button></p></form></div>';
 
         echo '<div class="alma-ideas-card"><h3>2. Risultati ricerca</h3><form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="add_selected_to_idea">';
-        foreach($labels as $k=>$label){ $rows=(array)($results_groups[$k]??array()); echo '<section class="alma-results-group"><h4>'.esc_html($label).' <span class="alma-count-badge">'.count($rows).'</span></h4>'; foreach($rows as $r){ $rk=sanitize_text_field($r['result_key'] ?? ''); $in=!empty($selected_map[$rk]); $usage=(int)($usage_counts[$rk] ?? 0); echo '<div class="alma-result-item'.($in?' is-already-added':'').'"><label><input type="checkbox" name="selected_result_keys[]" value="'.esc_attr($rk).'" '.disabled($in,true,false).'> <strong>'.esc_html($r['title']).'</strong></label>'; if($in){echo ' <span class="alma-added-badge">Già nell’idea</span>';} echo ' <span class="alma-usage-badge">Utilizzato in bozze: '.$usage.'</span><p class="alma-excerpt">'.esc_html(wp_trim_words((string)($r['excerpt'] ?? ''),20,'…')).'</p><p class="description">Score: '.(int)($r['score'] ?? 0).' · '.esc_html($r['reason'] ?? '').'</p>'; if($in){ echo '<button class="button button-small" type="button" disabled>Già aggiunto</button>'; } else { echo '<button class="button button-small" type="submit" name="do" value="add_result_to_idea" formaction="'.esc_url(admin_url('admin-post.php')).'" formmethod="post">Aggiungi all’idea</button><input type="hidden" name="result_key" value="'.esc_attr($rk).'">'; } echo '</div>'; }
+        $has_results = false;
+        foreach($labels as $k=>$label){ $rows=(array)($results_groups[$k]??array()); if (!empty($rows)) { $has_results = true; } echo '<section class="alma-results-group"><h4>'.esc_html($label).' <span class="alma-count-badge">'.count($rows).'</span></h4>'; foreach($rows as $r){ $rk=sanitize_text_field($r['result_key'] ?? ''); $in=!empty($selected_map[$rk]); $usage=(int)($usage_counts[$rk] ?? 0); echo '<div class="alma-result-item'.($in?' is-already-added':'').'"><label><input type="checkbox" name="selected_result_keys[]" value="'.esc_attr($rk).'" '.disabled($in,true,false).'> <strong>'.esc_html($r['title']).'</strong></label>'; if($in){echo ' <span class="alma-added-badge">Già nell’idea</span>';} echo ' <span class="alma-usage-badge">Utilizzato in bozze: '.$usage.'</span><p class="alma-excerpt">'.esc_html(wp_trim_words((string)($r['excerpt'] ?? ''),20,'…')).'</p><p class="description">Score: '.(int)($r['score'] ?? 0).' · '.esc_html($r['reason'] ?? '').'</p>'; if($in){ echo '<button class="button button-small" type="button" disabled>Già aggiunto</button>'; } else { echo '<button class="button button-small" type="submit" name="do" value="add_result_to_idea" formaction="'.esc_url(admin_url('admin-post.php')).'" formmethod="post">Aggiungi all’idea</button><input type="hidden" name="result_key" value="'.esc_attr($rk).'">'; } echo '</div>'; }
         echo '</section>'; }
+        if (!$has_results) { echo '<p class="description">Nessun risultato disponibile. Esegui una ricerca per popolare questa sezione.</p>'; }
         echo '<p><button class="button button-primary">Aggiungi selezionati all’idea</button></p></form></div></main>';
 
         echo '<aside class="alma-ideas-col alma-ideas-col-right"><div class="alma-ideas-card"><h3>3. Sessione contenuto</h3><p><strong>Totale elementi aggiunti:</strong> '.(int)($summary['selected_total'] ?? 0).'</p>';

--- a/includes/class-ai-content-agent-ideas.php
+++ b/includes/class-ai-content-agent-ideas.php
@@ -40,9 +40,26 @@ class ALMA_AI_Content_Agent_Ideas {
         return (int)$id;
     }
 
+    private static function normalize_meta_rows($value) {
+        if (!is_array($value)) { return array(); }
+        $normalized = array();
+        foreach ($value as $row) {
+            if (!is_array($row)) { continue; }
+            $normalized[] = $row;
+        }
+        return $normalized;
+    }
+
+    private static function normalize_meta_query($value) {
+        return is_array($value) ? $value : array();
+    }
+
     public static function get($id) {
         $p = get_post(absint($id)); if (!$p || $p->post_type !== self::CPT) { return array(); }
-        return array('ID'=>$p->ID,'title'=>$p->post_title,'profile_id'=>absint(get_post_meta($p->ID,self::META_PROFILE_ID,true)),'prompt'=>get_post_meta($p->ID,self::META_PROMPT,true),'last_query'=>get_post_meta($p->ID,self::META_LAST_QUERY,true),'results'=>(array)get_post_meta($p->ID,self::META_RESULTS,true),'selection'=>(array)get_post_meta($p->ID,self::META_SELECTION,true),'executed_at'=>sanitize_text_field((string)get_post_meta($p->ID,self::META_EXECUTED_AT,true)),'draft_post_id'=>absint(get_post_meta($p->ID,self::META_DRAFT_POST_ID,true)),'modified'=>$p->post_modified);
+        $last_query = self::normalize_meta_query(get_post_meta($p->ID, self::META_LAST_QUERY, true));
+        $results = self::normalize_meta_rows(get_post_meta($p->ID, self::META_RESULTS, true));
+        $selection = self::normalize_meta_rows(get_post_meta($p->ID, self::META_SELECTION, true));
+        return array('ID'=>$p->ID,'title'=>$p->post_title,'profile_id'=>absint(get_post_meta($p->ID,self::META_PROFILE_ID,true)),'prompt'=>get_post_meta($p->ID,self::META_PROMPT,true),'last_query'=>$last_query,'results'=>$results,'selection'=>$selection,'executed_at'=>sanitize_text_field((string)get_post_meta($p->ID,self::META_EXECUTED_AT,true)),'draft_post_id'=>absint(get_post_meta($p->ID,self::META_DRAFT_POST_ID,true)),'modified'=>$p->post_modified);
     }
 
     public static function save_from_request($idea_id, $data) {

--- a/includes/class-ai-content-agent-selection-session.php
+++ b/includes/class-ai-content-agent-selection-session.php
@@ -13,20 +13,61 @@ class ALMA_AI_Content_Agent_Selection_Session {
 
     private static function key() { return 'alma_ai_agent_selection_session_' . get_current_user_id(); }
 
+    private static function allowed_groups() {
+        return array('affiliate_link','post','document_txt','source_online','page','media','other');
+    }
+
+    private static function normalize_group($group) {
+        $group = sanitize_key((string)$group);
+        return in_array($group, self::allowed_groups(), true) ? $group : 'other';
+    }
+
+    private static function extract_result_key($row) {
+        if (!is_array($row)) { return ''; }
+        $candidates = array($row['result_key'] ?? '', $row['key'] ?? '', $row['raw_key'] ?? '', $row['origin_key'] ?? '', $row['result_id'] ?? '');
+        foreach ($candidates as $candidate) {
+            $key = sanitize_text_field((string)$candidate);
+            if ($key !== '') { return $key; }
+        }
+        return '';
+    }
+
+    private static function normalize_session_rows($rows, $force_selected = false) {
+        if (!is_array($rows)) { return array(); }
+        $normalized = array();
+        foreach ($rows as $row) {
+            if (!is_array($row)) { continue; }
+            $key = self::extract_result_key($row);
+            if ($key === '') { continue; }
+            $row['result_key'] = $key;
+            $row['source_group'] = self::normalize_group($row['source_group'] ?? '');
+            $row['selected'] = $force_selected ? true : !empty($row['selected']);
+            $normalized[$key] = $row;
+        }
+        return $normalized;
+    }
+
+    private static function normalize_session_payload($session) {
+        if (!is_array($session)) { $session = array(); }
+        $session = wp_parse_args($session, self::empty_session());
+        $search_rows = is_array($session['search_results']) ? $session['search_results'] : (is_array($session['results'] ?? null) ? $session['results'] : array());
+        $session['search_results'] = self::normalize_session_rows($search_rows, false);
+        $session['selected_results'] = self::normalize_session_rows($session['selected_results'], true);
+        foreach ($session['selected_results'] as $key => $row) {
+            if (!isset($session['search_results'][$key])) { $session['search_results'][$key] = $row; }
+        }
+        $session['query_history'] = is_array($session['query_history']) ? $session['query_history'] : array();
+        $session['last_query'] = is_array($session['last_query']) ? $session['last_query'] : array();
+        $session['openai_prompt'] = sanitize_textarea_field($session['openai_prompt'] ?? ($session['last_query']['openai_prompt'] ?? ''));
+        $session['updated_at'] = sanitize_text_field($session['updated_at'] ?? '');
+        $session['status'] = empty($session['search_results']) ? 'empty' : 'active';
+        $session['counts'] = self::count_summary($session['search_results'], $session['selected_results']);
+        return $session;
+    }
+
     public static function get_session() {
         $s = get_transient(self::key());
-        if (!is_array($s)) { return self::empty_session(); }
-        $s = wp_parse_args($s, self::empty_session());
-        if (!is_array($s['search_results'])) { $s['search_results'] = is_array($s['results'] ?? null) ? $s['results'] : array(); }
-        if (!is_array($s['selected_results'])) { $s['selected_results'] = array(); }
-        if (!is_array($s['query_history'])) { $s['query_history'] = array(); }
-        $s['last_query'] = is_array($s['last_query']) ? $s['last_query'] : array();
-        $s['counts'] = is_array($s['counts']) ? $s['counts'] : array();
-        $s['openai_prompt'] = sanitize_textarea_field($s['openai_prompt'] ?? ($s['last_query']['openai_prompt'] ?? ''));
-        $s['updated_at'] = sanitize_text_field($s['updated_at'] ?? '');
-        $s['status'] = in_array(($s['status'] ?? ''), array('empty','active'), true) ? $s['status'] : (empty($s['search_results']) ? 'empty' : 'active');
-        $s['counts'] = wp_parse_args($s['counts'], self::count_summary($s['search_results'], $s['selected_results']));
-        return $s;
+        return self::normalize_session_payload($s);
     }
 
     public static function clear() { delete_transient(self::key()); }
@@ -76,6 +117,7 @@ class ALMA_AI_Content_Agent_Selection_Session {
         $session['instruction_snapshot_hash'] = sanitize_text_field($payload['instruction_snapshot_hash'] ?? '');
         $session['openai_prompt'] = $openai_prompt;
         $session['counts'] = self::count_summary($session['search_results'], $session['selected_results']);
+        $session = self::normalize_session_payload($session);
         set_transient(self::key(), $session, self::TTL);
         return array('found'=>$found,'added'=>$added,'duplicates'=>$duplicates,'total'=>count($session['search_results']));
     }
@@ -86,7 +128,7 @@ class ALMA_AI_Content_Agent_Selection_Session {
         $next = (array)$session['selected_results'];
         $counts = array('post'=>0,'page'=>0,'affiliate_link'=>0,'document_txt'=>0,'source_online'=>0,'media'=>0);
         $limits = array('post'=>self::MAX_SELECTED_POSTS,'page'=>self::MAX_SELECTED_PAGES,'affiliate_link'=>self::MAX_SELECTED_AFFILIATE_LINKS,'document_txt'=>self::MAX_SELECTED_DOCUMENT_TXT,'source_online'=>self::MAX_SELECTED_SOURCE_ONLINE,'media'=>self::MAX_SELECTED_MEDIA);
-        foreach ($next as $row) { $g = sanitize_key($row['source_group'] ?? ''); if (isset($counts[$g])) { $counts[$g]++; } }
+        foreach ($next as $row) { if (!is_array($row)) { continue; } $g = self::normalize_group($row['source_group'] ?? ''); if (isset($counts[$g])) { $counts[$g]++; } }
         $added = 0; $duplicates = 0;
         foreach ($selected as $k => $truev) {
             if (!isset($session['search_results'][$k])) { continue; }
@@ -116,6 +158,7 @@ class ALMA_AI_Content_Agent_Selection_Session {
         $session['openai_prompt'] = sanitize_textarea_field($session['openai_prompt'] ?? ($session['last_query']['openai_prompt'] ?? ''));
         $session['counts'] = self::count_summary($session['search_results'], $session['selected_results']);
         $session['status'] = empty($session['search_results']) ? 'empty' : 'active';
+        $session = self::normalize_session_payload($session);
         set_transient(self::key(), $session, self::TTL);
         $message = 'Aggiunti '.(int)$added.' elementi all’idea.';
         if ($duplicates > 0) { $message .= ' '.(int)$duplicates.' duplicati ignorati.'; }
@@ -195,8 +238,9 @@ class ALMA_AI_Content_Agent_Selection_Session {
         $groups = array_fill_keys($order, array());
         $rows_source = $selected_only ? (array)$session['selected_results'] : (array)$session['search_results'];
         foreach ($rows_source as $row) {
-            $k = isset($groups[$row['source_group']]) ? $row['source_group'] : 'other';
-            $groups[$k][] = $row;
+            if (!is_array($row)) { continue; }
+            $group_key = self::normalize_group($row['source_group'] ?? '');
+            $groups[$group_key][] = $row;
         }
         foreach ($groups as $k => $rows) {
             usort($rows, function($a, $b){
@@ -216,10 +260,11 @@ class ALMA_AI_Content_Agent_Selection_Session {
 
     private static function count_summary($search_rows, $selected_rows = array()) {
         $c = array('total_results'=>0,'selected_total'=>0,'selected_post'=>0,'selected_page'=>0,'selected_affiliate_link'=>0,'selected_document_txt'=>0,'selected_source_online'=>0,'selected_media'=>0);
-        foreach ((array)$search_rows as $r) { $c['total_results']++; }
+        foreach ((array)$search_rows as $r) { if (!is_array($r)) { continue; } $c['total_results']++; }
         foreach ((array)$selected_rows as $r) {
+            if (!is_array($r)) { continue; }
             $c['selected_total']++;
-            $key = 'selected_' . sanitize_key($r['source_group']);
+            $key = 'selected_' . self::normalize_group($r['source_group'] ?? 'other');
             if (isset($c[$key])) { $c[$key]++; }
         }
         return $c;
@@ -229,25 +274,23 @@ class ALMA_AI_Content_Agent_Selection_Session {
     public static function persist_to_idea($idea_id) {
         $idea_id = absint($idea_id); if ($idea_id < 1) { return; }
         $session = self::get_session();
+        $session = self::normalize_session_payload($session);
         update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_LAST_QUERY, (array)$session['last_query']);
-        update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_RESULTS, (array)$session['search_results']);
-        update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_SELECTION, (array)$session['selected_results']);
+        update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_RESULTS, array_values($session['search_results']));
+        update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_SELECTION, array_values($session['selected_results']));
     }
 
     public static function load_from_idea($idea) {
         if (empty($idea['ID'])) { self::clear(); return; }
-        $results = (array)($idea['results'] ?? array());
-        $selected = (array)($idea['selection'] ?? array());
         $session = self::empty_session();
-        $session['status'] = empty($results) ? 'empty' : 'active';
-        $session['last_query'] = (array)($idea['last_query'] ?? array());
-        $session['search_results'] = $results;
-        $session['selected_results'] = array();
-        foreach($selected as $row){ if(empty($row['result_key'])) continue; $row['selected']=true; $session['selected_results'][$row['result_key']]=$row; }
+        $session['last_query'] = is_array($idea['last_query'] ?? null) ? $idea['last_query'] : array();
+        $session['search_results'] = self::normalize_session_rows($idea['results'] ?? array(), false);
+        $session['selected_results'] = self::normalize_session_rows($idea['selection'] ?? array(), true);
         $session['instruction_profile_id'] = absint($idea['profile_id'] ?? 0);
         $session['updated_at'] = current_time('mysql');
         $session['openai_prompt'] = sanitize_textarea_field($idea['prompt'] ?? ($session['last_query']['openai_prompt'] ?? ''));
         $session['counts'] = self::count_summary($results, $session['selected_results']);
+        $session = self::normalize_session_payload($session);
         set_transient(self::key(), $session, self::TTL);
     }
 
@@ -259,11 +302,13 @@ class ALMA_AI_Content_Agent_Selection_Session {
         $session['updated_at'] = current_time('mysql');
         $session['status'] = empty($session['search_results']) ? 'empty' : 'active';
         $session['counts'] = self::count_summary($session['search_results'], $session['selected_results']);
+        $session = self::normalize_session_payload($session);
         set_transient(self::key(), $session, self::TTL);
         return array('success'=>true,'message'=>'Elemento rimosso dalla sessione contenuto.');
     }
     public static function build_context_package() {
         $s = self::get_session();
+        $s = self::normalize_session_payload($s);
         $selected = array_values((array)$s['selected_results']);
         return array('last_query'=>$s['last_query'],'query_history'=>$s['query_history'],'selected_results'=>$selected,'counts'=>$s['counts'],'updated_at'=>$s['updated_at'],'instruction_profile_id'=>$s['instruction_profile_id'],'instruction_profile_name'=>sanitize_text_field($s['instruction_profile_name'] ?? ''),'instruction_snapshot_hash'=>sanitize_text_field($s['instruction_snapshot_hash'] ?? ''),'openai_prompt'=>sanitize_textarea_field($s['openai_prompt'] ?? ''));
     }


### PR DESCRIPTION
### Motivation
- Risolvere i fatal runtime ancora presenti nella tab "AI Content Agent > Idee contenuto" causati da meta/transient legacy o corrotti (righe scalari/stringhe in search_results/selected_results che causavano accessi offset non validi in PHP 8). 
- Rendere realmente efficace e stabile la nuova UI a 3 colonne consolidando regole CSS duplicate e assicurando il caricamento degli stili nella pagina agente.

### Description
- Normalizzazione sicura dei meta idea in `ALMA_AI_Content_Agent_Ideas::get()`: introdotte `normalize_meta_rows()` e `normalize_meta_query()` e rimosso il cast cieco `(array)get_post_meta(...)` restituendo sempre strutture controllate per `last_query`, `results`, `selection`.
- Normalizzazione centrale e difensiva in `ALMA_AI_Content_Agent_Selection_Session`: aggiunti metodi `allowed_groups()`, `normalize_group()`, `extract_result_key()`, `normalize_session_rows()` e `normalize_session_payload()` e applicata la normalizzazione in `get_session()`, prima di `set_transient()`, in `load_from_idea()`, `persist_to_idea()` e `build_context_package()` per garantire chiavi associative per `result_key`, righe array-only e fallback `other` per `source_group`.
- Hardening runtime di API session/viste: `grouped_results()` e `count_summary()` ora ignorano righe non-array e non accedono a offset prima di validare i row; `persist_to_idea()` salva i risultati/selection come array indicizzati (evita salvataggi con scalari). 
- Hardening UI server-side in `render_ideas_tab()` (admin): validazione di `_alma_active_idea_id` contro post reale/CPT (cancella user meta invalido), non chiamare `load_from_idea()` su idea vuota, gestire profili non-array, costruire `usage_keys` solo da `result_key` validi e mostrare stati vuoti chiari se non ci sono risultati o selezionati; preservate toolbar, pulsanti e badge richiesti.
- Consolidamento CSS: rimosse sezioni duplicate di regole Ideas e lasciata una sola sezione coerente e scoped `.alma-ai-agent-admin` con layout 3 colonne desktop e fallback responsive; piccoli aggiustamenti di spacing/width per leggibilità.
- Enqueue admin: garantito l'enqueue di `assets/admin.css` anche su hook `affiliate_link_page_alma-ai-content-agent` (miglior copertura per la tab agente).
- Versioning e documentazione: aggiornamento versione plugin a `2.24.7` (`affiliate-link-manager-ai.php`, `ALMA_VERSION`) e aggiunta voce in `README.md` / `CHANGELOG.md` descrivendo le modifiche implementate.

### Testing
- Eseguiti i controlli di sintassi PHP con `php -l` sui file modificati e correlati e tutti con esito positivo: `affiliate-link-manager-ai.php`, `includes/class-ai-content-agent-admin.php`, `includes/class-ai-content-agent-selection-session.php`, `includes/class-ai-content-agent-ideas.php`, `includes/class-ai-content-agent-result-usage.php` (nessun syntax error rilevato).
- Verifiche testuali/grep effettuate per pattern rischiosi e duplicati: ricerca di accessi a `$row['source_group']` / `$r['source_group']`, accessi a `$row['result_key']`, cast diretti `(array)get_post_meta`, e regole CSS duplicate/non-scoped `.alma-ideas-*`; le istanze sono state corrette o accorpate nella sezione scoped e i punti critici normalizzati.
- Nota: i test manuali end-to-end UI (apri tab Idee, crea idea, ricerca, add/remove, transient manipolati) non sono stati eseguiti in un browser WordPress interattivo in questo ambiente; il codice è stato però hardenizzato per eliminare i fatal identificati e i controlli automatizzati sopra sono passati.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8bc0298dc83328bb060792fe04671)