### PR TITLE
Refine AI payload context and Instructions AI profile UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.25.28 — PR 8.28 Affiliate Context Cleanup and AI Instructions Profile UI
+- Rafforzata la pulizia finale di `affiliate_links[].context` nel payload OpenAI normalizzato per rimuovere residui Viator/legacy come fonte/provider, codice prodotto, URL affiliato diagnostico, destination/tag ID, `Durata: Array` e placeholder tecnici.
+- Migliorata la UI di **Istruzioni AI → Modifica profilo**: Nome profilo e Lingua restano in alto, i campi principali sono organizzati in griglia responsive a due colonne, il Prompt libero personalizzato è ampio e a tutta larghezza e le Note interne restano secondarie.
+- Corretta la checkbox **Attiva questo profilo dopo il salvataggio** per riflettere lo stato `is_active` del profilo in modifica, mantenendo la logica esistente di attivazione.
+- Versione plugin aggiornata a `2.25.28`.
+
 ## 2.25.27 — PR 8.27 Advanced Debug Download and Rule Sentence Normalization
 - Spostato il download **Scarica JSON debug completo** negli **Strumenti avanzati**, con label diagnostica esplicita e visibilità limitata agli admin con capability adeguata.
 - Rifinita la normalizzazione di `affiliate_rules`, `seo_rules` e `source_policies` per preservare frasi/listati naturali, completare frammenti pendenti e pulire virgolette/caratteri speciali.

--- a/README.md
+++ b/README.md
@@ -141,11 +141,17 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.27
+Versione 2.25.28
 
 
 
 
+
+## Novità 2.25.28 — PR 8.28 Affiliate Context Cleanup and AI Instructions Profile UI
+
+- Pulizia finale di `affiliate_links[].context` nel payload OpenAI normalizzato: rimossi residui tecnici Viator/legacy come fonte/provider, codice prodotto, URL affiliato diagnostico, destination/tag ID, `Durata: Array` e placeholder non utili.
+- UI **Istruzioni AI → Modifica profilo** più leggibile: Nome profilo e Lingua in alto, campi principali in griglia responsive a due colonne, Prompt libero personalizzato ampio a tutta larghezza e Note interne secondarie.
+- Checkbox **Attiva questo profilo dopo il salvataggio** allineata allo stato `is_active` del profilo esistente, senza modificare la logica di attivazione/predefinito.
 
 ## Novità 2.25.27 — PR 8.27 Advanced Debug Download and Rule Sentence Normalization
 

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.27
+ * Version: 2.25.28
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.27');
+define('ALMA_VERSION', '2.25.28');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -754,3 +754,72 @@ button:disabled {
     border-radius: 6px;
     background: #fff;
 }
+
+/* ===== AI Content Agent: Instruction Profile Form ===== */
+.alma-ai-agent-admin .alma-instructions-profile-form {
+    max-width: 1180px;
+}
+
+.alma-ai-agent-admin .alma-instructions-profile-top,
+.alma-ai-agent-admin .alma-instructions-profile-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px 20px;
+    margin: 0 0 16px;
+}
+
+.alma-ai-agent-admin .alma-instructions-field {
+    margin: 0;
+}
+
+.alma-ai-agent-admin .alma-instructions-field label {
+    display: block;
+}
+
+.alma-ai-agent-admin .alma-instructions-field input.regular-text,
+.alma-ai-agent-admin .alma-instructions-field textarea.large-text {
+    width: 100%;
+    max-width: 100%;
+    margin-top: 6px;
+}
+
+.alma-ai-agent-admin .alma-instructions-profile-wide {
+    box-sizing: border-box;
+    margin: 18px 0;
+}
+
+.alma-ai-agent-admin .alma-instructions-custom-prompt {
+    padding: 16px;
+    border: 1px solid #c3c4c7;
+    border-left: 4px solid #2271b1;
+    background: #fff;
+}
+
+.alma-ai-agent-admin .alma-instructions-custom-prompt textarea.large-text {
+    min-height: 260px;
+}
+
+.alma-ai-agent-admin .alma-instructions-internal-notes {
+    padding: 12px 14px;
+    border: 1px solid #dcdcde;
+    background: #f6f7f7;
+}
+
+.alma-ai-agent-admin .alma-instructions-internal-notes textarea.large-text {
+    min-height: 110px;
+}
+
+.alma-ai-agent-admin .alma-instructions-activate {
+    margin-top: 18px;
+}
+
+@media screen and (max-width: 782px) {
+    .alma-ai-agent-admin .alma-instructions-profile-top,
+    .alma-ai-agent-admin .alma-instructions-profile-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .alma-ai-agent-admin .alma-instructions-custom-prompt {
+        padding: 12px;
+    }
+}

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -375,11 +375,46 @@ class ALMA_AI_Content_Agent_Admin {
         echo '</div></div></div>';
     }
 
