### PR TITLE
R 8.13 — Ideas Instruction Profile Single Select Form Submission Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.25.13 — PR 8.13 Ideas Instruction Profile Single Select Form Submission Fix
+- Corretto il submit del select unico **Profilo Istruzioni AI** nella tab Idee: il form **Cerca contenuti** invia sempre `instruction_profile_id` (incluso `0` per **Nessun profilo**).
+- Il form **Salva idea** mantiene il profilo tramite hidden `instruction_profile_id` sincronizzato con il select visibile (JS vanilla difensivo in `assets/admin.js`).
+- Hardening backend nel flusso `search_knowledge_base`: se `instruction_profile_id` è assente o invalido, il profilo idea esistente viene preservato e non azzerato implicitamente.
+- Nessuna modifica a indice Link affiliati, batch/sync affiliate o OpenAI Service.
+
 ## 2.25.12 — PR 8.12 Ideas UI Instruction Profile Cleanup and Clear Profile Fix
 - Rimossa la duplicazione UI del campo **Profilo Istruzioni AI** nella tab Idee contenuto (resta un solo select visibile).
 - Corretto il salvataggio esplicito di **Nessun profilo**: `instruction_profile_id=0` viene persistito sull'idea senza richiedere `clear_instruction_profile`.

--- a/README.md
+++ b/README.md
@@ -141,8 +141,15 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.12
+Versione 2.25.13
 
+
+## Novità 2.25.13 — PR 8.13 Ideas Instruction Profile Single Select Form Submission Fix
+
+- Il select unico **Profilo Istruzioni AI** nella card **1. Cerca contenuti** invia ora correttamente `instruction_profile_id` al form `search_knowledge_base`.
+- Il form **Salva idea** riceve lo stesso valore profilo tramite campo hidden sincronizzato in modo difensivo con JavaScript vanilla (`assets/admin.js`), senza duplicare il select visibile.
+- Hardening backend: `instruction_profile_id` assente non viene interpretato come clear; il profilo esistente viene preservato, mentre `0` resta una scelta esplicita valida (**Nessun profilo**).
+- Nessuna modifica a indice Link affiliati, ricerca/scoring affiliate, batch/sync affiliate o OpenAI Service.
 
 ## Novità 2.25.12 — PR 8.12 Ideas UI Instruction Profile Cleanup and Clear Profile Fix
 

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.12
+ * Version: 2.25.13
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.12');
+define('ALMA_VERSION', '2.25.13');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -712,6 +712,15 @@ class AffiliateManagerAI {
                         'error'      => __('Errore durante la generazione', 'affiliate-link-manager-ai'),
                     ),
                 ));
