### PR TITLE
PR 8.4 — Affiliate Index Safe Maintenance and Pre‑Sync Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.25.4 — PR 8.4 Affiliate Index Safe Maintenance and Pre-Sync Validation
+- Aggiunte azioni operative sicure in Dashboard per `reset_affiliate_index_state` (non distruttiva) e `clear_affiliate_index` (svuota solo indice tecnico).
+- Implementato svuotamento sicuro di `{$wpdb->prefix}alma_ai_affiliate_index` con fallback table-missing senza fatal e reset automatico di `alma_ai_affiliate_index_state`.
+- Estesa validazione pre-sync con conteggi diagnostici aggregati: `missing_index`, `orphan_index_records`, `active_invalid_records`, oltre a `needs_update`, `without_affiliate_url`, `inactive_index_records`.
+- Nuovo stato operativo leggibile nella card “Indice Link affiliati” per guidare primo sync completo e batch progressivi.
+- Confermata retrocompatibilità: nessuna modifica a OpenAI, Draft Builder, provider/API, importer, shortcode, tracking, Post/Pagine/TXT/Fonti online/Media.
+
 ## 2.25.3 — PR 8.3 Affiliate Index Autosync Ordering and Native Results Pagination
 - Auto-sync indice affiliate su `save_post_affiliate_link` spostato a priorità alta per garantire esecuzione dopo salvataggio meta/tassonomie del CPT `affiliate_link`, mantenendo guard autosave/revision/post type e filtro `alma_ai_affiliate_index_disable_autosync`.
 - Rimossi dalla card “2. Risultati ricerca” il pulsante **Svuota ricerca** e il filtro **Tipologia contenuto** (`alma_result_type`) con relativa logica/rendering UI.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## 2.25.4 — PR 8.4 Affiliate Index Safe Maintenance and Pre-Sync Validation
+- Aggiunte azioni admin sicure per **Reset stato batch** e **Svuota indice e ricomincia** (solo indice tecnico), con capability `manage_options` e nonce esistenti.
+- Svuotamento sicuro della sola tabella tecnica `{$wpdb->prefix}alma_ai_affiliate_index` senza impatto su CPT, meta, tassonomie, immagini o tracking; reset batch automatico post-operazione.
+- Estese diagnostiche `get_index_stats()` con `missing_index`, `orphan_index_records`, `active_invalid_records`, `needs_update`, `without_affiliate_url`, `inactive_index_records`, `last_indexed_at`, `table_exists`, `batch_state`.
+- Card Dashboard “Indice Link affiliati” estesa con stato operativo leggibile (guida UX) e avviso esplicito che il reset indice non elimina i Link affiliati.
+- Compatibilità fallback ricerca mantenuta: con indice vuoto la ricerca Idee continua via WordPress fallback per i soli `affiliate_link`.
+
 ## 2.25.3 — PR 8.3 Affiliate Index Autosync Ordering and Native Results Pagination
 - Auto-sync indice affiliate su `save_post_affiliate_link` spostato a priorità alta per garantire esecuzione dopo salvataggio meta/tassonomie del CPT `affiliate_link`, mantenendo guard autosave/revision/post type e filtro `alma_ai_affiliate_index_disable_autosync`.
 - Rimossi dalla card “2. Risultati ricerca” il pulsante **Svuota ricerca** e il filtro **Tipologia contenuto** (`alma_result_type`) con relativa logica/rendering UI.
