### PR TITLE
Refine OpenAI payload normalization: omit unreadable Viator duration and preserve full rule sentences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.25.26 — PR 8.26 Refine OpenAI Payload Rules and Viator Duration
+- Rifinito il payload OpenAI normalizzato del flusso `create_article_draft_from_selected_sources` senza modificare la struttura pubblica né reintrodurre campi diagnostici.
+- Omessa la durata dal contesto sintetico Viator quando il valore non è scalare o non è leggibile, evitando output tecnici come `Durata: Array`.
+- Aggiornata la normalizzazione di `affiliate_rules`, `seo_rules` e `source_policies` per deduplicare regole complete senza troncamenti con puntini di sospensione.
+- Versione plugin aggiornata a `2.25.26`.
+
 ## 2.25.25 — PR 8.25 Separate OpenAI Payload Download from Full Debug JSON
 - Corretto il download **Scarica JSON payload OpenAI**: ora esporta il payload compatto prodotto da `normalize_payload_for_openai()`, non il payload diagnostico completo.
 - Aggiunto il download separato **Scarica JSON debug completo**, con wrapper esplicito `debug_payload_full` + `openai_payload_normalized` per confrontare diagnostica interna e payload realmente inviato al modello.

--- a/README.md
+++ b/README.md
@@ -141,12 +141,18 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.25
+Versione 2.25.26
 
 
 
 
 
