### PR TITLE
PR 8.19 — Preserve Affiliate Filter Metadata in Session Results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.25.19 — PR 8.19 Preserve Affiliate Filter Metadata in Session Results
+- `ALMA_AI_Content_Agent_Selection_Session::normalize_result()` ora preserva nei risultati di sessione i metadati affiliate utili alla UI: `link_types`, `provenance`, `provider`, `source`.
+- `link_types` viene normalizzato in forma stabile (array di stringhe sanificate), con supporto input array/CSV/stringa singola, rimozione vuoti e deduplica.
+- I filtri **Tipologie Link** e **Fonte / Source / Provider** nella card **2. Risultati ricerca** si popolano correttamente dopo una nuova ricerca affiliate.
+- Nessuna modifica a scoring, indice affiliate (batch/sync), OpenAI Service, Draft Builder o provider/importer.
+
 ## 2.25.18 — PR 8.18 Affiliate Results Filters and Stable Idea Title
 - Aggiunti filtri UI nella card **2. Risultati ricerca** per **Tipologie Link** (`alma_link_type_filter`) e **Fonte / Source / Provider** (`alma_source_filter`), costruiti dinamicamente dai risultati presenti in sessione.
 - Filtri applicati lato rendering/sessione, prima della paginazione, senza rifare la ricerca e senza modificare `search_results` o `selected_results`.

--- a/README.md
+++ b/README.md
@@ -141,20 +141,18 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.18
+Versione 2.25.19
 
 
 
 
 
-## Novità 2.25.18 — PR 8.18 Affiliate Results Filters and Stable Idea Title
+## Novità 2.25.19 — PR 8.19 Preserve Affiliate Filter Metadata in Session Results
 
-- La ricerca nella tab **Idee contenuto** resta affiliate-only (`search_scope=affiliate_links_only`) e mostra risultati `affiliate_link` fino a 200 elementi paginati.
-- Aggiunti filtri in card **2. Risultati ricerca** per **Tipologie Link** e **Fonte / Source / Provider** con applicazione lato rendering/sessione.
-- I filtri sono applicati prima della paginazione e mantenuti nei link pagina; **Reset filtri** rimuove solo i parametri filtro senza effetti distruttivi.
-- Stato vuoto filtrato dedicato quando i risultati esistono ma sono esclusi dai filtri selezionati.
-- Il **Titolo idea** è ora indipendente dal testo in **Cerca contenuti**: la query aggiorna solo `last_query` e non sovrascrive più il titolo di idee esistenti.
-- Nessuna modifica a indice affiliate, batch/sync/scoring, OpenAI Service o Draft Builder.
+- `ALMA_AI_Content_Agent_Selection_Session::normalize_result()` preserva ora nei risultati in sessione i metadati affiliate necessari ai filtri UI: `link_types`, `provenance`, `provider`, `source`.
+- `link_types` viene normalizzato in formato stabile (array di stringhe sanificate) con supporto input array, CSV o stringa singola, deduplica e rimozione valori vuoti.
+- I filtri della card **2. Risultati ricerca** (**Tipologie Link** e **Fonte / Source / Provider**) si popolano correttamente dopo una nuova ricerca affiliate e continuano a funzionare con paginazione/reset.
+- Nessuna modifica a scoring, indice affiliate (batch/sync), OpenAI Service, Draft Builder, provider/importer, shortcode o tracking.
 
 ## Novità 2.25.15 — PR 8.15 Ideas Active Box UI and Affiliate Index Action Descriptions
 

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.18
+ * Version: 2.25.19
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.18');
+define('ALMA_VERSION', '2.25.19');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-selection-session.php
+++ b/includes/class-ai-content-agent-selection-session.php
@@ -250,9 +250,35 @@ class ALMA_AI_Content_Agent_Selection_Session {
             'score' => (int)($row['score'] ?? 0),
             'reason' => sanitize_text_field($row['reason'] ?? ''),
             'admin_url' => esc_url_raw($row['admin_url'] ?? ($row['edit_url'] ?? '')),
+            'link_types' => self::normalize_link_types($row['link_types'] ?? array()),
+            'provenance' => sanitize_text_field((string)($row['provenance'] ?? '')),
+            'provider' => sanitize_text_field((string)($row['provider'] ?? '')),
+            'source' => sanitize_text_field((string)($row['source'] ?? '')),
             'selectable' => true,
             'selected' => !empty($row['preselected']),
         );
