### PR TITLE
PR 8.14 — Ideas Instruction Profile Save Order and Session Persistence Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.25.14 — PR 8.14 Ideas Instruction Profile Save Order and Session Persistence Fix
+- Fix definitivo perdita profilo su **Salva idea**: `persist_to_idea()` non sovrascrive più `_alma_idea_profile_id` con `instruction_profile_id` stale proveniente dalla sessione/transient.
+- L'Idea contenuto resta la fonte persistente primaria del profilo istruzioni; la sessione continua a persistere query/risultati/selezione/snapshot hash senza alterare il meta profilo.
+- Hardening `save_from_request()` su update parziali: `openai_prompt` viene salvato solo se il campo è presente nel payload, evitando azzeramenti involontari.
+- Nel ramo `save_content_idea` la sessione viene ricaricata dall'idea aggiornata dopo la persistenza, garantendo coerenza sessione↔idea anche dopo reload/azioni successive.
+- Profilo istruzioni confermato come input per i flussi AI/OpenAI (idea/bozza), non per la ricerca Link affiliati.
+- Nessuna modifica a indice Link affiliati e nessuna modifica a OpenAI Service.
+
 ## 2.25.13 — PR 8.13 Ideas Instruction Profile Single Select Form Submission Fix
 - Corretto il submit del select unico **Profilo Istruzioni AI** nella tab Idee: il form **Cerca contenuti** invia sempre `instruction_profile_id` (incluso `0` per **Nessun profilo**).
 - Il form **Salva idea** mantiene il profilo tramite hidden `instruction_profile_id` sincronizzato con il select visibile (JS vanilla difensivo in `assets/admin.js`).

--- a/README.md
+++ b/README.md
@@ -141,8 +141,18 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.13
+Versione 2.25.14
 
+
+
+
+## Novità 2.25.14 — PR 8.14 Ideas Instruction Profile Save Order and Session Persistence Fix
+
+- Il **Profilo Istruzioni AI** ora resta persistente sull'Idea contenuto anche dopo **Salva idea**: la persistenza sessione non sovrascrive più il meta idea con valori stale.
+- Hardening su update parziali: `openai_prompt` viene aggiornato solo quando presente nel payload, quindi non viene più azzerato implicitamente.
+- Nel flusso tab Idee la sessione viene riallineata all'idea aggiornata dopo il salvataggio, mantenendo coerenza tra select UI, hidden e metadati persistenti.
+- Il profilo istruzioni resta destinato ai flussi AI/OpenAI (brief/bozza), non alla ricerca dei Link affiliati.
+- Nessuna modifica a indice Link affiliati, batch/sync affiliate o OpenAI Service.
 
 ## Novità 2.25.13 — PR 8.13 Ideas Instruction Profile Single Select Form Submission Fix
 

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.13
+ * Version: 2.25.14
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.13');
+define('ALMA_VERSION', '2.25.14');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -132,7 +132,13 @@ class ALMA_AI_Content_Agent_Admin {
         } elseif ($do === 'save_content_idea') {
             $idea_id = absint($_POST['idea_id'] ?? 0);
             $ok = ALMA_AI_Content_Agent_Ideas::save_from_request($idea_id, $_POST);
-            if ($ok) { ALMA_AI_Content_Agent_Selection_Session::persist_to_idea($idea_id); }
+            if ($ok) {
+                ALMA_AI_Content_Agent_Selection_Session::persist_to_idea($idea_id);
+                $updated_idea = ALMA_AI_Content_Agent_Ideas::get($idea_id);
+                if (!empty($updated_idea)) {
+                    ALMA_AI_Content_Agent_Selection_Session::load_from_idea($updated_idea);
+                }
+            }
             $result = array('success' => $ok, 'message' => $ok ? 'Idea salvata.' : 'Errore salvataggio idea.');
         } elseif ($do === 'delete_content_idea') {
             $idea_id = absint($_POST['idea_id'] ?? 0); $ok = $idea_id > 0 ? (bool)wp_delete_post($idea_id, true) : false;

--- a/includes/class-ai-content-agent-ideas.php
+++ b/includes/class-ai-content-agent-ideas.php
@@ -86,7 +86,9 @@ class ALMA_AI_Content_Agent_Ideas {
                 update_post_meta($idea_id, self::META_PROFILE_ID, 0);
             }
         }
