### PR TITLE
PR 8.9: Affiliate Incremental Sync Covers Non-Active Candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
-## 2.25.8 — PR 8.8 Affiliate Index Pending Semantics for Non-Active Records
-- Aggiunto `non_active_candidate_records` in `get_index_stats()` per contare i Link affiliati pubblicati e candidabili con record indice presente ma non `active`.
-- Aggiornata la semantica pending: `needs_update` ora include `missing_index + stale_index_records + non_active_candidate_records` evitando doppi conteggi tra categorie mutualmente esclusive.
-- Card Dashboard aggiornata: “Da lavorare totale” include anche i candidabili non attivi, resta clampato ai candidabili e impedisce falsi 100%/falso stato “Indice aggiornato”.
-- Stato operativo/CTA guidati: se restano solo record stale o candidabili non attivi viene proposta sync incrementale/verifica indice.
-- Nessuna modifica a ricerca/scoring, batch cursor-based, OpenAI, Draft Builder, provider/importer, shortcode o tracking.
-
+## 2.25.9 — PR 8.9 Affiliate Incremental Sync Covers Non-Active Candidates
+- Allineata `sync_incremental()` alla semantica pending della Dashboard: ora include record mancanti, record obsoleti e candidabili non attivi.
+- La query incrementale seleziona solo candidabili (`affiliate_link` pubblicati con URL affiliato valorizzato) con `DISTINCT`, `EXISTS`, `LIMIT` e condizione `i.status <> active`.
+- La CTA/notice di **Sync incrementale** chiarisce che l’azione recupera mancanti, aggiorna obsoleti e riattiva candidabili non attivi.
+- Coerenza garantita con `get_index_stats()` sulle categorie `missing_index`, `stale_index_records`, `non_active_candidate_records`.
+- Nessuna modifica a batch cursor-based completo, ricerca/scoring, OpenAI, Draft Builder, provider/importer, shortcode o tracking.
 ## 2.25.7 — PR 8.7 Affiliate Index Progress Count Fix and Pending Work Semantics
 - Fix doppio conteggio pending nella Dashboard: rimosso l'errore semantico `missing_index + needs_update` che duplicava i mancanti.
 - Aggiunto conteggio `stale_index_records` per separare i Link affiliati mancanti dall'indice da quelli da aggiornare dopo modifica.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-## 2.25.8 — PR 8.8 Affiliate Index Pending Semantics for Non-Active Records
-- Aggiunto `non_active_candidate_records` per contare i Link affiliati candidabili (publish + URL valido) con record indice presente ma non `active`.
-- Semantica pending aggiornata: `needs_update` ora include `missing_index + stale_index_records + non_active_candidate_records` senza sovrapposizioni.
-- La Dashboard ora include i candidabili non attivi in “Da lavorare totale”, con clamp ai candidabili e progresso sempre 0..100.
-- Evitato il falso stato “Indice aggiornato” quando restano candidabili non attivi; stato operativo e CTA guidano verso sync incrementale/verifica indice.
-- Nessuna modifica a ricerca/scoring, batch cursor-based, OpenAI, Draft Builder, provider/importer, shortcode o tracking.
-
+## 2.25.9 — PR 8.9 Affiliate Incremental Sync Covers Non-Active Candidates
+- Allineata `sync_incremental()` alla semantica pending della Dashboard: ora include record mancanti, record obsoleti e candidabili non attivi.
+- La query incrementale seleziona solo candidabili (`affiliate_link` pubblicati con URL affiliato valorizzato) con `DISTINCT`, `EXISTS`, `LIMIT` e condizione `i.status <> active`.
+- La CTA/notice di **Sync incrementale** chiarisce che l’azione recupera mancanti, aggiorna obsoleti e riattiva candidabili non attivi.
+- Coerenza garantita con `get_index_stats()` sulle categorie `missing_index`, `stale_index_records`, `non_active_candidate_records`.
+- Nessuna modifica a batch cursor-based completo, ricerca/scoring, OpenAI, Draft Builder, provider/importer, shortcode o tracking.
 ## 2.25.6 — PR 8.6 Affiliate Index Guided Batch Sync UX and Progress Feedback
 - Card “Indice Link affiliati” aggiornata con barra di progresso in stile admin (percentuale, candidabili, elementi da lavorare) calcolata da `get_index_stats()` evitando query pesanti aggiuntive.
 - Nuovo stato operativo guidato e sezione “Prossima azione consigliata” con CTA primaria dinamica (primo batch/continua batch/sync incrementale/indice aggiornato).
