### PR TITLE
PR 8.7 — Affiliate Index Progress Count Fix and Pending Work Semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.25.7 — PR 8.7 Affiliate Index Progress Count Fix and Pending Work Semantics
+- Fix doppio conteggio pending nella Dashboard: rimosso l'errore semantico `missing_index + needs_update` che duplicava i mancanti.
+- Aggiunto conteggio `stale_index_records` per separare i Link affiliati mancanti dall'indice da quelli da aggiornare dopo modifica.
+- `needs_update` mantenuto per backward compatibility come totale operativo (`missing_index + stale_index_records`).
+- Barra progresso resa coerente: “Da lavorare totale” non può superare “Candidabili”; percentuale clampata tra 0 e 100.
+- Stato operativo guidato, prossima azione consigliata e CTA primaria riallineati ai nuovi conteggi (batch prima, sync incrementale dopo).
+- Nessuna modifica a ricerca/scoring/batch cursor-based, OpenAI, Draft Builder, provider/importer, shortcode o tracking.
+
 ## 2.25.6 — PR 8.6 Affiliate Index Guided Batch Sync UX and Progress Feedback
 - Aggiunta barra progresso indicizzazione nella card “Indice Link affiliati” con percentuale, candidabili e pending calcolati dai dati già disponibili in `get_index_stats()`.
 - Aggiunto stato operativo guidato e blocco “Prossima azione consigliata” con CTA primaria dinamica per primo batch, continuazione batch e sync incrementale.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## 2.25.7 — PR 8.7 Affiliate Index Progress Count Fix and Pending Work Semantics
+- Corretto il calcolo dei pending nella card “Indice Link affiliati”: eliminato il doppio conteggio (`missing_index + needs_update`) che poteva superare i candidabili.
+- Introdotto `stale_index_records` nei dati indice per distinguere chiaramente i record mancanti dai record presenti ma obsoleti.
+- `needs_update` mantenuto retrocompatibile come totale operativo (`missing_index + stale_index_records`) senza alterare batch cursor-based, ricerca o scoring.
+- Barra progresso resa affidabile con clamp di “Da lavorare totale” entro i candidabili e percentuale sempre tra 0 e 100.
+- Stato operativo, prossima azione consigliata e CTA primaria aggiornati per privilegiare primo batch quando mancano record e sync incrementale solo per obsolescenza/anomalie.
+- Nessuna modifica a ricerca/scoring/batch, OpenAI, Draft Builder, provider/importer, shortcode o tracking.
+
 ## 2.25.6 — PR 8.6 Affiliate Index Guided Batch Sync UX and Progress Feedback
 - Card “Indice Link affiliati” aggiornata con barra di progresso in stile admin (percentuale, candidabili, elementi da lavorare) calcolata da `get_index_stats()` evitando query pesanti aggiuntive.
 - Nuovo stato operativo guidato e sezione “Prossima azione consigliata” con CTA primaria dinamica (primo batch/continua batch/sync incrementale/indice aggiornato).
