### PR TITLE
Refine AI draft payload: affiliate URL policy, deduplicated source prompts and precise warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.25.22 — PR 8.22 Refine AI Draft Payload Affiliate URL Policy and Source Instructions
+- Rifinita la policy payload per link affiliati nel Draft Builder: shortcode WordPress preferiti, `affiliate_url` consentito per link testuali diretti, divieto di URL inventati e uso esclusivo dei link presenti nel payload.
+- Aggiunta sezione globale `source_agent_prompts` con prompt Source non vuoti, deduplicati e collegati ai `link_ids`, per ridurre duplicazioni nei singoli `affiliate_links`.
+- Warnings aggiornati con messaggi più precisi su comportamento agente globale e disponibilità istruzioni Source, inclusa nota sintetica per link manuali/legacy senza prompt dedicato.
+- Gestione esplicita non bloccante dei link manuali/legacy senza Source prompt (link mantenuti utilizzabili nel payload).
+- Nessuna modifica a OpenAI Service, endpoint/chiamata modello, indice Link affiliati, ricerca affiliate, batch/sync, provider/importer, shortcode rendering o tracking.
+
 ## 2.25.21 — PR 8.21 Safe AI Payload JSON Builder and Download Hardening
 - `ALMA_AI_Content_Agent_Selection_Session::normalize_result()` ora preserva nei risultati di sessione i metadati affiliate utili alla UI: `link_types`, `provenance`, `provider`, `source`.
 - `link_types` viene normalizzato in forma stabile (array di stringhe sanificate), con supporto input array/CSV/stringa singola, rimozione vuoti e deduplica.

--- a/README.md
+++ b/README.md
@@ -141,11 +141,21 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.21
+Versione 2.25.22
 
 
 
 
+
+## Novità 2.25.22 — PR 8.22 Refine AI Draft Payload Affiliate URL Policy and Source Instructions
+
+- Rifinita la policy payload AI per i link affiliati: shortcode WordPress preferiti per box/link, con `affiliate_url` ammesso quando serve un link testuale diretto.
+- La sezione `rules` richiede esplicitamente: `prefer_affiliate_shortcodes`, `allow_affiliate_urls_for_text_links`, `do_not_invent_affiliate_urls`, `use_only_payload_affiliate_links`.
+- Aggiunta sezione globale `source_agent_prompts` che raggruppa i prompt Source non vuoti, deduplicati e collegati ai relativi `link_ids`.
+- Nei singoli `affiliate_links` restano campi leggeri di riferimento (`source_agent_prompt_key` / disponibilità prompt) per ridurre duplicazione dei prompt lunghi.
+- Gestione non bloccante dei link manuali o legacy senza Source prompt: i link restano selezionabili/usabili se hanno dati principali (`title/content/affiliate_url/shortcode`).
+- Warning payload più precisi su configurazione comportamento agente globale e disponibilità istruzioni Source.
+- Nessuna modifica a OpenAI Service, indice affiliati, ricerca affiliate, batch/sync, provider/importer, shortcode rendering o tracking.
 
 ## Novità 2.25.21 — PR 8.21 Safe AI Payload JSON Builder and Download Hardening
 

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.21
+ * Version: 2.25.22
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.21');
+define('ALMA_VERSION', '2.25.22');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -114,6 +114,9 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         $warnings = array();
         $selection_context = array();
         $affiliate_links = array();
+        $source_agent_prompts_map = array();
+        $has_any_source_prompt = false;
+        $missing_source_prompt_count = 0;
         $selected = array_values((array)($session['selected_results'] ?? array()));
 
         foreach ($selected as $row) {
@@ -163,7 +166,31 @@ class ALMA_AI_Content_Agent_Draft_Builder {
                     if (is_array($src_settings)) { $source_prompt = sanitize_textarea_field((string)($src_settings['ai_source_instructions'] ?? '')); }
                 }
             }
