### PR TITLE
Aggiungi widget scorciatoia "AI Content Agent" nella Bacheca

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.25.30 — PR 8.30 AI Content Agent Dashboard Shortcut Widget
+- Aggiunto nella Bacheca WordPress il widget leggero **AI Content Agent**, registrato con `wp_dashboard_setup` in contesto principale ad alta priorità per apparire nella fascia alta al primo caricamento.
+- Il widget mostra una descrizione sintetica, icona Dashicons e pulsante primario **Apri AI Content Agent** verso l'URL admin già registrato (`alma-ai-content-agent`).
+- La scorciatoia è visibile solo agli utenti autorizzati con la stessa capability della pagina AI Content Agent (`manage_options`).
+- Nessun impatto su OpenAI, payload AI, CPT, shortcode, tracking, import provider o logica AI; il widget espone solo link di navigazione e testo statico.
+- Versione plugin aggiornata a `2.25.30`.
+
 ## 2.25.29 — PR 8.29 AI Content Agent Toolbar and Ideas Pagination UI
 - Migliorata la toolbar principale di **AI Content Agent** con pulsanti scoped più distinguibili: azioni primarie blu, salvataggio verde, eliminazione rossa con icona trash e download JSON OpenAI grigio/secondario.
 - Aggiunta paginazione server-side alla colonna **Idee create** con massimo 10 idee per pagina, controlli **Precedente**/**Successiva**, indicatore pagina corrente e mantenimento dell’idea attiva.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## 2.25.30 — PR 8.30 AI Content Agent Dashboard Shortcut Widget
+- Aggiunto nella Bacheca WordPress il widget leggero **AI Content Agent**, registrato con `wp_dashboard_setup` in contesto principale ad alta priorità per apparire nella fascia alta al primo caricamento.
+- Il widget mostra una descrizione sintetica, icona Dashicons e pulsante primario **Apri AI Content Agent** verso l'URL admin già registrato (`alma-ai-content-agent`).
+- La scorciatoia è visibile solo agli utenti autorizzati con la stessa capability della pagina AI Content Agent (`manage_options`).
+- Nessun impatto su OpenAI, payload AI, CPT, shortcode, tracking, import provider o logica AI; il widget espone solo link di navigazione e testo statico.
+- Versione plugin aggiornata a `2.25.30`.
+
 ## 2.25.29 — PR 8.29 AI Content Agent Toolbar and Ideas Pagination UI
 - Migliorata la toolbar principale di **AI Content Agent** con pulsanti scoped più distinguibili: azioni primarie blu, salvataggio verde, eliminazione rossa con icona trash e download JSON OpenAI grigio/secondario.
 - Aggiunta paginazione server-side alla colonna **Idee create** con massimo 10 idee per pagina, controlli **Precedente**/**Successiva**, indicatore pagina corrente e mantenimento dell’idea attiva.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.29
