### PR TITLE
PR 8.3 — Affiliate Index Autosync Ordering and Native Results Pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.25.3 — PR 8.3 Affiliate Index Autosync Ordering and Native Results Pagination
+- Auto-sync indice affiliate su `save_post_affiliate_link` spostato a priorità alta per garantire esecuzione dopo salvataggio meta/tassonomie del CPT `affiliate_link`, mantenendo guard autosave/revision/post type e filtro `alma_ai_affiliate_index_disable_autosync`.
+- Rimossi dalla card “2. Risultati ricerca” il pulsante **Svuota ricerca** e il filtro **Tipologia contenuto** (`alma_result_type`) con relativa logica/rendering UI.
+- Sostituita la paginazione custom con paginazione in stile admin WordPress (`tablenav`, `tablenav-pages`, `displaying-num`, `pagination-links`) con link prima/precedente/successiva/ultima e normalizzazione pagina corrente.
+
 ## 2.25.2 — PR 8.2 Affiliate Index Relevance Scoring, Auto Sync Hooks and Result Diagnostics
 - Migliorato scoring `affiliate_link` con pesi per titolo, Contesto AI, tipologie, contenuto e provider; esclusi record non pubblicati/inattivi/senza URL valido.
 - Validazione URL affiliato centralizzata in `ALMA_AI_Content_Agent_Affiliate_Index::get_affiliate_url_data()` riusata da indicizzazione e fallback ricerca.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## 2.25.3 — PR 8.3 Affiliate Index Autosync Ordering and Native Results Pagination
+- Auto-sync indice affiliate su `save_post_affiliate_link` spostato a priorità alta per garantire esecuzione dopo salvataggio meta/tassonomie del CPT `affiliate_link`, mantenendo guard autosave/revision/post type e filtro `alma_ai_affiliate_index_disable_autosync`.
+- Rimossi dalla card “2. Risultati ricerca” il pulsante **Svuota ricerca** e il filtro **Tipologia contenuto** (`alma_result_type`) con relativa logica/rendering UI.
+- Sostituita la paginazione custom con paginazione in stile admin WordPress (`tablenav`, `tablenav-pages`, `displaying-num`, `pagination-links`) con link prima/precedente/successiva/ultima e normalizzazione pagina corrente.
+
 ## 2.25.2 — PR 8.1 Affiliate Index Batch Progression, Search Fallback and Admin Status UI
 - Nuovo indice tecnico dedicato ai soli `affiliate_link` (`{$wpdb->prefix}alma_ai_affiliate_index`) creato via Store/dbDelta.
 - Batch indice affiliate con cursore ID stabile, stato robusto e statistiche leggere per dashboard/admin.