+            }
+            if ($hook === 'affiliate_link_page_alma-ai-content-agent' && file_exists(ALMA_PLUGIN_DIR . 'assets/admin.js')) {
+                wp_enqueue_script(
+                    'alma-admin-script',
+                    ALMA_PLUGIN_URL . 'assets/admin.js',
+                    array(),
+                    ALMA_VERSION,
+                    true
+                );
             }
 
             if ($hook === 'affiliate_link_page_alma-affiliate-sources') {

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -1,0 +1,17 @@
+(function () {
+  'use strict';
+
+  var profileSelect = document.getElementById('alma-idea-instruction-profile');
+  var saveProfileHidden = document.getElementById('alma-save-idea-instruction-profile-id');
+
+  if (!profileSelect || !saveProfileHidden) {
+    return;
+  }
+
+  var syncProfile = function () {
+    saveProfileHidden.value = profileSelect.value;
+  };
+
+  syncProfile();
+  profileSelect.addEventListener('change', syncProfile);
+})();

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -63,7 +63,22 @@ class ALMA_AI_Content_Agent_Admin {
                 $result = array('success' => false, 'message' => 'Errore durante lo svuotamento dell\'indice tecnico Link affiliati.');
             }
         } elseif ($do === 'search_knowledge_base' || $do === 'add_new_search') {
-            $profile_id = absint($_POST['instruction_profile_id'] ?? 0);
+            $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true));
+            $active_idea = $active_idea_id > 0 ? ALMA_AI_Content_Agent_Ideas::get($active_idea_id) : array();
+            $current_profile_id = absint($active_idea['instruction_profile_id'] ?? ($active_idea['profile_id'] ?? 0));
+            $profile_id = $current_profile_id;
+            if (array_key_exists('instruction_profile_id', $_POST)) {
+                $raw_profile_id = sanitize_text_field((string) $_POST['instruction_profile_id']);
+                if ($raw_profile_id === '0' || $raw_profile_id === '') {
+                    $profile_id = 0;
+                } else {
+                    $candidate_profile_id = absint($raw_profile_id);
+                    $candidate_profile = $candidate_profile_id > 0 ? ALMA_AI_Content_Agent_Instructions_Manager::get_profile($candidate_profile_id) : array();
+                    if (!empty($candidate_profile['id'])) {
+                        $profile_id = (int) $candidate_profile['id'];
+                    }
+                }
+            }
             $profile = $profile_id ? ALMA_AI_Content_Agent_Instructions_Manager::get_profile($profile_id) : array();
             $payload = array('max_ideas'=>absint($_POST['max_ideas'] ?? 1),'content_search_query'=>sanitize_text_field($_POST['content_search_query'] ?? ($_POST['search_terms'] ?? '')),'search_terms'=>sanitize_text_field($_POST['search_terms'] ?? ($_POST['content_search_query'] ?? '')),'theme'=>sanitize_text_field($_POST['theme'] ?? ''),'destination'=>sanitize_text_field($_POST['destination'] ?? ''),'temporary_instructions'=>sanitize_textarea_field($_POST['temporary_instructions'] ?? ''),'openai_prompt'=>sanitize_textarea_field($_POST['openai_prompt'] ?? $_POST['temporary_instructions'] ?? ''),'instruction_profile_id'=>$profile_id,'instruction_profile_name'=>sanitize_text_field($profile['profile_name'] ?? ''),'instruction_snapshot_hash'=>sanitize_text_field($profile ? ALMA_AI_Content_Agent_Instructions_Manager::snapshot_hash(wp_json_encode($profile)) : ''));
             $search = ALMA_AI_Content_Agent_Knowledge_Search::search($payload);
