### PR TITLE
PR 8.10 — Affiliate Index Pending Query Consistency and Pre-Test Hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.25.10 — PR 8.10 Affiliate Index Pending Query Consistency and Pre-Test Hardening
+- Allineata in modo rigoroso la semantica pending tra Dashboard e `sync_incremental()`: i candidabili da lavorare restano `missing_index + stale_index_records + non_active_candidate_records`.
+- Hardening SQL su `non_active_candidate_records`: i record non active includono ora in modo esplicito status diverso da `active`, vuoto (`''`) o `NULL` (inclusi valori anomali/non previsti).
+- `sync_incremental()` aggiornato con categorie pending mutualmente esclusive e coerenti: mancanti, obsoleti solo se `active`, non active con status nullo/vuoto/anomalo.
+- Migliorato messaggio admin post-sync: se un batch processa 0 record ma restano pending, non comunica “tutto aggiornato” e suggerisce verifica indice + nuovo sync/batch.
+- Aggiunta nota operativa pre-test in README: primo avvio guidato a batch progressivi e uso di “Svuota indice e ricomincia” solo in caso di diagnostica incoerente.
+- Nessuna modifica a ricerca/scoring, OpenAI, Draft Builder, provider/importer o batch completo cursor-based.
+
 ## 2.25.9 — PR 8.9 Affiliate Incremental Sync Covers Non-Active Candidates
 - Allineata `sync_incremental()` alla semantica pending della Dashboard: ora include record mancanti, record obsoleti e candidabili non attivi.
 - La query incrementale seleziona solo candidabili (`affiliate_link` pubblicati con URL affiliato valorizzato) con `DISTINCT`, `EXISTS`, `LIMIT` e condizione `i.status <> active`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## 2.25.9 — PR 8.9 Affiliate Incremental Sync Covers Non-Active Candidates
+## 2.25.10 — PR 8.10 Affiliate Index Pending Query Consistency and Pre-Test Hardening
 - Allineata `sync_incremental()` alla semantica pending della Dashboard: ora include record mancanti, record obsoleti e candidabili non attivi.
 - La query incrementale seleziona solo candidabili (`affiliate_link` pubblicati con URL affiliato valorizzato) con `DISTINCT`, `EXISTS`, `LIMIT` e condizione `i.status <> active`.
 - La CTA/notice di **Sync incrementale** chiarisce che l’azione recupera mancanti, aggiorna obsoleti e riattiva candidabili non attivi.
@@ -141,15 +141,25 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.9
+Versione 2.25.10
 
-## Novità 2.25.9 — Sync incrementale allineata ai candidabili non attivi
+## Novità 2.25.10 — Pending/sync consistency hardening + nota pre-test
 
-- `sync_incremental()` ora processa anche i Link affiliati candidabili (post `publish` con URL affiliato valido) presenti nell’indice con stato non `active`.
-- La CTA **Sync incrementale** risolve in modo diretto anche `non_active_candidate_records`, oltre a record mancanti e obsoleti.
-- Guida operativa: usa **Sync incrementale** quando non ci sono mancanti (`missing_index = 0`) ma restano record obsoleti (`stale_index_records > 0`) o candidabili non attivi (`non_active_candidate_records > 0`).
+- `get_index_stats()` e `sync_incremental()` condividono ora la stessa semantica robusta per i record non active: `status` diverso da `active`, vuoto (`''`) o `NULL`.
+- Categorie pending mutualmente esclusive confermate: `missing_index` (nessun record), `stale_index_records` (record `active` obsoleto), `non_active_candidate_records` (record presente non active).
+- La CTA **Sync incrementale** resta l’azione primaria quando `missing_index = 0` e restano record obsoleti o candidabili non attivi.
 - Nessuna modifica a ricerca/scoring e nessuna modifica al batch completo cursor-based.
 
