### PR TITLE
PR 8.23 — Enforce Valid OpenAI Draft JSON and Improve API Error Feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.25.23 — PR 8.23 Enforce Valid OpenAI Draft JSON and Improve API Error Feedback
+- Verificato e aggiornato il wrapper OpenAI su endpoint `POST /v1/responses` con gestione strutturata di `response_format`, `max_output_tokens`, `timeout` e codifica errori API.
+- Implementata richiesta output JSON tecnica per `content_draft_generation` con schema contract e fallback automatico a JSON object mode se `response_format` non supportato.
+- Aggiornato prompt finale Draft Builder: risposta solo JSON object, niente Markdown/code-fence, campi contract obbligatori e array vuoti quando non usati.
+- Parser risposta AI reso robusto (decode diretto, strip code-fence, estrazione primo JSON bilanciato) senza retry automatici e senza fatal.
+- Validazione output contract rafforzata con blocco draft su `title/content` vuoti e normalizzazione difensiva dei campi array/stringa non critici.
+- Logging e feedback admin migliorati con distinzione errori API vs JSON (error category/code, `json_last_error_msg`, lunghezza risposta, preview sanitizzata, campi mancanti, uso `response_format`).
+- Confermato uso effettivo di `max_output_tokens` configurato nel task draft generation; nessuna modifica a indice affiliate, ricerca affiliate, batch/sync, provider/importer, shortcode/tracking.
+
 ## 2.25.22 — PR 8.22 Refine AI Draft Payload Affiliate URL Policy and Source Instructions
 - Rifinita la policy payload per link affiliati nel Draft Builder: shortcode WordPress preferiti, `affiliate_url` consentito per link testuali diretti, divieto di URL inventati e uso esclusivo dei link presenti nel payload.
 - Aggiunta sezione globale `source_agent_prompts` con prompt Source non vuoti, deduplicati e collegati ai `link_ids`, per ridurre duplicazioni nei singoli `affiliate_links`.

--- a/README.md
+++ b/README.md
@@ -141,11 +141,21 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.22
+Versione 2.25.23
 
 
 
 
+
+
+## Novità 2.25.23 — PR 8.23 Enforce Valid OpenAI Draft JSON and Improve API Error Feedback
+
+- Creazione bozza articolo da Idea/Sessione con richiesta output JSON più vincolante (solo oggetto JSON, niente Markdown) e contratto campi esplicito.
+- Supporto `response_format` nel wrapper OpenAI con uso prioritario schema JSON per `content_draft_generation` e fallback sicuro quando non supportato dal modello.
+- Parser risposta AI robusto: decode diretto, rimozione code-fence, estrazione JSON bilanciato e diagnostica dettagliata su errori di parsing.
+- Validazione output contract con controllo campi obbligatori e blocco creazione bozza se `title` o `content` sono vuoti.
+- Distinzione esplicita errori API vs errori JSON con log/notice più utili (categoria errore, codice, preview sicura risposta).
+- Nessuna modifica a indice Link affiliati, ricerca affiliate, batch/sync, provider/importer, shortcode rendering o tracking.
 
 ## Novità 2.25.22 — PR 8.22 Refine AI Draft Payload Affiliate URL Policy and Source Instructions
 

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.22
+ * Version: 2.25.23
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.22');
+define('ALMA_VERSION', '2.25.23');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -7,6 +7,71 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         return array_merge(array('success'=>false,'error'=>sanitize_text_field($message),'warnings'=>array()), $extra);
     }
 