-        update_post_meta($idea_id, self::META_PROMPT, sanitize_textarea_field($data['openai_prompt'] ?? ''));
+        if (array_key_exists('openai_prompt', (array)$data)) {
+            update_post_meta($idea_id, self::META_PROMPT, sanitize_textarea_field((string)$data['openai_prompt']));
+        }
         return true;
     }
 }

--- a/includes/class-ai-content-agent-selection-session.php
+++ b/includes/class-ai-content-agent-selection-session.php
@@ -294,11 +294,6 @@ class ALMA_AI_Content_Agent_Selection_Session {
         update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_LAST_QUERY, (array)$session['last_query']);
         update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_RESULTS, array_values($session['search_results']));
         update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_SELECTION, array_values($session['selected_results']));
-        if (array_key_exists('instruction_profile_id', (array)$session)) {
-            update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_PROFILE_ID, absint($session['instruction_profile_id']));
-        } elseif (array_key_exists('instruction_profile_id', (array)$idea)) {
-            update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_PROFILE_ID, absint($idea['instruction_profile_id']));
-        }
         $snapshot_hash = sanitize_text_field($session['instruction_snapshot_hash'] ?? '');
         if ($snapshot_hash === '') {
             $snapshot_hash = sanitize_text_field($idea['instruction_snapshot_hash'] ?? '');


### PR DESCRIPTION
### Motivation
- Fixa la perdita del `instruction_profile_id` sull’Idea contenuto che avveniva quando la sessione/transient riscriveva il meta idea dopo il salvataggio. 
- Evitare che la sessione sovrascriva valori stale dell’idea e prevenire azzeramenti non voluti del prompt `openai_prompt` nei salvataggi parziali.

### Description
- `persist_to_idea()` non scrive più il meta `META_PROFILE_ID` dall’oggetto sessione lasciando l’Idea come fonte persistente primaria del profilo istruzioni; rimane la persistenza di `last_query`, `results`, `selection` e snapshot/hash. (`includes/class-ai-content-agent-selection-session.php`)
- Nel flusso `save_content_idea` la sessione viene riallineata all’idea aggiornata dopo `save_from_request()` e `persist_to_idea()` usando `ALMA_AI_Content_Agent_Selection_Session::load_from_idea()`, garantendo coerenza sessione↔idea. (`includes/class-ai-content-agent-admin.php`)
- `ALMA_AI_Content_Agent_Ideas::save_from_request()` ora aggiorna `openai_prompt` solo se il campo è presente nel payload, evitando il reset implicito del prompt quando manca il campo; la logica su `instruction_profile_id` mantiene il comportamento esplicito per `0`/clear. (`includes/class-ai-content-agent-ideas.php`)
- Aggiornata la versione plugin a `2.25.14` e documentazione (`affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`).

### Testing
- Eseguiti lint PHP su files richiesti con `php -l` e tutti i file hanno riportato: `No syntax errors detected` for `affiliate-link-manager-ai.php`, `includes/class-ai-content-agent-admin.php`, `includes/class-ai-content-agent-ideas.php`, `includes/class-ai-content-agent-selection-session.php`, `includes/class-ai-content-agent-brief-builder.php`, `includes/class-ai-content-agent-draft-builder.php`, `includes/class-ai-content-agent-context-builder.php`.
- Verificata la presenza delle modifiche richieste (rimozione scrittura `META_PROFILE_ID` in `persist_to_idea()`, condizionale su `openai_prompt`, riallineamento sessione dopo `save_content_idea`) mediante ispezione del codice e aggiornamento di `README.md`/`CHANGELOG.md` (static checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9daf6ce788332b321cf45803ea914)