@@ -118,7 +123,7 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.15.0
+Versione 2.25.3
 
 
 ## Novità 2.12.1 — Pagina Importa contenuti + fix import

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.2
+ * Version: 2.25.3
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.2');
+define('ALMA_VERSION', '2.25.3');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -655,7 +655,5 @@ button:disabled {
 @media (max-width: 782px){.alma-ai-agent-admin .alma-idea-title-input{min-width:100%}}
 
 .alma-ai-agent-admin .alma-results-header{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap}
-.alma-ai-agent-admin .alma-results-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
-.alma-ai-agent-admin .alma-results-actions form{margin:0}
-.alma-ai-agent-admin .alma-results-actions select{min-width:190px}
-@media (max-width:782px){.alma-ai-agent-admin .alma-results-header{align-items:flex-start;flex-direction:column}.alma-ai-agent-admin .alma-results-actions{width:100%}.alma-ai-agent-admin .alma-results-actions form,.alma-ai-agent-admin .alma-results-actions select{width:100%}}
+@media (max-width:782px){.alma-ai-agent-admin .alma-results-header{align-items:flex-start;flex-direction:column}}
+.alma-ai-agent-admin .alma-ideas-card .tablenav.top{margin:8px 0 12px;}

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -73,16 +73,6 @@ class ALMA_AI_Content_Agent_Admin {
         } elseif ($do === 'clear_selection_session') {
             ALMA_AI_Content_Agent_Selection_Session::clear();
             $result = array('success' => true, 'message' => 'Sessione contenuto svuotata.');
-        } elseif ($do === 'clear_content_idea_search') {
-            $session = ALMA_AI_Content_Agent_Selection_Session::clear_search_results();
-            $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true));
-            if ($active_idea_id > 0) {
-                update_post_meta($active_idea_id, ALMA_AI_Content_Agent_Ideas::META_LAST_QUERY, array());
-                update_post_meta($active_idea_id, ALMA_AI_Content_Agent_Ideas::META_RESULTS, array());
-                update_post_meta($active_idea_id, ALMA_AI_Content_Agent_Ideas::META_SELECTION, array_values((array)($session['selected_results'] ?? array())));
-                ALMA_AI_Content_Agent_Selection_Session::persist_to_idea($active_idea_id);
-            }
-            $result = array('success' => true, 'message' => 'Risultati ricerca svuotati.');
         } elseif ($do === 'download_ai_payload_json') {
             $summary = ALMA_AI_Content_Agent_Selection_Session::summary();
             if ((int)($summary['selected_total'] ?? 0) < 1) { $result = array('success'=>false,'message'=>'Seleziona almeno una fonte prima di scaricare il JSON payload AI.'); }
@@ -158,10 +148,6 @@ class ALMA_AI_Content_Agent_Admin {
 
         self::set_notice($result);
         $redirect_url = wp_get_referer();
-        if ($do === 'clear_content_idea_search') {
-            $redirect_url = admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=idee');
-            $redirect_url = remove_query_arg(array('alma_results_page', 'alma_result_type'), $redirect_url);
-        }
         wp_safe_redirect($redirect_url); exit;
     }
 
@@ -332,44 +318,40 @@ class ALMA_AI_Content_Agent_Admin {
 
         $all_rows = array();
         foreach($labels as $k=>$label){ foreach((array)($results_groups[$k]??array()) as $r){ $all_rows[] = array('group'=>$k,'label'=>$label,'row'=>$r); } }
-        $available_groups = array();
-        foreach ($all_rows as $item) { $available_groups[$item['group']] = true; }
-        $active_result_type = sanitize_key($_GET['alma_result_type'] ?? '');
-        if ($active_result_type === '' || !isset($available_groups[$active_result_type])) { $active_result_type = 'all'; }
-        $filtered_rows = $all_rows;
-        if ($active_result_type !== 'all') {
-            $filtered_rows = array_values(array_filter($all_rows, function($item) use ($active_result_type){ return ($item['group'] ?? '') === $active_result_type; }));
-        }
         $per_page = 10;
-        $total_results = count($filtered_rows);
+        $total_results = count($all_rows);
         $total_pages = max(1, (int)ceil($total_results / $per_page));
         $requested_page = absint($_GET['alma_results_page'] ?? 1);
-        $filter_in_request = array_key_exists('alma_result_type', $_GET);
-        $current_page = $filter_in_request ? 1 : max(1, $requested_page);
-        if ($current_page > $total_pages) { $current_page = $total_pages; }
-        $paged_rows = array_slice($filtered_rows, ($current_page-1)*$per_page, $per_page);
+        $current_page = max(1, min($requested_page, $total_pages));
+        $paged_rows = array_slice($all_rows, ($current_page-1)*$per_page, $per_page);
 
-        echo '<div class="alma-ideas-card"><div class="alma-results-header"><h3>2. Risultati ricerca</h3>';
-        if (!empty($all_rows)) {
-            echo '<div class="alma-results-actions">';
-            echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="clear_content_idea_search"><button class="button" type="submit">Svuota ricerca</button></form>';
-            echo '<form method="get" action="'.esc_url(admin_url('edit.php')).'"><input type="hidden" name="post_type" value="affiliate_link"><input type="hidden" name="page" value="alma-ai-content-agent"><input type="hidden" name="tab" value="idee"><label for="alma_result_type" class="screen-reader-text">Tipologia contenuto</label><select id="alma_result_type" name="alma_result_type" onchange="this.form.submit()"><option value="all">Tutte le tipologie</option>';
-            foreach(array_keys($available_groups) as $group_key){ echo '<option value="'.esc_attr($group_key).'" '.selected($active_result_type,$group_key,false).'>'.esc_html($labels[$group_key] ?? ucfirst($group_key)).'</option>'; }
-            echo '</select></form></div>';
+        echo '<div class="alma-ideas-card"><div class="alma-results-header"><h3>2. Risultati ricerca</h3></div>';
+
+        echo '<div class="tablenav top"><div class="tablenav-pages">';
+        echo '<span class="displaying-num">'.(int)$total_results.' elementi</span>';
+        echo '<span class="pagination-links">';
+        $base = admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=idee');
+        $is_first = ($current_page <= 1);
+        $is_last = ($current_page >= $total_pages);
+        if ($is_first) { echo '<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&laquo;</span><span class="tablenav-pages-navspan button disabled" aria-hidden="true">&lsaquo;</span>'; }
+        else {
+            echo '<a class="first-page button" href="'.esc_url(add_query_arg(array('alma_results_page'=>1), $base)).'"><span class="screen-reader-text">Prima pagina</span><span aria-hidden="true">&laquo;</span></a>';
+            echo '<a class="prev-page button" href="'.esc_url(add_query_arg(array('alma_results_page'=>$current_page-1), $base)).'"><span class="screen-reader-text">Pagina precedente</span><span aria-hidden="true">&lsaquo;</span></a>';
         }
-        echo '</div>';
+        echo '<span class="paging-input"><span class="tablenav-paging-text">'.(int)$current_page.' di <span class="total-pages">'.(int)$total_pages.'</span></span></span>';
+        if ($is_last) { echo '<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&rsaquo;</span><span class="tablenav-pages-navspan button disabled" aria-hidden="true">&raquo;</span>'; }
+        else {
+            echo '<a class="next-page button" href="'.esc_url(add_query_arg(array('alma_results_page'=>$current_page+1), $base)).'"><span class="screen-reader-text">Pagina successiva</span><span aria-hidden="true">&rsaquo;</span></a>';
+            echo '<a class="last-page button" href="'.esc_url(add_query_arg(array('alma_results_page'=>$total_pages), $base)).'"><span class="screen-reader-text">Ultima pagina</span><span aria-hidden="true">&raquo;</span></a>';
+        }
+        echo '</span></div></div>';
 
-        echo '<p class="description">Totale risultati: '.(int)$total_results.' · Pagina '.(int)$current_page.' di '.(int)$total_pages.'</p>';
         echo '<form id="alma-bulk-add-form" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="add_selected_to_idea"></form>';
         if (empty($paged_rows)) {
-            if ($active_result_type !== 'all' && !empty($all_rows)) { echo '<p class="description">Nessun risultato per questa tipologia. Cambia filtro o svuota la ricerca.</p>'; }
-            else { echo '<p class="description">Nessun risultato disponibile. Esegui una ricerca per popolare questa sezione.</p>'; }
+            echo '<p class="description">Nessun risultato disponibile. Esegui una ricerca per popolare questa sezione.</p>';
         }
         foreach($paged_rows as $item){ $r=(array)$item['row']; $rk=sanitize_text_field($r['result_key'] ?? ''); if($rk===''){continue;} $in=!empty($selected_map[$rk]); $usage=(int)($usage_counts[$rk] ?? 0); echo '<div class="alma-result-item'.($in?' is-already-added':'').'"><p><strong>'.esc_html($r['title']).'</strong> <span class="alma-count-badge">'.esc_html($item['label']).'</span>'; if($in){echo ' <span class="alma-added-badge">Già nell’idea</span>';} echo ' <span class="alma-usage-badge">Utilizzato in bozze: '.$usage.'</span></p><label><input type="checkbox" name="selected_result_keys[]" value="'.esc_attr($rk).'" form="alma-bulk-add-form" '.disabled($in,true,false).'> Seleziona</label><p class="alma-excerpt">'.esc_html(wp_trim_words((string)($r['excerpt'] ?? ''),20,'…')).'</p><p class="description">Score: '.(int)($r['score'] ?? 0).' · '.esc_html($r['reason'] ?? '').'</p>'; if($in){ echo '<button class="button button-small" type="button" disabled>Già aggiunto</button>'; } else { echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="add_result_to_idea"><input type="hidden" name="result_key" value="'.esc_attr($rk).'"><button class="button button-small">Aggiungi all’idea</button></form>'; } echo '</div>'; }
-        $base = admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=idee');
-        $nav_args = array();
-        if ($active_result_type !== 'all') { $nav_args['alma_result_type'] = $active_result_type; }
-        echo '<p>'; if ($current_page>1){ echo '<a class="button" href="'.esc_url(add_query_arg(array_merge($nav_args, array('alma_results_page'=>$current_page-1)),$base)).'">← Precedente</a> '; } if ($current_page<$total_pages){ echo '<a class="button" href="'.esc_url(add_query_arg(array_merge($nav_args, array('alma_results_page'=>$current_page+1)),$base)).'">Successiva →</a>'; } echo '</p><p><button class="button button-primary" type="submit" form="alma-bulk-add-form">Aggiungi selezionati all’idea</button></p></div></main>';
+        echo '<p><button class="button button-primary" type="submit" form="alma-bulk-add-form">Aggiungi selezionati all’idea</button></p></div></main>';
 
 echo '<aside class="alma-ideas-col alma-ideas-col-right"><div class="alma-ideas-card"><h3>3. Sessione contenuto</h3><p><strong>Totale elementi aggiunti:</strong> '.(int)($summary['selected_total'] ?? 0).'</p>';
         if ((int)($summary['selected_total'] ?? 0) < 1) { echo '<p>Nessun contenuto aggiunto all’idea.</p>'; }

--- a/includes/class-ai-content-agent-affiliate-index.php
+++ b/includes/class-ai-content-agent-affiliate-index.php
@@ -176,7 +176,7 @@ add_action('save_post_affiliate_link', function($post_id, $post, $update){
     if (!($post instanceof WP_Post) || $post->post_type !== 'affiliate_link') { return; }
     if (apply_filters('alma_ai_affiliate_index_disable_autosync', false, $post_id, $post, $update)) { return; }
     ALMA_AI_Content_Agent_Affiliate_Index::index_single($post_id, true);
-}, 10, 3);
+}, 100, 3);
 
 add_action('before_delete_post', function($post_id){
     $post = get_post($post_id);


### PR DESCRIPTION
### Motivation
- Risolvere il P1 segnalato su ordering dell’auto-sync dell’indice Affiliate affinché legga i meta/tassonomie aggiornati dopo lo save del CPT `affiliate_link`.
- Semplificare la card “2. Risultati ricerca” nella tab AI Content Agent > Idee contenuto rimuovendo controlli ridondanti esposti in UI.
- Allineare la paginazione dei risultati allo stile visivo e semantico dell’admin WordPress per migliorare coerenza e accessibilità.

### Description
- Spostato callback auto-sync su `save_post_affiliate_link` a priorità `100` (era `10`) mantenendo guard contro `DOING_AUTOSAVE`, autosave/revision, controllo `post_type` e filtro `alma_ai_affiliate_index_disable_autosync`, e continuando a indicizzare solo il singolo record con `index_single` senza avviare batch o chiamare OpenAI. (file: `includes/class-ai-content-agent-affiliate-index.php`)
- Rimosso il pulsante e il form UI **Svuota ricerca** e la branch di gestione `clear_content_idea_search` dall’handler delle azioni admin, eliminando l’action UI esposta per svuotare i risultati di ricerca. (file: `includes/class-ai-content-agent-admin.php`)
- Eliminata la logica/filtro GET `alma_result_type` e relativa UI; la card risultati ora mostra tutti i risultati disponibili e li pagina in modo unificato. (file: `includes/class-ai-content-agent-admin.php`)
- Sostituita la paginazione custom con markup e classi admin-native (`tablenav`, `tablenav-pages`, `displaying-num`, `pagination-links`) includendo link Prima/Precedente/Successiva/Ultima, normalizzazione pagina fuori-range e preservazione solo dei parametri amministrativi necessari (`post_type`, `page`, `tab`, `alma_results_page`). (file: `includes/class-ai-content-agent-admin.php`)
- Preservata separazione form bulk vs single: il form bulk rimane con `id="alma-bulk-add-form"`, checkbox collegati tramite `form` attribute e ogni azione singola mantiene un form proprio con un solo `result_key`. (file: `includes/class-ai-content-agent-admin.php`)
- Eseguito CSS cleanup minimale scoped sotto `.alma-ai-agent-admin` rimuovendo stili legati alla toolbar risultati e aggiungendo spacing per la paginazione admin nella card risultati. (file: `assets/admin.css`)
- Aggiornata versione plugin a `2.25.3` (plugin header e costante `ALMA_VERSION`) e documentazione `README.md` / `CHANGELOG.md` con voce `2.25.3 — PR 8.3`. (file: `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`)

### Testing
- Eseguiti i controlli sintattici PHP: `php -l affiliate-link-manager-ai.php`, `php -l includes/class-ai-content-agent-affiliate-index.php`, `php -l includes/class-ai-content-agent-admin.php`, `php -l includes/class-ai-content-agent-knowledge-search.php`, `php -l includes/class-ai-content-agent-selection-session.php`, `php -l includes/class-affiliate-source-manager.php` e tutti sono risultati senza errori.
- Verifiche testuali sul codice (grep/rg) confermano che il `save_post_affiliate_link` è ora registrato con priorità `100` e che il filtro `alma_ai_affiliate_index_disable_autosync` è ancora presente. (files: `includes/class-ai-content-agent-affiliate-index.php`)
- Verifiche testuali confermano che `clear_content_idea_search` non è più esposto nella UI della card risultati e che `alma_result_type` non è più usato per filtrare/renderizzare i risultati. (file: `includes/class-ai-content-agent-admin.php`)
- Verifiche testuali confermano la presenza del markup di paginazione admin (`tablenav`, `tablenav-pages`, `displaying-num`, `pagination-links`) e la presenza del form bulk separato `id="alma-bulk-add-form"` con singoli form per azioni `result_key`. (file: `includes/class-ai-content-agent-admin.php`)
- Nota: non è stato eseguito il test manuale end-to-end dentro un’istanza WordPress con salvataggi/trash/status transitions in questa sessione; raccomandata la checklist manuale prevista per validare UX e comportamenti sul sito target.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9979d3af08332aef1d74bccb6a705)