### PR TITLE
Separare download payload OpenAI e payload debug completo (2.25.25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.25.25 — PR 8.25 Separate OpenAI Payload Download from Full Debug JSON
+- Corretto il download **Scarica JSON payload OpenAI**: ora esporta il payload compatto prodotto da `normalize_payload_for_openai()`, non il payload diagnostico completo.
+- Aggiunto il download separato **Scarica JSON debug completo**, con wrapper esplicito `debug_payload_full` + `openai_payload_normalized` per confrontare diagnostica interna e payload realmente inviato al modello.
+- Confermata esclusione dal payload OpenAI normalizzato di `content_search_query`, `theme`, `destination`, `selected_results_count`, `selection_context`, score/reason/provider/source/provenance, Source prompt, snapshot istruzioni, `internal_notes`, autori e timestamp amministrativi.
+- Rafforzata la sintesi del contesto Viator escludendo anche righe tecniche provider/source dal contesto breve dei link affiliati.
+- Versione plugin aggiornata a `2.25.25`.
+
 ## 2.25.24 — PR 8.24 Compact OpenAI Draft Payload and JSON Diagnostics
 - Normalizzato il payload inviato a OpenAI nel flusso `create_article_draft_from_selected_sources`: dati editoriali, profilo, regole e link affiliati vengono inviati in sezioni compatte dedicate, senza campi diagnostici o duplicazioni del prompt.
 - Separati payload completo diagnostico/download e payload effettivamente inviato a OpenAI, preservando i dati tecnici per debug interno senza esporli al modello.

--- a/README.md
+++ b/README.md
@@ -141,12 +141,20 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.24
+Versione 2.25.25
 
 
 
 
 
+
+## Novità 2.25.25 — PR 8.25 Separate OpenAI Payload Download from Full Debug JSON
+
+- Il pulsante **Scarica JSON payload OpenAI** genera ora il JSON normalizzato compatto prodotto da `normalize_payload_for_openai()`, cioè la struttura usata nel contesto inviato a OpenAI.
+- Aggiunto il pulsante separato **Scarica JSON debug completo**: il file contiene `payload_type`, `debug_payload_full` e `openai_payload_normalized`, così è esplicito quali dati restano solo diagnostici e quali dati entrano nel prompt OpenAI.
+- Il payload OpenAI esportabile resta privo di campi diagnostici/amministrativi (`content_search_query`, `theme`, `destination`, `selected_results_count`, `selection_context`, score/reason/provider/source/provenance, Source prompt, snapshot istruzioni, `internal_notes`, audit timestamps/autori) e mantiene `slug_required: true`.
+- Le regole duplicate restano deduplicate nelle sezioni finali `affiliate_rules`, `seo_rules`, `source_policies` ed `editorial_instructions.operational_rules`; il prompt personalizzato del profilo è disponibile in alto in `editorial_instructions.custom_prompt`.
+- Il contesto Viator nei link affiliati viene ulteriormente sintetizzato escludendo righe tecniche su provider/source oltre a product code, rating/recensioni e note operative.
 
 ## Novità 2.25.24 — PR 8.24 Compact OpenAI Draft Payload and JSON Diagnostics
 
@@ -413,13 +421,15 @@ Miglioramenti principali:
 
 
 
-### AI Content Agent — payload OpenAI compatto (2.25.24)
+### AI Content Agent — payload OpenAI compatto e download debug separato (2.25.25)
 
 Nel flusso **Crea Bozza con OpenAI** da risultati selezionati, il payload effettivamente inviato al modello viene ora normalizzato in una struttura compatta focalizzata sulla generazione editoriale.
 
 - Il modello riceve sezioni dedicate per task, sito, richiesta articolo, istruzioni editoriali, requisiti output, link affiliati, regole affiliate/SEO, policy fonti e warning.
-- I dati diagnostici o amministrativi restano disponibili nel payload completo di debug/download, ma non vengono inviati a OpenAI.
-- Sono esclusi dal payload AI campi come `theme`, `destination`, `selected_results_count`, score/reason/provider/source/provenance, prompt Source completi, snapshot istruzioni ridondanti e `internal_notes`.
+- **Scarica JSON payload OpenAI** esporta il payload normalizzato realmente usato nel contesto OpenAI (`alma-ai-openai-payload-idea-*.json`).
+- **Scarica JSON debug completo** esporta un wrapper diagnostico (`alma-ai-debug-payload-idea-*.json`) con `debug_payload_full` per troubleshooting e `openai_payload_normalized` per confronto diretto.
+- I dati diagnostici o amministrativi restano disponibili solo in `debug_payload_full`, ma non vengono inviati a OpenAI.
+- Sono esclusi dal payload AI campi come `content_search_query`, `theme`, `destination`, `selected_results_count`, `selection_context`, score/reason/provider/source/provenance, prompt Source completi, snapshot istruzioni ridondanti, `internal_notes`, autori e timestamp amministrativi.
 - Il prompt personalizzato del profilo istruzioni viene esposto in alto dentro le istruzioni editoriali, insieme a tono, pubblico e stile.
 - Il contesto Viator viene sintetizzato in modo prudente, senza blocchi provider tecnici, rating/recensioni aggregate, product code o note operative lunghe.
 - Il contract JSON richiede sempre `title`, `slug`, `excerpt`, `content`, `seo_title`, `seo_description`, `affiliate_shortcodes_used`, `affiliate_urls_used`, `media_used` e `warnings`. Se lo slug manca o non è valido, viene generato/sanificato localmente senza bloccare la bozza.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.24
+ * Version: 2.25.25
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.24');
+define('ALMA_VERSION', '2.25.25');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -104,8 +104,9 @@ class ALMA_AI_Content_Agent_Admin {
         } elseif ($do === 'clear_selection_session') {
             ALMA_AI_Content_Agent_Selection_Session::clear();
             $result = array('success' => true, 'message' => 'Sessione contenuto svuotata.');
-        } elseif ($do === 'download_ai_payload_json') {
+        } elseif ($do === 'download_ai_payload_json' || $do === 'download_ai_debug_payload_json') {
             $idea_id = absint($_POST['idea_id'] ?? 0);
+            $payload_mode = $do === 'download_ai_debug_payload_json' ? 'debug' : 'openai';
             if ($idea_id < 1) {
                 $result = array('success'=>false,'message'=>'Idea non valida per il download JSON.');
             } else {
@@ -114,7 +115,7 @@ class ALMA_AI_Content_Agent_Admin {
                     $result = array('success'=>false,'message'=>'Idea non trovata: impossibile scaricare il JSON payload AI.');
                 } else {
                     ALMA_AI_Content_Agent_Selection_Session::load_from_idea($idea);
-                    $download = ALMA_AI_Content_Agent_Draft_Builder::download_payload_json_from_selection_session(get_current_user_id(), $idea_id);
+                    $download = ALMA_AI_Content_Agent_Draft_Builder::download_payload_json_from_selection_session(get_current_user_id(), $idea_id, $payload_mode);
                     if (is_wp_error($download)) {
                         $result = array('success'=>false,'message'=>$download->get_error_message());
                     }
@@ -437,7 +438,8 @@ class ALMA_AI_Content_Agent_Admin {
         self::action_form('new_content_idea','Crea nuova idea');
         if($active_idea_id){ echo '<form id="alma-save-idea-form" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_content_idea"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><input type="hidden" name="idea_status" value="bozza"><input type="hidden" id="alma-save-idea-openai-prompt" name="openai_prompt" value="'.esc_attr($active_idea['prompt']??'').'"><input type="hidden" id="alma-save-idea-instruction-profile-id" name="instruction_profile_id" value="'.(int)$selected_profile_id.'"><button class="button">Salva idea</button></form>'; }
         if($active_idea_id){ echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="delete_content_idea"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><button class="button">Elimina</button></form>'; }
-        self::action_form('download_ai_payload_json','Scarica JSON payload AI',$active_idea_id ? '<input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'">' : '');
+        self::action_form('download_ai_payload_json','Scarica JSON payload OpenAI',$active_idea_id ? '<input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'">' : '');
+        self::action_form('download_ai_debug_payload_json','Scarica JSON debug completo',$active_idea_id ? '<input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'">' : '');
         self::action_form('create_draft_from_selection','Crea Bozza con OpenAI');
         echo '</div></div>';
 

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -233,7 +233,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         foreach (preg_split('/\r\n|\r|\n|;/', $context) as $line) {
             $line = trim(wp_strip_all_tags((string)$line));
             if ($line === '') { continue; }
-            if (preg_match('/fonte\s*:\s*viator|codice prodotto|product\s*code|url affiliato disponibile|rating|recension|destination id|tag id|source key|prompt source|note operative/i', $line)) { continue; }
+            if (preg_match('/fonte\s*:\s*viator|codice prodotto|product\s*code|url affiliato disponibile|rating|recension|destination id|tag id|source key|prompt source|note operative|provider|fornitore|source/i', $line)) { continue; }
             foreach ($patterns as $pattern) {
                 if (preg_match($pattern, $line)) {
                     $allowed[] = self::compact_text($line, 28);
@@ -495,23 +495,43 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         ), $profile_payload);
     }
 
-    public static function download_payload_json_from_selection_session($user_id = 0, $idea_id = 0) {
+    private static function build_payload_download_document($full_payload, $mode = 'openai') {
+        $full_payload = is_array($full_payload) ? $full_payload : array();
+        $normalized_payload = self::normalize_payload_for_openai($full_payload);
+        $mode = sanitize_key($mode);
+
+        if ($mode === 'debug') {
+            return array(
+                'payload_type' => 'debug_payload_full_with_openai_payload_normalized',
+                'description' => 'debug_payload_full contiene il contesto diagnostico completo; openai_payload_normalized è il payload compatto realmente inviato a OpenAI.',
+                'debug_payload_full' => $full_payload,
+                'openai_payload_normalized' => $normalized_payload,
+            );
+        }
+
+        return $normalized_payload;
+    }
+
+    public static function download_payload_json_from_selection_session($user_id = 0, $idea_id = 0, $mode = 'openai') {
         if (!current_user_can('manage_options')) { return new WP_Error('alma_forbidden', 'Operazione non autorizzata.'); }
+        $mode = sanitize_key($mode);
+        if (!in_array($mode, array('openai', 'debug'), true)) { $mode = 'openai'; }
         try {
             $payload = self::build_payload_from_selection_session($user_id);
+            $download_payload = self::build_payload_download_document($payload, $mode);
         } catch (Throwable $e) {
             if (defined('WP_DEBUG') && WP_DEBUG) {
                 error_log('ALMA payload download error: ' . $e->getMessage());
             }
-            return new WP_Error('alma_payload_exception', 'Errore durante la costruzione del payload JSON diagnostico.');
+            return new WP_Error('alma_payload_exception', 'Errore durante la costruzione del payload JSON.');
         }
-        if (!is_array($payload) || empty($payload)) {
-            return new WP_Error('alma_payload_unavailable', 'Impossibile costruire il payload JSON diagnostico.');
+        if (!is_array($download_payload) || empty($download_payload)) {
+            return new WP_Error('alma_payload_unavailable', 'Impossibile costruire il payload JSON.');
         }
 
-        $json = wp_json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        $json = wp_json_encode($download_payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
         if (!is_string($json) || $json === '') {
-            return new WP_Error('alma_payload_encoding_failed', 'Impossibile codificare il payload JSON diagnostico.');
+            return new WP_Error('alma_payload_encoding_failed', 'Impossibile codificare il payload JSON.');
         }
 
         while (ob_get_level() > 0) {
@@ -522,7 +542,8 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         }
         nocache_headers();
         $safe_idea_id = max(0, absint($idea_id));
-        $filename = 'alma-ai-payload-idea-' . $safe_idea_id . '-' . gmdate('Y-m-d-His') . '.json';
+        $prefix = $mode === 'debug' ? 'alma-ai-debug-payload-idea-' : 'alma-ai-openai-payload-idea-';
+        $filename = $prefix . $safe_idea_id . '-' . gmdate('Y-m-d-His') . '.json';
         header('Content-Type: application/json; charset=utf-8');
         header('Content-Disposition: attachment; filename="' . sanitize_file_name($filename) . '"');
         header('Content-Transfer-Encoding: binary');


### PR DESCRIPTION
### Motivation
- Correggere il comportamento in cui il file JSON scaricabile conteneva ancora il payload diagnostico completo invece del payload normalizzato realmente inviato a OpenAI. 
- Rendere esplicito e distinguibile il payload diagnostico (per debug interno) e il payload compatto inviato al modello per evitare di esporre campi tecnici non necessari.

### Description
- Aggiunta di `build_payload_download_document()` e modifica di `download_payload_json_from_selection_session()` per supportare due modalità di export `openai` e `debug` e per usare `normalize_payload_for_openai()` per il payload OpenAI compatto; file modificato: `includes/class-ai-content-agent-draft-builder.php`.
- Interfaccia admin aggiornata per esporre due azioni separate `Scarica JSON payload OpenAI` e `Scarica JSON debug completo`, passando la modalità corretta al downloader; file modificato: `includes/class-ai-content-agent-admin.php`.
- Raffinata la sintesi del contesto Viator per escludere righe tecniche su provider/source (product code, rating, note operative ecc.) e prevenire la fuga di dati tecnici nel payload OpenAI; aggiornamento in `includes/class-ai-content-agent-draft-builder.php`.
- Aggiornati versione plugin e documentazione con note su come distinguere i due file (`README.md`, `CHANGELOG.md`) e aggiornata la versione in `affiliate-link-manager-ai.php`.

### Testing
- Eseguiti controlli di sintassi PHP con `php -l` su `affiliate-link-manager-ai.php`, `includes/class-ai-content-agent-admin.php` e `includes/class-ai-content-agent-draft-builder.php` e sono passati con esito positivo. 
- Generato un payload di test tramite script PHP che invoca internamente `normalize_payload_for_openai()` e verificato che il JSON normalizzato non contenga chiavi vietate (`content_search_query`, `theme`, `destination`, `selected_results_count`, `selection_context`, `score`, `reason`, `provider`, `source`, `provenance`, `affiliate_link_post_id`, `source_agent_prompt*`, `instruction_snapshot*`, `internal_notes`, metadati audit), che il prompt utente compaia una sola volta e che `output_requirements.slug_required` sia `true`; test superato. 
- Eseguiti check con `jq` per confermare la presenza delle sezioni `article_request`, `editorial_instructions`, `output_requirements`, `affiliate_links` e la struttura compatta; test superato. 
- Eseguita scansione ricorsiva tramite Python per validare l'assenza di chiavi proibite nel payload normalizzato e `git diff --check` per verifiche formali; entrambi passati con esito positivo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae95377e88332ab1a5f9967e2dc95)