### PR TITLE
PR 8.16 — Restrict Ideas Search to Affiliate Links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.25.16 — PR 8.16 Restrict Ideas Search to Affiliate Links
+- La ricerca Idee usa ora uno scope esplicito `affiliate_links_only` e interroga solo `search_affiliate_links()`.
+- Escluse temporaneamente dalla card “2. Risultati ricerca” le sorgenti Post/Pagine/TXT/Fonti online/Media e risultati Knowledge Base editoriali.
+- Preservato fallback WordPress solo su CPT `affiliate_link` pubblicati con URL affiliato valido quando l’indice dedicato è vuoto/non disponibile.
+- Nuova ricerca affiliate-only sostituisce i risultati precedenti in sessione per evitare residui legacy (es. Post) senza svuotare i contenuti già aggiunti alla colonna 3.
+- Nessuna modifica a indice affiliate, batch/sync, scoring, OpenAI Service o Draft Builder.
+
 ## 2.25.15 — PR 8.15 Ideas Active Box UI and Affiliate Index Action Descriptions
 - Migliorata la leggibilità del box **Idea attiva** nella tab Idee contenuto con sezioni distinte: riepilogo, lista idee create e dettagli idea.
 - Ogni idea creata viene mostrata come record/card separato con titolo, ultima modifica, badge **Attiva** e pulsante **Carica** invariato lato azioni.

--- a/README.md
+++ b/README.md
@@ -141,10 +141,19 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.15
+Versione 2.25.16
 
 
 
+
+
+## Novità 2.25.16 — PR 8.16 Restrict Ideas Search to Affiliate Links
+
+- La ricerca nella tab **Idee contenuto** (card **2. Risultati ricerca**) usa ora esplicitamente `search_scope=affiliate_links_only` e mostra solo risultati `affiliate_link`.
+- Esclusi temporaneamente dalla ricerca Idee: Post, Pagine, Documenti TXT, Fonti online AI, Media e risultati editoriali Knowledge Base.
+- Preservato il fallback: se l’indice dedicato non restituisce risultati, la ricerca usa WordPress solo su `post_type=affiliate_link` pubblicati con URL affiliato valido.
+- Il **Profilo Istruzioni AI** resta destinato ai flussi AI/OpenAI e bozza; non modifica la ricerca affiliate-only in questa fase.
+- Nessuna modifica a indice affiliate, batch/sync, scoring, OpenAI Service o Draft Builder.
 
 ## Novità 2.25.15 — PR 8.15 Ideas Active Box UI and Affiliate Index Action Descriptions
 

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.15
+ * Version: 2.25.16
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.15');
+define('ALMA_VERSION', '2.25.16');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -80,7 +80,7 @@ class ALMA_AI_Content_Agent_Admin {
                 }
             }
             $profile = $profile_id ? ALMA_AI_Content_Agent_Instructions_Manager::get_profile($profile_id) : array();