+
+## Novità 2.25.26 — PR 8.26 Refine OpenAI Payload Rules and Viator Duration
+
+- Il payload OpenAI normalizzato mantiene la struttura compatta attuale e non reintroduce campi diagnostici.
+- Il contesto sintetico dei link Viator omette la durata quando il valore non è leggibile, ad esempio array o placeholder tecnici.
+- Le sezioni `affiliate_rules`, `seo_rules` e `source_policies` deduplicano le regole senza troncarle con puntini di sospensione, preservando frasi complete e autonome.
 
 ## Novità 2.25.25 — PR 8.25 Separate OpenAI Payload Download from Full Debug JSON
 

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.25
+ * Version: 2.25.26
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.25');
+define('ALMA_VERSION', '2.25.26');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-affiliate-link-ai-context-builder.php
+++ b/includes/class-affiliate-link-ai-context-builder.php
@@ -65,6 +65,8 @@ class ALMA_Affiliate_Link_AI_Context_Builder {
         $description = wp_strip_all_tags((string)($item['description'] ?? $normalized['post_content'] ?? ''));
         if (strlen($description) > 400) { $description = substr($description, 0, 400) . '…'; }
 
+        $duration = $this->format_duration($item['duration'] ?? '');
+
         $lines = array(
             'Fonte: ' . ($source['provider_label'] ?? $source['provider'] ?? 'N/D') . '.',
             'Tipo contenuto: esperienza/tour.',
@@ -73,7 +75,7 @@ class ALMA_Affiliate_Link_AI_Context_Builder {
             'URL affiliato: disponibile nel campo dedicato.',
             'Descrizione sintetica: ' . ($description ?: 'N/D') . '.',
             $this->format_destination($item) . '.',
-            'Durata: ' . $this->format_duration($item['duration'] ?? 'N/D') . '.',
+            $duration !== '' ? 'Durata: ' . $duration . '.' : '',
             'Prezzo indicativo: ' . $this->format_price($item) . '.',
             'Rating aggregato: ' . sanitize_text_field((string)($item['reviews']['combinedAverageRating'] ?? $item['rating'] ?? 'N/D')) . '.',
             'Numero recensioni: ' . sanitize_text_field((string)($item['reviews']['totalReviews'] ?? 'N/D')) . '.',
@@ -154,15 +156,11 @@ class ALMA_Affiliate_Link_AI_Context_Builder {
         return !empty($flat) ? implode(', ', array_slice($flat, 0, 20)) : 'N/D';
     }
     private function format_duration($duration) {
-        if (is_array($duration)) {
-            $fixed = (int)($duration['fixedDurationInMinutes'] ?? 0);
-            if ($fixed > 0) return $fixed . ' minuti';
-            $from = (int)($duration['minDurationInMinutes'] ?? 0);
-            $to = (int)($duration['maxDurationInMinutes'] ?? 0);
-            if ($from > 0 && $to > 0) return 'da ' . $from . ' a ' . $to . ' minuti';
-            return $this->short_text(wp_json_encode($duration));
-        }
-        return $this->short_text((string)$duration);
+        if (is_array($duration) || is_object($duration)) { return ''; }
+        if (!is_scalar($duration)) { return ''; }
+        $duration = trim((string)$duration);
+        if ($duration === '' || strcasecmp($duration, 'Array') === 0 || strcasecmp($duration, 'N/D') === 0) { return ''; }
+        return $this->short_text($duration);
     }
     private function format_translation_auto($translation_info) { return (is_array($translation_info) && !empty($translation_info['containsMachineTranslatedText'])) ? 'sì' : 'no'; }
     private function format_translation_source($translation_info) { return is_array($translation_info) ? sanitize_text_field((string)($translation_info['translationSource'] ?? 'N/D')) : 'N/D'; }

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -208,14 +208,43 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         $out = array();
         $seen = array();
         foreach ((array)$rules as $rule) {
-            $rule = self::compact_text($rule, 70);
-            if ($rule === '') { continue; }
-            $key = md5(mb_strtolower($rule));
-            if (isset($seen[$key])) { continue; }
-            $seen[$key] = true;
-            $out[] = $rule;
+            foreach (self::normalize_rule_items($rule) as $rule_item) {
+                $key = md5(mb_strtolower($rule_item));
+                if (isset($seen[$key])) { continue; }
+                $seen[$key] = true;
+                $out[] = $rule_item;
+            }
         }
         return $out;
+    }
+
+    private static function normalize_rule_items($rule) {
+        $rule = wp_strip_all_tags((string)$rule);
+        $rule = preg_replace('/^[ \t]*(?:[•*]|-|–|—)[ \t]+/m', '', $rule);
+        $rule = trim($rule);
+        if ($rule === '') { return array(); }
+
+        $parts = preg_split('/\r\n|\r|\n/', $rule, -1, PREG_SPLIT_NO_EMPTY);
+        $items = array();
+        foreach ((array)$parts as $part) {
+            $part = trim(preg_replace('/\s+/', ' ', $part));
+            if ($part === '') { continue; }
+            $sentences = preg_split('/(?<=[.!?。！？])\s+/u', $part, -1, PREG_SPLIT_NO_EMPTY);
+            foreach ((array)$sentences as $sentence) {
+                $sentence = self::normalize_complete_rule_sentence($sentence);
+                if ($sentence !== '') { $items[] = $sentence; }
+            }
+        }
+        return $items;
+    }
+
+    private static function normalize_complete_rule_sentence($sentence) {
+        $sentence = trim(preg_replace('/\s+/', ' ', (string)$sentence));
+        $sentence = preg_replace('/(?:\.\.\.|…)+$/u', '', $sentence);
+        $sentence = trim($sentence, " \t\n\r\0\x0B-–—:;,");
+        if ($sentence === '') { return ''; }
+        if (!preg_match('/[.!?。！？]$/u', $sentence)) { $sentence .= '.'; }
+        return $sentence;
     }
 
     private static function is_viator_context($provider, $source, $context) {
@@ -234,6 +263,8 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             $line = trim(wp_strip_all_tags((string)$line));
             if ($line === '') { continue; }
             if (preg_match('/fonte\s*:\s*viator|codice prodotto|product\s*code|url affiliato disponibile|rating|recension|destination id|tag id|source key|prompt source|note operative|provider|fornitore|source/i', $line)) { continue; }
+            if (preg_match('/^durata\s*:\s*(array|n\/?d|non disponibile)?\.?$/i', $line)) { continue; }
+            if (preg_match('/^durata\s*:/i', $line) && preg_match('/array|[{}\[\]]/i', $line)) { continue; }
             foreach ($patterns as $pattern) {
                 if (preg_match($pattern, $line)) {
                     $allowed[] = self::compact_text($line, 28);


### PR DESCRIPTION
### Motivation
- Evitare che nel contesto sintetico inviato a OpenAI compaiano valori tecnici non leggibili come `Durata: Array` per link Viator.\
- Garantire che le regole in `affiliate_rules`, `seo_rules` e `source_policies` siano frasi complete e non troncate con puntini di sospensione.\
- Mantenere invariata la struttura normalizzata del payload `create_article_draft_from_selected_sources` senza reintrodurre campi diagnostici.\

### Description
- Aggiornata la generazione del contesto Viator in `includes/class-affiliate-link-ai-context-builder.php` per calcolare `$duration = $this->format_duration($item['duration'] ?? '');` e includere la riga `Durata: ...` solo se `$duration !== ''`.\
- Modificata la funzione `format_duration` in `ALMA_Affiliate_Link_AI_Context_Builder` per restituire stringa vuota su array/oggetto o valori non scalari e per ignorare placeholder come `Array` o `N/D`, evitando output tecnici.\
- Rifatta la normalizzazione delle regole in `includes/class-ai-content-agent-draft-builder.php`: `compact_rule_list` ora utilizza `normalize_rule_items` e `normalize_complete_rule_sentence` per suddividere elenchi/linee in frasi autonome, rimuovere ellissi finali e assicurare che ogni regola termini con un segno di interpunzione; la deduplicazione rimane attiva sui valori normalizzati.\
- Migliorato il filtro sintetizzatore Viator `summarize_affiliate_context_for_ai` per scartare esplicitamente linee `Durata:` contenenti array o placeholder tecnici prima di selezionare le righe rilevanti.\
- Aggiornata versione plugin a `2.25.26` e documentate le modifiche in `README.md` e `CHANGELOG.md`.\

### Testing
- Eseguito controllo sintassi PHP con `php -l` su `includes/class-affiliate-link-ai-context-builder.php`, `includes/class-ai-content-agent-draft-builder.php` e `affiliate-link-manager-ai.php`, tutti senza errori.\
- Eseguito uno smoke test PHP (Reflection) che valida la normalizzazione delle regole, il filtraggio di righe Viator con `Durata: Array` e l’omissione della riga durata nel contesto generato; tutti i controlli automatici sono passati.\
- Non sono stati introdotti cambiamenti nella struttura pubblica del payload normalizzato (`task`, `site`, `article_request`, `editorial_instructions`, `output_requirements`, `affiliate_links`, `affiliate_rules`, `seo_rules`, `source_policies`, `warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faec0fefc4833288751afd4b8624a1)