### PR TITLE
Show affiliate image thumbnails in AI search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.25.35 — AI search result affiliate image thumbnails
+- Aggiunta la miniatura dell'immagine affiliata nei **Risultati ricerca** dell'AI Content Agent, allineata a destra del record senza modificare i pulsanti di selezione/aggiunta.
+- La miniatura usa la stessa risoluzione strutturata del payload AI: featured image WordPress reale del CPT `affiliate_link`, fallback a `_alma_featured_image_url` solo se URL assoluto valido, nessun placeholder pesante quando manca l'immagine.
+- Rafforzato il payload OpenAI compatto affinché `image.image_url` sia sempre un URL assoluto valido quando disponibile e mai un attachment ID o path relativo.
+- Confermati limiti PR: nessun download remoto, nessun sideload, nessuna creazione attachment, nessuna galleria multipla e nessuna generazione immagini AI.
+- Versione plugin aggiornata a `2.25.35`.
+
 ## 2.25.34 — AI profiles multi-activation and affiliate images in drafts
 - Corretta l'attivazione multipla dei profili **Istruzioni AI**: ogni profilo mantiene il proprio `is_active` e l'attivazione/disattivazione dalla lista modifica solo il profilo scelto.
 - Aggiornato il pulsante lista profili con label contestuale **Attiva/Disattiva**, badge **Attivo/Non attivo**, nonce dedicato, capability admin e notice chiara dopo redirect.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## 2.25.35 — AI search result affiliate image thumbnails
+- Aggiunta la miniatura dell'immagine affiliata nei **Risultati ricerca** dell'AI Content Agent, allineata a destra del record senza modificare i pulsanti di selezione/aggiunta.
+- La miniatura usa la stessa risoluzione strutturata del payload AI: featured image WordPress reale del CPT `affiliate_link`, fallback a `_alma_featured_image_url` solo se URL assoluto valido, nessun placeholder pesante quando manca l'immagine.
+- Rafforzato il payload OpenAI compatto affinché `image.image_url` sia sempre un URL assoluto valido quando disponibile e mai un attachment ID o path relativo.
+- Confermati limiti PR: nessun download remoto, nessun sideload, nessuna creazione attachment, nessuna galleria multipla e nessuna generazione immagini AI.
+- Versione plugin aggiornata a `2.25.35`.
+
 ## 2.25.34 — AI profiles multi-activation and affiliate images in drafts
 - Corretta l'attivazione multipla dei profili **Istruzioni AI**: ogni profilo mantiene il proprio `is_active` e l'attivazione/disattivazione dalla lista modifica solo il profilo scelto.
 - Aggiornato il pulsante lista profili con label contestuale **Attiva/Disattiva**, badge **Attivo/Non attivo**, nonce dedicato, capability admin e notice chiara dopo redirect.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.34