-            $payload = array('max_ideas'=>absint($_POST['max_ideas'] ?? 1),'content_search_query'=>sanitize_text_field($_POST['content_search_query'] ?? ($_POST['search_terms'] ?? '')),'search_terms'=>sanitize_text_field($_POST['search_terms'] ?? ($_POST['content_search_query'] ?? '')),'theme'=>sanitize_text_field($_POST['theme'] ?? ''),'destination'=>sanitize_text_field($_POST['destination'] ?? ''),'temporary_instructions'=>sanitize_textarea_field($_POST['temporary_instructions'] ?? ''),'openai_prompt'=>sanitize_textarea_field($_POST['openai_prompt'] ?? $_POST['temporary_instructions'] ?? ''),'instruction_profile_id'=>$profile_id,'instruction_profile_name'=>sanitize_text_field($profile['profile_name'] ?? ''),'instruction_snapshot_hash'=>sanitize_text_field($profile ? ALMA_AI_Content_Agent_Instructions_Manager::snapshot_hash(wp_json_encode($profile)) : ''));
+            $payload = array('max_ideas'=>absint($_POST['max_ideas'] ?? 1),'content_search_query'=>sanitize_text_field($_POST['content_search_query'] ?? ($_POST['search_terms'] ?? '')),'search_terms'=>sanitize_text_field($_POST['search_terms'] ?? ($_POST['content_search_query'] ?? '')),'theme'=>sanitize_text_field($_POST['theme'] ?? ''),'destination'=>sanitize_text_field($_POST['destination'] ?? ''),'temporary_instructions'=>sanitize_textarea_field($_POST['temporary_instructions'] ?? ''),'openai_prompt'=>sanitize_textarea_field($_POST['openai_prompt'] ?? $_POST['temporary_instructions'] ?? ''),'instruction_profile_id'=>$profile_id,'instruction_profile_name'=>sanitize_text_field($profile['profile_name'] ?? ''),'instruction_snapshot_hash'=>sanitize_text_field($profile ? ALMA_AI_Content_Agent_Instructions_Manager::snapshot_hash(wp_json_encode($profile)) : ''),'search_scope'=>'affiliate_links_only');
             $search = ALMA_AI_Content_Agent_Knowledge_Search::search($payload);
             $stats = ALMA_AI_Content_Agent_Selection_Session::add_search_results($payload, $search);
             $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true));