+ * Version: 2.25.30
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.29');
+define('ALMA_VERSION', '2.25.30');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -79,6 +79,10 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-links-source-filter.php
  * Classe principale del plugin
  */
 class AffiliateManagerAI {
+    const AI_CONTENT_AGENT_MENU_SLUG = 'alma-ai-content-agent';
+    const AI_CONTENT_AGENT_CAPABILITY = 'manage_options';
+    const AFFILIATE_LINK_PARENT_MENU = 'edit.php?post_type=affiliate_link';
+
     private $dashboard_stats;
     private $source_manager;
     private $affiliate_links_source_filter;
@@ -667,6 +671,7 @@ class AffiliateManagerAI {
 
         // Dashboard widget
         add_action('wp_dashboard_setup', array($this, 'add_dashboard_widget'));
+        add_action('wp_dashboard_setup', array($this, 'add_ai_content_agent_dashboard_widget'));
         add_action('pre_get_posts', array($this, 'filter_posts_without_affiliates'));
     }
     
@@ -1250,11 +1255,11 @@ class AffiliateManagerAI {
 
         // AI Content Agent
         add_submenu_page(
-            'edit.php?post_type=affiliate_link',
+            self::AFFILIATE_LINK_PARENT_MENU,
             __('AI Content Agent', 'affiliate-link-manager-ai'),
             __('AI Content Agent', 'affiliate-link-manager-ai'),
-            'manage_options',
-            'alma-ai-content-agent',
+            self::AI_CONTENT_AGENT_CAPABILITY,
+            self::AI_CONTENT_AGENT_MENU_SLUG,
             array('ALMA_AI_Content_Agent_Admin', 'render_page')
         );
 
@@ -1311,7 +1316,7 @@ class AffiliateManagerAI {
             'alma-bot-affiliate-settings',
             'affiliate-chat-ai',
             'alma-affiliate-sources',
-            'alma-ai-content-agent',
+            self::AI_CONTENT_AGENT_MENU_SLUG,
             'affiliate-link-manager-settings',
             'alma-css-editor',
         );
@@ -1818,6 +1823,65 @@ class AffiliateManagerAI {
         echo '<a href="' . admin_url('edit.php?post_type=affiliate_link') . '" class="button button-primary">Gestisci Link</a> ';
         echo '<a href="' . admin_url('admin.php?page=affiliate-link-manager-dashboard') . '" class="button">Dashboard Completa</a>';
         echo '</p>';
+    }
+
+    /**
+     * Build the existing AI Content Agent admin URL without duplicating routing logic in widgets.
+     *
+     * @param string $tab Optional AI Content Agent tab.
+     * @return string
+     */
+    private function get_ai_content_agent_admin_url($tab = 'dashboard') {
+        $args = array(
+            'post_type' => 'affiliate_link',
+            'page'      => self::AI_CONTENT_AGENT_MENU_SLUG,
+        );
+
+        $tab = sanitize_key($tab);
+        if ($tab !== '') {
+            $args['tab'] = $tab;
+        }
+
+        return add_query_arg($args, admin_url('edit.php'));
+    }
+
+    /**
+     * Add a lightweight WordPress Dashboard shortcut to AI Content Agent.
+     */
+    public function add_ai_content_agent_dashboard_widget() {
+        if (!current_user_can(self::AI_CONTENT_AGENT_CAPABILITY)) {
+            return;
+        }
+
+        wp_add_dashboard_widget(
+            'alma_ai_content_agent_dashboard_widget',
+            __('AI Content Agent', 'affiliate-link-manager-ai'),
+            array($this, 'render_ai_content_agent_dashboard_widget'),
+            null,
+            null,
+            'normal',
+            'high'
+        );
+    }
+
+    /**
+     * Render the AI Content Agent dashboard shortcut widget.
+     */
+    public function render_ai_content_agent_dashboard_widget() {
+        if (!current_user_can(self::AI_CONTENT_AGENT_CAPABILITY)) {
+            return;
+        }
+
+        $agent_url = $this->get_ai_content_agent_admin_url('dashboard');
+
+        echo '<div class="alma-ai-content-agent-widget">';
+        echo '<div class="alma-ai-content-agent-widget__icon" aria-hidden="true"><span class="dashicons dashicons-edit-page"></span></div>';
+        echo '<div class="alma-ai-content-agent-widget__content">';
+        echo '<p class="alma-ai-content-agent-widget__description">' . esc_html__('Crea idee, genera brief e prepara bozze articolo con supporto AI.', 'affiliate-link-manager-ai') . '</p>';
+        echo '<p class="alma-ai-content-agent-widget__actions"><a class="button button-primary" href="' . esc_url($agent_url) . '">' . esc_html__('Apri AI Content Agent', 'affiliate-link-manager-ai') . '</a></p>';
+        echo '<p class="alma-ai-content-agent-widget__note">' . esc_html__('Scorciatoia rapida alla sezione admin: nessun dato AI o payload OpenAI viene mostrato nella Bacheca.', 'affiliate-link-manager-ai') . '</p>';
+        echo '</div>';
+        echo '</div>';
     }
 
     /**

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -58,6 +58,75 @@
     margin-top: 5px;
 }
 
+
+/* ===== WordPress Dashboard: AI Content Agent shortcut ===== */
+#alma_ai_content_agent_dashboard_widget .inside {
+    margin-bottom: 0;
+}
+
+#alma_ai_content_agent_dashboard_widget .alma-ai-content-agent-widget {
+    display: flex;
+    gap: 14px;
+    align-items: flex-start;
+    padding: 4px 0 2px;
+}
+
+#alma_ai_content_agent_dashboard_widget .alma-ai-content-agent-widget__icon {
+    display: inline-flex;
+    width: 42px;
+    height: 42px;
+    flex: 0 0 42px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    background: #f0f6fc;
+    color: #2271b1;
+}
+
+#alma_ai_content_agent_dashboard_widget .alma-ai-content-agent-widget__icon .dashicons {
+    width: 24px;
+    height: 24px;
+    font-size: 24px;
+    line-height: 1;
+}
+
+#alma_ai_content_agent_dashboard_widget .alma-ai-content-agent-widget__content {
+    min-width: 0;
+}
+
+#alma_ai_content_agent_dashboard_widget .alma-ai-content-agent-widget__description {
+    margin: 0 0 12px;
+    color: #1d2327;
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+#alma_ai_content_agent_dashboard_widget .alma-ai-content-agent-widget__actions {
+    margin: 0 0 10px;
+}
+
+#alma_ai_content_agent_dashboard_widget .alma-ai-content-agent-widget__note {
+    margin: 0;
+    color: #646970;
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+@media (max-width: 480px) {
+    #alma_ai_content_agent_dashboard_widget .alma-ai-content-agent-widget {
+        display: block;
+    }
+
+    #alma_ai_content_agent_dashboard_widget .alma-ai-content-agent-widget__icon {
+        margin-bottom: 10px;
+    }
+
+    #alma_ai_content_agent_dashboard_widget .alma-ai-content-agent-widget__actions .button {
+        width: 100%;
+        text-align: center;
+    }
+}
+
 /* ===== Editor Modal Styles ===== */
 .alma-modal-overlay {
     position: fixed !important;


### PR DESCRIPTION
### Motivation
- Aggiungere nella Bacheca WordPress una scorciatoia leggera e visibile in alto per accedere velocemente alla sezione admin “AI Content Agent”.
- Riutilizzare lo slug e la capability già registrati dal plugin per mantenere compatibilità e non mostrare il widget a utenti non autorizzati.

### Description
- Introdotte le costanti `AI_CONTENT_AGENT_MENU_SLUG`, `AI_CONTENT_AGENT_CAPABILITY` e `AFFILIATE_LINK_PARENT_MENU` e riutilizzate nella registrazione della submenu `alma-ai-content-agent` per evitare duplicazione dello slug/capability esistente. 
- Aggiunti i metodi `get_ai_content_agent_admin_url()`, `add_ai_content_agent_dashboard_widget()` e `render_ai_content_agent_dashboard_widget()` e collegato il widget a `wp_dashboard_setup` con contesto/priorità alta per posizionarlo nella prima fascia della Bacheca; il widget è mostrato solo a utenti con la capability configurata. 
- Aggiunto CSS scoped in `assets/admin.css` per lo stile del widget (icona Dashicons, descrizione, pulsante primario blu) con fallback responsive e senza stili globali su `.button`, `.postbox` o altri selettori generici. 
- Aggiornati header versione e costante `ALMA_VERSION` a `2.25.30` e documentazione in `README.md` e `CHANGELOG.md` con nota sulla nuova scorciatoia. 

### Testing
- Eseguito `php -l affiliate-link-manager-ai.php` e `php -l includes/class-ai-content-agent-admin.php` e i controlli di sintassi PHP su tutti i file PHP del repo, tutti eseguiti con esito positivo. 
- Eseguito `git diff --check` e controlli automatici di linting/merge che non hanno riportato errori. 
- Non è stata eseguita una validazione nel browser/istanza WordPress del pannello admin per limiti dell'ambiente, ma il widget è costruito senza query pesanti, con escaping per URL/testi e con controllo `current_user_can()` per la capability.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faffaad8288332a49576f1e7b99916)