### PR TITLE
Fix AI payload profile and affiliate images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.25.36 — AI payload profile and affiliate image consistency
+- Aggiunto nel payload OpenAI normalizzato il blocco `instruction_profile` compatto (`id`, `name`, `snapshot_hash`) riferito solo al profilo istruzioni selezionato dall’utente.
+- Garantito che il payload OpenAI non includa liste di profili attivi e non scelga un profilo diverso da quello associato alla sessione/idea.
+- Propagate immagini affiliate coerenti in `selection_context`, sessione selezione e `affiliate_links`, usando featured image WordPress reale con fallback a `_alma_featured_image_url` solo se URL assoluto valido.
+- Aggiunte `media_rules` al payload OpenAI compatto senza duplicarle inutilmente nelle istruzioni editoriali.
+- Migliorata la diagnostica debug per immagini mancanti dei link affiliati con `image_debug`, utile anche per verificare link Viator senza featured image/meta URL/import status valido.
+- Confermata l’assenza di download remoto, sideload, gallerie multiple, traveler photos, video o generazione immagini AI durante la generazione bozza.
+- Versione plugin aggiornata a `2.25.36`.
+
 ## 2.25.35 — AI search result affiliate image thumbnails
 - Aggiunta la miniatura dell'immagine affiliata nei **Risultati ricerca** dell'AI Content Agent, allineata a destra del record senza modificare i pulsanti di selezione/aggiunta.
 - La miniatura usa la stessa risoluzione strutturata del payload AI: featured image WordPress reale del CPT `affiliate_link`, fallback a `_alma_featured_image_url` solo se URL assoluto valido, nessun placeholder pesante quando manca l'immagine.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## 2.25.36 — AI payload profile and affiliate image consistency
+- Aggiunto nel payload OpenAI normalizzato il blocco `instruction_profile` compatto (`id`, `name`, `snapshot_hash`) riferito solo al profilo istruzioni selezionato dall’utente.
+- Garantito che il payload OpenAI non includa liste di profili attivi e non scelga un profilo diverso da quello associato alla sessione/idea.
+- Propagate immagini affiliate coerenti in `selection_context`, sessione selezione e `affiliate_links`, usando featured image WordPress reale con fallback a `_alma_featured_image_url` solo se URL assoluto valido.
+- Aggiunte `media_rules` al payload OpenAI compatto senza duplicarle inutilmente nelle istruzioni editoriali.
+- Migliorata la diagnostica debug per immagini mancanti dei link affiliati con `image_debug`, utile anche per verificare link Viator senza featured image/meta URL/import status valido.
+- Confermata l’assenza di download remoto, sideload, gallerie multiple, traveler photos, video o generazione immagini AI durante la generazione bozza.
+- Versione plugin aggiornata a `2.25.36`.
+
 ## 2.25.35 — AI search result affiliate image thumbnails
 - Aggiunta la miniatura dell'immagine affiliata nei **Risultati ricerca** dell'AI Content Agent, allineata a destra del record senza modificare i pulsanti di selezione/aggiunta.
 - La miniatura usa la stessa risoluzione strutturata del payload AI: featured image WordPress reale del CPT `affiliate_link`, fallback a `_alma_featured_image_url` solo se URL assoluto valido, nessun placeholder pesante quando manca l'immagine.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.35
+ * Version: 2.25.36
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.35');
+define('ALMA_VERSION', '2.25.36');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-affiliate-index.php
+++ b/includes/class-ai-content-agent-affiliate-index.php
@@ -184,7 +184,7 @@ class ALMA_AI_Content_Agent_Affiliate_Index {
             'featured_image_caption' => '',
             'has_featured_image' => false,
             'image_source' => '',
-            'image_import_status' => sanitize_text_field((string)get_post_meta($post_id, '_alma_image_import_status', true)),
+            'image_import_status' => sanitize_text_field((string)(get_post_meta($post_id, '_alma_image_import_status', true) ?: get_post_meta($post_id, '_alma_featured_image_import_status', true))),
         );
         if ($post_id < 1) { return $empty; }
 