+    }
+
+    private static function normalize_link_types($raw_link_types) {
+        $values = array();
+        if (is_array($raw_link_types)) {
+            $values = $raw_link_types;
+        } elseif (is_string($raw_link_types)) {
+            $raw = trim($raw_link_types);
+            if ($raw !== '') {
+                $values = strpos($raw, ',') !== false ? explode(',', $raw) : array($raw);
+            }
+        }
+
+        $normalized = array();
+        foreach ($values as $value) {
+            if (!is_scalar($value)) { continue; }
+            $clean = sanitize_text_field((string)$value);
+            if ($clean === '') { continue; }
+            $normalized[$clean] = $clean;
+        }
+
+        return array_values($normalized);
     }
 
     public static function grouped_results($selected_only = false) {


### PR DESCRIPTION
### Motivation
- Fixare il bug dei filtri vuoti nella card “2. Risultati ricerca” causato dalla perdita dei metadati affiliate durante la normalizzazione dei risultati in sessione.
- I risultati generati da `ALMA_AI_Content_Agent_Knowledge_Search` già contengono `link_types` e `provenance`/`provider`/`source`, ma tali campi venivano scartati da `ALMA_AI_Content_Agent_Selection_Session::normalize_result()` prima di salvare in sessione.
- Occorre preservare solo i metadati utili alla UI e ai filtri, sanificarli e mantenere retrocompatibilità con risultati legacy.

### Description
- Aggiornata `ALMA_AI_Content_Agent_Selection_Session::normalize_result()` per preservare e sanificare i campi `link_types`, `provenance`, `provider` e `source` nei risultati normalizzati.
- Aggiunto helper `normalize_link_types()` che accetta input array/CSV/stringa singola, rimuove vuoti, deduplica e ritorna un array stabile di stringhe sanificate per UI.
- Aggiornato versioning a `2.25.19` nel header plugin e nella costante `ALMA_VERSION` e aggiornati `README.md` e `CHANGELOG.md` con la nota `2.25.19 — PR 8.19`.
- File modificati: `includes/class-ai-content-agent-selection-session.php`, `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`.

### Testing
- Eseguiti i controlli di sintassi PHP con `php -l` su i file principali: `php -l affiliate-link-manager-ai.php`, `php -l includes/class-ai-content-agent-selection-session.php`, `php -l includes/class-ai-content-agent-knowledge-search.php`, `php -l includes/class-ai-content-agent-admin.php`, `php -l includes/class-ai-content-agent-affiliate-index.php` e tutti hanno restituito "No syntax errors detected".
- Verificata la presenza dei nuovi campi e delle funzioni con ricerche testuali nel codice (`rg`/`grep`) per `normalize_result`, `normalize_link_types`, `link_types`, `provenance`, `provider`, `source` e confermata la coerenza con il `Knowledge_Search` esistente.
- Verificato l'aggiornamento del versioning in `affiliate-link-manager-ai.php`, `README.md` e `CHANGELOG.md` con ricerca testuale; commit e PR preparati con i cambiamenti applicati.
- Nota: il test manuale end-to-end nella UI WordPress (click sui menu filtri, reset, paginazione) è raccomandato in ambiente WP reale perché non eseguibile in questa sessione CLI, ma la modifica è mirata esclusivamente a preservare i metadati necessari al rendering/filtri già implementati.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ed57c0a08332ba30d97bc8d94073)