-            if ($source_prompt === '') { $warnings[] = 'Comportamento agente AI/Sources non configurato.'; }
+            if ($source_prompt !== '') {
+                $has_any_source_prompt = true;
+                $prompt_key_parts = array(
+                    sanitize_key($source_provider !== '' ? $source_provider : 'unknown'),
+                    sanitize_title($source_name !== '' ? $source_name : (string)($row['source'] ?? '')),
+                    (string)$source_meta_id,
+                    md5($source_prompt),
+                );
+                $source_prompt_key = implode(':', $prompt_key_parts);
+                if (!isset($source_agent_prompts_map[$source_prompt_key])) {
+                    $source_agent_prompts_map[$source_prompt_key] = array(
+                        'source_agent_prompt_key' => $source_prompt_key,
+                        'provider' => sanitize_text_field($source_provider),
+                        'source' => sanitize_text_field($source_name !== '' ? $source_name : ($row['source'] ?? '')),
+                        'source_id' => $source_meta_id,
+                        'label' => sanitize_text_field($source_name !== '' ? $source_name : ($row['source'] ?? '')),
+                        'prompt' => $source_prompt,
+                        'link_ids' => array(),
+                    );
+                }
+                $source_agent_prompts_map[$source_prompt_key]['link_ids'][] = (int)$p->ID;
+            } else {
+                $missing_source_prompt_count++;
+                $source_prompt_key = '';
+            }
 
             $affiliate_links[] = array(
                 'id' => (int)$p->ID,
@@ -180,6 +207,8 @@ class ALMA_AI_Content_Agent_Draft_Builder {
                 'score' => (int)($row['score'] ?? 0),
                 'reason' => sanitize_text_field($row['reason'] ?? ''),
                 'affiliate_link_post_id' => (int)$p->ID,
+                'source_agent_prompt_key' => $source_prompt_key,
+                'source_agent_prompt_available' => $source_prompt !== '',
                 'source_agent_prompt' => $source_prompt,
             );
         }
@@ -194,8 +223,8 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'Non inventare link affiliati.',
             'Preferire shortcode WordPress per box/link affiliati.',
             'Usare affiliate_url solo per link testuali diretti quando necessario.',
-            'Non usare URL raw dove è richiesto shortcode.',
             'Compilare affiliate_shortcodes_used con gli shortcode realmente usati.',
+            'Se usi URL diretti, compilare affiliate_urls_used con gli URL realmente usati.',
             'Non usare link non presenti nel payload.',
         );
         if (!empty($profile_payload['instruction_profile_rules']['affiliate_rules'])) { $affiliate_rules[] = $profile_payload['instruction_profile_rules']['affiliate_rules']; }
@@ -208,6 +237,21 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         );
         if (!empty($profile_payload['instruction_profile_rules']['seo_rules'])) { $seo_rules[] = $profile_payload['instruction_profile_rules']['seo_rules']; }
 
+        $source_agent_prompts = array_values(array_map(function ($entry) {
+            $entry['link_ids'] = array_values(array_unique(array_map('absint', (array)($entry['link_ids'] ?? array()))));
+            return $entry;
+        }, $source_agent_prompts_map));
+
+        $agent_behavior = '';
+        if ($agent_behavior === '' && $has_any_source_prompt) {
+            $warnings[] = 'Comportamento agente globale non configurato; presenti istruzioni Source per alcuni link.';
+        } elseif ($agent_behavior === '' && empty($source_agent_prompts)) {
+            $warnings[] = 'Comportamento agente globale e istruzioni Source non configurati.';
+        }
+        if ($missing_source_prompt_count > 0 && $has_any_source_prompt) {
+            $warnings[] = 'Alcuni link manuali o legacy non hanno istruzioni Source dedicate.';
+        }
+
         return array_merge(array(
             'task'=>'create_article_draft_from_selected_sources',
             'site_context'=>array('site_name'=>get_bloginfo('name'),'language'=>get_bloginfo('language'),'generated_at'=>current_time('mysql')),
@@ -215,16 +259,26 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'idea_context'=>array('idea_title'=>sanitize_text_field($session['last_query']['content_search_query'] ?? ''),'idea_prompt'=>sanitize_textarea_field($session['openai_prompt'] ?? ''),'search_query'=>sanitize_text_field($session['last_query']['search_terms'] ?? ($session['last_query']['content_search_query'] ?? '')),'selected_results_count'=>count($selection_context)),
             'openai_prompt'=>sanitize_textarea_field($session['openai_prompt'] ?? ($session['last_query']['temporary_instructions'] ?? '')),
             'temporary_instructions'=>sanitize_textarea_field($session['last_query']['temporary_instructions'] ?? ''),
-            'rules'=>array('output_json'=>true,'title_required'=>true,'content_required'=>true,'slug_optional'=>true,'no_raw_affiliate_urls'=>true),
+            'rules'=>array(
+                'output_json'=>true,
+                'title_required'=>true,
+                'content_required'=>true,
+                'slug_optional'=>true,
+                'prefer_affiliate_shortcodes'=>true,
+                'allow_affiliate_urls_for_text_links'=>true,
+                'do_not_invent_affiliate_urls'=>true,
+                'use_only_payload_affiliate_links'=>true,
+            ),
             'selection_context'=>$selection_context,
             'affiliate_links'=>$affiliate_links,
+            'source_agent_prompts'=>$source_agent_prompts,
             'posts'=>array(),'documents'=>array(),'sources_online'=>array(),'pages'=>array(),'media'=>array(),
             'affiliate_rules'=>$affiliate_rules,
             'seo_rules'=>$seo_rules,
             'media_rules'=>array(),
             'output_contract'=>array('title','slug','excerpt','content','seo_title','seo_description','affiliate_shortcodes_used','affiliate_urls_used','media_used','warnings'),
             'warnings'=>array_values(array_unique($warnings)),
-            'agent_behavior'=>'',
+            'agent_behavior'=>$agent_behavior,
         ), $profile_payload);
     }
 


