### PR TITLE
PR 8.11 — Persist AI Instruction Profile on Content Ideas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.25.11 — PR 8.11 Persist AI Instruction Profile on Content Ideas
+- Persistenza del Profilo Istruzioni AI sull'Idea contenuto (`instruction_profile_id`/meta idea) durante creazione e salvataggio idea.
+- Preservazione del profilo istruzioni durante azioni non correlate nella tab Idee contenuto (ricerca, aggiunta/rimozione risultati, persistenza sessione).
+- Fallback sicuro quando il profilo associato non è più valido o non esiste (nessun warning/fatal; fallback controllato in UI).
+- Nessuna modifica all'indice Link affiliati e nessuna modifica a OpenAI Service.
+
 ## 2.25.10 — PR 8.10 Affiliate Index Pending Query Consistency and Pre-Test Hardening
 - Allineata in modo rigoroso la semantica pending tra Dashboard e `sync_incremental()`: i candidabili da lavorare restano `missing_index + stale_index_records + non_active_candidate_records`.
 - Hardening SQL su `non_active_candidate_records`: i record non active includono ora in modo esplicito status diverso da `active`, vuoto (`''`) o `NULL` (inclusi valori anomali/non previsti).

--- a/README.md
+++ b/README.md
@@ -141,10 +141,14 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.10
+Versione 2.25.11
 
-## Novità 2.25.10 — Pending/sync consistency hardening + nota pre-test
+## Novità 2.25.11 — PR 8.11 Persist AI Instruction Profile on Content Ideas
 
+- Profilo Istruzioni AI selezionato ora persistito sull'Idea contenuto e ricaricato in modo coerente dopo salvataggi/reload.
+- Profilo istruzioni preservato durante azioni non correlate (ricerca, aggiunta/rimozione risultati, persistenza sessione).
+- Fallback sicuro se il profilo associato non è più valido (nessun fatal, fallback al profilo attivo solo quando necessario).
+- Nessuna modifica a indice Link affiliati e OpenAI Service.
 - `get_index_stats()` e `sync_incremental()` condividono ora la stessa semantica robusta per i record non active: `status` diverso da `active`, vuoto (`''`) o `NULL`.
 - Categorie pending mutualmente esclusive confermate: `missing_index` (nessun record), `stale_index_records` (record `active` obsoleto), `non_active_candidate_records` (record presente non active).
 - La CTA **Sync incrementale** resta l’azione primaria quando `missing_index = 0` e restano record obsoleti o candidabili non attivi.
@@ -403,7 +407,7 @@ Workflow base completo: genera idee → genera brief → genera bozza → apri i
 
 
 ## AI Content Agent 2.24.3