@@ -456,7 +456,7 @@ class ALMA_AI_Content_Agent_Admin {
         $current_page = max(1, min($requested_page, $total_pages));
         $paged_rows = array_slice($all_rows, ($current_page-1)*$per_page, $per_page);
 
-        echo '<div class="alma-ideas-card"><div class="alma-results-header"><h3>2. Risultati ricerca</h3></div>';
+        echo '<div class="alma-ideas-card"><div class="alma-results-header"><h3>2. Risultati ricerca</h3></div><p class="description">In questa fase la ricerca mostra solo Link affiliati indicizzati.</p>'; 
 
         echo '<div class="tablenav top"><div class="tablenav-pages">';
         echo '<span class="displaying-num">'.(int)$total_results.' elementi</span>';

--- a/includes/class-ai-content-agent-knowledge-search.php
+++ b/includes/class-ai-content-agent-knowledge-search.php
@@ -8,13 +8,19 @@ class ALMA_AI_Content_Agent_Knowledge_Search {
     public static function search($input = array()) {
         $query = self::normalize_input($input);
         $results = array();
+        $search_scope = sanitize_key((string)($input['search_scope'] ?? ''));
 
-        $affiliate_results = self::search_affiliate_links($query);
-        $results = array_merge($results, $affiliate_results);
-        $results = array_merge($results, self::search_wordpress($query));
-        $results = array_merge($results, self::search_knowledge_items($query));
-        $results = array_merge($results, self::search_sources($query));
-        $results = array_merge($results, self::search_media($query));
+        if ($search_scope === 'affiliate_links_only') {
+            $results = array_merge($results, self::search_affiliate_links($query));
+        } else {
+            $affiliate_results = self::search_affiliate_links($query);
+            $results = array_merge($results, $affiliate_results);
+            // Manteniamo attive le altre sorgenti per fasi future multi-source.
+            $results = array_merge($results, self::search_wordpress($query));
+            $results = array_merge($results, self::search_knowledge_items($query));
+            $results = array_merge($results, self::search_sources($query));
+            $results = array_merge($results, self::search_media($query));
+        }
 
         $results = self::dedupe($results);
         $grouped = self::group_and_rank($results);

--- a/includes/class-ai-content-agent-selection-session.php
+++ b/includes/class-ai-content-agent-selection-session.php
@@ -78,6 +78,11 @@ class ALMA_AI_Content_Agent_Selection_Session {
 
     public static function add_search_results($payload, $search_results) {
         $session = self::get_session();
+        $search_scope = sanitize_key((string)($payload['search_scope'] ?? ''));
+        if ($search_scope === 'affiliate_links_only') {
+            // Nuova ricerca affiliate-only: sostituisce i risultati precedenti preservando la selezione corrente.
+            $session['search_results'] = array();
+        }
         $added = 0; $duplicates = 0; $found = 0;
         foreach ((array)($search_results['groups'] ?? array()) as $group => $rows) {
             foreach ((array)$rows as $row) {


### PR DESCRIPTION
### Motivation
- Limitare la ricerca nella tab "Idee contenuto" (card 2) ai soli Link affiliati indicizzati per questa fase, evitando che compaiano Post/Pagine/Media/TXT/Fonti online/risultati KB editoriali.
- Usare l'indice dedicato `affiliate_link` come priorità e mantenere un fallback WordPress che cerchi solo il CPT `affiliate_link` pubblicato con URL affiliato valido.
- Evitare di rimuovere o disabilitare i metodi multi-sorgente esistenti, lasciandoli disponibili per fasi future.
- Allineare versioning e documentazione alla nuova regola operativo (`2.25.16`).

### Description
- Introdotto il parametro `search_scope` in `ALMA_AI_Content_Agent_Knowledge_Search::search()` e gestito il valore operativo `affiliate_links_only` in modo che, se impostato, venga chiamato esclusivamente `search_affiliate_links()`; la struttura di output (`query`, `groups`, `generated_at`) resta invariata.
- Aggiornato il flusso admin della tab Idee (`search_knowledge_base`) per passare esplicitamente `'search_scope' => 'affiliate_links_only'` nel payload di ricerca, evitando dipendere da default impliciti.
- Modificata la logica di sessione in `ALMA_AI_Content_Agent_Selection_Session::add_search_results()` per azzerare `search_results` quando la ricerca è `affiliate_links_only`, preservando però `selected_results` (colonna 3) in modo che le selezioni già aggiunte non vengano rimosse.
- Aggiunta una breve nota UI nella card 2: `In questa fase la ricerca mostra solo Link affiliati indicizzati.` per chiarezza operativa.
- Aggiornamento versioning e documentazione: header plugin e costante `ALMA_VERSION` a `2.25.16`, e aggiornamento di `README.md` e `CHANGELOG.md` con la sezione PR 8.16.
- File modificati: `includes/class-ai-content-agent-knowledge-search.php`, `includes/class-ai-content-agent-admin.php`, `includes/class-ai-content-agent-selection-session.php`, `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`.
- Non sono stati rimossi né modificati i metodi `search_wordpress()`, `search_knowledge_items()`, `search_sources()` e `search_media()` né è stata toccata la logica dell'indice affiliati, batch/sync, scoring, OpenAI Service o Draft Builder.

### Testing
- Sintassi PHP verificata con `php -l` per i file modificati e altri rilevanti e tutti senza errori: `affiliate-link-manager-ai.php`, `includes/class-ai-content-agent-knowledge-search.php`, `includes/class-ai-content-agent-admin.php`, `includes/class-ai-content-agent-selection-session.php`, `includes/class-ai-content-agent-affiliate-index.php` (tutti passati).
- Ricerca testuale/grep eseguita per confermare: versione `2.25.16`, presenza di `search_scope`, `affiliate_links_only` e pass esplicito dello scope dal ramo `search_knowledge_base` (verifiche superate).
- Controlli automatici eseguiti per garantire che i metodi multi-sorgente siano ancora presenti e che il fallback affiliate rimanga intatto (ispezione del codice, OK).
- Nota: i test manuali UI in ambiente WordPress (es.: eseguire ricerche in wp-admin e verificare che nella card 2 compaiano solo risultati `affiliate_link`, che la paginazione e i pulsanti funzionino, e che OpenAI non venga chiamata) sono richiesti in un ambiente runtime e non sono stati eseguiti in questa sessione CLI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e3675e508332b2be37864c9e920d)