### PR TITLE
PR 7.9 — Add Clear Search Action and Content Type Filter to AI Content Agent Ideas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 2.24.8 — PR 7.7 AI Content Agent Data Normalization Fatal Fix and Ideas Layout Hardening
+## 2.24.9 — PR 7.9 AI Content Agent Search Results Clear Action and Content Type Filter
+- Aggiunta action admin `clear_content_idea_search` con nonce/capability check, svuotamento dei soli risultati ricerca e redirect pulito alla tab Idee.
+- Nuovo metodo dedicato in Selection Session per svuotare `search_results` preservando `selected_results`, stato sessione e persistenza transient.
+- Toolbar nella card “2. Risultati ricerca” con pulsante **Svuota ricerca** e filtro GET **Tipologia contenuto** (`alma_result_type`) con opzioni dinamiche.
+- Filtro applicato prima della paginazione e paginazione aggiornata per preservare `alma_result_type` nei link Prev/Next.
+- Compatibilità mantenuta con form bulk/single separati (nessun annidamento form).
+
+## 2.24.8 — PR 7.8 AI Content Agent Data Normalization Fatal Fix and Ideas Layout Hardening
 - Hardening runtime su meta/transient legacy o corrotti: normalizzazione difensiva di risultati/sessione e guard su rendering gruppi/conteggi.
 - Fix definitivo fatal PHP 8 su accessi offset stringa in Selection Session (`grouped_results`, `count_summary`, load/persist/build context).
 - Hardening tab Idee contenuto: validazione idea attiva, fallback profili/usage sicuri, stati vuoti espliciti e nessun fatal con tabelle usage mancanti.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-## 2.24.8 — PR 7.7 AI Content Agent Data Normalization Fatal Fix and Ideas Layout Hardening
+## 2.24.9 — PR 7.9 AI Content Agent Search Results Clear Action and Content Type Filter
+- Aggiunta action admin `clear_content_idea_search` con nonce/capability check, svuotamento dei soli risultati ricerca e redirect pulito alla tab Idee.
+- Nuovo metodo dedicato in Selection Session per svuotare `search_results` preservando `selected_results`, stato sessione e persistenza transient.
+- Toolbar nella card “2. Risultati ricerca” con pulsante **Svuota ricerca** e filtro GET **Tipologia contenuto** (`alma_result_type`) con opzioni dinamiche.
+- Filtro applicato prima della paginazione e paginazione aggiornata per preservare `alma_result_type` nei link Prev/Next.
+- Compatibilità mantenuta con form bulk/single separati (nessun annidamento form).
+
+## 2.24.8 — PR 7.8 AI Content Agent Data Normalization Fatal Fix and Ideas Layout Hardening
 - Hardening runtime su meta/transient legacy o corrotti: normalizzazione difensiva di risultati/sessione e guard su rendering gruppi/conteggi.
 - Fix definitivo fatal PHP 8 su accessi offset stringa in Selection Session (`grouped_results`, `count_summary`, load/persist/build context).
 - Hardening tab Idee contenuto: validazione idea attiva, fallback profili/usage sicuri, stati vuoti espliciti e nessun fatal con tabelle usage mancanti.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.24.8
