### PR TITLE
Viator media extraction and import preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.25.31 — Viator media extraction and import preview
+- Aggiunta estrazione difensiva delle immagini Viator da `images[]`/`variants[]` con selezione di un URL candidato principale senza download o creazione attachment.
+- Aggiunta colonna **Immagine** nella preview import Viator con miniatura, badge Cover/Supplier e warning non bloccanti quando l'immagine manca o non ha URL valido.
+- Salvati nel CPT `affiliate_link` URL candidato e metadati media sicuri (`_alma_featured_image_url`, fonte, caption, dimensioni, flag cover, conteggi e JSON media normalizzato).
+- Aggiornato il fallback dell'indice AI per usare `_alma_featured_image_url` quando non esiste una featured image WordPress.
+- Sideload in Media Library, `media_handle_sideload`, `download_url`, `set_post_thumbnail` e `_thumbnail_id` non sono implementati in questa PR e restano per una PR successiva.
+- Versione plugin aggiornata a `2.25.31`.
+
 ## 2.25.30 — PR 8.30 AI Content Agent Dashboard Shortcut Widget
 - Aggiunto nella Bacheca WordPress il widget leggero **AI Content Agent**, registrato con `wp_dashboard_setup` in contesto principale ad alta priorità per apparire nella fascia alta al primo caricamento.
 - Il widget mostra una descrizione sintetica, icona Dashicons e pulsante primario **Apri AI Content Agent** verso l'URL admin già registrato (`alma-ai-content-agent`).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## 2.25.31 — Viator media extraction and import preview
+- Aggiunta estrazione difensiva delle immagini Viator da `images[]`/`variants[]` con selezione di un URL candidato principale senza download o creazione attachment.
+- Aggiunta colonna **Immagine** nella preview import Viator con miniatura, badge Cover/Supplier e warning non bloccanti quando l'immagine manca o non ha URL valido.
+- Salvati nel CPT `affiliate_link` URL candidato e metadati media sicuri (`_alma_featured_image_url`, fonte, caption, dimensioni, flag cover, conteggi e JSON media normalizzato).
+- Aggiornato il fallback dell'indice AI per usare `_alma_featured_image_url` quando non esiste una featured image WordPress.
+- Sideload in Media Library, `media_handle_sideload`, `download_url`, `set_post_thumbnail` e `_thumbnail_id` non sono implementati in questa PR e restano per una PR successiva.
+- Versione plugin aggiornata a `2.25.31`.
+
 ## 2.25.30 — PR 8.30 AI Content Agent Dashboard Shortcut Widget
 - Aggiunto nella Bacheca WordPress il widget leggero **AI Content Agent**, registrato con `wp_dashboard_setup` in contesto principale ad alta priorità per apparire nella fascia alta al primo caricamento.
 - Il widget mostra una descrizione sintetica, icona Dashicons e pulsante primario **Apri AI Content Agent** verso l'URL admin già registrato (`alma-ai-content-agent`).
@@ -155,7 +163,7 @@
 
 # Affiliate Link Manager AI
 
-Versione 2.25.28
+Versione 2.25.31
 
 
 

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.30
+ * Version: 2.25.31
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.30');
+define('ALMA_VERSION', '2.25.31');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -60,6 +60,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-client-
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-client-custom-api.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-client-viator.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-viator-field-catalog.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-viator-media-resolver.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-client-factory.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-connection-test-storage.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-connection-service.php';

--- a/assets/affiliate-sources.css
+++ b/assets/affiliate-sources.css
@@ -17,6 +17,13 @@
 .alma-import-filters p{margin:0 0 8px}
 .alma-import-filters p:last-child{margin-bottom:0}
 .alma-import-filters label{display:flex;align-items:center;gap:8px}