+
+    private static function sanitize_response_preview($text, $max = 800) {
+        $text = trim(preg_replace('/\s+/', ' ', wp_strip_all_tags((string)$text)));
+        if (strlen($text) > $max) { $text = substr($text, 0, $max) . '…'; }
+        return $text;
+    }
+
+    private static function parse_ai_json_response($response_text) {
+        $raw = (string)$response_text;
+        if (trim($raw) === '') {
+            return new WP_Error('empty_response', 'OpenAI ha restituito una risposta vuota.');
+        }
+
+        $attempt = json_decode($raw, true);
+        if (is_array($attempt)) { return $attempt; }
+        $first_error = function_exists('json_last_error_msg') ? json_last_error_msg() : 'json_decode_failed';
+
+        $clean = preg_replace('/^```(?:json)?\s*/i', '', trim($raw));
+        $clean = preg_replace('/\s*```$/', '', (string)$clean);
+        $attempt = json_decode((string)$clean, true);
+        if (is_array($attempt)) { return $attempt; }
+
+        $extracted = ALMA_AI_Content_Agent_Text_Utils::extract_first_json((string)$clean);
+        $attempt = json_decode((string)$extracted, true);
+        if (is_array($attempt)) { return $attempt; }
+
+        $second_error = function_exists('json_last_error_msg') ? json_last_error_msg() : 'json_decode_failed';
+        $code = (strpos((string)$clean, '```') !== false || strpos((string)$raw, '```') !== false) ? 'markdown_wrapper' : 'json_decode_failed';
+        return new WP_Error($code, 'OpenAI ha restituito una risposta non JSON valida.', array('json_error'=>$second_error ?: $first_error));
+    }
+
+    private static function validate_output_contract($parsed) {
+        if (!is_array($parsed)) { return new WP_Error('json_not_object', 'La risposta JSON non contiene un oggetto valido.'); }
+        $required = array('title','content','excerpt','seo_title','seo_description','affiliate_shortcodes_used','affiliate_urls_used','media_used','warnings');
+        $missing = array();
+        foreach ($required as $key) { if (!array_key_exists($key, $parsed)) { $missing[] = $key; } }
+
+        $out = $parsed;
+        foreach (array('excerpt','seo_title','seo_description','slug') as $k) { if (!isset($out[$k]) || !is_string($out[$k])) { $out[$k] = ''; } }
+        foreach (array('affiliate_shortcodes_used','affiliate_urls_used','media_used','warnings') as $k) { if (!isset($out[$k]) || !is_array($out[$k])) { $out[$k] = array(); } }
+        $out['title'] = isset($out['title']) ? (string)$out['title'] : '';
+        $out['content'] = isset($out['content']) ? (string)$out['content'] : '';
+        if (trim($out['title']) === '') { return new WP_Error('title_empty', 'La risposta JSON è valida ma il campo title è vuoto.', array('missing_fields'=>$missing)); }
+        if (trim(wp_strip_all_tags($out['content'])) === '') { return new WP_Error('content_empty', 'La risposta JSON è valida ma il campo content è vuoto.', array('missing_fields'=>$missing)); }
+        if (!empty($missing)) { $out['_missing_fields'] = $missing; }
+        return $out;
+    }
+
+    private static function build_draft_generation_prompt() {
+        return 'Rispondi esclusivamente con un singolo oggetto JSON valido. Non usare Markdown. Non usare blocchi ```json. Non aggiungere spiegazioni o testo prima/dopo il JSON. Includi sempre: title, slug, excerpt, content, seo_title, seo_description, affiliate_shortcodes_used, affiliate_urls_used, media_used, warnings. content deve essere stringa JSON valida. Se usi shortcode, inseriscili sia in content sia in affiliate_shortcodes_used. Se usi URL affiliati diretti, inseriscili in affiliate_urls_used. Se non usi shortcode/URL/media usa array vuoti. Non inventare campi.';
+    }
+
+    private static function build_draft_response_format() {
+        return array('type'=>'json_schema','name'=>'content_draft_generation','schema'=>array('type'=>'object','additionalProperties'=>false,'required'=>array('title','slug','excerpt','content','seo_title','seo_description','affiliate_shortcodes_used','affiliate_urls_used','media_used','warnings'),'properties'=>array('title'=>array('type'=>'string'),'slug'=>array('type'=>'string'),'excerpt'=>array('type'=>'string'),'content'=>array('type'=>'string'),'seo_title'=>array('type'=>'string'),'seo_description'=>array('type'=>'string'),'affiliate_shortcodes_used'=>array('type'=>'array','items'=>array('type'=>'string')),'affiliate_urls_used'=>array('type'=>'array','items'=>array('type'=>'string')),'media_used'=>array('type'=>'array','items'=>array('type'=>'string')),'warnings'=>array('type'=>'array','items'=>array('type'=>'string')))));
+    }
+
+    private static function map_openai_error_to_admin_message($res, $fallback='Risposta OpenAI fallita.') {
+        $code = sanitize_key((string)($res['error_code'] ?? ''));
+        if ($code === 'empty_response') return 'OpenAI ha restituito una risposta vuota.';
+        if ($code === 'response_format_unsupported') return 'Il modello non supporta response_format: fallback attivo.';
+        if ($code === 'timeout') return 'Timeout OpenAI: aumenta timeout o riduci il payload.';
+        if ($code === 'rate_limit') return 'Rate limit OpenAI raggiunto: riprova tra poco.';
+        if ($code === 'auth_error') return 'Errore autenticazione OpenAI: verifica API key.';
+        return sanitize_text_field((string)($res['error'] ?? $fallback));
+    }
     private static function resolve_document_knowledge_item_id($row) {
         $candidates = array(
             $row['knowledge_item_id'] ?? '',
@@ -404,11 +469,33 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         $payload['sources_online'] = $ctx['sources_online'];
         $payload['pages'] = $ctx['pages'];
         $payload['media'] = $ctx['media'];
-        $prompt = 'Genera solo JSON con chiavi: title,content,slug,warnings. Usa solo shortcode affiliati autorizzati.';
-        $res = ALMA_OpenAI_Service::request(array('system_prompt'=>'Sei un content editor WordPress. Output solo JSON valido.', 'user_prompt'=>$prompt.' CONTEXT: '.wp_json_encode($payload), 'json_output'=>true, 'max_output_tokens'=>1800));
-        if (empty($res['success'])) { return self::fail($res['error'] ?? 'Risposta OpenAI fallita.', $res['model'] ?? '', 'session:user:'.$user_id); }
-        $parsed = json_decode((string)$res['response'], true); if (!is_array($parsed)) { $parsed = json_decode(ALMA_AI_Content_Agent_Text_Utils::extract_first_json((string)$res['response']), true); }
-        if (!is_array($parsed)) { return self::fail('Draft JSON non valido', $res['model'] ?? '', 'session:user:'.$user_id); }
+        $prompt = self::build_draft_generation_prompt();
+        $configured_max_tokens = absint(get_option('alma_openai_max_output_tokens', 1800));
+        $max_output_tokens = $configured_max_tokens > 0 ? $configured_max_tokens : 1800;
+        $response_format = self::build_draft_response_format();
+        $res = ALMA_OpenAI_Service::request(array('system_prompt'=>'Sei un content editor WordPress per output strutturato.', 'user_prompt'=>$prompt.' CONTEXT: '.wp_json_encode($payload), 'response_format'=>$response_format, 'json_output'=>true, 'max_output_tokens'=>$max_output_tokens, 'timeout'=>absint(get_option('alma_openai_timeout', 120))));
+        if (empty($res['success']) && (($res['error_code'] ?? '') === 'response_format_unsupported' || strpos(strtolower((string)($res['error'] ?? '')), 'response_format') !== false)) {
+            $res = ALMA_OpenAI_Service::request(array('system_prompt'=>'Sei un content editor WordPress per output strutturato.', 'user_prompt'=>$prompt.' CONTEXT: '.wp_json_encode($payload), 'json_output'=>true, 'max_output_tokens'=>$max_output_tokens, 'timeout'=>absint(get_option('alma_openai_timeout', 120))));
+            $res['response_format_used'] = 'fallback_json_object';
+        }
+        if (empty($res['success'])) {
+            return self::fail(self::map_openai_error_to_admin_message($res), $res['model'] ?? '', 'session:user:'.$user_id, array('error_category'=>'api','error_code'=>$res['error_code'] ?? 'openai_error'));
+        }
+        $parsed = self::parse_ai_json_response((string)($res['response'] ?? ''));
+        if (is_wp_error($parsed)) {
+            $diag = array('task'=>self::TASK_SELECTION,'model'=>$res['model'] ?? '','error_category'=>'json','error_code'=>$parsed->get_error_code(),'json_error'=>sanitize_text_field((string)$parsed->get_error_data('json_error')),'response_length'=>strlen((string)($res['response'] ?? '')),'response_preview'=>self::sanitize_response_preview((string)($res['response'] ?? ''), 1000),'response_format_used'=>sanitize_text_field((string)($res['response_format_used'] ?? 'none')),'max_output_tokens'=>absint($res['max_output_tokens'] ?? $max_output_tokens));
+            ALMA_AI_Usage_Logger::log(array('task'=>self::TASK_SELECTION,'success'=>false,'error'=>'JSON error ['.$diag['error_code'].']: '.$parsed->get_error_message(),'model'=>$res['model'] ?? '','reference_id'=>'session:user:'.$user_id));
+            if (defined('WP_DEBUG') && WP_DEBUG) { error_log('ALMA Draft JSON diagnostic: '.wp_json_encode($diag)); }
+            return self::fail('OpenAI ha restituito una risposta non JSON. Controlla il log per la preview.', $res['model'] ?? '', 'session:user:'.$user_id, array('error_category'=>'json','error_code'=>$parsed->get_error_code()));
+        }
+        $validated = self::validate_output_contract($parsed);
+        if (is_wp_error($validated)) {
+            $missing_fields = (array)$validated->get_error_data('missing_fields');
+            $diag = array('task'=>self::TASK_SELECTION,'model'=>$res['model'] ?? '','error_category'=>'json_contract','error_code'=>$validated->get_error_code(),'missing_fields'=>$missing_fields,'response_length'=>strlen((string)($res['response'] ?? '')),'response_preview'=>self::sanitize_response_preview((string)($res['response'] ?? ''), 500),'response_format_used'=>sanitize_text_field((string)($res['response_format_used'] ?? 'none')));
+            if (defined('WP_DEBUG') && WP_DEBUG) { error_log('ALMA Draft contract diagnostic: '.wp_json_encode($diag)); }
+            return self::fail($validated->get_error_message(), $res['model'] ?? '', 'session:user:'.$user_id, array('error_category'=>'json_contract','error_code'=>$validated->get_error_code(),'missing_fields'=>$missing_fields));
+        }
+        $parsed = $validated;
         $parsed['content_html'] = (string)($parsed['content'] ?? '');
         $candidate_affiliate_ids = array_values(array_map('absint', wp_list_pluck((array)$ctx['affiliate_links'], 'id')));
         $candidate_image_ids = array_values(array_map('absint', wp_list_pluck((array)$ctx['media'], 'attachment_id')));

--- a/includes/class-openai-service.php
+++ b/includes/class-openai-service.php
@@ -25,7 +25,15 @@ class ALMA_OpenAI_Service {
 
         $body = array('model'=>$model,'input'=>$input,'max_output_tokens'=>$max_output_tokens);
         if ($temperature >= 0 && $temperature <= 2) { $body['temperature'] = $temperature; }
-        if (!empty($args['json_output'])) { $body['text'] = array('format'=>array('type'=>'json_object')); }
+
+        $response_format_used = 'none';
+        if (!empty($args['response_format']) && is_array($args['response_format'])) {
+            $body['text'] = array('format'=>$args['response_format']);
+            $response_format_used = sanitize_key((string)($args['response_format']['type'] ?? 'custom'));
+        } elseif (!empty($args['json_output'])) {
+            $body['text'] = array('format'=>array('type'=>'json_object'));
+            $response_format_used = 'json_object';
+        }
 
         $start = microtime(true);
         $res = wp_remote_post('https://api.openai.com/v1/responses', array(
@@ -35,12 +43,20 @@ class ALMA_OpenAI_Service {
         ));
         $rt = round((microtime(true)-$start)*1000);
 
-        if (is_wp_error($res)) return array('success'=>false,'error'=>__('Errore connessione AI', 'affiliate-link-manager-ai'),'response_time'=>$rt);
+        if (is_wp_error($res)) return array('success'=>false,'error'=>__('Errore connessione AI', 'affiliate-link-manager-ai'),'error_code'=>'api_connection_error','error_category'=>'api','response_time'=>$rt,'model'=>$model,'max_output_tokens'=>$max_output_tokens,'response_format_used'=>$response_format_used);
         $code = wp_remote_retrieve_response_code($res);
         $data = json_decode(wp_remote_retrieve_body($res), true);
         if ($code < 200 || $code >= 300) {
             $err = $data['error']['message'] ?? __('Errore OpenAI', 'affiliate-link-manager-ai');
-            return array('success'=>false,'error'=>sanitize_text_field($err),'response_time'=>$rt,'model'=>$model);
+            $error_code = 'openai_http_error';
+            $error_type = sanitize_key((string)($data['error']['type'] ?? ''));
+            $error_msg_l = strtolower((string)($data['error']['message'] ?? ''));
+            if ($code === 401 || $code === 403) { $error_code = 'auth_error'; }
+            elseif ($code === 429) { $error_code = 'rate_limit'; }
+            elseif ($code === 408) { $error_code = 'timeout'; }
+            elseif (strpos($error_msg_l, 'response_format') !== false) { $error_code = 'response_format_unsupported'; }
+            elseif (strpos($error_msg_l, 'model') !== false && strpos($error_msg_l, 'support') !== false) { $error_code = 'model_unsupported'; }
+            return array('success'=>false,'error'=>sanitize_text_field($err),'error_code'=>$error_code,'error_type'=>$error_type,'error_category'=>'api','http_status'=>$code,'response_time'=>$rt,'model'=>$model,'max_output_tokens'=>$max_output_tokens,'response_format_used'=>$response_format_used);
         }
         $text = '';
         if (!empty($data['output_text'])) { $text = (string)$data['output_text']; }
@@ -49,7 +65,7 @@ class ALMA_OpenAI_Service {
                 foreach ((array)($out['content'] ?? array()) as $c) { if (($c['type'] ?? '') === 'output_text' && !empty($c['text'])) { $text .= $c['text']; } }
             }
         }
-        if (trim($text) === '') return array('success'=>false,'error'=>__('Risposta AI non valida', 'affiliate-link-manager-ai'),'response_time'=>$rt,'model'=>$data['model'] ?? $model);
-        return array('success'=>true,'response'=>$text,'model'=>$data['model'] ?? $model,'response_time'=>$rt,'usage'=>$data['usage'] ?? null);
+        if (trim($text) === '') return array('success'=>false,'error'=>__('Risposta AI vuota', 'affiliate-link-manager-ai'),'error_code'=>'empty_response','error_category'=>'api','response_time'=>$rt,'model'=>$data['model'] ?? $model,'max_output_tokens'=>$max_output_tokens,'response_format_used'=>$response_format_used);
+        return array('success'=>true,'response'=>$text,'model'=>$data['model'] ?? $model,'response_time'=>$rt,'usage'=>$data['usage'] ?? null,'max_output_tokens'=>$max_output_tokens,'response_format_used'=>$response_format_used);
     }
 }


### PR DESCRIPTION
### Motivation
- Risolvere i casi in cui il flusso “Crea bozza articolo da Idea/Sessione” fallisce con il messaggio generico "Draft JSON non valido" nonostante il payload inviato fosse corretto e completo.
- Rendere il flusso robusto rispetto a risposte OpenAI non conformi (markdown wrappers, testo extra, decode falliti) e fornire diagnosi utili agli amministratori.
- Distinguere chiaramente errori API (timeout, auth, rate limit, response_format non supportato) dagli errori JSON/contract per migliorare logging e feedback.

### Description
- Aggiornato il wrapper OpenAI `ALMA_OpenAI_Service::request()` per supportare `response_format` opzionale, riportare `response_format_used` e propagare `max_output_tokens` e `timeout`, oltre a classificare errori API con `error_code`/`error_category`. (file: `includes/class-openai-service.php`)
- Nel Draft Builder `ALMA_AI_Content_Agent_Draft_Builder` introdotti: prompt finale vincolante (`build_draft_generation_prompt()`), richiesta `response_format` con schema JSON per `content_draft_generation` e fallback a `json_object` se non supportato dal modello. (file: `includes/class-ai-content-agent-draft-builder.php`)
- Implementato parser robusto `parse_ai_json_response()` che esegue: decode diretto → rimozione code fences Markdown → estrazione primo oggetto JSON bilanciato; restituisce `WP_Error` diagnostico con `json_last_error_msg()` quando il parsing fallisce. (file: `includes/class-ai-content-agent-draft-builder.php`)
- Aggiunta validazione dell’`output_contract` tramite `validate_output_contract()` che impone campi richiesti (`title`, `content`, `excerpt`, `seo_title`, `seo_description`, `affiliate_shortcodes_used`, `affiliate_urls_used`, `media_used`, `warnings`), normalizza array/stringhe non critici e blocca la creazione della bozza se `title` o `content` risultano vuoti. (file: `includes/class-ai-content-agent-draft-builder.php`)
- Migliorato logging/diagnostica sicura: log con categoria errore (api/json/json_contract), codice interno, `json_last_error_msg`, lunghezza risposta e preview sanitizzata/troncata senza esporre prompt/payload sensibili, e mappatura messaggi admin più utili con `map_openai_error_to_admin_message()`. (file: `includes/class-ai-content-agent-draft-builder.php`)
- Versioning/documentazione: aggiornato plugin header e costante `ALMA_VERSION` a `2.25.23` e aggiunte note in `README.md` e `CHANGELOG.md`. (file: `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`)

### Testing
- Sintassi PHP verificata con: `php -l affiliate-link-manager-ai.php`, `php -l includes/class-ai-content-agent-draft-builder.php`, `php -l includes/class-openai-service.php`, `php -l includes/class-ai-utils.php`, `php -l includes/class-ai-usage-logger.php`, `php -l includes/class-ai-content-agent-admin.php`; tutti i controlli hanno restituito "No syntax errors detected". ✅
- Verificata a livello di codice la costruzione della request verso `POST /v1/responses` inclusi i parametri `model`, `max_output_tokens`, `timeout` e l’uso opzionale di `response_format`; confermato il fallback quando la chiamata API segnala `response_format` non supportato. ✅
- Test manuale end-to-end nell’ambiente WordPress reale non eseguito in questa sessione (mancano credenziali OpenAI e UI attiva); raccomandazione: eseguire un test in ambiente di staging con la stessa Idea/payload e le impostazioni `model=gpt-5.4`, `max_output_tokens=10000`, `timeout=120` per confermare comportamento runtime, preview log diagnostico e creazione bozza. ⚠️
- Limitazioni residue: `generate_for_idea()` non è stato convertito nello stesso modo per minimizzare scope della PR; la modifica principale interessa il flusso di creazione bozza da sessione/idea selezionata come richiesto.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa063976bc8332b55c125e7445f3be)