+ * Version: 2.25.35
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.34');
+define('ALMA_VERSION', '2.25.35');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -714,6 +714,10 @@ button:disabled {
 .alma-ai-agent-admin .alma-results-group{margin:0 0 12px}
 .alma-ai-agent-admin .alma-result-item{padding:10px;border:1px solid #e2e4e7;border-radius:4px;margin:0 0 8px}
 .alma-ai-agent-admin .alma-result-item.is-already-added{background:#eef8f0;border-color:#46b450}
+.alma-ai-agent-admin .alma-result-body{display:flex;align-items:flex-start;justify-content:space-between;gap:14px}
+.alma-ai-agent-admin .alma-result-copy{min-width:0;flex:1 1 auto}
+.alma-ai-agent-admin .alma-result-thumbnail{flex:0 0 92px;align-self:flex-start;border:1px solid #dcdcde;border-radius:6px;overflow:hidden;background:#f6f7f7}
+.alma-ai-agent-admin .alma-result-thumbnail-img{display:block;width:92px;height:92px;object-fit:cover}
 .alma-ai-agent-admin .alma-added-badge,.alma-ai-agent-admin .alma-usage-badge,.alma-ai-agent-admin .alma-count-badge{display:inline-block;padding:2px 8px;border-radius:999px;font-size:11px;margin-left:6px}
 .alma-ai-agent-admin .alma-added-badge{background:#e7f5ea;color:#1e7e34}
 .alma-ai-agent-admin .alma-usage-badge{background:#f0f0f1;color:#1d2327}
@@ -739,6 +743,9 @@ button:disabled {
     .alma-ai-agent-admin .alma-idea-title-input{min-width:100%;width:100%}
     .alma-ai-agent-admin .alma-idea-main-actions,.alma-ai-agent-admin .alma-idea-main-actions form{width:100%}
     .alma-ai-agent-admin .alma-action-button{justify-content:center;width:100%}
+    .alma-ai-agent-admin .alma-result-body{gap:10px}
+    .alma-ai-agent-admin .alma-result-thumbnail{flex-basis:72px}
+    .alma-ai-agent-admin .alma-result-thumbnail-img{width:72px;height:72px}
     .alma-ai-agent-admin .alma-ideas-pagination{align-items:stretch;flex-direction:column}
     .alma-ai-agent-admin .alma-ideas-pagination .button{text-align:center}
 }

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -676,7 +676,21 @@ class ALMA_AI_Content_Agent_Admin {
         if (empty($paged_rows)) {
             if (!empty($all_rows) && $total_results === 0) { echo '<p class="description">Nessun Link affiliato corrisponde ai filtri selezionati.</p>'; } else { echo '<p class="description">Nessun risultato disponibile. Esegui una ricerca per popolare questa sezione.</p>'; }
         }
-        foreach($paged_rows as $item){ $r=(array)$item['row']; $rk=sanitize_text_field($r['result_key'] ?? ''); if($rk===''){continue;} $in=!empty($selected_map[$rk]); $usage=(int)($usage_counts[$rk] ?? 0); echo '<div class="alma-result-item'.($in?' is-already-added':'').'"><p><strong>'.esc_html($r['title']).'</strong> <span class="alma-count-badge">'.esc_html($item['label']).'</span>'; if($in){echo ' <span class="alma-added-badge">Già nell’idea</span>';} echo ' <span class="alma-usage-badge">Utilizzato in bozze: '.$usage.'</span></p><label><input type="checkbox" name="selected_result_keys[]" value="'.esc_attr($rk).'" form="alma-bulk-add-form" '.disabled($in,true,false).'> Seleziona</label><p class="alma-excerpt">'.esc_html(wp_trim_words((string)($r['excerpt'] ?? ''),20,'…')).'</p><p class="description">Score: <span class="alma-score-value">'.(int)($r['score'] ?? 0).'</span> · '.esc_html($r['reason'] ?? '').'</p>'; if($in){ echo '<button class="button button-small" type="button" disabled>Già aggiunto</button>'; } else { echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="add_result_to_idea"><input type="hidden" name="result_key" value="'.esc_attr($rk).'"><button class="button button-small">Aggiungi all’idea</button></form>'; } echo '</div>'; }
+        foreach($paged_rows as $item){
+            $r=(array)$item['row'];
+            $rk=sanitize_text_field($r['result_key'] ?? '');
+            if($rk===''){continue;}
+            $in=!empty($selected_map[$rk]);
+            $usage=(int)($usage_counts[$rk] ?? 0);
+            $thumbnail_html = self::render_affiliate_result_thumbnail($r);
+            echo '<div class="alma-result-item alma-result-item-with-thumbnail'.($in?' is-already-added':'').'"><div class="alma-result-body">';
+            echo '<div class="alma-result-copy"><p><strong>'.esc_html($r['title']).'</strong> <span class="alma-count-badge">'.esc_html($item['label']).'</span>';
+            if($in){echo ' <span class="alma-added-badge">Già nell’idea</span>';}
+            echo ' <span class="alma-usage-badge">Utilizzato in bozze: '.$usage.'</span></p><label><input type="checkbox" name="selected_result_keys[]" value="'.esc_attr($rk).'" form="alma-bulk-add-form" '.disabled($in,true,false).'> Seleziona</label><p class="alma-excerpt">'.esc_html(wp_trim_words((string)($r['excerpt'] ?? ''),20,'…')).'</p><p class="description">Score: <span class="alma-score-value">'.(int)($r['score'] ?? 0).'</span> · '.esc_html($r['reason'] ?? '').'</p>';
+            if($in){ echo '<button class="button button-small" type="button" disabled>Già aggiunto</button>'; }
+            else { echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="add_result_to_idea"><input type="hidden" name="result_key" value="'.esc_attr($rk).'"><button class="button button-small">Aggiungi all’idea</button></form>'; }
+            echo '</div>'.$thumbnail_html.'</div></div>';
+        }
         echo '<p><button class="button button-primary" type="submit" form="alma-bulk-add-form">Aggiungi selezionati all’idea</button></p></div></main>';
 
 echo '<aside class="alma-ideas-col alma-ideas-col-right"><div class="alma-ideas-card"><h3>3. Sessione contenuto</h3><p><strong>Totale elementi aggiunti:</strong> '.(int)($summary['selected_total'] ?? 0).'</p>';
@@ -691,6 +705,23 @@ echo '<aside class="alma-ideas-col alma-ideas-col-right"><div class="alma-ideas-
     private static function inline_document_actions($document_id, $is_active) { $document_id=absint($document_id); if($document_id<1||!current_user_can('manage_options')){return '';} $toggle=$is_active?'inactive':'active'; return '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="toggle_txt_document"><input type="hidden" name="document_id" value="'.$document_id.'"><input type="hidden" name="status" value="'.esc_attr($toggle).'"><button class="button button-small">'.($is_active?'Disabilita':'Abilita').'</button></form><form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="delete_txt_document"><input type="hidden" name="document_id" value="'.$document_id.'"><button class="button button-small">Elimina</button></form>'; }
     private static function inline_source_actions($source_id, $is_active) { $source_id=absint($source_id); if($source_id<1||!current_user_can('manage_options')){return '';} $next=(int)$is_active?0:1; return '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="toggle_source"><input type="hidden" name="source_id" value="'.$source_id.'"><input type="hidden" name="is_active" value="'.$next.'"><button class="button button-small">'.($is_active?'Disabilita':'Abilita').'</button></form><form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="delete_source"><input type="hidden" name="source_id" value="'.$source_id.'"><button class="button button-small">Elimina</button></form>'; }
     private static function inline_profile_action_form($do, $label, $profile_id) { $profile_id=absint($profile_id); if($profile_id<1||!current_user_can('manage_options')){return '';} return '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'" style="display:inline-block;margin-left:4px;">'.wp_nonce_field('alma_ai_instruction_profile_toggle_'.$profile_id,'_alma_profile_nonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="'.esc_attr($do).'"><input type="hidden" name="profile_id" value="'.$profile_id.'"><button class="button button-small">'.esc_html($label).'</button></form>'; }
+
+
+    private static function render_affiliate_result_thumbnail($row) {
+        if (!is_array($row) || sanitize_key((string)($row['source_group'] ?? '')) !== 'affiliate_link') { return ''; }
+        $image = is_array($row['image'] ?? null) ? $row['image'] : array();
+        $url = esc_url_raw((string)($image['image_url'] ?? ($row['featured_image_url'] ?? ($row['image_url'] ?? ''))));
+        $attachment_id = absint($row['featured_image_id'] ?? 0);
+        if ($attachment_id > 0) {
+            $attachment_url = wp_get_attachment_image_url($attachment_id, 'thumbnail');
+            if (!$attachment_url) { $attachment_url = wp_get_attachment_image_url($attachment_id, 'large'); }
+            if ($attachment_url) { $url = esc_url_raw((string)$attachment_url); }
+        }
+        if ($url === '' || !wp_http_validate_url($url)) { return ''; }
+        $alt = sanitize_text_field((string)($image['image_alt'] ?? ($row['featured_image_alt'] ?? ($row['title'] ?? ''))));
+        if ($alt === '') { $alt = sanitize_text_field((string)($row['title'] ?? '')); }
+        return '<div class="alma-result-thumbnail" aria-label="'.esc_attr__('Immagine link affiliato', 'affiliate-link-manager-ai').'"><img class="alma-result-thumbnail-img" src="'.esc_url($url).'" alt="'.esc_attr($alt).'" loading="lazy" decoding="async"></div>';
+    }
 
     private static function action_form($do,$label,$extra='',$button_class='button',$icon_class=''){ echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_ai_agent_action'); $button_content = $icon_class !== '' ? '<span class="dashicons '.esc_attr($icon_class).'" aria-hidden="true"></span><span>'.esc_html($label).'</span>' : esc_html($label); echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="'.esc_attr($do).'">'.$extra.'<p><button class="'.esc_attr($button_class).'">'.$button_content.'</button></p></form>'; }
 }

--- a/includes/class-ai-content-agent-affiliate-index.php
+++ b/includes/class-ai-content-agent-affiliate-index.php
@@ -192,17 +192,21 @@ class ALMA_AI_Content_Agent_Affiliate_Index {
         if ($thumb_id > 0 && get_post_type($thumb_id) === 'attachment') {
             $url = wp_get_attachment_image_url($thumb_id, 'large');
             if (!$url) { $url = wp_get_attachment_image_url($thumb_id, 'full'); }
-            $attachment = get_post($thumb_id);
-            $caption = $attachment ? sanitize_text_field((string)$attachment->post_excerpt) : '';
-            return array(
-                'featured_image_id' => $thumb_id,
-                'featured_image_url' => esc_url_raw((string)$url),
-                'featured_image_alt' => sanitize_text_field((string)get_post_meta($thumb_id, '_wp_attachment_image_alt', true)),
-                'featured_image_caption' => $caption,
-                'has_featured_image' => !empty($url),
-                'image_source' => 'wordpress_featured_image',
-                'image_import_status' => sanitize_text_field((string)(get_post_meta($post_id, '_alma_image_import_status', true) ?: get_post_meta($post_id, '_alma_featured_image_import_status', true))),
-            );
+            $url = esc_url_raw((string)$url);
+            if ($url !== '' && !wp_http_validate_url($url)) { $url = ''; }
+            if ($url !== '') {
+                $attachment = get_post($thumb_id);
+                $caption = $attachment ? sanitize_text_field((string)$attachment->post_excerpt) : '';
+                return array(
+                    'featured_image_id' => $thumb_id,
+                    'featured_image_url' => $url,
+                    'featured_image_alt' => sanitize_text_field((string)get_post_meta($thumb_id, '_wp_attachment_image_alt', true)),
+                    'featured_image_caption' => $caption,
+                    'has_featured_image' => true,
+                    'image_source' => 'wordpress_featured_image',
+                    'image_import_status' => sanitize_text_field((string)(get_post_meta($post_id, '_alma_image_import_status', true) ?: get_post_meta($post_id, '_alma_featured_image_import_status', true))),
+                );
+            }
         }
 
         $remote_url = esc_url_raw((string)get_post_meta($post_id, '_alma_featured_image_url', true));

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -391,6 +391,15 @@ class ALMA_AI_Content_Agent_Draft_Builder {
                 $description
             );
             $image = is_array($link['image'] ?? null) ? $link['image'] : array();
+            $image_url = esc_url_raw((string)($image['image_url'] ?? ($link['featured_image_url'] ?? '')));
+            $attachment_id = absint($link['featured_image_id'] ?? 0);
+            if ($attachment_id > 0 && ($image_url === '' || !wp_http_validate_url($image_url))) {
+                $attachment_url = wp_get_attachment_image_url($attachment_id, 'large');
+                if (!$attachment_url) { $attachment_url = wp_get_attachment_image_url($attachment_id, 'full'); }
+                $image_url = esc_url_raw((string)$attachment_url);
+            }
+            if ($image_url !== '' && !wp_http_validate_url($image_url)) { $image_url = ''; }
+            $has_image = $image_url !== '' && (!empty($image['has_image']) || !empty($link['has_featured_image']) || !empty($link['featured_image_url']));
             $item = array(
                 'id' => absint($link['id'] ?? 0),
                 'title' => sanitize_text_field((string)($link['title'] ?? '')),
@@ -399,15 +408,15 @@ class ALMA_AI_Content_Agent_Draft_Builder {
                 'shortcode' => sanitize_text_field((string)($link['shortcode'] ?? '')),
                 'link_types' => array_values(array_unique(array_filter(array_map('sanitize_text_field', (array)($link['link_types'] ?? array()))))),
                 'image' => array(
-                    'has_image' => !empty($image['has_image']),
-                    'image_url' => esc_url_raw((string)($image['image_url'] ?? '')),
-                    'image_alt' => sanitize_text_field((string)($image['image_alt'] ?? '')),
-                    'image_caption' => self::compact_text((string)($image['image_caption'] ?? ''), 20),
-                    'image_source' => sanitize_text_field((string)($image['image_source'] ?? '')),
-                    'can_use_in_content' => !empty($image['can_use_in_content']),
+                    'has_image' => (bool)$has_image,
+                    'image_url' => $has_image ? $image_url : '',
+                    'image_alt' => sanitize_text_field((string)($image['image_alt'] ?? ($link['featured_image_alt'] ?? ($link['title'] ?? '')))),
+                    'image_caption' => self::compact_text((string)($image['image_caption'] ?? ($link['featured_image_caption'] ?? '')), 20),
+                    'image_source' => sanitize_text_field((string)($image['image_source'] ?? ($link['image_source'] ?? ''))),
+                    'can_use_in_content' => (bool)($has_image && !empty($image['can_use_in_content'])),
                 ),
             );
-            if (empty($item['image']['has_image']) || $item['image']['image_url'] === '') { $item['image'] = array('has_image'=>false,'image_url'=>'','image_alt'=>'','image_caption'=>'','image_source'=>'','can_use_in_content'=>false); }
+            if (!$has_image || empty($item['image']['can_use_in_content'])) { $item['image'] = array('has_image'=>false,'image_url'=>'','image_alt'=>'','image_caption'=>'','image_source'=>'','can_use_in_content'=>false); }
             if ($context !== '') { $item['context'] = $context; }
             $affiliate_links[] = $item;
         }

--- a/includes/class-ai-content-agent-selection-session.php
+++ b/includes/class-ai-content-agent-selection-session.php
@@ -41,10 +41,50 @@ class ALMA_AI_Content_Agent_Selection_Session {
             if ($key === '') { continue; }
             $row['result_key'] = $key;
             $row['source_group'] = self::normalize_group($row['source_group'] ?? '');
+            $row = self::normalize_affiliate_image_fields($row);
             $row['selected'] = $force_selected ? true : !empty($row['selected']);
             $normalized[$key] = $row;
         }
         return $normalized;
+    }
+
+    private static function normalize_affiliate_image_fields($row) {
+        if (!is_array($row)) { return array(); }
+        $source_group = self::normalize_group($row['source_group'] ?? '');
+        if ($source_group !== 'affiliate_link') { return $row; }
+
+        $wp_id = absint($row['wp_id'] ?? ($row['source_id'] ?? 0));
+        $image = array();
+        if ($wp_id > 0 && class_exists('ALMA_AI_Content_Agent_Affiliate_Index')) {
+            $image = ALMA_AI_Content_Agent_Affiliate_Index::get_image_data($wp_id);
+        }
+
+        $featured_image_id = absint($image['featured_image_id'] ?? ($row['featured_image_id'] ?? 0));
+        $featured_image_url = esc_url_raw((string)($image['featured_image_url'] ?? ($row['featured_image_url'] ?? ($row['image_url'] ?? ''))));
+        if ($featured_image_id > 0 && ($featured_image_url === '' || !wp_http_validate_url($featured_image_url))) {
+            $attachment_url = wp_get_attachment_image_url($featured_image_id, 'large');
+            if (!$attachment_url) { $attachment_url = wp_get_attachment_image_url($featured_image_id, 'full'); }
+            $featured_image_url = esc_url_raw((string)$attachment_url);
+        }
+        if ($featured_image_url !== '' && !wp_http_validate_url($featured_image_url)) { $featured_image_url = ''; }
+
+        $row['featured_image_id'] = $featured_image_id;
+        $row['featured_image_url'] = $featured_image_url;
+        $row['featured_image_alt'] = sanitize_text_field((string)($image['featured_image_alt'] ?? ($row['featured_image_alt'] ?? ($row['image_alt'] ?? ($row['title'] ?? '')))));
+        $row['featured_image_caption'] = sanitize_text_field((string)($image['featured_image_caption'] ?? ($row['featured_image_caption'] ?? ($row['image_caption'] ?? ''))));
+        $row['has_featured_image'] = $featured_image_url !== '';
+        $row['image_source'] = sanitize_text_field((string)($image['image_source'] ?? ($row['image_source'] ?? '')));
+        $row['image_import_status'] = sanitize_text_field((string)($image['image_import_status'] ?? ($row['image_import_status'] ?? '')));
+        $row['image'] = array(
+            'has_image' => $featured_image_url !== '',
+            'image_url' => $featured_image_url,
+            'image_alt' => sanitize_text_field((string)($row['featured_image_alt'] ?? ($row['title'] ?? ''))),
+            'image_caption' => sanitize_text_field((string)($row['featured_image_caption'] ?? '')),
+            'image_source' => sanitize_text_field((string)($row['image_source'] ?? '')),
+            'can_use_in_content' => $featured_image_url !== '',
+        );
+
+        return $row;
     }
 
     private static function normalize_session_payload($session) {
@@ -237,7 +277,7 @@ class ALMA_AI_Content_Agent_Selection_Session {
         elseif ($source_group === 'media' && $wp_id > 0) { $result_key = 'media:' . $wp_id; }
         else { $result_key = $source_group . ':' . ($source_id ?: ($knowledge_item_id ?: ($wp_id ?: substr(md5(wp_json_encode($row)), 0, 12)))); }
 
-        return array(
+        $normalized = array(
             'result_key' => sanitize_text_field($result_key),
             'origin_key' => $origin_key,
             'raw_key' => sanitize_text_field($row['result_key'] ?? ''),
@@ -259,12 +299,22 @@ class ALMA_AI_Content_Agent_Selection_Session {
             'has_featured_image' => !empty($row['has_featured_image']),
             'image_source' => sanitize_text_field($row['image_source'] ?? ''),
             'image_import_status' => sanitize_text_field($row['image_import_status'] ?? ''),
+            'image' => is_array($row['image'] ?? null) ? array(
+                'has_image' => !empty($row['image']['has_image']),
+                'image_url' => esc_url_raw((string)($row['image']['image_url'] ?? '')),
+                'image_alt' => sanitize_text_field((string)($row['image']['image_alt'] ?? '')),
+                'image_caption' => sanitize_text_field((string)($row['image']['image_caption'] ?? '')),
+                'image_source' => sanitize_text_field((string)($row['image']['image_source'] ?? '')),
+                'can_use_in_content' => !empty($row['image']['can_use_in_content']),
+            ) : array(),
             'provenance' => sanitize_text_field((string)($row['provenance'] ?? '')),
             'provider' => sanitize_text_field((string)($row['provider'] ?? '')),
             'source' => sanitize_text_field((string)($row['source'] ?? '')),
             'selectable' => true,
             'selected' => !empty($row['preselected']),
         );
+
+        return self::normalize_affiliate_image_fields($normalized);
     }
 
     private static function normalize_link_types($raw_link_types) {


### PR DESCRIPTION
### Motivation

- Migliorare l'usabilità della card “Risultati ricerca” dell’AI Content Agent mostrando per ogni record affiliato la miniatura dell’immagine associata, mantenendo inalterati i controlli di selezione/aggiunta e il flusso esistente.
- Garantire coerenza tra UI e payload OpenAI: l'immagine mostrata deve usare la stessa logica di risoluzione e il `image.image_url` nel payload deve essere un URL assoluto valido.
- Non introdurre download remoto, sideload o modifiche alla Media Library (vincoli già esistenti).

### Description

- Aggiunta rendering della miniatura nei risultati ricerca con layout flex (testo/pulsanti a sinistra, miniatura a destra) e markup HTML leggero in `includes/class-ai-content-agent-admin.php` (nuova funzione `render_affiliate_result_thumbnail`).
- Centralizzata normalizzazione dei campi immagine per i risultati/sessioni in `includes/class-ai-content-agent-selection-session.php` tramite `normalize_affiliate_image_fields` in modo che `search_results` e `selected_results` contengano i campi immagine coerenti (`image`, `featured_image_url`, `featured_image_id`, `has_featured_image`, ecc.).
- Rafforzata la risoluzione immagine in `includes/class-ai-content-agent-affiliate-index.php` per preferire l’URL attachment WordPress (tramite `wp_get_attachment_image_url()` e validazione `wp_http_validate_url()`), con fallback a `_alma_featured_image_url` solo se è un URL assoluto valido.
- Consolidata la logica di payload nel Draft Builder (`includes/class-ai-content-agent-draft-builder.php`) in modo che `image.image_url` nel payload OpenAI sia un URL assoluto valido (se disponibile) e non un attachment ID o path relativo; la sezione immagine rimane compatta con i campi minimi richiesti.
- Aggiunte classi CSS leggere in `assets/admin.css` per layout responsivo della miniatura (`.alma-result-body`, `.alma-result-copy`, `.alma-result-thumbnail`, `.alma-result-thumbnail-img`) e riduzione dimensione su viewport stretti.
- Aggiornati header plugin e costante `ALMA_VERSION` a `2.25.35` e aggiornati `README.md` e `CHANGELOG.md` con le note di rilascio.

### Testing

- Eseguiti i check sintattici PHP con `php -l` su tutti i file modificati: `includes/class-ai-content-agent-affiliate-index.php`, `includes/class-ai-content-agent-selection-session.php`, `includes/class-ai-content-agent-admin.php`, `includes/class-ai-content-agent-draft-builder.php`, `affiliate-link-manager-ai.php`; tutti i file sono risultati senza errori di sintassi.
- Eseguito `git diff --check` per rilevare whitespace/indentazione: nessun errore rilevato.
- Commit locale del set di modifiche e controllo diff: modifiche rilevate come previste (CSS, admin rendering, normalizzazione immagine, draft builder, versione e documentazione).
- Tutti i test/controlli automatici eseguiti in ambiente di sviluppo hanno avuto esito positivo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb59b70e6483328094c6c0431743ea)