+
+## Nota operativa pre-test (primo sync controllato indice Link affiliati)
+
+1. Verifica Dashboard e conteggi (`Candidabili`, `Mancanti`, `Obsoleti`, `Candidabili non attivi`).
+2. Non avviare subito sync completo su tutto il dataset reale.
+3. Esegui un primo batch di indicizzazione.
+4. Esegui un secondo batch e verifica avanzamento/progress bar/conteggi.
+5. Prosegui batch-by-batch fino al completamento.
+6. Usa **Sync incrementale** per record obsoleti o candidabili non attivi.
+7. Usa **Svuota indice e ricomincia** solo se la diagnostica risulta incoerente.
 
 ## Novità 2.12.1 — Pagina Importa contenuti + fix import
 

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.9
+ * Version: 2.25.10
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.9');
+define('ALMA_VERSION', '2.25.10');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -42,7 +42,14 @@ class ALMA_AI_Content_Agent_Admin {
             $result = array('success' => true, 'message' => sprintf('Batch indicizzazione eseguito: processati %d, indicizzati %d. %s', (int)$batch['processed'], (int)$batch['indexed'], !empty($batch['done']) ? 'Indicizzazione completata.' : 'Continua con il prossimo batch per completare l’indice.'));
         } elseif ($do === 'sync_affiliate_links_incremental') {
             $sync = ALMA_AI_Content_Agent_Affiliate_Index::sync_incremental();
-            $result = array('success' => true, 'message' => sprintf('Sync incrementale completata: processati %d, aggiornati %d. %s', (int)$sync['processed'], (int)$sync['indexed'], (int)$sync['processed'] > 0 ? 'Indice tecnico aggiornato su record mancanti, obsoleti e candidabili non attivi rilevati.' : 'Nessun record candidabile da aggiornare in questo batch.'));
+            $stats_after_sync = ALMA_AI_Content_Agent_Affiliate_Index::get_index_stats();
+            $pending_after_sync = max(0, (int)($stats_after_sync['needs_update'] ?? 0));
+            $sync_tail_message = (int)$sync['processed'] > 0
+                ? 'Indice tecnico aggiornato su record mancanti, obsoleti e candidabili non attivi rilevati.'
+                : ($pending_after_sync > 0
+                    ? 'Nessun record processato in questo batch: restano candidabili da lavorare. Verifica indice tecnico e ripeti sync incrementale o batch indicizzazione se presenti mancanti.'
+                    : 'Nessun record candidabile da aggiornare in questo batch.');
+            $result = array('success' => true, 'message' => sprintf('Sync incrementale completata: processati %d, aggiornati %d. %s', (int)$sync['processed'], (int)$sync['indexed'], $sync_tail_message));
         } elseif ($do === 'reset_affiliate_index_state') {
             ALMA_AI_Content_Agent_Affiliate_Index::reset_batch_state();
             $result = array('success' => true, 'message' => 'Stato batch resettato: nessun Link affiliato è stato eliminato e l’indice tecnico resta disponibile.');

--- a/includes/class-ai-content-agent-affiliate-index.php
+++ b/includes/class-ai-content-agent-affiliate-index.php
@@ -107,7 +107,7 @@ class ALMA_AI_Content_Agent_Affiliate_Index {
         $stats['last_indexed_at'] = (string)$wpdb->get_var("SELECT MAX(indexed_at) FROM $table");
         $stats['missing_index'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM {$wpdb->posts} p LEFT JOIN $table i ON i.affiliate_link_id = p.ID WHERE p.post_type=%s AND p.post_status='publish' AND i.affiliate_link_id IS NULL AND EXISTS (SELECT 1 FROM {$wpdb->postmeta} pm WHERE pm.post_id = p.ID AND pm.meta_key IN (%s, %s) AND TRIM(pm.meta_value) <> '')", 'affiliate_link', '_affiliate_url', '_alma_affiliate_url'));
         $stats['stale_index_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(DISTINCT p.ID) FROM {$wpdb->posts} p INNER JOIN $table i ON i.affiliate_link_id = p.ID AND i.status = %s WHERE p.post_type=%s AND p.post_status='publish' AND EXISTS (SELECT 1 FROM {$wpdb->postmeta} pm WHERE pm.post_id = p.ID AND pm.meta_key IN (%s, %s) AND TRIM(pm.meta_value) <> '') AND (i.post_modified_gmt IS NULL OR p.post_modified_gmt > i.post_modified_gmt)", self::STATUS_ACTIVE, 'affiliate_link', '_affiliate_url', '_alma_affiliate_url'));
-        $stats['non_active_candidate_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(DISTINCT p.ID) FROM {$wpdb->posts} p INNER JOIN $table i ON i.affiliate_link_id = p.ID WHERE p.post_type=%s AND p.post_status='publish' AND EXISTS (SELECT 1 FROM {$wpdb->postmeta} pm WHERE pm.post_id = p.ID AND pm.meta_key IN (%s, %s) AND TRIM(pm.meta_value) <> '') AND i.status <> %s", 'affiliate_link', '_affiliate_url', '_alma_affiliate_url', self::STATUS_ACTIVE));
+        $stats['non_active_candidate_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(DISTINCT p.ID) FROM {$wpdb->posts} p INNER JOIN $table i ON i.affiliate_link_id = p.ID WHERE p.post_type=%s AND p.post_status='publish' AND EXISTS (SELECT 1 FROM {$wpdb->postmeta} pm WHERE pm.post_id = p.ID AND pm.meta_key IN (%s, %s) AND TRIM(pm.meta_value) <> '') AND (i.status IS NULL OR TRIM(i.status) = '' OR i.status <> %s)", 'affiliate_link', '_affiliate_url', '_alma_affiliate_url', self::STATUS_ACTIVE));
         $stats['needs_update'] = max(0, (int) $stats['missing_index'] + (int) $stats['stale_index_records'] + (int) $stats['non_active_candidate_records']);
         $stats['orphan_index_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM $table i LEFT JOIN {$wpdb->posts} p ON p.ID = i.affiliate_link_id WHERE p.ID IS NULL OR p.post_type <> %s", 'affiliate_link'));
         $stats['active_invalid_records'] = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(1) FROM $table i LEFT JOIN {$wpdb->posts} p ON p.ID = i.affiliate_link_id WHERE i.status = %s AND (p.ID IS NULL OR p.post_type <> %s OR p.post_status <> 'publish' OR NOT EXISTS (SELECT 1 FROM {$wpdb->postmeta} pm WHERE pm.post_id = p.ID AND pm.meta_key IN (%s, %s) AND TRIM(pm.meta_value) <> ''))", self::STATUS_ACTIVE, 'affiliate_link', '_affiliate_url', '_alma_affiliate_url'));
@@ -136,15 +136,21 @@ class ALMA_AI_Content_Agent_Affiliate_Index {
                    )
                    AND (
                         i.affiliate_link_id IS NULL
-                        OR i.post_modified_gmt IS NULL
-                        OR p.post_modified_gmt > i.post_modified_gmt
-                        OR i.status <> %s
+                        OR (
+                            i.status = %s
+                            AND (i.post_modified_gmt IS NULL OR p.post_modified_gmt > i.post_modified_gmt)
+                        )
+                        OR (
+                            i.affiliate_link_id IS NOT NULL
+                            AND (i.status IS NULL OR TRIM(i.status) = '' OR i.status <> %s)
+                        )
                    )
                  ORDER BY p.ID ASC
                  LIMIT %d",
                 'affiliate_link',
                 '_affiliate_url',
                 '_alma_affiliate_url',
+                self::STATUS_ACTIVE,
                 self::STATUS_ACTIVE,
                 $limit
             ),


### PR DESCRIPTION
### Motivation
- Stabilizzare la fase “Indice Link affiliati” assicurando che i record contati come “Da lavorare” dalla Dashboard siano effettivamente selezionati e processati dallo sync incrementale.
- Correggere una regressione SQL: la condizione `i.status <> 'active'` non intercetta `NULL` o stringhe vuote, causando discrepanze tra statistiche e selezione dei candidati.
- Fornire un piccolo hardening operativo e una nota pre-test per il primo test controllato su dataset reale senza modificare batch completo, ricerca/scoring o flussi OpenAI/Importer.

### Description
- Aggiornata la query di `non_active_candidate_records` in `ALMA_AI_Content_Agent_Affiliate_Index::get_index_stats()` per contare righe indice con `i.status IS NULL OR TRIM(i.status) = '' OR i.status <> 'active'`, mantenendo `COUNT(DISTINCT p.ID)` e gating `EXISTS` su meta URL non vuoto. (file: `includes/class-ai-content-agent-affiliate-index.php`)
- Modificata la selezione in `ALMA_AI_Content_Agent_Affiliate_Index::sync_incremental()` per rendere le categorie pendenti mutualmente esclusive e coerenti: manca (no index row), obsoleto (solo record `active` con `post_modified_gmt` nullo/obsoleto) e non-active (record presente con status NULL/empty/non-active). La query mantiene `SELECT DISTINCT p.ID`, `EXISTS` su `_affiliate_url/_alma_affiliate_url`, filtro `post_type='affiliate_link'` e `post_status='publish'` e il `LIMIT` batch. (file: `includes/class-ai-content-agent-affiliate-index.php`)
- Hardening del messaggio admin post-sync in `handle_action()` per `sync_affiliate_links_incremental`: se `processed == 0` ma rimangono pending, il messaggio non dichiara “tutto aggiornato” e suggerisce verifica indice + nuovo sync/batch. (file: `includes/class-ai-content-agent-admin.php`)
- Aggiornato versioning a `2.25.10` (plugin header + `ALMA_VERSION`) e documentazione: `README.md` e `CHANGELOG.md` aggiornati con sezione `2.25.10` e nota operativa pre-test. (file: `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`)
- Non sono state introdotte nuove classi, non è stato modificato il batch cursor-based completo (`index_batch()`), non sono state toccate ricerche/scoring/OpenAI/Draft Builder/provider/importer/shortcode/tracking e non sono stati cambiati gli schemi DB.

### Testing
- Eseguiti i controlli di sintassi PHP con `php -l` su file chiave e tutti hanno riportato esito OK: `affiliate-link-manager-ai.php`, `includes/class-ai-content-agent-affiliate-index.php`, `includes/class-ai-content-agent-admin.php` (tutti passati).
- Verifiche testuali/grep per pattern critici e aggiornamenti (versione `2.25.10`, presenza di `status IS NULL` / `TRIM(i.status) = ''`, uso di `SELECT DISTINCT p.ID`, presenza di `EXISTS` su URL affiliato, `needs_update` formula) sono andate a buon fine sui file aggiornati.
- Commit dei cambiamenti eseguito con messaggio di PR; nessun test automatico unitario aggiuntivo era presente o richiesto.
- Limitazione: non è stato eseguito il test manuale end-to-end su un ambiente WordPress reale in questa sessione (modifica runtime di status NULL/empty e verifica UI live), raccomandato eseguire i passaggi della nota pre-test prima del primo run su dati reali.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ce73e17483329be5dafd511401ac)