@@ -135,7 +143,7 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.6
+Versione 2.25.7
 
 
 ## Novità 2.12.1 — Pagina Importa contenuti + fix import

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.6
+ * Version: 2.25.7
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.6');
+define('ALMA_VERSION', '2.25.7');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -254,12 +254,15 @@ class ALMA_AI_Content_Agent_Admin {
         $without_affiliate_url = (int)$stats['without_affiliate_url'];
         $indexed_active = (int)$stats['indexed_active'];
         $missing_index = (int)$stats['missing_index'];
-        $needs_update = (int)$stats['needs_update'];
+        $stale_index_records = (int)($stats['stale_index_records'] ?? 0);
+        $needs_update = max(0, (int)$stats['needs_update']);
         $active_invalid_records = (int)$stats['active_invalid_records'];
         $orphan_index_records = (int)$stats['orphan_index_records'];
 
         $eligible_total = max(0, $total_published - $without_affiliate_url);
-        $pending_total = max(0, $missing_index + $needs_update);
+        $pending_total = max(0, $missing_index + $stale_index_records);
+        if ($needs_update !== $pending_total) { $needs_update = $pending_total; }
+        $pending_total = min($eligible_total, $pending_total);
         $progress_percent = 0;
         if ($eligible_total > 0) {
             if ($pending_total < 1 && $indexed_active >= $eligible_total) {
@@ -267,6 +270,7 @@ class ALMA_AI_Content_Agent_Admin {
             } else {
                 $completed_estimate = max(0, min($eligible_total, $eligible_total - $pending_total));
                 $progress_percent = (int) round(($completed_estimate / $eligible_total) * 100);
+                $progress_percent = max(0, min(100, $progress_percent));
             }
         }
 
@@ -274,27 +278,31 @@ class ALMA_AI_Content_Agent_Admin {
         if ($total_published < 1) { $operational_state = 'Nessun Link affiliato pubblicato'; }
         elseif (empty($stats['table_exists'])) { $operational_state = 'Indice non ancora creato'; }
         elseif ($eligible_total > 0 && $indexed_active < 1 && $missing_index > 0) { $operational_state = 'Pronto per primo batch'; }
-        elseif (!empty($batch['updated_at']) && empty($batch['done'])) { $operational_state = 'Indicizzazione in corso'; }
-        elseif (!empty($batch['done']) && $missing_index < 1 && $needs_update < 1 && $active_invalid_records < 1 && $orphan_index_records < 1) { $operational_state = 'Indice aggiornato'; }
-        elseif (!empty($batch['done']) && $missing_index < 1 && $needs_update < 1) { $operational_state = 'Indicizzazione completata'; }
-        elseif ($needs_update > 0 || $missing_index > 0) { $operational_state = 'Indice da aggiornare'; }
+        elseif ($active_invalid_records > 0 || $orphan_index_records > 0) { $operational_state = 'Richiede verifica'; }
+        elseif ($missing_index > 0) { $operational_state = !empty($batch['updated_at']) && empty($batch['done']) ? 'Indicizzazione in corso' : 'Pronto per primo batch'; }
+        elseif ($stale_index_records > 0) { $operational_state = 'Indice da aggiornare'; }
+        elseif ($eligible_total > 0) { $operational_state = 'Indice aggiornato'; }
 
         $next_action_text = 'Verifica i conteggi dell’indice tecnico.';
         $primary_do = '';
         $primary_label = '';
-        if ($eligible_total > 0 && $indexed_active < 1 && $missing_index > 0) {
+        if ($eligible_total > 0 && $missing_index > 0 && $indexed_active < 1) {
             $next_action_text = 'Avvia il primo batch di indicizzazione.';
             $primary_do = 'index_affiliate_links';
             $primary_label = 'Avvia primo batch';
-        } elseif (!empty($batch['updated_at']) && empty($batch['done'])) {
-            $next_action_text = 'Continua con il prossimo batch.';
+        } elseif ($missing_index > 0) {
+            $next_action_text = !empty($batch['updated_at']) && empty($batch['done']) ? 'Continua con il prossimo batch di indicizzazione.' : 'Completa il primo batch di indicizzazione prima della sync incrementale.';
             $primary_do = 'index_affiliate_links';
-            $primary_label = 'Continua indicizzazione';
-        } elseif (!empty($batch['done']) && ($needs_update > 0 || $missing_index > 0 || $active_invalid_records > 0 || $orphan_index_records > 0)) {
-            $next_action_text = 'Esegui sync incrementale o verifica l’indice tecnico.';
-            $primary_do = ($needs_update > 0 || $missing_index > 0) ? 'sync_affiliate_links_incremental' : '';
+            $primary_label = !empty($batch['updated_at']) && empty($batch['done']) ? 'Continua indicizzazione' : 'Avvia primo batch';
+        } elseif ($stale_index_records > 0) {
+            $next_action_text = 'Esegui sync incrementale per aggiornare i record obsoleti.';
+            $primary_do = 'sync_affiliate_links_incremental';
             $primary_label = 'Esegui sync incrementale';
-        } elseif (!empty($batch['done']) && $missing_index < 1 && $needs_update < 1 && $active_invalid_records < 1 && $orphan_index_records < 1) {
+        } elseif ($active_invalid_records > 0 || $orphan_index_records > 0) {
+            $next_action_text = 'Verifica record orfani/non validi e riesegui la sync incrementale.';
+            $primary_do = 'sync_affiliate_links_incremental';
+            $primary_label = 'Verifica e sync incrementale';
+        } elseif ($eligible_total > 0) {
             $next_action_text = 'Nessuna azione necessaria.';
         }
 
@@ -302,9 +310,9 @@ class ALMA_AI_Content_Agent_Admin {
         if (empty($stats['table_exists'])) { echo '<p class="description"><em>Tabella indice non disponibile. La ricerca userà fallback WordPress per i Link affiliati.</em></p>'; }
         echo '<p class="alma-affiliate-index-warning"><strong>Questa operazione non elimina i Link affiliati. Cancella solo l’indice tecnico rigenerabile.</strong></p>';
         echo '<div class="alma-affiliate-operational-state"><strong>Stato operativo:</strong> '.esc_html($operational_state).'</div>';
-        echo '<div class="alma-affiliate-progress" role="status" aria-live="polite"><div class="alma-affiliate-progress-head"><strong>Progresso indicizzazione</strong> <span>'.(int)$progress_percent.'%</span></div><div class="alma-affiliate-progress-bar" aria-hidden="true"><span style="width: '.(int)$progress_percent.'%;"></span></div><p class="description">Candidabili: '.(int)$eligible_total.' · Da lavorare: '.(int)$pending_total.'</p></div>';
+        echo '<div class="alma-affiliate-progress" role="status" aria-live="polite"><div class="alma-affiliate-progress-head"><strong>Progresso indicizzazione</strong> <span>'.(int)$progress_percent.'%</span></div><div class="alma-affiliate-progress-bar" aria-hidden="true"><span style="width: '.(int)$progress_percent.'%;"></span></div><p class="description">Candidabili: '.(int)$eligible_total.' · Da lavorare totale: '.(int)$pending_total.'</p></div>';
         echo '<div class="alma-affiliate-next-action"><strong>Prossima azione consigliata</strong><p>'.esc_html($next_action_text).'</p></div>';
-        echo '<ul><li>Totale Link affiliati pubblicati: '.$total_published.'</li><li>Indicizzati attivi: '.$indexed_active.'</li><li>Non indicizzati / missing index: '.$missing_index.'</li><li>Da aggiornare: '.$needs_update.'</li><li>Link affiliati senza URL affiliato: '.$without_affiliate_url.'</li><li>Record indice inattivi: '.(int)$stats['inactive_index_records'].'</li><li>Record indice orfani: '.$orphan_index_records.'</li><li>Record attivi non validi: '.$active_invalid_records.'</li><li>Ultimo aggiornamento indice: '.esc_html($stats['last_indexed_at'] ?: 'N/D').'</li><li>Stato batch: '.esc_html($batch_status).'</li><li>Last processed ID: '.(int)($batch['last_processed_id'] ?? 0).'</li>'.(!empty($batch['last_error'])?'<li>Ultimo errore: '.esc_html($batch['last_error']).'</li>':'').'</ul>';
+        echo '<ul><li>Totale Link affiliati pubblicati: '.$total_published.'</li><li>Indicizzati attivi: '.$indexed_active.'</li><li>Mancanti dall’indice: '.$missing_index.'</li><li>Da aggiornare: '.$stale_index_records.'</li><li>Da lavorare totale: '.$pending_total.'</li><li>Link affiliati senza URL affiliato: '.$without_affiliate_url.'</li><li>Record indice inattivi: '.(int)$stats['inactive_index_records'].'</li><li>Record indice orfani: '.$orphan_index_records.'</li><li>Record attivi non validi: '.$active_invalid_records.'</li><li>Ultimo aggiornamento indice: '.esc_html($stats['last_indexed_at'] ?: 'N/D').'</li><li>Stato batch: '.esc_html($batch_status).'</li><li>Last processed ID: '.(int)($batch['last_processed_id'] ?? 0).'</li>'.(!empty($batch['last_error'])?'<li>Ultimo errore: '.esc_html($batch['last_error']).'</li>':'').'</ul>';
 
         echo '<div class="alma-actions-inline alma-affiliate-primary-actions">';
         if ($primary_do !== '' && $primary_label !== '') {

--- a/includes/class-ai-content-agent-affiliate-index.php
+++ b/includes/class-ai-content-agent-affiliate-index.php
@@ -92,6 +92,7 @@ class ALMA_AI_Content_Agent_Affiliate_Index {
             'inactive_index_records' => 0,
             'orphan_index_records' => 0,
             'active_invalid_records' => 0,
+            'stale_index_records' => 0,
             'needs_update' => 0,
             'last_indexed_at' => '',
             'batch_state' => self::get_batch_state(),
@@ -103,8 +104,9 @@ class ALMA_AI_Content_Agent_Affiliate_Index {
         $stats['indexed_active'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM $table WHERE status=%s AND post_status='publish' AND affiliate_url_present=1", self::STATUS_ACTIVE));
         $stats['inactive_index_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM $table WHERE status=%s", self::STATUS_INACTIVE));
         $stats['last_indexed_at'] = (string)$wpdb->get_var("SELECT MAX(indexed_at) FROM $table");
-        $stats['needs_update'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(DISTINCT p.ID) FROM {$wpdb->posts} p LEFT JOIN $table i ON i.affiliate_link_id = p.ID AND i.status = %s WHERE p.post_type=%s AND p.post_status='publish' AND (i.affiliate_link_id IS NULL OR i.post_modified_gmt IS NULL OR p.post_modified_gmt > i.post_modified_gmt)", self::STATUS_ACTIVE, 'affiliate_link'));
         $stats['missing_index'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM {$wpdb->posts} p LEFT JOIN $table i ON i.affiliate_link_id = p.ID WHERE p.post_type=%s AND p.post_status='publish' AND i.affiliate_link_id IS NULL AND EXISTS (SELECT 1 FROM {$wpdb->postmeta} pm WHERE pm.post_id = p.ID AND pm.meta_key IN (%s, %s) AND TRIM(pm.meta_value) <> '')", 'affiliate_link', '_affiliate_url', '_alma_affiliate_url'));
+        $stats['stale_index_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(DISTINCT p.ID) FROM {$wpdb->posts} p INNER JOIN $table i ON i.affiliate_link_id = p.ID AND i.status = %s WHERE p.post_type=%s AND p.post_status='publish' AND EXISTS (SELECT 1 FROM {$wpdb->postmeta} pm WHERE pm.post_id = p.ID AND pm.meta_key IN (%s, %s) AND TRIM(pm.meta_value) <> '') AND (i.post_modified_gmt IS NULL OR p.post_modified_gmt > i.post_modified_gmt)", self::STATUS_ACTIVE, 'affiliate_link', '_affiliate_url', '_alma_affiliate_url'));
+        $stats['needs_update'] = max(0, (int) $stats['missing_index'] + (int) $stats['stale_index_records']);
         $stats['orphan_index_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM $table i LEFT JOIN {$wpdb->posts} p ON p.ID = i.affiliate_link_id WHERE p.ID IS NULL OR p.post_type <> %s", 'affiliate_link'));
         $stats['active_invalid_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM $table i LEFT JOIN {$wpdb->posts} p ON p.ID = i.affiliate_link_id WHERE i.status = %s AND (p.ID IS NULL OR p.post_type <> %s OR p.post_status <> 'publish' OR NOT EXISTS (SELECT 1 FROM {$wpdb->postmeta} pm WHERE pm.post_id = p.ID AND pm.meta_key IN (%s, %s) AND TRIM(pm.meta_value) <> ''))", self::STATUS_ACTIVE, 'affiliate_link', '_affiliate_url', '_alma_affiliate_url'));
         $stats['not_indexed'] = max(0, (int) $stats['missing_index']);


### PR DESCRIPTION
### Motivation
- Fix a bug where the dashboard could show “Da lavorare” greater than “Candidabili” because the UI summed `missing_index + needs_update` while `needs_update` already included missing records.
- Separate the concepts of missing vs stale index records so progress, operational state and recommended CTA behave predictably before extending to other content types.

### Description
- Add `stale_index_records` to `ALMA_AI_Content_Agent_Affiliate_Index::get_index_stats()` and compute `needs_update = missing_index + stale_index_records` to preserve backward compatibility while separating semantics.
- Change admin rendering in `ALMA_AI_Content_Agent_Admin::render_affiliate_index_status_box()` to compute `pending_total = missing_index + stale_index_records`, clamp `pending_total` to `eligible_total`, and clamp `progress_percent` to the 0..100 range.
- Update UI labels in the affiliate index card to show distinct values for “Mancanti dall’indice”, “Da aggiornare”, and “Da lavorare totale”, and update operational state / next action / primary CTA logic to prioritize first-batch indexing when `missing_index > 0` and incremental sync when only stale records remain.
- Bump plugin version to `2.25.7` in `affiliate-link-manager-ai.php` and update `README.md` and `CHANGELOG.md` with PR 8.7 notes; no changes to batch cursor, DB schema, knowledge search, scoring, OpenAI, Draft Builder, providers/importer, shortcode or tracking.

### Testing
- Ran `php -l affiliate-link-manager-ai.php`, `php -l includes/class-ai-content-agent-affiliate-index.php`, and `php -l includes/class-ai-content-agent-admin.php` with no syntax errors.
- Performed textual checks confirming `2.25.7` in header/constant/README/CHANGELOG, presence of `stale_index_records`, removal of the old `pending_total = missing_index + needs_update` formula, clamping of `pending_total` to `eligible_total`, and progress clamped to 0..100.
- Verified diffs to ensure only the intended files were modified: `includes/class-ai-content-agent-affiliate-index.php`, `includes/class-ai-content-agent-admin.php`, `affiliate-link-manager-ai.php`, `README.md`, and `CHANGELOG.md`.
- Manual WordPress UI tests (dashboard dataset, batch runs, incremental sync) could not be executed in this environment and must be run in a WP instance as specified in the PR testing instructions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a4e22dec833294a3c4a84c300a7d)