@@ -123,7 +130,7 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.3
+Versione 2.25.4
 
 
 ## Novità 2.12.1 — Pagina Importa contenuti + fix import

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.3
+ * Version: 2.25.4
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.3');
+define('ALMA_VERSION', '2.25.4');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -657,3 +657,10 @@ button:disabled {
 .alma-ai-agent-admin .alma-results-header{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap}
 @media (max-width:782px){.alma-ai-agent-admin .alma-results-header{align-items:flex-start;flex-direction:column}}
 .alma-ai-agent-admin .alma-ideas-card .tablenav.top{margin:8px 0 12px;}
+
+
+.alma-ai-agent-admin .alma-affiliate-index-card .alma-affiliate-index-warning {
+    background: #fff8e5;
+    border-left: 4px solid #dba617;
+    padding: 8px 10px;
+}

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -46,6 +46,15 @@ class ALMA_AI_Content_Agent_Admin {
         } elseif ($do === 'reset_affiliate_index_state') {
             ALMA_AI_Content_Agent_Affiliate_Index::reset_batch_state();
             $result = array('success' => true, 'message' => 'Stato batch indice link affiliati resettato (azione non distruttiva).');
+        } elseif ($do === 'clear_affiliate_index') {
+            $clear = ALMA_AI_Content_Agent_Affiliate_Index::clear_index();
+            if (empty($clear['table_exists'])) {
+                $result = array('success' => true, 'message' => 'Indice tecnico non presente: stato batch resettato.');
+            } elseif (!empty($clear['success'])) {
+                $result = array('success' => true, 'message' => sprintf('Indice tecnico Link affiliati svuotato: %d record rimossi. Stato batch azzerato.', (int) ($clear['deleted'] ?? 0)));
+            } else {
+                $result = array('success' => false, 'message' => 'Errore durante lo svuotamento dell\'indice tecnico Link affiliati.');
+            }
         } elseif ($do === 'search_knowledge_base' || $do === 'add_new_search') {
             $profile_id = absint($_POST['instruction_profile_id'] ?? 0);
             $profile = $profile_id ? ALMA_AI_Content_Agent_Instructions_Manager::get_profile($profile_id) : array();
@@ -240,13 +249,23 @@ class ALMA_AI_Content_Agent_Admin {
         $stats = ALMA_AI_Content_Agent_Affiliate_Index::get_index_stats();
         $batch = (array)($stats['batch_state'] ?? array());
         $batch_status = !empty($batch['done']) ? 'completato' : (!empty($batch['updated_at']) ? 'in corso' : 'mai avviato');
-        echo '<div class="alma-agent-card"><h3>Indice Link affiliati</h3>';
-        if (empty($stats['table_exists'])) { echo '<p><em>Tabella indice non disponibile. La ricerca userà fallback WordPress per i Link affiliati.</em></p>'; }
-        echo '<ul><li>Totale Link affiliati pubblicati: '.(int)$stats['total_published'].'</li><li>Indicizzati attivi: '.(int)$stats['indexed_active'].'</li><li>Non indicizzati stimati: '.(int)$stats['not_indexed'].'</li><li>Da aggiornare: '.(int)($stats['needs_update'] ?? 0).'</li><li>Link affiliati senza URL affiliato: '.(int)$stats['without_affiliate_url'].'</li><li>Record indice inattivi: '.(int)$stats['inactive_index_records'].'</li><li>Ultimo aggiornamento indice: '.esc_html($stats['last_indexed_at'] ?: 'N/D').'</li><li>Stato batch: '.esc_html($batch_status).'</li><li>Last processed ID: '.(int)($batch['last_processed_id'] ?? 0).'</li>'.(!empty($batch['last_error'])?'<li>Ultimo errore: '.esc_html($batch['last_error']).'</li>':'').'</ul>';
+        $operational_state = 'Richiede verifica';
+        if (empty($stats['table_exists'])) { $operational_state = 'Indice non ancora creato'; }
+        elseif ((int)$stats['indexed_active'] < 1 && (int)$stats['inactive_index_records'] < 1) { $operational_state = 'Indice vuoto'; }
+        elseif (!empty($batch['updated_at']) && empty($batch['done'])) { $operational_state = 'Indicizzazione in corso'; }
+        elseif (!empty($batch['done']) && (int)$stats['missing_index'] < 1 && (int)$stats['needs_update'] < 1 && (int)$stats['active_invalid_records'] < 1 && (int)$stats['orphan_index_records'] < 1) { $operational_state = 'Indicizzazione completata'; }
+        elseif ((int)$stats['missing_index'] > 0 && (int)$stats['indexed_active'] < 1) { $operational_state = 'Pronto per primo batch'; }
+        elseif ((int)$stats['needs_update'] > 0 || (int)$stats['missing_index'] > 0) { $operational_state = 'Da aggiornare'; }
+
+        echo '<div class="alma-agent-card alma-affiliate-index-card"><h3>Indice Link affiliati</h3>';
+        if (empty($stats['table_exists'])) { echo '<p class="description"><em>Tabella indice non disponibile. La ricerca userà fallback WordPress per i Link affiliati.</em></p>'; }
+        echo '<p class="alma-affiliate-index-warning"><strong>Questa operazione non elimina i Link affiliati. Cancella solo l’indice tecnico rigenerabile.</strong></p>';
+        echo '<ul><li>Totale Link affiliati pubblicati: '.(int)$stats['total_published'].'</li><li>Indicizzati attivi: '.(int)$stats['indexed_active'].'</li><li>Non indicizzati / missing index: '.(int)$stats['missing_index'].'</li><li>Da aggiornare: '.(int)($stats['needs_update'] ?? 0).'</li><li>Link affiliati senza URL affiliato: '.(int)$stats['without_affiliate_url'].'</li><li>Record indice inattivi: '.(int)$stats['inactive_index_records'].'</li><li>Record indice orfani: '.(int)$stats['orphan_index_records'].'</li><li>Record attivi non validi: '.(int)$stats['active_invalid_records'].'</li><li>Ultimo aggiornamento indice: '.esc_html($stats['last_indexed_at'] ?: 'N/D').'</li><li>Stato batch: '.esc_html($batch_status).'</li><li>Last processed ID: '.(int)($batch['last_processed_id'] ?? 0).'</li><li>Stato operativo: <strong>'.esc_html($operational_state).'</strong></li>'.(!empty($batch['last_error'])?'<li>Ultimo errore: '.esc_html($batch['last_error']).'</li>':'').'</ul>';
         echo '<div class="alma-actions-inline">';
         self::action_form('index_affiliate_links','Indicizza prossimo batch');
         self::action_form('sync_affiliate_links_incremental','Sync incrementale');
         self::action_form('reset_affiliate_index_state','Reset stato batch');
+        self::action_form('clear_affiliate_index','Svuota indice e ricomincia');
         echo '</div></div>';
     }
 

--- a/includes/class-ai-content-agent-affiliate-index.php
+++ b/includes/class-ai-content-agent-affiliate-index.php
@@ -63,15 +63,35 @@ class ALMA_AI_Content_Agent_Affiliate_Index {
         return array('last_processed_id'=>0,'processed'=>0,'indexed'=>0,'skipped'=>0,'done'=>false,'started_at'=>'','updated_at'=>'','last_error'=>'');
     }
 
+
+    public static function clear_index() {
+        global $wpdb;
+        $table = self::table_name();
+        if (in_array($table, ALMA_AI_Content_Agent_Store::missing_tables(), true)) {
+            self::reset_batch_state();
+            return array('success' => true, 'deleted' => 0, 'table_exists' => false);
+        }
+        $deleted = $wpdb->query("DELETE FROM {$table}");
+        if ($deleted === false) {
+            self::reset_batch_state();
+            return array('success' => false, 'deleted' => 0, 'table_exists' => true, 'error' => sanitize_text_field($wpdb->last_error));
+        }
+        self::reset_batch_state();
+        return array('success' => true, 'deleted' => (int) $deleted, 'table_exists' => true);
+    }
+
     public static function get_index_stats() {
         global $wpdb;
         $stats = array(
             'table_exists' => true,
             'total_published' => 0,
             'indexed_active' => 0,
+            'missing_index' => 0,
             'not_indexed' => 0,
             'without_affiliate_url' => 0,
             'inactive_index_records' => 0,
+            'orphan_index_records' => 0,
+            'active_invalid_records' => 0,
             'needs_update' => 0,
             'last_indexed_at' => '',
             'batch_state' => self::get_batch_state(),
@@ -84,7 +104,10 @@ class ALMA_AI_Content_Agent_Affiliate_Index {
         $stats['inactive_index_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM $table WHERE status=%s", self::STATUS_INACTIVE));
         $stats['last_indexed_at'] = (string)$wpdb->get_var("SELECT MAX(indexed_at) FROM $table");
         $stats['needs_update'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM {$wpdb->posts} p LEFT JOIN $table i ON i.affiliate_link_id = p.ID AND i.status = %s WHERE p.post_type=%s AND p.post_status='publish' AND (i.affiliate_link_id IS NULL OR i.post_modified_gmt IS NULL OR p.post_modified_gmt > i.post_modified_gmt)", self::STATUS_ACTIVE, 'affiliate_link'));
-        $stats['not_indexed'] = max(0, $stats['total_published'] - $stats['indexed_active'] - $stats['without_affiliate_url']);
+        $stats['missing_index'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM {$wpdb->posts} p LEFT JOIN {$wpdb->postmeta} m1 ON p.ID = m1.post_id AND m1.meta_key = %s LEFT JOIN {$wpdb->postmeta} m2 ON p.ID = m2.post_id AND m2.meta_key = %s LEFT JOIN $table i ON i.affiliate_link_id = p.ID WHERE p.post_type=%s AND p.post_status='publish' AND TRIM(COALESCE(NULLIF(m1.meta_value,''), NULLIF(m2.meta_value,''), '')) <> '' AND i.affiliate_link_id IS NULL", '_affiliate_url', '_alma_affiliate_url', 'affiliate_link'));
+        $stats['orphan_index_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM $table i LEFT JOIN {$wpdb->posts} p ON p.ID = i.affiliate_link_id WHERE p.ID IS NULL OR p.post_type <> %s", 'affiliate_link'));
+        $stats['active_invalid_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM $table i LEFT JOIN {$wpdb->posts} p ON p.ID = i.affiliate_link_id LEFT JOIN {$wpdb->postmeta} m1 ON p.ID = m1.post_id AND m1.meta_key = %s LEFT JOIN {$wpdb->postmeta} m2 ON p.ID = m2.post_id AND m2.meta_key = %s WHERE i.status = %s AND (p.ID IS NULL OR p.post_type <> %s OR p.post_status <> 'publish' OR TRIM(COALESCE(NULLIF(m1.meta_value,''), NULLIF(m2.meta_value,''), '')) = '')", '_affiliate_url', '_alma_affiliate_url', self::STATUS_ACTIVE, 'affiliate_link'));
+        $stats['not_indexed'] = max(0, (int) $stats['missing_index']);
         return $stats;
     }
 


### PR DESCRIPTION
### Motivation
- Provide safe, non‑destructive maintenance and pre‑sync diagnostics for the dedicated affiliate index before running a first full sync on large datasets. 
- Give admins clear, aggregate diagnostics and non‑blocking guidance in the Dashboard to decide when to run incremental/full indexing without touching affiliate content, providers, OpenAI flows or other excluded areas.

### Description
- Added `ALMA_AI_Content_Agent_Affiliate_Index::clear_index()` to safely delete only the technical index table `{$wpdb->prefix}alma_ai_affiliate_index`, handle a missing table without fatal, and always reset the batch state after the operation. 
- Exposed a protected admin action `clear_affiliate_index` in the central `handle_action` flow to call the new clear routine and return a clear post‑redirect admin message; `reset_affiliate_index_state` remains as the non‑destructive batch state reset. 
- Extended `get_index_stats()` to return aggregate diagnostics (`missing_index`, `orphan_index_records`, `active_invalid_records`) while keeping existing metrics (`needs_update`, `without_affiliate_url`, `inactive_index_records`, `last_indexed_at`, `table_exists`, `batch_state`) and returning a safe array when the table is absent. 
- Enhanced the Dashboard card (Indice Link affiliati) to show the new counts, a readable operational state (e.g. Indice non ancora creato / Indice vuoto / Pronto per primo batch / Indicizzazione in corso / Indicizzazione completata / Da aggiornare / Richiede verifica), action buttons (Indicizza prossimo batch, Sync incrementale, Reset stato batch, Svuota indice e ricomincia) and an explicit UX warning that clearing the index does NOT delete affiliate_link CPTs; added scoped CSS for the warning and bumped plugin version to `2.25.4` with README/CHANGELOG updates.

### Testing
- Ran PHP lint on critical files and they passed: `php -l affiliate-link-manager-ai.php`, `php -l includes/class-ai-content-agent-affiliate-index.php`, `php -l includes/class-ai-content-agent-admin.php`, `php -l includes/class-ai-content-agent-store.php`, `php -l includes/class-ai-content-agent-knowledge-search.php`, `php -l includes/class-ai-content-agent-selection-session.php` (all OK). 
- Performed textual/code checks confirming: plugin version bumped to `2.25.4`; presence of `clear_affiliate_index` action handling and `clear_index()` method; presence of `reset_affiliate_index_state`; new diagnostics `missing_index`, `orphan_index_records`, `active_invalid_records`; dashboard warning text that clearing index does not delete affiliate links; no changes made to OpenAI service, Draft Builder, provider/importer/shortcode/tracking. 
- Note: full manual end‑to‑end WordPress UI/DB tests (clicking Dashboard actions, verifying real DB table contents and fallback search behavior) were not executed here because no running WP instance/dataset was available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f99c384d7483328d217d1444348342)