-La tab Idee contenuto ora usa idee persistenti (CPT), layout operativo in 3 colonne, prompt OpenAI per idea, sessione contenuto associata all'idea e creazione bozza con una sola chiamata OpenAI.
+La tab Idee contenuto ora usa idee persistenti (CPT), layout operativo in 3 colonne, prompt OpenAI per idea, sessione contenuto associata all'idea e creazione bozza con una sola chiamata OpenAI. Il Profilo Istruzioni AI selezionato resta associato all'idea e viene mantenuto anche dopo salvataggi/reload.
 
 
 ## AI Content Agent 2.24.5

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.10
+ * Version: 2.25.11
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.10');
+define('ALMA_VERSION', '2.25.11');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -71,7 +71,7 @@ class ALMA_AI_Content_Agent_Admin {
             $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true));
             if ($active_idea_id < 1) {
                 $idea_title = sanitize_text_field($payload['content_search_query'] ?: 'Nuova idea');
-                $active_idea_id = ALMA_AI_Content_Agent_Ideas::create($idea_title);
+                $active_idea_id = ALMA_AI_Content_Agent_Ideas::create($idea_title, $profile_id);
                 if ($active_idea_id > 0) { update_user_meta(get_current_user_id(), '_alma_active_idea_id', $active_idea_id); }
             }
             if ($active_idea_id > 0) {
@@ -364,6 +364,16 @@ class ALMA_AI_Content_Agent_Admin {
         $profiles = ALMA_AI_Content_Agent_Instructions_Manager::get_profiles(100,0);
         if (!is_array($profiles)) { $profiles = array(); }
         $session = ALMA_AI_Content_Agent_Selection_Session::get_session();
+        $active_profile = ALMA_AI_Content_Agent_Instructions_Manager::get_active_profile();
+        $idea_profile_id = absint($active_idea['instruction_profile_id'] ?? ($active_idea['profile_id'] ?? 0));
+        $idea_profile_valid = false;
+        foreach ($profiles as $profile_row) {
+            if ((int)($profile_row['id'] ?? 0) === $idea_profile_id) {
+                $idea_profile_valid = true;
+                break;
+            }
+        }
+        $selected_profile_id = $idea_profile_valid ? $idea_profile_id : absint($active_profile['id'] ?? 0);
         $summary = ALMA_AI_Content_Agent_Selection_Session::summary();
         $results_groups = ALMA_AI_Content_Agent_Selection_Session::grouped_results(false);
         $selected_groups = ALMA_AI_Content_Agent_Selection_Session::grouped_results(true);
@@ -386,7 +396,7 @@ class ALMA_AI_Content_Agent_Admin {
         if (!empty($active_idea['draft_post_id']) && get_post((int)$active_idea['draft_post_id'])) { echo '<a class="button" href="'.esc_url(get_edit_post_link((int)$active_idea['draft_post_id'],'raw')).'">Apri bozza</a>'; }
         echo '<div class="alma-actions-inline">';
         self::action_form('new_content_idea','Crea nuova idea');
-        if($active_idea_id){ echo '<form id="alma-save-idea-form" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_content_idea"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><input type="hidden" name="idea_status" value="bozza"><input type="hidden" name="instruction_profile_id" value="'.(int)($active_idea['profile_id']??0).'"><input type="hidden" name="openai_prompt" value="'.esc_attr($active_idea['prompt']??'').'"><button class="button">Salva idea</button></form>'; }
+        if($active_idea_id){ echo '<form id="alma-save-idea-form" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_content_idea"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><input type="hidden" name="idea_status" value="bozza"><input type="hidden" name="openai_prompt" value="'.esc_attr($active_idea['prompt']??'').'"><p><label for="alma-save-idea-instruction-profile">Profilo Istruzioni AI</label><select id="alma-save-idea-instruction-profile" class="widefat" name="instruction_profile_id"><option value="0">Nessun profilo</option>'; foreach($profiles as $p){ $sel=selected($selected_profile_id,(int)$p['id'],false); echo '<option value="'.(int)$p['id'].'" '.$sel.'>'.esc_html($p['profile_name']).'</option>'; } echo '</select></p><button class="button">Salva idea</button></form>'; }
         if($active_idea_id){ echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="delete_content_idea"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><button class="button">Elimina</button></form>'; }
         self::action_form('download_ai_payload_json','Scarica JSON payload AI');
         self::action_form('create_draft_from_selection','Crea Bozza con OpenAI');
@@ -403,7 +413,7 @@ class ALMA_AI_Content_Agent_Admin {
         echo '<ul><li>Contenuti aggiunti: '.(int)($summary['selected_total'] ?? 0).'</li><li>Profilo istruzioni AI: '.(int)($active_idea['profile_id'] ?? 0).'</li><li>Prompt OpenAI: '.(!empty($active_idea['prompt']) ? 'Presente' : 'Assente').'</li></ul></div></aside>';
 
         echo '<main class="alma-ideas-col alma-ideas-col-main"><div class="alma-ideas-card"><h3>1. Cerca contenuti</h3><form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="search_knowledge_base"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><p><input class="widefat" type="text" name="content_search_query" placeholder="Cerca contenuti" value="'.esc_attr($session['last_query']['content_search_query'] ?? '').'" required></p><p><label>Profilo Istruzioni AI</label><select class="widefat" name="instruction_profile_id"><option value="0">Nessun profilo</option>';
-        foreach($profiles as $p){ $sel=selected((int)($active_idea['profile_id'] ?? 0),(int)$p['id'],false); echo '<option value="'.(int)$p['id'].'" '.$sel.'>'.esc_html($p['profile_name']).'</option>'; }
+        foreach($profiles as $p){ $sel=selected($selected_profile_id,(int)$p['id'],false); echo '<option value="'.(int)$p['id'].'" '.$sel.'>'.esc_html($p['profile_name']).'</option>'; }
         echo '</select></p><p><label>Prompt per OpenAI</label><textarea class="widefat" rows="4" name="openai_prompt">'.esc_textarea($active_idea['prompt'] ?? ($session['openai_prompt'] ?? '')).'</textarea><span class="description">Questo prompt verrà inviato a OpenAI insieme ai contenuti raccolti e guiderà cosa scrivere nella bozza.</span></p><p><button class="button button-primary">Cerca contenuti</button></p></form></div>';
 
         $all_rows = array();

--- a/includes/class-ai-content-agent-ideas.php
+++ b/includes/class-ai-content-agent-ideas.php
@@ -11,6 +11,8 @@ class ALMA_AI_Content_Agent_Ideas {
     const META_SELECTION = '_alma_idea_selected_results';
     const META_EXECUTED_AT = '_alma_idea_executed_at';
     const META_DRAFT_POST_ID = '_alma_idea_draft_post_id';
+    const META_INSTRUCTION_SNAPSHOT_HASH = '_alma_idea_instruction_snapshot_hash';
+    const META_INSTRUCTION_SNAPSHOT = '_alma_idea_instruction_snapshot';
 
     public static function init() {
         add_action('init', array(__CLASS__, 'register_cpt'));
@@ -27,16 +29,25 @@ class ALMA_AI_Content_Agent_Ideas {
         ));
     }
 
-    public static function create($title = 'Nuova idea') {
+    private static function sanitize_instruction_profile_id($value) {
+        $profile_id = absint($value);
+        if ($profile_id < 1) { return 0; }
+        $profile = ALMA_AI_Content_Agent_Instructions_Manager::get_profile($profile_id);
+        return !empty($profile['id']) ? absint($profile['id']) : 0;
+    }
+
+    public static function create($title = 'Nuova idea', $instruction_profile_id = 0) {
         $id = wp_insert_post(array('post_type'=>self::CPT,'post_status'=>'publish','post_title'=>sanitize_text_field($title),'post_author'=>get_current_user_id()), true);
         if (is_wp_error($id) || !$id) { return 0; }
-        update_post_meta($id, self::META_PROFILE_ID, 0);
+        update_post_meta($id, self::META_PROFILE_ID, self::sanitize_instruction_profile_id($instruction_profile_id));
         update_post_meta($id, self::META_PROMPT, '');
         update_post_meta($id, self::META_LAST_QUERY, array());
         update_post_meta($id, self::META_RESULTS, array());
         update_post_meta($id, self::META_SELECTION, array());
         update_post_meta($id, self::META_EXECUTED_AT, '');
         update_post_meta($id, self::META_DRAFT_POST_ID, 0);
+        update_post_meta($id, self::META_INSTRUCTION_SNAPSHOT_HASH, '');
+        update_post_meta($id, self::META_INSTRUCTION_SNAPSHOT, '');
         return (int)$id;
     }
 
@@ -59,13 +70,20 @@ class ALMA_AI_Content_Agent_Ideas {
         $last_query = self::normalize_meta_query(get_post_meta($p->ID, self::META_LAST_QUERY, true));
         $results = self::normalize_meta_rows(get_post_meta($p->ID, self::META_RESULTS, true));
         $selection = self::normalize_meta_rows(get_post_meta($p->ID, self::META_SELECTION, true));
-        return array('ID'=>$p->ID,'title'=>$p->post_title,'profile_id'=>absint(get_post_meta($p->ID,self::META_PROFILE_ID,true)),'prompt'=>get_post_meta($p->ID,self::META_PROMPT,true),'last_query'=>$last_query,'results'=>$results,'selection'=>$selection,'executed_at'=>sanitize_text_field((string)get_post_meta($p->ID,self::META_EXECUTED_AT,true)),'draft_post_id'=>absint(get_post_meta($p->ID,self::META_DRAFT_POST_ID,true)),'modified'=>$p->post_modified);
+        return array('ID'=>$p->ID,'title'=>$p->post_title,'profile_id'=>absint(get_post_meta($p->ID,self::META_PROFILE_ID,true)),'instruction_profile_id'=>absint(get_post_meta($p->ID,self::META_PROFILE_ID,true)),'prompt'=>get_post_meta($p->ID,self::META_PROMPT,true),'last_query'=>$last_query,'results'=>$results,'selection'=>$selection,'instruction_snapshot_hash'=>sanitize_text_field((string)get_post_meta($p->ID,self::META_INSTRUCTION_SNAPSHOT_HASH,true)),'instruction_snapshot'=>sanitize_textarea_field((string)get_post_meta($p->ID,self::META_INSTRUCTION_SNAPSHOT,true)),'executed_at'=>sanitize_text_field((string)get_post_meta($p->ID,self::META_EXECUTED_AT,true)),'draft_post_id'=>absint(get_post_meta($p->ID,self::META_DRAFT_POST_ID,true)),'modified'=>$p->post_modified);
     }
 
     public static function save_from_request($idea_id, $data) {
         $idea_id = absint($idea_id); if ($idea_id < 1) { return false; }
         if (isset($data['idea_title'])) { wp_update_post(array('ID'=>$idea_id,'post_title'=>sanitize_text_field($data['idea_title']))); }
-        update_post_meta($idea_id, self::META_PROFILE_ID, absint($data['instruction_profile_id'] ?? 0));
+        if (array_key_exists('instruction_profile_id', (array)$data)) {
+            $next_profile_id = self::sanitize_instruction_profile_id($data['instruction_profile_id']);
+            if ($next_profile_id > 0) {
+                update_post_meta($idea_id, self::META_PROFILE_ID, $next_profile_id);
+            } elseif (!empty($data['clear_instruction_profile'])) {
+                update_post_meta($idea_id, self::META_PROFILE_ID, 0);
+            }
+        }
         update_post_meta($idea_id, self::META_PROMPT, sanitize_textarea_field($data['openai_prompt'] ?? ''));
         return true;
     }

--- a/includes/class-ai-content-agent-selection-session.php
+++ b/includes/class-ai-content-agent-selection-session.php
@@ -290,9 +290,27 @@ class ALMA_AI_Content_Agent_Selection_Session {
         $idea_id = absint($idea_id); if ($idea_id < 1) { return; }
         $session = self::get_session();
         $session = self::normalize_session_payload($session);
+        $idea = ALMA_AI_Content_Agent_Ideas::get($idea_id);
         update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_LAST_QUERY, (array)$session['last_query']);
         update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_RESULTS, array_values($session['search_results']));
         update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_SELECTION, array_values($session['selected_results']));
+        $session_profile_id = absint($session['instruction_profile_id'] ?? 0);
+        if ($session_profile_id > 0) {
+            update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_PROFILE_ID, $session_profile_id);
+        } elseif (!empty($idea['instruction_profile_id'])) {
+            update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_PROFILE_ID, absint($idea['instruction_profile_id']));
+        }
+        $snapshot_hash = sanitize_text_field($session['instruction_snapshot_hash'] ?? '');
+        if ($snapshot_hash === '') {
+            $snapshot_hash = sanitize_text_field($idea['instruction_snapshot_hash'] ?? '');
+        }
+        if ($snapshot_hash !== '') {
+            update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_INSTRUCTION_SNAPSHOT_HASH, $snapshot_hash);
+        }
+        $snapshot = sanitize_textarea_field($idea['instruction_snapshot'] ?? '');
+        if ($snapshot !== '') {
+            update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_INSTRUCTION_SNAPSHOT, $snapshot);
+        }
     }
 
     public static function load_from_idea($idea) {
@@ -302,6 +320,9 @@ class ALMA_AI_Content_Agent_Selection_Session {
         $session['search_results'] = self::normalize_session_rows($idea['results'] ?? array(), false);
         $session['selected_results'] = self::normalize_session_rows($idea['selection'] ?? array(), true);
         $session['instruction_profile_id'] = absint($idea['profile_id'] ?? 0);
+        $profile = $session['instruction_profile_id'] > 0 ? ALMA_AI_Content_Agent_Instructions_Manager::get_profile($session['instruction_profile_id']) : array();
+        $session['instruction_profile_name'] = sanitize_text_field($profile['profile_name'] ?? '');
+        $session['instruction_snapshot_hash'] = sanitize_text_field($idea['instruction_snapshot_hash'] ?? '');
         $session['updated_at'] = current_time('mysql');
         $session['openai_prompt'] = sanitize_textarea_field($idea['prompt'] ?? ($session['last_query']['openai_prompt'] ?? ''));
         $session['counts'] = self::count_summary($session['search_results'], $session['selected_results']);


### PR DESCRIPTION
### Motivation
- Risolvere il bug per cui il campo Profilo Istruzioni AI si disassociava dall’Idea contenuto dopo salvataggi o azioni successive, rendendo persistente la scelta dell’utente senza toccare indice affiliate o OpenAI Service.
- Garantire fallback sicuro quando il profilo salvato non esiste più e preservare snapshot/hash istruzioni durante azioni non correlate nella tab Idee.

### Description
- Aggiunta validazione e salvataggio coerente del profilo istruzioni su creazione e update idea con la nuova funzione `sanitize_instruction_profile_id()` e con `ALMA_AI_Content_Agent_Ideas::create()` che ora accetta un parametro `instruction_profile_id` e salva meta sicuri (`_alma_idea_profile_id`, `_alma_idea_instruction_snapshot_hash`, `_alma_idea_instruction_snapshot`).
- Hardened `save_from_request()` per aggiornare il profilo solo se il campo è presente e valido e per permettere cancellazione esplicita solo con flag dedicato, evitando overwrite con valori vuoti/invalidi.
- `ALMA_AI_Content_Agent_Selection_Session::persist_to_idea()` preserva ora `instruction_profile_id` e `instruction_snapshot_hash` (usa il valore di sessione se valido, altrimenti mantiene il valore idea esistente) e `load_from_idea()` ricarica `instruction_profile_name` e `instruction_snapshot_hash` nella sessione.
- UI/admin: la tab Idee passa il `profile_id` selezionato quando crea una nuova idea, e il select profilo risolve la `selected` value dando priorità al profilo associato all’idea con fallback al profilo globale attivo; infine versione e documentazione aggiornate a `2.25.11` (header, `ALMA_VERSION`, `README.md`, `CHANGELOG.md`).

### Testing
- Eseguiti i controlli di sintassi PHP con `php -l` sui file principali e tutti sono risultati senza errori: `affiliate-link-manager-ai.php`, `includes/class-ai-content-agent-admin.php`, `includes/class-ai-content-agent-ideas.php`, `includes/class-ai-content-agent-selection-session.php`, `includes/class-ai-content-agent-instructions-manager.php`, `includes/class-ai-content-agent-brief-builder.php`, `includes/class-ai-content-agent-draft-builder.php`.
- Verifiche testuali/statiche eseguite tramite ricerca su sorgenti per `instruction_profile_id`, `META_INSTRUCTION_SNAPSHOT`, `persist_to_idea` e la presenza della nuova versione `2.25.11` in header/README/CHANGELOG; risultato OK.
- Commit integrato in branch locale con messaggio `PR 8.11 persist instruction profile on content ideas` e modifiche documentate; nessuna modifica ai file/aree fuori-scope (affiliate index/OpenAI Service non toccati).
- Nota: i test manuali end-to-end in WordPress (UI runtime) non sono stati eseguiti in questo ambiente CLI e sono raccomandati in staging prima del rilascio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d04357ac8332884d047dde3d3da4)