### PR TITLE
PR 8.8: Include non-active affiliate index candidates in pending semantics (v2.25.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.25.8 — PR 8.8 Affiliate Index Pending Semantics for Non-Active Records
+- Aggiunto `non_active_candidate_records` in `get_index_stats()` per contare i Link affiliati pubblicati e candidabili con record indice presente ma non `active`.
+- Aggiornata la semantica pending: `needs_update` ora include `missing_index + stale_index_records + non_active_candidate_records` evitando doppi conteggi tra categorie mutualmente esclusive.
+- Card Dashboard aggiornata: “Da lavorare totale” include anche i candidabili non attivi, resta clampato ai candidabili e impedisce falsi 100%/falso stato “Indice aggiornato”.
+- Stato operativo/CTA guidati: se restano solo record stale o candidabili non attivi viene proposta sync incrementale/verifica indice.
+- Nessuna modifica a ricerca/scoring, batch cursor-based, OpenAI, Draft Builder, provider/importer, shortcode o tracking.
+
 ## 2.25.7 — PR 8.7 Affiliate Index Progress Count Fix and Pending Work Semantics
 - Fix doppio conteggio pending nella Dashboard: rimosso l'errore semantico `missing_index + needs_update` che duplicava i mancanti.
 - Aggiunto conteggio `stale_index_records` per separare i Link affiliati mancanti dall'indice da quelli da aggiornare dopo modifica.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-## 2.25.7 — PR 8.7 Affiliate Index Progress Count Fix and Pending Work Semantics
-- Corretto il calcolo dei pending nella card “Indice Link affiliati”: eliminato il doppio conteggio (`missing_index + needs_update`) che poteva superare i candidabili.
-- Introdotto `stale_index_records` nei dati indice per distinguere chiaramente i record mancanti dai record presenti ma obsoleti.
-- `needs_update` mantenuto retrocompatibile come totale operativo (`missing_index + stale_index_records`) senza alterare batch cursor-based, ricerca o scoring.
-- Barra progresso resa affidabile con clamp di “Da lavorare totale” entro i candidabili e percentuale sempre tra 0 e 100.
-- Stato operativo, prossima azione consigliata e CTA primaria aggiornati per privilegiare primo batch quando mancano record e sync incrementale solo per obsolescenza/anomalie.
-- Nessuna modifica a ricerca/scoring/batch, OpenAI, Draft Builder, provider/importer, shortcode o tracking.
+## 2.25.8 — PR 8.8 Affiliate Index Pending Semantics for Non-Active Records
+- Aggiunto `non_active_candidate_records` per contare i Link affiliati candidabili (publish + URL valido) con record indice presente ma non `active`.
+- Semantica pending aggiornata: `needs_update` ora include `missing_index + stale_index_records + non_active_candidate_records` senza sovrapposizioni.
+- La Dashboard ora include i candidabili non attivi in “Da lavorare totale”, con clamp ai candidabili e progresso sempre 0..100.
+- Evitato il falso stato “Indice aggiornato” quando restano candidabili non attivi; stato operativo e CTA guidano verso sync incrementale/verifica indice.
+- Nessuna modifica a ricerca/scoring, batch cursor-based, OpenAI, Draft Builder, provider/importer, shortcode o tracking.
 
 ## 2.25.6 — PR 8.6 Affiliate Index Guided Batch Sync UX and Progress Feedback
 - Card “Indice Link affiliati” aggiornata con barra di progresso in stile admin (percentuale, candidabili, elementi da lavorare) calcolata da `get_index_stats()` evitando query pesanti aggiuntive.
@@ -143,7 +142,7 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.7
+Versione 2.25.8
 
 
 ## Novità 2.12.1 — Pagina Importa contenuti + fix import

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.7
+ * Version: 2.25.8
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.7');
+define('ALMA_VERSION', '2.25.8');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -255,12 +255,13 @@ class ALMA_AI_Content_Agent_Admin {
         $indexed_active = (int)$stats['indexed_active'];
         $missing_index = (int)$stats['missing_index'];
         $stale_index_records = (int)($stats['stale_index_records'] ?? 0);
+        $non_active_candidate_records = (int)($stats['non_active_candidate_records'] ?? 0);
         $needs_update = max(0, (int)$stats['needs_update']);
         $active_invalid_records = (int)$stats['active_invalid_records'];
         $orphan_index_records = (int)$stats['orphan_index_records'];
 
         $eligible_total = max(0, $total_published - $without_affiliate_url);
-        $pending_total = max(0, $missing_index + $stale_index_records);
+        $pending_total = max(0, $missing_index + $stale_index_records + $non_active_candidate_records);
         if ($needs_update !== $pending_total) { $needs_update = $pending_total; }
         $pending_total = min($eligible_total, $pending_total);
         $progress_percent = 0;
@@ -280,7 +281,7 @@ class ALMA_AI_Content_Agent_Admin {
         elseif ($eligible_total > 0 && $indexed_active < 1 && $missing_index > 0) { $operational_state = 'Pronto per primo batch'; }
         elseif ($active_invalid_records > 0 || $orphan_index_records > 0) { $operational_state = 'Richiede verifica'; }
         elseif ($missing_index > 0) { $operational_state = !empty($batch['updated_at']) && empty($batch['done']) ? 'Indicizzazione in corso' : 'Pronto per primo batch'; }
-        elseif ($stale_index_records > 0) { $operational_state = 'Indice da aggiornare'; }
+        elseif ($stale_index_records > 0 || $non_active_candidate_records > 0) { $operational_state = 'Indice da aggiornare'; }
         elseif ($eligible_total > 0) { $operational_state = 'Indice aggiornato'; }
 
         $next_action_text = 'Verifica i conteggi dell’indice tecnico.';
@@ -294,8 +295,10 @@ class ALMA_AI_Content_Agent_Admin {
             $next_action_text = !empty($batch['updated_at']) && empty($batch['done']) ? 'Continua con il prossimo batch di indicizzazione.' : 'Completa il primo batch di indicizzazione prima della sync incrementale.';
             $primary_do = 'index_affiliate_links';
             $primary_label = !empty($batch['updated_at']) && empty($batch['done']) ? 'Continua indicizzazione' : 'Avvia primo batch';
-        } elseif ($stale_index_records > 0) {
-            $next_action_text = 'Esegui sync incrementale per aggiornare i record obsoleti.';
+        } elseif ($stale_index_records > 0 || $non_active_candidate_records > 0) {
+            $next_action_text = $stale_index_records > 0
+                ? 'Esegui sync incrementale per aggiornare i record obsoleti.'
+                : 'Esegui sync incrementale o verifica indice per riattivare i candidabili non attivi.';
             $primary_do = 'sync_affiliate_links_incremental';
             $primary_label = 'Esegui sync incrementale';
         } elseif ($active_invalid_records > 0 || $orphan_index_records > 0) {
@@ -312,7 +315,7 @@ class ALMA_AI_Content_Agent_Admin {
         echo '<div class="alma-affiliate-operational-state"><strong>Stato operativo:</strong> '.esc_html($operational_state).'</div>';
         echo '<div class="alma-affiliate-progress" role="status" aria-live="polite"><div class="alma-affiliate-progress-head"><strong>Progresso indicizzazione</strong> <span>'.(int)$progress_percent.'%</span></div><div class="alma-affiliate-progress-bar" aria-hidden="true"><span style="width: '.(int)$progress_percent.'%;"></span></div><p class="description">Candidabili: '.(int)$eligible_total.' · Da lavorare totale: '.(int)$pending_total.'</p></div>';
         echo '<div class="alma-affiliate-next-action"><strong>Prossima azione consigliata</strong><p>'.esc_html($next_action_text).'</p></div>';
-        echo '<ul><li>Totale Link affiliati pubblicati: '.$total_published.'</li><li>Indicizzati attivi: '.$indexed_active.'</li><li>Mancanti dall’indice: '.$missing_index.'</li><li>Da aggiornare: '.$stale_index_records.'</li><li>Da lavorare totale: '.$pending_total.'</li><li>Link affiliati senza URL affiliato: '.$without_affiliate_url.'</li><li>Record indice inattivi: '.(int)$stats['inactive_index_records'].'</li><li>Record indice orfani: '.$orphan_index_records.'</li><li>Record attivi non validi: '.$active_invalid_records.'</li><li>Ultimo aggiornamento indice: '.esc_html($stats['last_indexed_at'] ?: 'N/D').'</li><li>Stato batch: '.esc_html($batch_status).'</li><li>Last processed ID: '.(int)($batch['last_processed_id'] ?? 0).'</li>'.(!empty($batch['last_error'])?'<li>Ultimo errore: '.esc_html($batch['last_error']).'</li>':'').'</ul>';
+        echo '<ul><li>Totale Link affiliati pubblicati: '.$total_published.'</li><li>Indicizzati attivi: '.$indexed_active.'</li><li>Mancanti dall’indice: '.$missing_index.'</li><li>Da aggiornare: '.$stale_index_records.'</li><li>Candidabili non attivi: '.$non_active_candidate_records.'</li><li>Da lavorare totale: '.$pending_total.'</li><li>Link affiliati senza URL affiliato: '.$without_affiliate_url.'</li><li>Record indice inattivi: '.(int)$stats['inactive_index_records'].'</li><li>Record indice orfani: '.$orphan_index_records.'</li><li>Record attivi non validi: '.$active_invalid_records.'</li><li>Ultimo aggiornamento indice: '.esc_html($stats['last_indexed_at'] ?: 'N/D').'</li><li>Stato batch: '.esc_html($batch_status).'</li><li>Last processed ID: '.(int)($batch['last_processed_id'] ?? 0).'</li>'.(!empty($batch['last_error'])?'<li>Ultimo errore: '.esc_html($batch['last_error']).'</li>':'').'</ul>';
 
         echo '<div class="alma-actions-inline alma-affiliate-primary-actions">';
         if ($primary_do !== '' && $primary_label !== '') {

--- a/includes/class-ai-content-agent-affiliate-index.php
+++ b/includes/class-ai-content-agent-affiliate-index.php
@@ -93,6 +93,7 @@ class ALMA_AI_Content_Agent_Affiliate_Index {
             'orphan_index_records' => 0,
             'active_invalid_records' => 0,
             'stale_index_records' => 0,
+            'non_active_candidate_records' => 0,
             'needs_update' => 0,
             'last_indexed_at' => '',
             'batch_state' => self::get_batch_state(),
@@ -106,7 +107,8 @@ class ALMA_AI_Content_Agent_Affiliate_Index {
         $stats['last_indexed_at'] = (string)$wpdb->get_var("SELECT MAX(indexed_at) FROM $table");
         $stats['missing_index'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM {$wpdb->posts} p LEFT JOIN $table i ON i.affiliate_link_id = p.ID WHERE p.post_type=%s AND p.post_status='publish' AND i.affiliate_link_id IS NULL AND EXISTS (SELECT 1 FROM {$wpdb->postmeta} pm WHERE pm.post_id = p.ID AND pm.meta_key IN (%s, %s) AND TRIM(pm.meta_value) <> '')", 'affiliate_link', '_affiliate_url', '_alma_affiliate_url'));
         $stats['stale_index_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(DISTINCT p.ID) FROM {$wpdb->posts} p INNER JOIN $table i ON i.affiliate_link_id = p.ID AND i.status = %s WHERE p.post_type=%s AND p.post_status='publish' AND EXISTS (SELECT 1 FROM {$wpdb->postmeta} pm WHERE pm.post_id = p.ID AND pm.meta_key IN (%s, %s) AND TRIM(pm.meta_value) <> '') AND (i.post_modified_gmt IS NULL OR p.post_modified_gmt > i.post_modified_gmt)", self::STATUS_ACTIVE, 'affiliate_link', '_affiliate_url', '_alma_affiliate_url'));
-        $stats['needs_update'] = max(0, (int) $stats['missing_index'] + (int) $stats['stale_index_records']);
+        $stats['non_active_candidate_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(DISTINCT p.ID) FROM {$wpdb->posts} p INNER JOIN $table i ON i.affiliate_link_id = p.ID WHERE p.post_type=%s AND p.post_status='publish' AND EXISTS (SELECT 1 FROM {$wpdb->postmeta} pm WHERE pm.post_id = p.ID AND pm.meta_key IN (%s, %s) AND TRIM(pm.meta_value) <> '') AND i.status <> %s", 'affiliate_link', '_affiliate_url', '_alma_affiliate_url', self::STATUS_ACTIVE));
+        $stats['needs_update'] = max(0, (int) $stats['missing_index'] + (int) $stats['stale_index_records'] + (int) $stats['non_active_candidate_records']);
         $stats['orphan_index_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM $table i LEFT JOIN {$wpdb->posts} p ON p.ID = i.affiliate_link_id WHERE p.ID IS NULL OR p.post_type <> %s", 'affiliate_link'));
         $stats['active_invalid_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM $table i LEFT JOIN {$wpdb->posts} p ON p.ID = i.affiliate_link_id WHERE i.status = %s AND (p.ID IS NULL OR p.post_type <> %s OR p.post_status <> 'publish' OR NOT EXISTS (SELECT 1 FROM {$wpdb->postmeta} pm WHERE pm.post_id = p.ID AND pm.meta_key IN (%s, %s) AND TRIM(pm.meta_value) <> ''))", self::STATUS_ACTIVE, 'affiliate_link', '_affiliate_url', '_alma_affiliate_url'));
         $stats['not_indexed'] = max(0, (int) $stats['missing_index']);


### PR DESCRIPTION
### Motivation
- Correggere un bug P1 della Dashboard: link affiliati pubblicati con URL valido che hanno un record indice presente ma con `status != active` non venivano conteggiati come lavoro pendente, permettendo il falso stato “Indice aggiornato”.

### Description
- Aggiunto il campo diagnostico `non_active_candidate_records` in `ALMA_AI_Content_Agent_Affiliate_Index::get_index_stats()` calcolato con query aggregate preparata che usa `COUNT(DISTINCT p.ID)` e `EXISTS` su meta URL, con fallback `0` se la tabella manca, e senza loop PHP su post. 
- Aggiornata la semantica retrocompatibile di `needs_update` come somma delle tre categorie mutualmente esclusive: `missing_index + stale_index_records + non_active_candidate_records` (intero, non negativo). 
- Modificato il riquadro Dashboard in `ALMA_AI_Content_Agent_Admin::render_affiliate_index_status_box()` per leggere `non_active_candidate_records`, includerlo in `pending_total`, clampare `pending_total` a `eligible_total`, aggiornare `operational_state`, percentuale progresso 0..100, messaggistica e CTA (sync incrementale / verifica indice quando applicabile) e mostrare la voce leggibile `Candidabili non attivi` nella lista. 
- Effettuato il version bump a `2.25.8` aggiornando header plugin e `ALMA_VERSION`, e documentata la PR in `README.md` e `CHANGELOG.md`. 
- File modificati: `includes/class-ai-content-agent-affiliate-index.php`, `includes/class-ai-content-agent-admin.php`, `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`; nessuna nuova classe, nessuna modifica schema DB e nessuna modifica a batch cursor-based, ricerca/scoring, OpenAI, Draft Builder, provider/importer, shortcode o tracking.

### Testing
- Eseguiti i controlli di sintassi PHP con `php -l affiliate-link-manager-ai.php`, `php -l includes/class-ai-content-agent-affiliate-index.php` e `php -l includes/class-ai-content-agent-admin.php`, tutti senza errori. 
- Eseguite verifiche testuali sul codice per confermare il bump versione a `2.25.8`, la presenza di `non_active_candidate_records` e l'aggiornamento della formula `needs_update` e di `pending_total` nella dashboard; i risultati sono coerenti con le modifiche richieste. 
- Non è stato eseguito il test manuale end-to-end su una istanza WordPress con dati reali in questo ambiente CLI; raccomando di eseguire il test manuale descritto nella checklist (link inactive record -> apri Dashboard -> verificare conteggi e CTA -> eseguire `sync incrementale`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b281dbe08332bec377c7f165a980)