### PR DESCRIPTION
### Motivation
- Remove the contradictory absolute `no_raw_affiliate_urls` policy and make affiliate URL usage explicit and consistent with the payload data.  
- Avoid duplicating long Source prompts inside every `affiliate_link` and provide a single deduplicated place for AI Source instructions.  
- Provide clearer, non-repetitive warnings about agent behavior / Source prompts while keeping manual/legacy links usable and preserving backward compatibility.

### Description
- In `build_payload_from_selection_session` (`includes/class-ai-content-agent-draft-builder.php`) replaced the `no_raw_affiliate_urls` rule with explicit rules: `prefer_affiliate_shortcodes`, `allow_affiliate_urls_for_text_links`, `do_not_invent_affiliate_urls`, and `use_only_payload_affiliate_links`, and updated narrative `affiliate_rules` to require `affiliate_urls_used` when direct URLs are used.  
- Added a global `source_agent_prompts` block that collects only non-empty Source prompts, deduplicates them using a stable key (`provider/source/source_id + prompt hash`) and records associated `link_ids`, and added lightweight per-link references: `source_agent_prompt_key` and `source_agent_prompt_available` while preserving `source_agent_prompt` for compatibility.  
- Refined warnings/agent behavior logic to produce precise messages: `Comportamento agente globale non configurato; presenti istruzioni Source per alcuni link.` or `Comportamento agente globale e istruzioni Source non configurati.`, and a single synthetic note when some manual/legacy links lack source prompts; links without prompts are retained and usable.  
- Bumped plugin version to `2.25.22` (`affiliate-link-manager-ai.php`) and updated `README.md` and `CHANGELOG.md` with the PR notes; no changes were made to OpenAI service, affiliate index/search, batch/sync, providers/importer, shortcode rendering, tracking or DB schema.

### Testing
- Ran PHP linting: `php -l affiliate-link-manager-ai.php`, `php -l includes/class-ai-content-agent-draft-builder.php`, `php -l includes/class-ai-content-agent-selection-session.php`, `php -l includes/class-ai-content-agent-ideas.php`, and `php -l includes/class-ai-content-agent-instructions-manager.php`, all returned no syntax errors.  
- Performed text checks/grep for new keys and messages: verified presence of `2.25.22`, absence of `no_raw_affiliate_urls`, presence of `prefer_affiliate_shortcodes`, `allow_affiliate_urls_for_text_links`, `do_not_invent_affiliate_urls`, `source_agent_prompts`, the updated agent-behavior warning text, and `affiliate_urls_used` in `output_contract`.  
- Committed changes and prepared PR: commit created and files changed (`includes/class-ai-content-agent-draft-builder.php`, `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`).  All automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ff7b8aec83329f2b6edefc32fb4f)