@@ -142,7 +141,14 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.8
+Versione 2.25.9
+
+## Novità 2.25.9 — Sync incrementale allineata ai candidabili non attivi
+
+- `sync_incremental()` ora processa anche i Link affiliati candidabili (post `publish` con URL affiliato valido) presenti nell’indice con stato non `active`.
+- La CTA **Sync incrementale** risolve in modo diretto anche `non_active_candidate_records`, oltre a record mancanti e obsoleti.
+- Guida operativa: usa **Sync incrementale** quando non ci sono mancanti (`missing_index = 0`) ma restano record obsoleti (`stale_index_records > 0`) o candidabili non attivi (`non_active_candidate_records > 0`).
+- Nessuna modifica a ricerca/scoring e nessuna modifica al batch completo cursor-based.
 
 
 ## Novità 2.12.1 — Pagina Importa contenuti + fix import

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.8
+ * Version: 2.25.9
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.8');
+define('ALMA_VERSION', '2.25.9');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -42,7 +42,7 @@ class ALMA_AI_Content_Agent_Admin {
             $result = array('success' => true, 'message' => sprintf('Batch indicizzazione eseguito: processati %d, indicizzati %d. %s', (int)$batch['processed'], (int)$batch['indexed'], !empty($batch['done']) ? 'Indicizzazione completata.' : 'Continua con il prossimo batch per completare l’indice.'));
         } elseif ($do === 'sync_affiliate_links_incremental') {
             $sync = ALMA_AI_Content_Agent_Affiliate_Index::sync_incremental();
-            $result = array('success' => true, 'message' => sprintf('Sync incrementale completata: processati %d, aggiornati %d. %s', (int)$sync['processed'], (int)$sync['indexed'], (int)$sync['processed'] > 0 ? 'Indice tecnico aggiornato sui record rilevati.' : 'Nessun record da aggiornare in questo batch.'));
+            $result = array('success' => true, 'message' => sprintf('Sync incrementale completata: processati %d, aggiornati %d. %s', (int)$sync['processed'], (int)$sync['indexed'], (int)$sync['processed'] > 0 ? 'Indice tecnico aggiornato su record mancanti, obsoleti e candidabili non attivi rilevati.' : 'Nessun record candidabile da aggiornare in questo batch.'));
         } elseif ($do === 'reset_affiliate_index_state') {
             ALMA_AI_Content_Agent_Affiliate_Index::reset_batch_state();
             $result = array('success' => true, 'message' => 'Stato batch resettato: nessun Link affiliato è stato eliminato e l’indice tecnico resta disponibile.');
@@ -297,8 +297,8 @@ class ALMA_AI_Content_Agent_Admin {
             $primary_label = !empty($batch['updated_at']) && empty($batch['done']) ? 'Continua indicizzazione' : 'Avvia primo batch';
         } elseif ($stale_index_records > 0 || $non_active_candidate_records > 0) {
             $next_action_text = $stale_index_records > 0
-                ? 'Esegui sync incrementale per aggiornare i record obsoleti.'
-                : 'Esegui sync incrementale o verifica indice per riattivare i candidabili non attivi.';
+                ? 'Esegui sync incrementale per aggiornare record obsoleti, riattivare candidabili non attivi e recuperare eventuali mancanti residui.'
+                : 'Esegui sync incrementale per riattivare candidabili non attivi e recuperare eventuali mancanti residui.';
             $primary_do = 'sync_affiliate_links_incremental';
             $primary_label = 'Esegui sync incrementale';
         } elseif ($active_invalid_records > 0 || $orphan_index_records > 0) {

--- a/includes/class-ai-content-agent-affiliate-index.php
+++ b/includes/class-ai-content-agent-affiliate-index.php
@@ -120,7 +120,36 @@ class ALMA_AI_Content_Agent_Affiliate_Index {
         $limit = $limit === null ? self::batch_size() : max(1, min(500, absint($limit)));
         $table = self::table_name();
         if (in_array($table, ALMA_AI_Content_Agent_Store::missing_tables(), true)) { return array('processed'=>0,'indexed'=>0); }
-        $rows = $wpdb->get_results($wpdb->prepare("SELECT p.ID FROM {$wpdb->posts} p LEFT JOIN $table i ON i.affiliate_link_id = p.ID WHERE p.post_type='affiliate_link' AND (i.affiliate_link_id IS NULL OR p.post_modified_gmt > IFNULL(i.indexed_at, '1970-01-01 00:00:00')) ORDER BY p.ID ASC LIMIT %d", $limit), ARRAY_A);
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT DISTINCT p.ID
+                 FROM {$wpdb->posts} p
+                 LEFT JOIN $table i ON i.affiliate_link_id = p.ID
+                 WHERE p.post_type = %s
+                   AND p.post_status = 'publish'
+                   AND EXISTS (
+                        SELECT 1
+                        FROM {$wpdb->postmeta} pm
+                        WHERE pm.post_id = p.ID
+                          AND pm.meta_key IN (%s, %s)
+                          AND TRIM(pm.meta_value) <> ''
+                   )
+                   AND (
+                        i.affiliate_link_id IS NULL
+                        OR i.post_modified_gmt IS NULL
+                        OR p.post_modified_gmt > i.post_modified_gmt
+                        OR i.status <> %s
+                   )
+                 ORDER BY p.ID ASC
+                 LIMIT %d",
+                'affiliate_link',
+                '_affiliate_url',
+                '_alma_affiliate_url',
+                self::STATUS_ACTIVE,
+                $limit
+            ),
+            ARRAY_A
+        );
         $processed = 0; $indexed = 0;
         foreach ((array)$rows as $r) { $id = absint($r['ID'] ?? 0); if ($id < 1) { continue; } $processed++; if (self::index_single($id, true)) { $indexed++; } }
         return array('processed'=>$processed,'indexed'=>$indexed);


### PR DESCRIPTION
### Motivation
- The Dashboard counts `non_active_candidate_records` (published affiliate links with a valid URL that exist in the index but are not `active`), yet `sync_incremental()` only selected missing or modified records, allowing non-active candidates to remain unprocessed and leaving the Dashboard stuck in pending.

### Description
- Updated `ALMA_AI_Content_Agent_Affiliate_Index::sync_incremental()` to select all pending candidate affiliate links (missing index, stale active records, or indexed records with `i.status <> active`) and to restrict the query to published `affiliate_link` posts with a non-empty affiliate URL using `EXISTS`, `DISTINCT p.ID`, prepared SQL and the existing batch `LIMIT` semantics, preserving the cursor-based full batch unchanged.
- Clarified admin/CTA text so the incremental sync notice and primary action explicitly state it covers missing, stale and non-active candidate records and preserved the existing priority that first-batch indexing runs when `missing_index > 0`.
- Bumped plugin version to `2.25.9` (`affiliate-link-manager-ai.php` header and `ALMA_VERSION`) and updated `README.md` and `CHANGELOG.md` with PR 8.9 notes and operational guidance.
- Files modified: `includes/class-ai-content-agent-affiliate-index.php`, `includes/class-ai-content-agent-admin.php`, `affiliate-link-manager-ai.php`, `README.md`, and `CHANGELOG.md`.

### Testing
- Static checks: `php -l affiliate-link-manager-ai.php`, `php -l includes/class-ai-content-agent-affiliate-index.php`, and `php -l includes/class-ai-content-agent-admin.php` all returned no syntax errors.
- Code inspections: verified `sync_incremental()` contains `i.status <> %s`, `SELECT DISTINCT p.ID` and `EXISTS (` for affiliate URL filtering, and confirmed `2.25.9` is present in plugin header, constant, `README.md` and `CHANGELOG.md`.
- Repo checks: verified no unintended changes to `includes/class-ai-content-agent-knowledge-search.php`, `includes/class-ai-content-agent-selection-session.php` or `includes/class-ai-content-agent-store.php`, and committed the changes.
- Manual WP end-to-end scenario described in the PR instructions (process a published affiliate link with an inactive index record but unchanged `post_modified_gmt`) was not executed in this environment due to lack of a running WP+DB instance, so runtime verification on a site is still recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b79ed5bc8332a7c36bcd5747bd59)