@@ -401,7 +416,7 @@ class ALMA_AI_Content_Agent_Admin {
         if (!empty($active_idea['draft_post_id']) && get_post((int)$active_idea['draft_post_id'])) { echo '<a class="button" href="'.esc_url(get_edit_post_link((int)$active_idea['draft_post_id'],'raw')).'">Apri bozza</a>'; }
         echo '<div class="alma-actions-inline">';
         self::action_form('new_content_idea','Crea nuova idea');
-        if($active_idea_id){ echo '<form id="alma-save-idea-form" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_content_idea"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><input type="hidden" name="idea_status" value="bozza"><input type="hidden" name="openai_prompt" value="'.esc_attr($active_idea['prompt']??'').'"><input type="hidden" name="instruction_profile_id" value="'.(int)$selected_profile_id.'"><button class="button">Salva idea</button></form>'; }
+        if($active_idea_id){ echo '<form id="alma-save-idea-form" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_content_idea"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><input type="hidden" name="idea_status" value="bozza"><input type="hidden" name="openai_prompt" value="'.esc_attr($active_idea['prompt']??'').'"><input type="hidden" id="alma-save-idea-instruction-profile-id" name="instruction_profile_id" value="'.(int)$selected_profile_id.'"><button class="button">Salva idea</button></form>'; }
         if($active_idea_id){ echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="delete_content_idea"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><button class="button">Elimina</button></form>'; }
         self::action_form('download_ai_payload_json','Scarica JSON payload AI');
         self::action_form('create_draft_from_selection','Crea Bozza con OpenAI');
@@ -417,7 +432,7 @@ class ALMA_AI_Content_Agent_Admin {
         else { echo '<ul class="alma-ideas-list">'; foreach($ideas as $idea_post){ echo '<li><strong>'.esc_html($idea_post->post_title).'</strong><br><span class="description">'.esc_html($idea_post->post_modified).'</span> '.(((int)$idea_post->ID===(int)$active_idea_id)?'<span class="alma-added-badge">Attiva</span>':'').'<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="load_content_idea"><input type="hidden" name="idea_id" value="'.(int)$idea_post->ID.'"><button class="button button-small">Carica</button></form></li>'; } echo '</ul>'; }
         echo '<ul><li>Contenuti aggiunti: '.(int)($summary['selected_total'] ?? 0).'</li><li>Profilo istruzioni AI: '.(int)($active_idea['profile_id'] ?? 0).'</li><li>Prompt OpenAI: '.(!empty($active_idea['prompt']) ? 'Presente' : 'Assente').'</li></ul></div></aside>';
 
-        echo '<main class="alma-ideas-col alma-ideas-col-main"><div class="alma-ideas-card"><h3>1. Cerca contenuti</h3><form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="search_knowledge_base"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><p><input class="widefat" type="text" name="content_search_query" placeholder="Cerca contenuti" value="'.esc_attr($session['last_query']['content_search_query'] ?? '').'" required></p><p><label for="alma-idea-instruction-profile">Profilo Istruzioni AI</label><select id="alma-idea-instruction-profile" class="widefat" name="instruction_profile_id" form="alma-save-idea-form"><option value="0">Nessun profilo</option>';
+        echo '<main class="alma-ideas-col alma-ideas-col-main"><div class="alma-ideas-card"><h3>1. Cerca contenuti</h3><form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="search_knowledge_base"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><p><input class="widefat" type="text" name="content_search_query" placeholder="Cerca contenuti" value="'.esc_attr($session['last_query']['content_search_query'] ?? '').'" required></p><p><label for="alma-idea-instruction-profile">Profilo Istruzioni AI</label><select id="alma-idea-instruction-profile" class="widefat" name="instruction_profile_id"><option value="0">Nessun profilo</option>';
         foreach($profiles as $p){ $sel=selected($selected_profile_id,(int)$p['id'],false); echo '<option value="'.(int)$p['id'].'" '.$sel.'>'.esc_html($p['profile_name']).'</option>'; }
         echo '</select></p><p><label>Prompt per OpenAI</label><textarea class="widefat" rows="4" name="openai_prompt">'.esc_textarea($active_idea['prompt'] ?? ($session['openai_prompt'] ?? '')).'</textarea><span class="description">Questo prompt verrà inviato a OpenAI insieme ai contenuti raccolti e guiderà cosa scrivere nella bozza.</span></p><p><button class="button button-primary">Cerca contenuti</button></p></form></div>';
 


### PR DESCRIPTION
### Motivation
- Fix a P1 regression in the AI Content Agent > Idee tab where the single visible "Profilo Istruzioni AI" select was bound only to the save form, causing `search_knowledge_base` requests to miss `instruction_profile_id` and risk clearing or mis-setting the idea profile.
- Keep a single visible select in the UI while ensuring both the search and save flows submit the selected profile value reliably and safely.

### Description
- Removed the `form="alma-save-idea-form"` binding from the visible select and moved it into the search form so `search_knowledge_base` always receives `instruction_profile_id`. (modified: `includes/class-ai-content-agent-admin.php`)
- Added a hidden input `instruction_profile_id` (id `alma-save-idea-instruction-profile-id`) inside the save form and enqueue a defensive vanilla JS asset `assets/admin.js` to synchronize it with the visible select on load/change so `alma-save-idea-form` continues to save the chosen profile. (modified: `includes/class-ai-content-agent-admin.php`, added: `assets/admin.js`, updated enqueue in `affiliate-link-manager-ai.php`)
- Hardened backend profile resolution in the `search_knowledge_base` / `add_new_search` flow so it starts from the current idea profile and only applies an explicit request value if present, treating explicit `0`/empty as “Nessun profilo” while preserving existing profile on missing or invalid input. (modified: `includes/class-ai-content-agent-admin.php`)
- Bumped plugin version to `2.25.13` and updated `ALMA_VERSION`, README and CHANGELOG with a short note about the fix. (modified: `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`)

### Testing
- Ran PHP syntax checks: `php -l affiliate-link-manager-ai.php`, `php -l includes/class-ai-content-agent-admin.php`, `php -l includes/class-ai-content-agent-ideas.php`, and `php -l includes/class-ai-content-agent-selection-session.php`, all returned no syntax errors.
- Verified the plugin header and constant now reflect `2.25.13` and new files are present: `assets/admin.js` was added and enqueued only on the AI Content Agent admin page.
- Performed code inspections to confirm the visible select appears only once in the Ideas tab, it is no longer bound exclusively to the save form, the search form sends `instruction_profile_id`, and the save form has a hidden synchronized field; these textual checks passed.
- Note: interactive browser UI end-to-end checks (click/reload in WordPress admin) were not executed in this run; runtime behavior was validated by code review and defensive JS enqueueing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d593e18c83329a45d05ab3c1e1ee)