+ * Version: 2.24.9
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.24.8');
+define('ALMA_VERSION', '2.24.9');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -653,3 +653,9 @@ button:disabled {
 .alma-ai-agent-admin .alma-actions-inline{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
 @media (max-width: 1450px){.alma-ai-agent-admin .alma-ideas-layout{grid-template-columns:1fr}}
 @media (max-width: 782px){.alma-ai-agent-admin .alma-idea-title-input{min-width:100%}}
+
+.alma-ai-agent-admin .alma-results-header{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap}
+.alma-ai-agent-admin .alma-results-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.alma-ai-agent-admin .alma-results-actions form{margin:0}
+.alma-ai-agent-admin .alma-results-actions select{min-width:190px}
+@media (max-width:782px){.alma-ai-agent-admin .alma-results-header{align-items:flex-start;flex-direction:column}.alma-ai-agent-admin .alma-results-actions{width:100%}.alma-ai-agent-admin .alma-results-actions form,.alma-ai-agent-admin .alma-results-actions select{width:100%}}

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -63,6 +63,16 @@ class ALMA_AI_Content_Agent_Admin {
         } elseif ($do === 'clear_selection_session') {
             ALMA_AI_Content_Agent_Selection_Session::clear();
             $result = array('success' => true, 'message' => 'Sessione contenuto svuotata.');
+        } elseif ($do === 'clear_content_idea_search') {
+            $session = ALMA_AI_Content_Agent_Selection_Session::clear_search_results();
+            $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true));
+            if ($active_idea_id > 0) {
+                update_post_meta($active_idea_id, ALMA_AI_Content_Agent_Ideas::META_LAST_QUERY, array());
+                update_post_meta($active_idea_id, ALMA_AI_Content_Agent_Ideas::META_RESULTS, array());
+                update_post_meta($active_idea_id, ALMA_AI_Content_Agent_Ideas::META_SELECTION, array_values((array)($session['selected_results'] ?? array())));
+                ALMA_AI_Content_Agent_Selection_Session::persist_to_idea($active_idea_id);
+            }
+            $result = array('success' => true, 'message' => 'Risultati ricerca svuotati.');
         } elseif ($do === 'download_ai_payload_json') {
             $summary = ALMA_AI_Content_Agent_Selection_Session::summary();
             if ((int)($summary['selected_total'] ?? 0) < 1) { $result = array('success'=>false,'message'=>'Seleziona almeno una fonte prima di scaricare il JSON payload AI.'); }
@@ -137,7 +147,12 @@ class ALMA_AI_Content_Agent_Admin {
         }
 
         self::set_notice($result);
-        wp_safe_redirect(wp_get_referer()); exit;
+        $redirect_url = wp_get_referer();
+        if ($do === 'clear_content_idea_search') {
+            $redirect_url = admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=idee');
+            $redirect_url = remove_query_arg(array('alma_results_page', 'alma_result_type'), $redirect_url);
+        }
+        wp_safe_redirect($redirect_url); exit;
     }
 
     private static function set_notice($result) {
@@ -289,18 +304,46 @@ class ALMA_AI_Content_Agent_Admin {
         foreach($profiles as $p){ $sel=selected((int)($active_idea['profile_id'] ?? 0),(int)$p['id'],false); echo '<option value="'.(int)$p['id'].'" '.$sel.'>'.esc_html($p['profile_name']).'</option>'; }
         echo '</select></p><p><label>Prompt per OpenAI</label><textarea class="widefat" rows="4" name="openai_prompt">'.esc_textarea($active_idea['prompt'] ?? ($session['openai_prompt'] ?? '')).'</textarea><span class="description">Questo prompt verrà inviato a OpenAI insieme ai contenuti raccolti e guiderà cosa scrivere nella bozza.</span></p><p><button class="button button-primary">Cerca contenuti</button></p></form></div>';
 
-        echo '<div class="alma-ideas-card"><h3>2. Risultati ricerca</h3>';
         $all_rows = array();
         foreach($labels as $k=>$label){ foreach((array)($results_groups[$k]??array()) as $r){ $all_rows[] = array('group'=>$k,'label'=>$label,'row'=>$r); } }
-        $per_page = 10; $total_results = count($all_rows); $total_pages = max(1, (int)ceil($total_results / $per_page));
-        $current_page = max(1, absint($_GET['alma_results_page'] ?? 1)); if ($current_page > $total_pages) { $current_page = $total_pages; }
-        $paged_rows = array_slice($all_rows, ($current_page-1)*$per_page, $per_page);
+        $available_groups = array();
+        foreach ($all_rows as $item) { $available_groups[$item['group']] = true; }
+        $active_result_type = sanitize_key($_GET['alma_result_type'] ?? '');
+        if ($active_result_type === '' || !isset($available_groups[$active_result_type])) { $active_result_type = 'all'; }
+        $filtered_rows = $all_rows;
+        if ($active_result_type !== 'all') {
+            $filtered_rows = array_values(array_filter($all_rows, function($item) use ($active_result_type){ return ($item['group'] ?? '') === $active_result_type; }));
+        }
+        $per_page = 10;
+        $total_results = count($filtered_rows);
+        $total_pages = max(1, (int)ceil($total_results / $per_page));
+        $requested_page = absint($_GET['alma_results_page'] ?? 1);
+        $filter_in_request = array_key_exists('alma_result_type', $_GET);
+        $current_page = $filter_in_request ? 1 : max(1, $requested_page);
+        if ($current_page > $total_pages) { $current_page = $total_pages; }
+        $paged_rows = array_slice($filtered_rows, ($current_page-1)*$per_page, $per_page);
+
+        echo '<div class="alma-ideas-card"><div class="alma-results-header"><h3>2. Risultati ricerca</h3>';
+        if (!empty($all_rows)) {
+            echo '<div class="alma-results-actions">';
+            echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="clear_content_idea_search"><button class="button" type="submit">Svuota ricerca</button></form>';
+            echo '<form method="get" action="'.esc_url(admin_url('edit.php')).'"><input type="hidden" name="post_type" value="affiliate_link"><input type="hidden" name="page" value="alma-ai-content-agent"><input type="hidden" name="tab" value="idee"><label for="alma_result_type" class="screen-reader-text">Tipologia contenuto</label><select id="alma_result_type" name="alma_result_type" onchange="this.form.submit()"><option value="all">Tutte le tipologie</option>';
+            foreach(array_keys($available_groups) as $group_key){ echo '<option value="'.esc_attr($group_key).'" '.selected($active_result_type,$group_key,false).'>'.esc_html($labels[$group_key] ?? ucfirst($group_key)).'</option>'; }
+            echo '</select></form></div>';
+        }
+        echo '</div>';
+
         echo '<p class="description">Totale risultati: '.(int)$total_results.' · Pagina '.(int)$current_page.' di '.(int)$total_pages.'</p>';
         echo '<form id="alma-bulk-add-form" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="add_selected_to_idea"></form>';
-        if (empty($paged_rows)) { echo '<p class="description">Nessun risultato disponibile. Esegui una ricerca per popolare questa sezione.</p>'; }
+        if (empty($paged_rows)) {
+            if ($active_result_type !== 'all' && !empty($all_rows)) { echo '<p class="description">Nessun risultato per questa tipologia. Cambia filtro o svuota la ricerca.</p>'; }
+            else { echo '<p class="description">Nessun risultato disponibile. Esegui una ricerca per popolare questa sezione.</p>'; }
+        }
         foreach($paged_rows as $item){ $r=(array)$item['row']; $rk=sanitize_text_field($r['result_key'] ?? ''); if($rk===''){continue;} $in=!empty($selected_map[$rk]); $usage=(int)($usage_counts[$rk] ?? 0); echo '<div class="alma-result-item'.($in?' is-already-added':'').'"><p><strong>'.esc_html($r['title']).'</strong> <span class="alma-count-badge">'.esc_html($item['label']).'</span>'; if($in){echo ' <span class="alma-added-badge">Già nell’idea</span>';} echo ' <span class="alma-usage-badge">Utilizzato in bozze: '.$usage.'</span></p><label><input type="checkbox" name="selected_result_keys[]" value="'.esc_attr($rk).'" form="alma-bulk-add-form" '.disabled($in,true,false).'> Seleziona</label><p class="alma-excerpt">'.esc_html(wp_trim_words((string)($r['excerpt'] ?? ''),20,'…')).'</p><p class="description">Score: '.(int)($r['score'] ?? 0).' · '.esc_html($r['reason'] ?? '').'</p>'; if($in){ echo '<button class="button button-small" type="button" disabled>Già aggiunto</button>'; } else { echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="add_result_to_idea"><input type="hidden" name="result_key" value="'.esc_attr($rk).'"><button class="button button-small">Aggiungi all’idea</button></form>'; } echo '</div>'; }
         $base = admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=idee');
-        echo '<p>'; if ($current_page>1){ echo '<a class="button" href="'.esc_url(add_query_arg('alma_results_page',$current_page-1,$base)).'">← Precedente</a> '; } if ($current_page<$total_pages){ echo '<a class="button" href="'.esc_url(add_query_arg('alma_results_page',$current_page+1,$base)).'">Successiva →</a>'; } echo '</p><p><button class="button button-primary" type="submit" form="alma-bulk-add-form">Aggiungi selezionati all’idea</button></p></div></main>';
+        $nav_args = array();
+        if ($active_result_type !== 'all') { $nav_args['alma_result_type'] = $active_result_type; }
+        echo '<p>'; if ($current_page>1){ echo '<a class="button" href="'.esc_url(add_query_arg(array_merge($nav_args, array('alma_results_page'=>$current_page-1)),$base)).'">← Precedente</a> '; } if ($current_page<$total_pages){ echo '<a class="button" href="'.esc_url(add_query_arg(array_merge($nav_args, array('alma_results_page'=>$current_page+1)),$base)).'">Successiva →</a>'; } echo '</p><p><button class="button button-primary" type="submit" form="alma-bulk-add-form">Aggiungi selezionati all’idea</button></p></div></main>';
 
 echo '<aside class="alma-ideas-col alma-ideas-col-right"><div class="alma-ideas-card"><h3>3. Sessione contenuto</h3><p><strong>Totale elementi aggiunti:</strong> '.(int)($summary['selected_total'] ?? 0).'</p>';
         if ((int)($summary['selected_total'] ?? 0) < 1) { echo '<p>Nessun contenuto aggiunto all’idea.</p>'; }

--- a/includes/class-ai-content-agent-selection-session.php
+++ b/includes/class-ai-content-agent-selection-session.php
@@ -171,6 +171,21 @@ class ALMA_AI_Content_Agent_Selection_Session {
     }
 
 
+    public static function clear_search_results() {
+        $session = self::get_session();
+        $session = self::normalize_session_payload($session);
+        $session['search_results'] = array();
+        $session['last_query'] = array();
+        $session['counts'] = self::count_summary($session['search_results'], $session['selected_results']);
+        $session['status'] = empty($session['search_results']) ? 'empty' : 'active';
+        $session['updated_at'] = current_time('mysql');
+        $session['openai_prompt'] = sanitize_textarea_field($session['openai_prompt'] ?? '');
+        $session = self::normalize_session_payload($session);
+        set_transient(self::key(), $session, self::TTL);
+        return $session;
+    }
+
+
     private static function infer_knowledge_item_id($group, $row, $fallback_result_id = '') {
         $group = sanitize_key((string)$group);
         $candidates = array(


### PR DESCRIPTION
### Motivation
- Add a safe, admin-only “Svuota ricerca” action that clears only the column 2 search results while preserving the active idea, selected results and session content.
- Provide a dynamic, GET-based “Tipologia contenuto” filter to narrow results by content type before pagination, because search results are now rendered as a single list across groups.
- Keep forms separated (bulk, single, clear, filter) to avoid nested forms and preserve the fixes from the previous pagination PR.

### Description
- Added a new admin action handler `do=clear_content_idea_search` in the existing dispatcher to call a new session method, persist changes to the active idea meta and redirect to the Ideas tab while removing `alma_results_page` and `alma_result_type` from the URL (`includes/class-ai-content-agent-admin.php`).
- Implemented `ALMA_AI_Content_Agent_Selection_Session::clear_search_results()` to normalize/repair the session defensively, set `search_results` to an empty array, update `last_query/counts/status/updated_at/openai_prompt`, and save the transient while preserving `selected_results` (`includes/class-ai-content-agent-selection-session.php`).
- Reworked the card header for “2. Risultati ricerca” to include a secure POST-only `Svuota ricerca` form and a GET `Tipologia contenuto` select whose options are built dynamically from the groups actually present; the GET filter is applied before pagination and preserved in Prev/Next links (`includes/class-ai-content-agent-admin.php`).
- Updated pagination logic to compute pages on the filtered result set, normalize page numbers, reset to page 1 when a filter is applied, and preserve `alma_result_type` in navigation links (`includes/class-ai-content-agent-admin.php`).
- Ensured form separation: `alma-bulk-add-form` remains separate and checkboxes use the `form` attribute, single-add forms each contain one `result_key`, the clear action uses its own POST form and the filter uses a separate GET form (`includes/class-ai-content-agent-admin.php`).
- Added minimal scoped CSS under `.alma-ai-agent-admin` for the results header/toolbar and responsive stacking (`assets/admin.css`).
- Bumped plugin version to `2.24.9` and updated the plugin header constant, `README.md` and `CHANGELOG.md` with PR 7.9 notes and corrected the prior PR labeling (`affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`).

### Testing
- Ran PHP syntax checks: `php -l affiliate-link-manager-ai.php`, `php -l includes/class-ai-content-agent-admin.php`, `php -l includes/class-ai-content-agent-selection-session.php`, `php -l includes/class-ai-content-agent-ideas.php` — all returned "No syntax errors detected".
- Ran a code search to verify presence of key identifiers: `rg -n "clear_content_idea_search|alma_result_type|alma_results_page|selected_result_keys\[\]"` and confirmed the new action, filter and page param usage in the modified files.
- Performed static inspection to confirm no nested forms in the results card and that bulk/single/clear/filter forms remain separate.
- Manual end-to-end WordPress UI testing was not executed in this environment due to lack of a running WP admin instance, so interactive verification (clicks, reloads) is pending in a WP admin environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8cd7a0ac08332bc7f6cf29acb92be)