-    private static function render_instructions_tab() { $profiles = ALMA_AI_Content_Agent_Instructions_Manager::get_profiles(50,0); $active = ALMA_AI_Content_Agent_Instructions_Manager::get_active_profile(); $edit_id=absint($_GET['profile_id'] ?? ($active['id'] ?? 0)); $current=$edit_id?ALMA_AI_Content_Agent_Instructions_Manager::get_profile($edit_id):array(); echo '<h2>Istruzioni AI</h2><h3>Profili</h3><table class="widefat"><thead><tr><th>ID</th><th>Nome</th><th>Attivo</th><th>Default</th><th>Azioni</th></tr></thead><tbody>'; foreach($profiles as $p){ echo '<tr><td>'.(int)$p['id'].'</td><td>'.esc_html($p['profile_name']).'</td><td>'.((int)$p['is_active']?'Sì':'No').'</td><td>'.((int)$p['is_default']?'Sì':'No').'</td><td><a class="button" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=istruzioni-ai&profile_id='.(int)$p['id'])).'">Modifica</a> '.self::inline_profile_action_form('activate_instruction_profile','Attiva',(int)$p['id']).' '.self::inline_profile_action_form('deactivate_instruction_profile','Disattiva',(int)$p['id']).'</td></tr>'; } echo '</tbody></table><p><a class="button" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=istruzioni-ai&profile_id=0')).'">Crea nuovo profilo</a></p>';
-        echo '<h3>'.($edit_id>0?'Modifica profilo':'Nuovo profilo').'</h3><form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_ai_agent_action'); echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_instruction_profile"><input type="hidden" name="profile_id" value="'.(int)$edit_id.'">';
-        $fields=['profile_name'=>'Nome profilo','language_code'=>'Lingua','tone_of_voice'=>'Tono di voce','target_audience'=>'Pubblico target','editorial_style'=>'Stile editoriale','seo_rules'=>'Regole SEO','affiliate_rules'=>'Regole affiliate','image_rules'=>'Regole immagini','source_rules'=>'Regole fonti','anti_duplication_rules'=>'Regole anti-duplicazione','avoid_rules'=>'Cose da evitare','disclosure_policy'=>'Disclosure policy','custom_prompt'=>'Prompt libero personalizzato','internal_notes'=>'Note interne'];
-        foreach($fields as $k=>$l){ echo '<p><label><strong>'.esc_html($l).'</strong><br>'; if(in_array($k,['profile_name','language_code'],true)){ echo '<input class="regular-text" name="'.esc_attr($k).'" value="'.esc_attr($current[$k]??'').'">'; } else { echo '<textarea class="large-text" rows="3" name="'.esc_attr($k).'">'.esc_textarea($current[$k]??'').'</textarea>'; } echo '</label></p>'; }
-        echo '<p><label><input type="checkbox" name="activate_profile" value="1"> Attiva questo profilo dopo il salvataggio</label></p><p><button class="button button-primary">Salva profilo</button></p></form>';
+    private static function render_instructions_tab() {
+        $profiles = ALMA_AI_Content_Agent_Instructions_Manager::get_profiles(50,0);
+        $active = ALMA_AI_Content_Agent_Instructions_Manager::get_active_profile();
+        $edit_id = absint($_GET['profile_id'] ?? ($active['id'] ?? 0));
+        $current = $edit_id ? ALMA_AI_Content_Agent_Instructions_Manager::get_profile($edit_id) : array();
+        $is_current_active = $edit_id > 0 && !empty($current['is_active']);
+
+        echo '<h2>Istruzioni AI</h2><h3>Profili</h3><table class="widefat"><thead><tr><th>ID</th><th>Nome</th><th>Attivo</th><th>Default</th><th>Azioni</th></tr></thead><tbody>';
+        foreach($profiles as $p){
+            echo '<tr><td>'.(int)$p['id'].'</td><td>'.esc_html($p['profile_name']).'</td><td>'.((int)$p['is_active']?'Sì':'No').'</td><td>'.((int)$p['is_default']?'Sì':'No').'</td><td><a class="button" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=istruzioni-ai&profile_id='.(int)$p['id'])).'">Modifica</a> '.self::inline_profile_action_form('activate_instruction_profile','Attiva',(int)$p['id']).' '.self::inline_profile_action_form('deactivate_instruction_profile','Disattiva',(int)$p['id']).'</td></tr>';
+        }
+        echo '</tbody></table><p><a class="button" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=istruzioni-ai&profile_id=0')).'">Crea nuovo profilo</a></p>';
+
+        echo '<h3>'.($edit_id>0?'Modifica profilo':'Nuovo profilo').'</h3><form class="alma-instructions-profile-form" method="post" action="'.esc_url(admin_url('admin-post.php')).'">';
+        wp_nonce_field('alma_ai_agent_action');
+        echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_instruction_profile"><input type="hidden" name="profile_id" value="'.(int)$edit_id.'">';
+
+        echo '<div class="alma-instructions-profile-top">';
+        echo '<p class="alma-instructions-field"><label><strong>Nome profilo</strong><br><input class="regular-text" name="profile_name" value="'.esc_attr($current['profile_name']??'').'"></label></p>';
+        echo '<p class="alma-instructions-field"><label><strong>Lingua</strong><br><input class="regular-text" name="language_code" value="'.esc_attr($current['language_code']??'it').'"></label></p>';
+        echo '</div>';
+
+        $main_fields = array('tone_of_voice'=>'Tono di voce','target_audience'=>'Pubblico target','editorial_style'=>'Stile editoriale','seo_rules'=>'Regole SEO','affiliate_rules'=>'Regole affiliate','image_rules'=>'Regole immagini','source_rules'=>'Regole fonti','anti_duplication_rules'=>'Regole anti-duplicazione','avoid_rules'=>'Cose da evitare','disclosure_policy'=>'Disclosure policy');
+        echo '<div class="alma-instructions-profile-grid">';
+        foreach($main_fields as $k=>$l){
+            echo '<p class="alma-instructions-field"><label><strong>'.esc_html($l).'</strong><br><textarea class="large-text" rows="5" name="'.esc_attr($k).'">'.esc_textarea($current[$k]??'').'</textarea></label></p>';
+        }
+        echo '</div>';
+
+        echo '<div class="alma-instructions-profile-wide alma-instructions-custom-prompt">';
+        echo '<p class="alma-instructions-field"><label><strong>Prompt libero personalizzato</strong><br><textarea class="large-text" rows="12" name="custom_prompt">'.esc_textarea($current['custom_prompt']??'').'</textarea></label></p>';
+        echo '<p class="description">Campo principale per istruzioni editoriali aggiuntive specifiche del profilo.</p>';
+        echo '</div>';
+
+        echo '<div class="alma-instructions-profile-wide alma-instructions-internal-notes">';
+        echo '<p class="alma-instructions-field"><label><strong>Note interne</strong><br><textarea class="large-text" rows="4" name="internal_notes">'.esc_textarea($current['internal_notes']??'').'</textarea></label></p>';
+        echo '<p class="description">Note amministrative interne: non vengono esposte nel payload OpenAI normalizzato.</p>';
+        echo '</div>';
+
+        echo '<p class="alma-instructions-activate"><label><input type="checkbox" name="activate_profile" value="1" '.checked($is_current_active, true, false).'> Attiva questo profilo dopo il salvataggio</label></p><p><button class="button button-primary">Salva profilo</button></p></form>';
     }
 
     private static function render_ideas_tab() {

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -310,34 +310,61 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         return strpos($haystack, 'viator') !== false || strpos($haystack, 'productcode') !== false || strpos($haystack, 'codice prodotto') !== false || strpos($haystack, 'destination id') !== false;
     }
 