@@ -223,6 +223,40 @@ class ALMA_AI_Content_Agent_Affiliate_Index {
         }
 
         return $empty;
+    }
+
+
+    public static function get_image_debug_data($post_id) {
+        $post_id = absint($post_id);
+        $featured_image_id = $post_id > 0 ? (int)get_post_thumbnail_id($post_id) : 0;
+        $featured_meta_raw = $post_id > 0 ? (string)get_post_meta($post_id, '_alma_featured_image_url', true) : '';
+        $source_url_raw = $post_id > 0 ? (string)get_post_meta($post_id, '_alma_featured_image_source_url', true) : '';
+        $import_status = $post_id > 0 ? sanitize_text_field((string)(get_post_meta($post_id, '_alma_image_import_status', true) ?: get_post_meta($post_id, '_alma_featured_image_import_status', true) ?: get_post_meta($post_id, '_alma_import_status', true))) : '';
+        $featured_meta_url = esc_url_raw($featured_meta_raw);
+        $source_meta_url = esc_url_raw($source_url_raw);
+        $reason = 'no_featured_image_or_meta_url';
+
+        if ($featured_image_id > 0) {
+            $attachment_url = wp_get_attachment_image_url($featured_image_id, 'large');
+            if (!$attachment_url) { $attachment_url = wp_get_attachment_image_url($featured_image_id, 'full'); }
+            $reason = ($attachment_url && wp_http_validate_url((string)$attachment_url)) ? 'featured_image_available' : 'featured_image_url_invalid';
+        } elseif ($featured_meta_raw !== '' && ($featured_meta_url === '' || !wp_http_validate_url($featured_meta_url))) {
+            $reason = 'alma_featured_image_url_invalid';
+        } elseif ($featured_meta_url !== '' && wp_http_validate_url($featured_meta_url)) {
+            $reason = 'alma_featured_image_url_available';
+        } elseif ($source_url_raw !== '' && ($source_meta_url === '' || !wp_http_validate_url($source_meta_url))) {
+            $reason = 'source_url_meta_invalid';
+        } elseif ($import_status !== '' && preg_match('/fail|error|invalid|missing/i', $import_status)) {
+            $reason = 'image_import_status_' . sanitize_key($import_status);
+        }
+
+        return array(
+            'featured_image_id' => $featured_image_id,
+            'featured_image_url_meta_present' => $featured_meta_raw !== '',
+            'source_url_meta_present' => $source_url_raw !== '',
+            'import_status' => $import_status,
+            'reason' => $reason,
+        );
     }
 
     private static function build_row($post) {

--- a/includes/class-ai-content-agent-affiliate-selector.php
+++ b/includes/class-ai-content-agent-affiliate-selector.php
@@ -17,7 +17,17 @@ class ALMA_AI_Content_Agent_Affiliate_Selector {
             foreach (array($keywords,$theme,$destination) as $needle) { if ($needle !== '' && str_contains($blob, strtolower($needle))) { $score += 35; } }
             if ($score <= 0) { continue; }
             $image = class_exists('ALMA_AI_Content_Agent_Affiliate_Index') ? ALMA_AI_Content_Agent_Affiliate_Index::get_image_data($post->ID) : array();
-            $items[] = array_merge(array('link_id'=>$post->ID,'title'=>$post->post_title,'detected'=>$destination ?: $theme ?: 'generic','reason'=>'Match con keyword/tema/destinazione','score_match'=>min(100, $score),'shortcode'=>'[affiliate_link id="'.$post->ID.'"]','warning'=>$ctx === '' ? 'Contesto AI non disponibile' : ''), $image);
+            $image_url = esc_url_raw((string)($image['featured_image_url'] ?? ''));
+            if ($image_url !== '' && !wp_http_validate_url($image_url)) { $image_url = ''; }
+            $image_block = $image_url !== '' ? array(
+                'has_image' => true,
+                'image_url' => $image_url,
+                'image_alt' => sanitize_text_field((string)($image['featured_image_alt'] ?? $post->post_title)),
+                'image_caption' => sanitize_text_field((string)($image['featured_image_caption'] ?? '')),
+                'image_source' => sanitize_text_field((string)($image['image_source'] ?? '')),
+                'can_use_in_content' => true,
+            ) : array('has_image'=>false,'image_url'=>'','image_alt'=>'','image_caption'=>'','image_source'=>'','can_use_in_content'=>false);
+            $items[] = array_merge(array('link_id'=>$post->ID,'title'=>$post->post_title,'detected'=>$destination ?: $theme ?: 'generic','reason'=>'Match con keyword/tema/destinazione','score_match'=>min(100, $score),'shortcode'=>'[affiliate_link id="'.$post->ID.'"]','warning'=>$ctx === '' ? 'Contesto AI non disponibile' : '', 'image'=>$image_block), $image);
             if (count($items) >= $limit) { break; }
         }
         if (empty($items)) { $warnings[] = 'Link affiliati insufficienti per match forte.'; }

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -198,6 +198,38 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'instruction_snapshot' => $snapshot,
         );
     }