-.alma-import-preview th:nth-child(3),.alma-import-preview td:nth-child(3){width:170px}
+.alma-import-preview th:nth-child(2),.alma-import-preview td:nth-child(2){width:120px}.alma-import-preview th:nth-child(4),.alma-import-preview td:nth-child(4){width:170px}
 .alma-affiliate-link{display:inline-block;max-width:150px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;vertical-align:bottom}
 .alma-affiliate-link-empty{color:#646970}
+
+.alma-import-preview .alma-media-preview{max-width:96px}
+.alma-import-preview .alma-media-preview img{display:block;width:72px;height:54px;object-fit:cover;border:1px solid #c3c4c7;border-radius:4px;background:#f6f7f7}
+.alma-import-preview .alma-media-badges{margin-top:4px;display:flex;gap:4px;flex-wrap:wrap}
+.alma-import-preview .alma-media-badge{display:inline-block;padding:1px 6px;border-radius:10px;background:#eef3ff;color:#1d2327;font-size:11px;line-height:1.5}
+.alma-import-preview .alma-media-empty{display:inline-block;padding:4px 7px;border-radius:4px;background:#f6f7f7;color:#646970;font-size:12px}
+.alma-import-preview .alma-media-warning{margin-top:4px;max-width:140px;color:#8a6d3b;font-size:11px;line-height:1.3}

--- a/includes/class-affiliate-source-import-preview-service.php
+++ b/includes/class-affiliate-source-import-preview-service.php
@@ -39,6 +39,11 @@ class ALMA_Affiliate_Source_Import_Preview_Service {
         if ($title === '') $warnings[] = __('Titolo mancante: verrà usato fallback controllato.', 'affiliate-link-manager-ai');
         if ($affiliate_url_valid && !$contains_code) $warnings[] = __('URL affiliato sospetto: productCode non riconoscibile nel link.', 'affiliate-link-manager-ai');
 
+        $media = $this->resolve_viator_media($item);
+        if (empty($media['has_image'])) {
+            $warnings[] = __('Immagine Viator mancante o senza URL valido: import consentito senza immagine.', 'affiliate-link-manager-ai');
+        }
+
         $item['_alma_validation'] = array(
             'external_id' => $external_id,
             'url_origin' => 'productUrl',
@@ -46,12 +51,30 @@ class ALMA_Affiliate_Source_Import_Preview_Service {
             'product_code_in_url' => $contains_code,
             'errors' => $errors,
             'warnings' => $warnings,
+            'media' => $media,
             'status' => empty($errors) ? (empty($warnings) ? 'ok' : 'warning') : 'error',
             'selectable_default' => empty($errors),
         );
         return $item;
     }
 
+    private function resolve_viator_media($item) {
+        if (!class_exists('ALMA_Affiliate_Source_Viator_Media_Resolver')) {
+            return array('has_image'=>false,'featured_image_url'=>'','image_source'=>'','caption'=>'','is_cover'=>false,'width'=>0,'height'=>0,'warnings'=>array(__('Resolver media Viator non disponibile.', 'affiliate-link-manager-ai')));
+        }
+        $resolver = new ALMA_Affiliate_Source_Viator_Media_Resolver();
+        $media = $resolver->resolve($item);
+        return array(
+            'has_image' => !empty($media['has_image']),
+            'featured_image_url' => esc_url_raw((string)($media['featured_image_url'] ?? '')),
+            'image_source' => sanitize_text_field((string)($media['image_source'] ?? '')),
+            'caption' => sanitize_text_field((string)($media['caption'] ?? '')),
+            'is_cover' => !empty($media['is_cover']),
+            'width' => absint($media['width'] ?? 0),
+            'height' => absint($media['height'] ?? 0),
+            'warnings' => array_values(array_filter(array_map('sanitize_text_field', (array)($media['warnings'] ?? array())))),
+        );
+    }
 
 
     public function build_dedupe_map($source, $items, $duplicate_policy = 'skip_existing') {

--- a/includes/class-affiliate-source-manager.php
+++ b/includes/class-affiliate-source-manager.php
@@ -163,12 +163,33 @@ class ALMA_Affiliate_Source_Manager {
             $load_more_url=add_query_arg(array_merge($_GET,array('criteria_token'=>$criteria_token,'load_preview'=>'1','import_start'=>$next_start)),admin_url('edit.php'));
             echo '<div class="postbox"><h2 class="hndle"><span>Risultati anteprima</span></h2><div class="inside"><p>Recuperati API: '.count((array)$items).' · Nuovi mostrati: '.count($visible).' · Già importati nascosti: '.count($existing).' · Start corrente: '.(int)$criteria['import_start'].' · Prossimo start: '.$next_start.'</p><p><button type="button" class="button alma-load-more-results" data-href="'.esc_url($load_more_url).'">Carica altri risultati</button></p>';
             echo '<form method="post">'; wp_nonce_field('alma_import_selected','alma_import_selected_nonce'); echo '<input type="hidden" name="action_type" value="import_selected_items"/><input type="hidden" name="source_id" value="'.(int)$source_id.'"/><input type="hidden" name="criteria_token" value="'.esc_attr($criteria_token).'"/><input type="hidden" name="import_search_model" value="'.esc_attr($criteria['import_search_model']).'"/><input type="hidden" name="import_search_term" value="'.esc_attr($criteria['import_search_term']).'"/><input type="hidden" name="import_destination_id" value="'.esc_attr($criteria['import_destination_id']).'"/><input type="hidden" name="import_limit" value="'.(int)$criteria['import_limit'].'"/><input type="hidden" name="import_start" value="'.(int)$criteria['import_start'].'"/><input type="hidden" name="next_start" value="'.(int)$criteria['next_start'].'"/><input type="hidden" name="hide_existing" value="'.esc_attr($criteria['hide_existing']).'"/><input type="hidden" name="show_existing" value="'.esc_attr($criteria['show_existing']).'"/><input type="hidden" name="auto_fill_new_items" value="'.esc_attr($criteria['auto_fill_new_items']).'"/>';
-            echo '<p><button type="button" class="button alma-select-all">Seleziona tutti</button> <button type="button" class="button alma-deselect-all">Deseleziona tutti</button> <span class="alma-selected-counter">0 selezionati</span></p><table class="widefat striped alma-import-preview"><thead><tr><th></th><th>Titolo</th><th>Link affiliato</th><th>External ID</th><th>Azione</th></tr></thead><tbody>';
-            foreach((array)$visible as $it){$eid=(string)($it['productCode']??''); if($eid==='')continue; $exists=!empty($dedupe_map[$eid]['post_id']); $product_url=isset($it['productUrl'])?(string)$it['productUrl']:''; $affiliate_link=$product_url!==''?'<a class="alma-affiliate-link" href="'.esc_url($product_url).'" target="_blank" rel="noopener noreferrer" title="'.esc_attr($product_url).'">Apri</a>':'<span class="alma-affiliate-link-empty">N/D</span>'; echo '<tr'.($exists?' class="alma-row-existing"':'').'><td><input class="alma-select-item" type="checkbox" name="selected_external_ids[]" value="'.esc_attr($eid).'" '.checked(!$exists,true,false).'></td><td>'.esc_html($it['title']??$it['name']??'—').'</td><td>'.$affiliate_link.'</td><td>'.esc_html($eid).'</td><td>'.($exists?'salta':'crea').'</td></tr>';}
+            echo '<p><button type="button" class="button alma-select-all">Seleziona tutti</button> <button type="button" class="button alma-deselect-all">Deseleziona tutti</button> <span class="alma-selected-counter">0 selezionati</span></p><table class="widefat striped alma-import-preview"><thead><tr><th></th><th>Immagine</th><th>Titolo</th><th>Link affiliato</th><th>External ID</th><th>Azione</th></tr></thead><tbody>';
+            foreach((array)$visible as $it){$eid=(string)($it['productCode']??''); if($eid==='')continue; $exists=!empty($dedupe_map[$eid]['post_id']); $product_url=isset($it['productUrl'])?(string)$it['productUrl']:''; $affiliate_link=$product_url!==''?'<a class="alma-affiliate-link" href="'.esc_url($product_url).'" target="_blank" rel="noopener noreferrer" title="'.esc_attr($product_url).'">Apri</a>':'<span class="alma-affiliate-link-empty">N/D</span>'; $image_preview=$this->render_import_media_preview_cell($it); echo '<tr'.($exists?' class="alma-row-existing"':'').'><td><input class="alma-select-item" type="checkbox" name="selected_external_ids[]" value="'.esc_attr($eid).'" '.checked(!$exists,true,false).'></td><td>'.$image_preview.'</td><td>'.esc_html($it['title']??$it['name']??'—').'</td><td>'.$affiliate_link.'</td><td>'.esc_html($eid).'</td><td>'.($exists?'salta':'crea').'</td></tr>';}
             if(empty($term_ids)){ echo '<p class="description">I Link saranno creati senza Tipologia Link.</p>'; }
             echo '</tbody></table><p><button class="button button-primary">Importa selezionati</button></p></form></div></div>';
         }
         echo '</div>';
+    }
+    private function render_import_media_preview_cell($item){
+        $validation = is_array($item['_alma_validation'] ?? null) ? $item['_alma_validation'] : array();
+        $media = is_array($validation['media'] ?? null) ? $validation['media'] : array();
+        $url = esc_url_raw((string)($media['featured_image_url'] ?? ''));
+        $has_image = !empty($media['has_image']) && $url !== '' && wp_http_validate_url($url);
+        $warnings = array_values(array_filter(array_map('sanitize_text_field',(array)($media['warnings'] ?? array()))));
+        if(!$has_image){
+            $html = '<div class="alma-media-empty">Nessuna immagine</div>';
+        } else {
+            $alt = sanitize_text_field((string)($media['caption'] ?? ($item['title'] ?? $item['name'] ?? __('Anteprima immagine', 'affiliate-link-manager-ai'))));
+            $html = '<div class="alma-media-preview"><img src="'.esc_url($url).'" alt="'.esc_attr($alt).'" loading="lazy"/><div class="alma-media-badges">';
+            if(!empty($media['is_cover'])) $html .= '<span class="alma-media-badge">Cover</span>';
+            $source = sanitize_text_field((string)($media['image_source'] ?? ''));
+            if($source !== '' && stripos($source, 'supplier') !== false) $html .= '<span class="alma-media-badge">Supplier</span>';
+            $html .= '</div></div>';
+        }
+        if(!empty($warnings)){
+            $html .= '<div class="alma-media-warning">'.esc_html($warnings[0]).'</div>';
+        }
+        return $html;
     }
     private function handle_import_selected_items(){
         if(!wp_verify_nonce($_POST['alma_import_selected_nonce']??'','alma_import_selected')) wp_die('Nonce non valido');

--- a/includes/class-affiliate-source-normalizer.php
+++ b/includes/class-affiliate-source-normalizer.php
@@ -3,10 +3,15 @@ if (!defined('ABSPATH')) { exit; }
 
 class ALMA_Affiliate_Source_Normalizer {
     public static function normalize($item, $source, $options = array()) {
+        $item = is_array($item) ? $item : array();
+        $source = is_array($source) ? $source : array();
         $write_provider_specific_meta = isset($options['write_provider_specific_meta']) ? (bool)$options['write_provider_specific_meta'] : true;
+        $provider = sanitize_key($source['provider'] ?? 'manual');
+        $provider_preset = sanitize_key($source['provider_preset'] ?? '');
+        $effective_provider = $provider_preset !== '' ? $provider_preset : $provider;
         $meta = array(
-            '_alma_provider' => sanitize_key($source['provider'] ?? 'manual'),
-            '_alma_provider_preset' => sanitize_key($source['provider_preset'] ?? ''),
+            '_alma_provider' => $provider,
+            '_alma_provider_preset' => $provider_preset,
             '_alma_source_id' => (string) ($source['id'] ?? ''),
             '_alma_external_id' => sanitize_text_field($item['external_id'] ?? ($item['productCode'] ?? '')),
             '_alma_ai_visibility' => self::sanitize_ai_visibility($item['ai_visibility'] ?? 'available'),
@@ -15,10 +20,55 @@ class ALMA_Affiliate_Source_Normalizer {
         if ($write_provider_specific_meta) {
             $meta['_alma_metadata_json'] = wp_json_encode($item);
         }
-        $normalized = array('post_title'=>sanitize_text_field($item['title'] ?? ($item['name'] ?? '')),'post_content'=>wp_kses_post($item['description'] ?? ''),'featured_image_url'=>esc_url_raw($item['image'] ?? ''),'affiliate_url'=>esc_url_raw($item['affiliate_url'] ?? ($item['productUrl'] ?? '')),'original_url'=>esc_url_raw($item['original_url'] ?? ($item['productUrl'] ?? '')),'meta'=>$meta,'raw_item'=>is_array($item)?$item:array());
+
+        $featured_image_url = esc_url_raw($item['image'] ?? '');
+        if ($effective_provider === 'viator') {
+            $media = self::resolve_viator_media($item);
+            $featured_image_url = !empty($media['has_image']) ? esc_url_raw((string)$media['featured_image_url']) : '';
+            self::add_viator_media_meta($meta, $media);
+        }
+
+        $normalized = array('post_title'=>sanitize_text_field($item['title'] ?? ($item['name'] ?? '')),'post_content'=>wp_kses_post($item['description'] ?? ''),'featured_image_url'=>$featured_image_url,'affiliate_url'=>esc_url_raw($item['affiliate_url'] ?? ($item['productUrl'] ?? '')),'original_url'=>esc_url_raw($item['original_url'] ?? ($item['productUrl'] ?? '')),'meta'=>$meta,'raw_item'=>$item);
         $hash_base = !empty($normalized['original_url']) ? $normalized['original_url'] : $normalized['affiliate_url'];
         $normalized['meta']['_alma_sync_hash'] = $hash_base ? wp_hash($hash_base) : '';
         return $normalized;
     }
+
+    private static function resolve_viator_media($item) {
+        if (!class_exists('ALMA_Affiliate_Source_Viator_Media_Resolver')) {
+            return array('has_image'=>false,'featured_image_url'=>'','image_source'=>'','caption'=>'','is_cover'=>false,'width'=>0,'height'=>0,'variant_url'=>'','images_count'=>0,'variants_count'=>0,'warnings'=>array());
+        }
+        $resolver = new ALMA_Affiliate_Source_Viator_Media_Resolver();
+        return $resolver->resolve($item);
+    }
+
+    private static function add_viator_media_meta(&$meta, $media) {
+        $media = is_array($media) ? $media : array();
+        $safe_media = array(
+            'has_image' => !empty($media['has_image']),
+            'featured_image_url' => esc_url_raw((string)($media['featured_image_url'] ?? '')),
+            'image_source' => sanitize_text_field((string)($media['image_source'] ?? '')),
+            'caption' => sanitize_text_field((string)($media['caption'] ?? '')),
+            'is_cover' => !empty($media['is_cover']),
+            'width' => absint($media['width'] ?? 0),
+            'height' => absint($media['height'] ?? 0),
+            'variant_url' => esc_url_raw((string)($media['variant_url'] ?? '')),
+            'images_count' => absint($media['images_count'] ?? 0),
+            'variants_count' => absint($media['variants_count'] ?? 0),
+            'warnings' => array_values(array_filter(array_map('sanitize_text_field', (array)($media['warnings'] ?? array())))),
+        );
+
+        $meta['_alma_featured_image_url'] = $safe_media['featured_image_url'];
+        $meta['_alma_media_provider'] = 'viator';
+        $meta['_alma_media_source'] = $safe_media['image_source'];
+        $meta['_alma_media_caption'] = $safe_media['caption'];
+        $meta['_alma_media_width'] = (string)$safe_media['width'];
+        $meta['_alma_media_height'] = (string)$safe_media['height'];
+        $meta['_alma_media_is_cover'] = $safe_media['is_cover'] ? '1' : '0';
+        $meta['_alma_viator_images_count'] = (string)$safe_media['images_count'];
+        $meta['_alma_viator_image_variants_count'] = (string)$safe_media['variants_count'];
+        $meta['_alma_viator_media_json'] = wp_json_encode($safe_media);
+    }
+
     public static function sanitize_ai_visibility($value) { $allowed = array('available', 'excluded', 'manual_only'); return in_array($value, $allowed, true) ? $value : 'available'; }
 }

--- a/includes/class-affiliate-source-viator-media-resolver.php
+++ b/includes/class-affiliate-source-viator-media-resolver.php
@@ -1,0 +1,183 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_Affiliate_Source_Viator_Media_Resolver {
+    public function resolve($item) {
+        $item = $this->array_from_mixed($item);
+        $warnings = array();
+        $images = $this->list_from_mixed($item['images'] ?? array());
+        $images_count = count($images);
+        $variants_count = 0;
+        $best = null;
+
+        if ($images_count === 0) {
+            $warnings[] = __('Nessuna immagine Viator disponibile.', 'affiliate-link-manager-ai');
+        }
+
+        foreach ($images as $image_index => $raw_image) {
+            $image = $this->array_from_mixed($raw_image);
+            if (empty($image)) {
+                $warnings[] = __('Immagine Viator ignorata: struttura non valida.', 'affiliate-link-manager-ai');
+                continue;
+            }
+
+            $image_source = sanitize_text_field((string)($image['imageSource'] ?? $image['source'] ?? ''));
+            $caption = sanitize_text_field((string)($image['caption'] ?? $image['altText'] ?? $image['alt'] ?? ''));
+            $is_cover = $this->is_truthy($image['isCover'] ?? false);
+            $variants = $this->list_from_mixed($image['variants'] ?? array());
+            if (empty($variants) && !empty($image['url'])) {
+                $variants = array(array(
+                    'url' => $image['url'],
+                    'width' => $image['width'] ?? null,
+                    'height' => $image['height'] ?? null,
+                ));
+            }
+
+            $variants_count += count($variants);
+            if (empty($variants)) {
+                $warnings[] = __('Immagine Viator senza varianti utilizzabili.', 'affiliate-link-manager-ai');
+                continue;
+            }
+
+            foreach ($variants as $variant_index => $raw_variant) {
+                $variant = $this->array_from_mixed($raw_variant);
+                $url = $this->sanitize_valid_url($variant['url'] ?? '');
+                if ($url === '') {
+                    continue;
+                }
+
+                $width = isset($variant['width']) ? absint($variant['width']) : 0;
+                $height = isset($variant['height']) ? absint($variant['height']) : 0;
+                $candidate = array(
+                    'has_image' => true,
+                    'featured_image_url' => $url,
+                    'image_source' => $image_source,
+                    'caption' => $caption,
+                    'is_cover' => $is_cover,
+                    'width' => $width,
+                    'height' => $height,
+                    'variant_url' => $url,
+                    'images_count' => $images_count,
+                    'variants_count' => $variants_count,
+                    'warnings' => array(),
+                    '_score' => $this->score_candidate($is_cover, $image_source, $width, $height, $image_index, $variant_index),
+                );
+
+                if ($best === null || $candidate['_score'] > $best['_score']) {
+                    $best = $candidate;
+                }
+            }
+        }
+
+        if ($best === null) {
+            if ($images_count > 0) {
+                $warnings[] = __('Nessuna variante immagine Viator contiene un URL valido.', 'affiliate-link-manager-ai');
+            }
+            return array(
+                'has_image' => false,
+                'featured_image_url' => '',
+                'image_source' => '',
+                'caption' => '',
+                'is_cover' => false,
+                'width' => 0,
+                'height' => 0,
+                'variant_url' => '',
+                'images_count' => $images_count,
+                'variants_count' => $variants_count,
+                'warnings' => array_values(array_unique($warnings)),
+            );
+        }
+
+        unset($best['_score']);
+        $best['variants_count'] = $variants_count;
+        $best['warnings'] = array_values(array_unique($warnings));
+        return $best;
+    }
+
+    private function score_candidate($is_cover, $image_source, $width, $height, $image_index, $variant_index) {
+        $score = 0;
+        if ($is_cover) {
+            $score += 1000000;
+        }
+        if ($this->is_supplier_source($image_source)) {
+            $score += 100000;
+        }
+
+        if ($width > 0 && $height > 0) {
+            $area = $width * $height;
+            $score += min($area, 1920 * 1080) / 1000;
+            if ($width < 240 || $height < 180) {
+                $score -= 5000;
+            }
+            if ($width >= 640 && $height >= 360) {
+                $score += 2000;
+            }
+            if ($width > 3000 || $height > 3000) {
+                $score -= 250;
+            }
+        } else {
+            $score += 100;
+        }
+
+        $score -= ((int)$image_index * 10) + (int)$variant_index;
+        return $score;
+    }
+
+    public function is_supplier_source($image_source) {
+        $source = strtoupper(trim((string)$image_source));
+        return $source !== '' && (strpos($source, 'SUPPLIER') !== false || strpos($source, 'SUPPLY') !== false);
+    }
+
+    private function sanitize_valid_url($url) {
+        $url = is_scalar($url) ? trim((string)$url) : '';
+        if ($url === '') {
+            return '';
+        }
+        $url = esc_url_raw($url);
+        return ($url !== '' && wp_http_validate_url($url)) ? $url : '';
+    }
+
+    private function list_from_mixed($value) {
+        if (is_object($value)) {
+            $value = (array)$value;
+        }
+        if (!is_array($value)) {
+            return array();
+        }
+        if ($this->is_list($value)) {
+            return $value;
+        }
+        return array($value);
+    }
+
+    private function array_from_mixed($value) {
+        if (is_object($value)) {
+            return (array)$value;
+        }
+        return is_array($value) ? $value : array();
+    }
+
+    private function is_list($array) {
+        if (!is_array($array)) {
+            return false;
+        }
+        $expected = 0;
+        foreach ($array as $key => $_value) {
+            if ($key !== $expected++) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private function is_truthy($value) {
+        if (is_bool($value)) {
+            return $value;
+        }
+        if (is_numeric($value)) {
+            return (int)$value === 1;
+        }
+        $value = strtolower(trim((string)$value));
+        return in_array($value, array('1', 'true', 'yes', 'y'), true);
+    }
+}

--- a/includes/class-ai-content-agent-affiliate-index.php
+++ b/includes/class-ai-content-agent-affiliate-index.php
@@ -186,6 +186,7 @@ class ALMA_AI_Content_Agent_Affiliate_Index {
         $link_types = is_wp_error($type_names) ? '' : implode(', ', array_map('sanitize_text_field', (array)$type_names));
         $thumb_id = (int)get_post_thumbnail_id($post_id);
         $thumb_url = $thumb_id > 0 ? wp_get_attachment_image_url($thumb_id, 'thumbnail') : '';
+        if ($thumb_url === '') { $thumb_url = esc_url_raw((string)get_post_meta($post_id, '_alma_featured_image_url', true)); }
         $text = trim(implode(' ', array($post->post_title, wp_strip_all_tags((string)$post->post_content), $ctx, $affiliate_url, $provider, $link_types)));
         $normalized = strtolower(preg_replace('/\s+/u', ' ', $text));
         $keywords = implode(' ', self::extract_terms($normalized));
@@ -201,7 +202,7 @@ class ALMA_AI_Content_Agent_Affiliate_Index {
             'link_types'=>sanitize_text_field($link_types),
             'featured_image_id'=>$thumb_id,
             'featured_image_url'=>esc_url_raw((string)$thumb_url),
-            'content_hash'=>hash('sha256', $normalized.'|'.$affiliate_url.'|'.$link_types.'|'.$thumb_id),
+            'content_hash'=>hash('sha256', $normalized.'|'.$affiliate_url.'|'.$link_types.'|'.$thumb_id.'|'.$thumb_url),
             'post_modified_gmt'=>gmdate('Y-m-d H:i:s', strtotime((string)$post->post_modified_gmt ?: 'now')),
             'indexed_at'=>current_time('mysql', true),
             'status'=>($post->post_status === 'publish' && $affiliate['valid']) ? self::STATUS_ACTIVE : self::STATUS_INACTIVE,


### PR DESCRIPTION
### Motivation
- Supportare correttamente le immagini restituite da Viator (struttura `images[]`/`variants[]`) e mostrare una preview import senza ancora sideloadare le immagini nella Media Library.
- Salvare un URL candidato e metadati media utili nel CPT `affiliate_link` per poter completare il flusso in una PR successiva (sideload / set_post_thumbnail separati).

### Description
- Aggiunto servizio dedicato `ALMA_Affiliate_Source_Viator_Media_Resolver` in `includes/class-affiliate-source-viator-media-resolver.php` che analizza difensivamente `images[]` e `variants[]`, seleziona un candidato principale secondo priorità (`isCover`, fonte supplier-like, qualità dimensionale) e restituisce una struttura normalizzata senza effettuare chiamate remote o download.
- Integrato il resolver nel normalizer (`includes/class-affiliate-source-normalizer.php`) per provider/preset Viator; il normalizer continua a usare il fallback legacy `image` per provider non Viator e aggiunge meta provider-specific sicuri come `_alma_featured_image_url`, `_alma_media_provider`, `_alma_media_source`, `_alma_media_caption`, `_alma_media_width`, `_alma_media_height`, `_alma_media_is_cover`, `_alma_viator_images_count`, `_alma_viator_image_variants_count`, `_alma_viator_media_json`.
- Estesa la preview import (`includes/class-affiliate-source-import-preview-service.php`) per includere blocco `media` dentro `_alma_validation` e generare warning non bloccanti quando l’immagine manca o non ha URL valido.
- Aggiunta colonna Immagine nella tabella Risultati anteprima (`includes/class-affiliate-source-manager.php`) che mostra miniatura ridotta lazy-loaded, badge `Cover`/`Supplier`, stato “Nessuna immagine” e warning non invasivi; implementata funzione helper `render_import_media_preview_cell`.
- Aggiunte classi CSS leggere in `assets/affiliate-sources.css` per preview thumbnail, badge e warning; aggiornato il bootstrap per caricare il nuovo resolver (`affiliate-link-manager-ai.php`) e incrementata la versione a `2.25.31` con aggiornamenti in `README.md` e `CHANGELOG.md`.
- Aggiornamento non invasivo dell’indice AI (`includes/class-ai-content-agent-affiliate-index.php`) per usare `_alma_featured_image_url` come fallback quando non esiste una featured image WordPress.
- File creato: `includes/class-affiliate-source-viator-media-resolver.php`.
- File modificati: `affiliate-link-manager-ai.php`, `includes/class-affiliate-source-normalizer.php`, `includes/class-affiliate-source-import-preview-service.php`, `includes/class-affiliate-source-manager.php`, `includes/class-ai-content-agent-affiliate-index.php`, `assets/affiliate-sources.css`, `README.md`, `CHANGELOG.md`.

### Testing
- Eseguiti controlli sintassi PHP con `php -l` su i file principali interessati e non sono stati rilevati errori (tutti passati).
- Eseguiti test locali di resolver/normalizer con script stub PHP (`/tmp/test_viator_media_resolver.php` e `/tmp/test_viator_normalizer.php`) per casi: cover supplier, no-cover, images vuoto, variant con URL non valido, variant senza dimensioni; tutti i casi hanno prodotto l’output previsto (selezione candidato o warning) con comportamento difensivo verificato.
- Test di integrazione manuale suggeriti (da eseguire in WordPress): import preview di sorgente Viator con diversi payload (con `isCover`, senza `isCover`, images vuoto, variants senza URL, URL senza width/height), verifica creazione/aggiornamento CPT `affiliate_link` e presenza dei meta media elencati; nota: questi richiedono ambiente WP attivo e source Viator configurata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4b6445cc8332921c00ff5dae1af8)