+    private static function is_affiliate_context_placeholder($value) {
+        $value = trim(wp_strip_all_tags((string)$value));
+        if ($value === '') { return true; }
+        return (bool)preg_match('/^(?:array|object|stdclass|n\/?d|n\.?a\.?|null|none|non disponibile|disponibile nel campo dedicato|-|—|\[\]|\{\})\.?$/iu', $value);
+    }
+
+    private static function is_technical_affiliate_context_line($line) {
+        $line = trim(wp_strip_all_tags((string)$line));
+        if ($line === '') { return true; }
+        if (preg_match('/^(?:fonte|source|source key|provider|fornitore|titolo provider|codice prodotto|product\s*code|productcode|url affiliato|affiliate url|destinazione|destination(?: id)?|destination id|tag(?: id)?|categorie\/?tag provider|lingue disponibili|prompt source|note operative)\s*:/iu', $line)) { return true; }
+        if (preg_match('/\b(?:source[_ -]?key|product[_ -]?code|productcode|destination[_ -]?id|tag[_ -]?id|provider[_ -]?id)\b/iu', $line)) { return true; }
+        if (preg_match('/\b(?:destination|tag)\s*id\b/iu', $line)) { return true; }
+        if (preg_match('/^durata\s*:\s*(?:array|object|n\/?d|null|non disponibile|\[\]|\{\})?\.?$/iu', $line)) { return true; }
+        if (preg_match('/^durata\s*:/iu', $line) && preg_match('/(?:array|object|[{}\[\]])/iu', $line)) { return true; }
+        if (preg_match('/:\s*(?:array|object|stdclass|n\/?d|null|non disponibile|disponibile nel campo dedicato|\[\]|\{\})\.?$/iu', $line)) { return true; }
+        return false;
+    }
+
+    private static function clean_affiliate_context_line($line) {
+        $line = trim(wp_strip_all_tags((string)$line));
+        $line = preg_replace('/(?:^|\s+)durata\s*:\s*array\.?/iu', ' ', $line);
+        $line = preg_replace('/\b(?:source[_ -]?key|product[_ -]?code|productcode|destination[_ -]?id|tag[_ -]?id|provider[_ -]?id)\b\s*[:=]\s*[^;,.]+/iu', ' ', $line);
+        $line = trim(preg_replace('/\s+/', ' ', (string)$line));
+        if (self::is_technical_affiliate_context_line($line)) { return ''; }
+        if (strpos($line, ':') !== false) {
+            list($label, $value) = array_map('trim', explode(':', $line, 2));
+            if (self::is_affiliate_context_placeholder($value)) { return ''; }
+        }
+        return $line;
+    }
+
     private static function summarize_affiliate_context_for_ai($context, $provider = '', $source = '', $title = '', $description = '') {
         $context = sanitize_textarea_field((string)$context);
-        $context = preg_replace('/(?:^|\s+)durata\s*:\s*array\.?/i', ' ', $context);
-        $context = trim(preg_replace('/\s+/', ' ', (string)$context));
-        if ($context === '') { return self::compact_text($description, 50); }
-        if (!self::is_viator_context($provider, $source, $context)) { return self::compact_text($context, 90); }
+        $context = preg_replace('/(?:^|\s+)durata\s*:\s*array\.?/iu', ' ', $context);
+        $context = trim((string)$context);
 
         $allowed = array();
-        $patterns = array('/\btipo\b/i','/\bdescrizione\b/i','/\bprezzo\b/i','/\bvaluta\b/i','/\bdurata\b/i','/cancellazione/i','/privat/i','/inclus/i','/esclus/i','/caratteristiche/i','/tour/i','/esperienza/i');
-        foreach (preg_split('/\r\n|\r|\n|;/', $context) as $line) {
-            $line = trim(wp_strip_all_tags((string)$line));
-            $line = preg_replace('/(?:^|\s+)durata\s*:\s*array\.?/i', ' ', $line);
-            $line = trim(preg_replace('/\s+/', ' ', (string)$line));
+        $editorial_patterns = array('/\btipo\b/iu','/\bdescrizione\b/iu','/\bprezzo\b/iu','/\bvaluta\b/iu','/\bdurata\b/iu','/cancellazione/iu','/privat/iu','/inclus/iu','/esclus/iu','/caratteristiche/iu','/flag/iu','/tour/iu','/esperienza/iu','/attività/iu','/servizio/iu');
+        foreach (preg_split('/\r\n|\r|\n|;|\|/', $context) as $line) {
+            $line = self::clean_affiliate_context_line($line);
             if ($line === '') { continue; }
-            if (preg_match('/fonte\s*:\s*viator|codice prodotto|product\s*code|url affiliato disponibile|rating|recension|destination id|tag id|source key|prompt source|note operative|provider|fornitore|source/i', $line)) { continue; }
-            if (preg_match('/^durata\s*:\s*(array|n\/?d|non disponibile)?\.?$/i', $line)) { continue; }
-            if (preg_match('/^durata\s*:/i', $line) && preg_match('/array|[{}\[\]]/i', $line)) { continue; }
-            foreach ($patterns as $pattern) {
-                if (preg_match($pattern, $line)) {
-                    $allowed[] = self::compact_text($line, 28);
-                    break;
+            if (self::is_viator_context($provider, $source, $context)) {
+                $matches_editorial_pattern = false;
+                foreach ($editorial_patterns as $pattern) {
+                    if (preg_match($pattern, $line)) { $matches_editorial_pattern = true; break; }
                 }
+                if (!$matches_editorial_pattern) { continue; }
             }
+            $allowed[] = self::compact_text($line, 28);
             if (count($allowed) >= 8) { break; }
         }
+
         if (empty($allowed)) {
-            $base = $description !== '' ? $description : $context;
-            $allowed[] = 'Esperienza/tour: ' . self::compact_text($base, 45);
+            $base = self::clean_affiliate_context_line($description !== '' ? $description : $context);
+            if ($base !== '') { $allowed[] = 'Esperienza/tour: ' . self::compact_text($base, 45); }
         }
         $allowed[] = 'Nota: non copiare testo provider e non inventare prezzo, disponibilità o condizioni.';
         return implode(' ', self::compact_rule_list($allowed));


### PR DESCRIPTION
### Motivation
- Remove residual technical/diagnostic fragments (e.g. Viator source lines, product codes, placeholder arrays, destination/tag IDs, “URL affiliato: disponibile nel campo dedicato”, `Durata: Array`) from the OpenAI-normalized payload so `affiliate_links[].context` contains only editorially useful text and a short cautionary note. 
- Make the admin edit form for AI Instruction Profiles more readable and usable by surfacing `Nome profilo` and `Lingua` at the top, organizing main rule fields in a two-column grid on desktop, and promoting the custom prompt as the primary full-width field. 
- Ensure the “Attiva questo profilo dopo il salvataggio” checkbox reflects the actual `is_active` state of the profile being edited while preserving existing activation/save behavior and security checks.

### Description
- Hardened affiliate context normalization in `includes/class-ai-content-agent-draft-builder.php` by adding `is_affiliate_context_placeholder()`, `is_technical_affiliate_context_line()` and `clean_affiliate_context_line()` and updating `summarize_affiliate_context_for_ai()` to strip technical lines/placeholders and preserve only editorially meaningful snippets plus a final caution note. 
- Kept the normalized OpenAI payload structure produced by `normalize_payload_for_openai()` and ensured `affiliate_links[].context` no longer includes Viator/legacy residues or diagnostic placeholders. 
- Reworked the profile edit renderer in `includes/class-ai-content-agent-admin.php::render_instructions_tab()` to place `profile_name` and `language_code` on top, render main fields in a two-column responsive grid, make `custom_prompt` full-width and larger, keep `internal_notes` full-width but visually secondary, and pre-check the activate checkbox using the existing `is_active` value. 
- Added scoped admin styles in `assets/admin.css` to implement the two-column grid, larger textareas, visual emphasis for the custom prompt, and responsive fallback to a single column on small screens. 
- Bumped plugin version to `2.25.28` in `affiliate-link-manager-ai.php` and updated `README.md` and `CHANGELOG.md` to document the context cleanup, UI changes and active-profile checkbox fix.

### Testing
- Ran PHP lint across modified files with `php -l includes/class-ai-content-agent-draft-builder.php && php -l includes/class-ai-content-agent-admin.php && php -l affiliate-link-manager-ai.php`, and all files reported no syntax errors. 
- Executed an automated reflection smoke test invoking `ALMA_AI_Content_Agent_Draft_Builder::normalize_payload_for_openai()` on a synthetic Viator/legacy `ai_context` and asserted that forbidden residues (`Fonte: Viator`, `Codice prodotto`, `URL affiliato: disponibile nel campo dedicato`, `Durata: Array`, destination/tag/provider placeholders) do not appear while useful editorial fragments (e.g. description and price) are preserved, and the test passed. 
- Confirmed the updated `render_instructions_tab()` pre-checks the activate checkbox when editing an existing active profile via a PHP execution smoke test; note that no interactive browser/UI screenshot tests were performed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faf6fb19508332916b95eaa7e2ab8d)