+
+    private static function compact_instruction_profile_payload($payload) {
+        $payload = is_array($payload) ? $payload : array();
+        $profile_id = absint($payload['instruction_profile_id'] ?? 0);
+        if ($profile_id < 1) { return null; }
+        $profile = is_array($payload['instruction_profile'] ?? null) ? $payload['instruction_profile'] : array();
+        $name = sanitize_text_field((string)($payload['instruction_profile_name'] ?? ($profile['profile_name'] ?? '')));
+        if ($name === '') { $name = 'Profilo #' . $profile_id; }
+        $snapshot_hash = sanitize_text_field((string)($payload['instruction_snapshot_hash'] ?? ''));
+        if ($snapshot_hash === '' && !empty($payload['instruction_snapshot'])) {
+            $snapshot_hash = ALMA_AI_Content_Agent_Instructions_Manager::snapshot_hash((string)$payload['instruction_snapshot']);
+        }
+        return array('id'=>$profile_id, 'name'=>$name, 'snapshot_hash'=>$snapshot_hash);
+    }
+
+    private static function compact_affiliate_image_payload($image, $fallback_title = '') {
+        $image = is_array($image) ? $image : array();
+        $url = esc_url_raw((string)($image['image_url'] ?? ($image['featured_image_url'] ?? '')));
+        if ($url !== '' && !wp_http_validate_url($url)) { $url = ''; }
+        if ($url === '') {
+            return array('has_image'=>false,'image_url'=>'','image_alt'=>'','image_caption'=>'','image_source'=>'','can_use_in_content'=>false);
+        }
+        return array(
+            'has_image' => true,
+            'image_url' => $url,
+            'image_alt' => sanitize_text_field((string)($image['image_alt'] ?? ($image['featured_image_alt'] ?? $fallback_title))),
+            'image_caption' => sanitize_text_field((string)($image['image_caption'] ?? ($image['featured_image_caption'] ?? ''))),
+            'image_source' => sanitize_text_field((string)($image['image_source'] ?? '')),
+            'can_use_in_content' => true,
+        );
+    }
+
     private static function compact_text($text, $words = 80) {
         $text = trim(preg_replace('/\s+/', ' ', wp_strip_all_tags((string)$text)));
         if ($text === '') { return ''; }
@@ -373,6 +405,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
     private static function normalize_payload_for_openai($payload) {
         $payload = is_array($payload) ? $payload : array();
         $profile = is_array($payload['instruction_profile'] ?? null) ? $payload['instruction_profile'] : array();
+        $compact_instruction_profile = self::compact_instruction_profile_payload($payload);
         $profile_rules = is_array($payload['instruction_profile_rules'] ?? null) ? $payload['instruction_profile_rules'] : array();
         $user_prompt = sanitize_textarea_field((string)($payload['openai_prompt'] ?? ($payload['user_inputs']['openai_prompt'] ?? '')));
         $idea_title = sanitize_text_field((string)($payload['idea_context']['idea_title'] ?? ''));
@@ -391,15 +424,11 @@ class ALMA_AI_Content_Agent_Draft_Builder {
                 $description
             );
             $image = is_array($link['image'] ?? null) ? $link['image'] : array();
-            $image_url = esc_url_raw((string)($image['image_url'] ?? ($link['featured_image_url'] ?? '')));
-            $attachment_id = absint($link['featured_image_id'] ?? 0);
-            if ($attachment_id > 0 && ($image_url === '' || !wp_http_validate_url($image_url))) {
-                $attachment_url = wp_get_attachment_image_url($attachment_id, 'large');
-                if (!$attachment_url) { $attachment_url = wp_get_attachment_image_url($attachment_id, 'full'); }
-                $image_url = esc_url_raw((string)$attachment_url);
-            }
-            if ($image_url !== '' && !wp_http_validate_url($image_url)) { $image_url = ''; }
-            $has_image = $image_url !== '' && (!empty($image['has_image']) || !empty($link['has_featured_image']) || !empty($link['featured_image_url']));
+            if (empty($image['image_url']) && !empty($link['featured_image_url'])) { $image['image_url'] = $link['featured_image_url']; }
+            if (empty($image['image_alt']) && !empty($link['featured_image_alt'])) { $image['image_alt'] = $link['featured_image_alt']; }
+            if (empty($image['image_caption']) && !empty($link['featured_image_caption'])) { $image['image_caption'] = $link['featured_image_caption']; }
+            if (empty($image['image_source']) && !empty($link['image_source'])) { $image['image_source'] = $link['image_source']; }
+            $compact_image = self::compact_affiliate_image_payload($image, (string)($link['title'] ?? ''));
             $item = array(
                 'id' => absint($link['id'] ?? 0),
                 'title' => sanitize_text_field((string)($link['title'] ?? '')),
@@ -407,16 +436,8 @@ class ALMA_AI_Content_Agent_Draft_Builder {
                 'affiliate_url' => esc_url_raw((string)($link['affiliate_url'] ?? '')),
                 'shortcode' => sanitize_text_field((string)($link['shortcode'] ?? '')),
                 'link_types' => array_values(array_unique(array_filter(array_map('sanitize_text_field', (array)($link['link_types'] ?? array()))))),
-                'image' => array(
-                    'has_image' => (bool)$has_image,
-                    'image_url' => $has_image ? $image_url : '',
-                    'image_alt' => sanitize_text_field((string)($image['image_alt'] ?? ($link['featured_image_alt'] ?? ($link['title'] ?? '')))),
-                    'image_caption' => self::compact_text((string)($image['image_caption'] ?? ($link['featured_image_caption'] ?? '')), 20),
-                    'image_source' => sanitize_text_field((string)($image['image_source'] ?? ($link['image_source'] ?? ''))),
-                    'can_use_in_content' => (bool)($has_image && !empty($image['can_use_in_content'])),
-                ),
+                'image' => $compact_image,
             );
-            if (!$has_image || empty($item['image']['can_use_in_content'])) { $item['image'] = array('has_image'=>false,'image_url'=>'','image_alt'=>'','image_caption'=>'','image_source'=>'','can_use_in_content'=>false); }
             if ($context !== '') { $item['context'] = $context; }
             $affiliate_links[] = $item;
         }
@@ -435,6 +456,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'task' => 'create_article_draft_from_selected_sources',
             'site' => array('site_name'=>sanitize_text_field((string)($payload['site_context']['site_name'] ?? get_bloginfo('name'))), 'language'=>$language),
             'article_request' => array('prompt'=>$user_prompt, 'idea_title'=>$idea_title, 'keyword_or_topic'=>$search_query),
+            'instruction_profile' => $compact_instruction_profile,
             'editorial_instructions' => array(
                 'custom_prompt' => sanitize_textarea_field((string)($profile['custom_prompt'] ?? ($profile_rules['custom_prompt'] ?? ''))),
                 'tone_of_voice' => sanitize_textarea_field((string)($profile['tone_of_voice'] ?? '')),
@@ -446,6 +468,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'affiliate_links' => $affiliate_links,
             'affiliate_rules' => $affiliate_rules,
             'seo_rules' => $seo_rules,
+            'media_rules' => self::compact_rule_list((array)($payload['media_rules'] ?? array())),
             'source_policies' => $source_rules,
             'warnings' => self::compact_rule_list((array)($payload['warnings'] ?? array())),
         );
@@ -507,10 +530,15 @@ class ALMA_AI_Content_Agent_Draft_Builder {
                 'source' => sanitize_text_field($row['source'] ?? ''),
                 'provenance' => sanitize_text_field($row['provenance'] ?? ''),
                 'link_types' => array_values(array_map('sanitize_text_field', (array)($row['link_types'] ?? array()))),
+                'image' => self::compact_affiliate_image_payload(is_array($row['image'] ?? null) ? $row['image'] : array(
+                    'image_url' => $row['featured_image_url'] ?? '',
+                    'image_alt' => $row['featured_image_alt'] ?? ($row['title'] ?? ''),
+                    'image_caption' => $row['featured_image_caption'] ?? '',
+                    'image_source' => $row['image_source'] ?? '',
+                ), (string)($row['title'] ?? '')),
             );
-            $selection_context[] = $entry;
 
-            if ($source_group !== 'affiliate_link' && sanitize_key($row['source_type'] ?? '') !== 'affiliate_link') { continue; }
+            if ($source_group !== 'affiliate_link' && sanitize_key($row['source_type'] ?? '') !== 'affiliate_link') { $selection_context[] = $entry; continue; }
             $p = $source_id > 0 ? get_post($source_id) : null;
             if (!$p || $p->post_type !== 'affiliate_link') {
                 $warnings[] = 'Affiliate link selezionato non disponibile: #' . $source_id;
@@ -566,6 +594,15 @@ class ALMA_AI_Content_Agent_Draft_Builder {
 
             $image = ALMA_AI_Content_Agent_Affiliate_Index::get_image_data($p->ID);
             $has_image = !empty($image['has_featured_image']) && !empty($image['featured_image_url']) && wp_http_validate_url((string)$image['featured_image_url']);
+            $compact_image = self::compact_affiliate_image_payload(array(
+                'image_url' => $has_image ? (string)$image['featured_image_url'] : '',
+                'image_alt' => $image['featured_image_alt'] ?? $p->post_title,
+                'image_caption' => $image['featured_image_caption'] ?? '',
+                'image_source' => $image['image_source'] ?? '',
+            ), (string)$p->post_title);
+            $entry['image'] = $compact_image;
+            $selection_context[] = $entry;
+            $image_debug = class_exists('ALMA_AI_Content_Agent_Affiliate_Index') ? ALMA_AI_Content_Agent_Affiliate_Index::get_image_debug_data($p->ID) : array();
 
             $affiliate_links[] = array(
                 'id' => (int)$p->ID,
@@ -592,14 +629,8 @@ class ALMA_AI_Content_Agent_Draft_Builder {
                 'has_featured_image' => (bool)$has_image,
                 'image_source' => sanitize_text_field((string)($image['image_source'] ?? '')),
                 'image_import_status' => sanitize_text_field((string)($image['image_import_status'] ?? '')),
-                'image' => array(
-                    'has_image' => (bool)$has_image,
-                    'image_url' => $has_image ? esc_url_raw((string)$image['featured_image_url']) : '',
-                    'image_alt' => sanitize_text_field((string)($image['featured_image_alt'] ?? '')),
-                    'image_caption' => sanitize_text_field((string)($image['featured_image_caption'] ?? '')),
-                    'image_source' => sanitize_text_field((string)($image['image_source'] ?? '')),
-                    'can_use_in_content' => (bool)$has_image,
-                ),
+                'image' => $compact_image,
+                'image_debug' => $image_debug,
             );
         }
 
@@ -784,7 +815,8 @@ class ALMA_AI_Content_Agent_Draft_Builder {
                 $source_settings = is_array($source) ? json_decode((string)($source['settings'] ?? '{}'), true) : array();
                 $source_prompt = sanitize_textarea_field((string)($source_settings['ai_source_instructions'] ?? ''));
                 if ($source_id > 0 && $source_prompt === '') { $warnings[] = 'Comportamento AI source non trovato per affiliate link #'.$p->ID; }
-                $ctx['affiliate_links'][] = array('id'=>$p->ID,'title'=>sanitize_text_field($p->post_title),'description'=>sanitize_text_field($p->post_excerpt),'affiliate_url'=>esc_url_raw((string)get_post_meta($p->ID,'_affiliate_url',true)),'shortcode'=>'[affiliate_link id="'.$p->ID.'"]','ai_context'=>sanitize_textarea_field((string)get_post_meta($p->ID,'_alma_ai_context',true)),'source_id'=>$source_id,'source_name'=>sanitize_text_field($source['name'] ?? ''),'provider'=>sanitize_key($source['provider'] ?? ''),'source_ai_behavior_prompt'=>$source_prompt,'usage_rules'=>'Usa solo shortcode autorizzato; non inventare link affiliati.');
+                $image = class_exists('ALMA_AI_Content_Agent_Affiliate_Index') ? ALMA_AI_Content_Agent_Affiliate_Index::get_image_data($p->ID) : array();
+                $ctx['affiliate_links'][] = array('id'=>$p->ID,'title'=>sanitize_text_field($p->post_title),'description'=>sanitize_text_field($p->post_excerpt),'affiliate_url'=>esc_url_raw((string)get_post_meta($p->ID,'_affiliate_url',true)),'shortcode'=>'[affiliate_link id="'.$p->ID.'"]','ai_context'=>sanitize_textarea_field((string)get_post_meta($p->ID,'_alma_ai_context',true)),'source_id'=>$source_id,'source_name'=>sanitize_text_field($source['name'] ?? ''),'provider'=>sanitize_key($source['provider'] ?? ''),'source_ai_behavior_prompt'=>$source_prompt,'usage_rules'=>'Usa solo shortcode autorizzato; non inventare link affiliati.','featured_image_id'=>absint($image['featured_image_id'] ?? 0),'featured_image_url'=>esc_url_raw((string)($image['featured_image_url'] ?? '')),'featured_image_alt'=>sanitize_text_field((string)($image['featured_image_alt'] ?? '')),'featured_image_caption'=>sanitize_text_field((string)($image['featured_image_caption'] ?? '')),'image_source'=>sanitize_text_field((string)($image['image_source'] ?? '')),'image'=>self::compact_affiliate_image_payload(array('image_url'=>$image['featured_image_url'] ?? '', 'image_alt'=>$image['featured_image_alt'] ?? $p->post_title, 'image_caption'=>$image['featured_image_caption'] ?? '', 'image_source'=>$image['image_source'] ?? ''), (string)$p->post_title));
             } elseif ($group === 'document_txt') {
                 $kid = self::resolve_document_knowledge_item_id($row);
                 if ($kid <= 0) { $warnings[] = 'Documento TXT senza knowledge item id stabile.'; continue; }
@@ -807,11 +839,9 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             return self::fail('Nessuna fonte valida disponibile nella sessione selezionata.');
         }
         $profile_id = absint($session['instruction_profile_id'] ?? 0);
-        $profile = $profile_id ? ALMA_AI_Content_Agent_Instructions_Manager::get_profile($profile_id) : ALMA_AI_Content_Agent_Instructions_Manager::get_active_profile();
+        $profile = $profile_id ? ALMA_AI_Content_Agent_Instructions_Manager::get_profile($profile_id) : array();
         $payload = self::build_payload_from_selection_session($user_id);
-        $payload['instruction_profile'] = $profile;
-        $payload['selection_context'] = $ctx;
-        $payload['affiliate_links'] = $ctx['affiliate_links'];
+        if ($profile_id > 0 && !empty($profile)) { $payload['instruction_profile'] = $profile; }
         $payload['posts'] = $ctx['posts'];
         $payload['documents'] = $ctx['documents'];
         $payload['sources_online'] = $ctx['sources_online'];


### PR DESCRIPTION
### Motivation
- Ensure the OpenAI payload is compact and contains only the single instruction profile explicitly selected by the user, avoiding accidental inclusion/selection of other active profiles.
- Propagate affiliate images consistently from search results → selection session → normalized OpenAI payload and provide debug diagnostics for missing images (Viator and similar), without performing any remote downloads or sideloads.
- Include media rules in the normalized payload so the Draft Builder and model receive the same operational constraints about affiliate images.

### Description
- Added a compact `instruction_profile` block (`id`, `name`, `snapshot_hash`) to the normalized OpenAI payload and ensured the payload includes only the profile explicitly associated with the session/idea (absent or `null` when none selected). (modified: `includes/class-ai-content-agent-draft-builder.php`)
- Introduced `compact_instruction_profile_payload()` to build the compact profile representation and guarded against silently falling back to an active profile when no profile is explicitly selected. (modified: `includes/class-ai-content-agent-draft-builder.php`)
- Normalized affiliate image representation via `compact_affiliate_image_payload()` and consistently added `image` blocks to `selection_context[]`, `affiliate_links[]` and search selector results, enforcing absolute URL validation and setting `can_use_in_content` only for valid absolute URLs. (modified: `includes/class-ai-content-agent-draft-builder.php`, `includes/class-ai-content-agent-affiliate-selector.php`)
- Propagated WP featured image → `_alma_featured_image_url` fallback priority and ensured `affiliate_links[].image.image_url` is absolute when present; kept `has_image=false` and `can_use_in_content=false` otherwise. (modified: `includes/class-ai-content-agent-affiliate-index.php`, `includes/class-ai-content-agent-draft-builder.php`)
- Added `media_rules` to the normalized OpenAI payload (compact block) so image handling constraints travel with the payload, avoiding duplication in `editorial_instructions`. (modified: `includes/class-ai-content-agent-draft-builder.php`)
- Added `image_debug` diagnostics (debug-only) per affiliate link to explain missing images (featured image id, meta presence, import status, reason), useful to diagnose Viator/third-party cases while keeping normalized payload compact. (modified: `includes/class-ai-content-agent-affiliate-index.php`, `includes/class-ai-content-agent-draft-builder.php`)
- Ensured search/UI results expose the same `image` compact block for thumbnails so the admin UI and selection/session data are consistent and the miniatures render from `result.image.image_url` with `loading="lazy"`. (modified: `includes/class-ai-content-agent-affiliate-selector.php`, `includes/class-ai-content-agent-admin.php` uses existing thumbnail rendering)
- Updated plugin version and documentation entries. (modified: `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`)

Files changed:
- affiliate-link-manager-ai.php
- includes/class-ai-content-agent-affiliate-index.php
- includes/class-ai-content-agent-affiliate-selector.php
- includes/class-ai-content-agent-draft-builder.php
- README.md
- CHANGELOG.md

### Testing
- Ran PHP lint on modified files and there were no syntax errors: `php -l` passed for `affiliate-link-manager-ai.php`, `includes/class-ai-content-agent-affiliate-index.php`, `includes/class-ai-content-agent-affiliate-selector.php`, and `includes/class-ai-content-agent-draft-builder.php` (all OK).
- Ran a diff/check of the working tree to detect whitespace/patch issues and no blocking issues were found.
- Manual/functional checks to perform (recommended): select a specific AI instruction profile and download both debug and OpenAI JSON and verify `debug_payload_full.instruction_profile_id` equals `openai_payload_normalized.instruction_profile.id`; confirm `openai_payload_normalized` contains only the compact `instruction_profile`, `media_rules`, and `affiliate_links[].image`; confirm `selection_context[].image` is present for results with images; verify `image_debug` appears only in debug payload for links missing an image.

All automated checks executed succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5bddf4388332b3502bf6c44e0f7e)