### PR TITLE
Harden AI draft QA for affiliate disclosures, missing hrefs and media usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.25.38 — AI draft QA affiliate hardening
+- Rafforzate le regole operative inviate a OpenAI: vietate disclosure affiliate generiche, tag `<a>` senza `href`, shortcode usati come `href` e richiesto allineamento tra `affiliate_urls_used`, shortcode e URL diretti realmente inseriti.
+- Aggiunta rimozione automatica dal solo campo `content` delle disclosure affiliate generiche generate dall’AI, senza inserire disclosure sostitutive.
+- Aggiunta correzione locale degli `href` mancanti per immagini affiliate quando il `src` corrisponde a un’immagine del payload, preservando `<img>`, classi, URL e parametri di tracking.
+- Aggiunta correzione dei link testuali affiliati senza `href` quando il testo corrisponde in modo affidabile al titolo di un link affiliato del payload; i link non associabili vengono trasformati in testo semplice.
+- Reso coerente `affiliate_urls_used` con gli URL affiliati diretti effettivamente presenti negli `href` finali, mantenendo separati gli shortcode in `affiliate_shortcodes_used`.
+- Reso coerente `media_used` con le immagini affiliate cliccabili realmente presenti nel contenuto finale, includendo `image_url`, ID link affiliato, `affiliate_url`, alt e source quando disponibili.
+- Rafforzata la sanitizzazione HTML finale per preservare in modo sicuro `href`, `target`, `rel`, attributi immagine consentiti e `figure class`, senza consentire attributi pericolosi o URL JavaScript/data non necessari.
+- Versione plugin aggiornata a `2.25.38`.
+
 ## 2.25.37 — AI profile textarea preservation
 - Corretta la preservazione dei contenuti textarea nei profili **Istruzioni AI**, salvando testo libero admin non escaped e normalizzando solo line ending e caratteri di controllo non validi.
 - Preservati nei prompt esempi HTML testuali con `<a>`, `<img>`, placeholder come `{affiliate_url}` e `{image.image_url}`, simboli, virgolette e caratteri accentati.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## 2.25.38 — AI draft QA affiliate hardening
+- Rafforzate le regole operative inviate a OpenAI: vietate disclosure affiliate generiche, tag `<a>` senza `href`, shortcode usati come `href` e richiesto allineamento tra `affiliate_urls_used`, shortcode e URL diretti realmente inseriti.
+- Aggiunta rimozione automatica dal solo campo `content` delle disclosure affiliate generiche generate dall’AI, senza inserire disclosure sostitutive.
+- Aggiunta correzione locale degli `href` mancanti per immagini affiliate quando il `src` corrisponde a un’immagine del payload, preservando `<img>`, classi, URL e parametri di tracking.
+- Aggiunta correzione dei link testuali affiliati senza `href` quando il testo corrisponde in modo affidabile al titolo di un link affiliato del payload; i link non associabili vengono trasformati in testo semplice.
+- Reso coerente `affiliate_urls_used` con gli URL affiliati diretti effettivamente presenti negli `href` finali, mantenendo separati gli shortcode in `affiliate_shortcodes_used`.
+- Reso coerente `media_used` con le immagini affiliate cliccabili realmente presenti nel contenuto finale, includendo `image_url`, ID link affiliato, `affiliate_url`, alt e source quando disponibili.
+- Rafforzata la sanitizzazione HTML finale per preservare in modo sicuro `href`, `target`, `rel`, attributi immagine consentiti e `figure class`, senza consentire attributi pericolosi o URL JavaScript/data non necessari.
+- Versione plugin aggiornata a `2.25.38`.
+
 ## 2.25.37 — AI profile textarea preservation
 - Corretta la preservazione dei contenuti textarea nei profili **Istruzioni AI**, salvando testo libero admin non escaped e normalizzando solo line ending e caratteri di controllo non validi.
 - Preservati nei prompt esempi HTML testuali con `<a>`, `<img>`, placeholder come `{affiliate_url}` e `{image.image_url}`, simboli, virgolette e caratteri accentati.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.37
+ * Version: 2.25.38
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.37');
+define('ALMA_VERSION', '2.25.38');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -90,11 +90,11 @@ class ALMA_AI_Content_Agent_Draft_Builder {
     }
 
     private static function build_draft_generation_prompt() {
-        return 'Rispondi esclusivamente con un singolo oggetto JSON valido. Non usare Markdown. Non usare blocchi ```json. Non aggiungere spiegazioni o testo prima/dopo il JSON. Includi sempre: title, slug, excerpt, content, seo_title, seo_description, affiliate_shortcodes_used, affiliate_urls_used, media_used, warnings. content deve essere stringa JSON valida. Se usi shortcode, inseriscili sia in content sia in affiliate_shortcodes_used. Se usi URL affiliati diretti, inseriscili in affiliate_urls_used. Usa immagini affiliate solo se pertinenti alla sezione: non inventare URL immagini, usa solo image_url presenti in affiliate_links[].image con can_use_in_content=true, non duplicare la stessa immagine, non forzare immagini dove non servono e mantieni disclosure affiliata. Se inserisci un’immagine usa figure/img HTML con alt sensato e registra l’URL in media_used. Se non usi shortcode/URL/media usa array vuoti. Non inventare campi.';
+        return 'Rispondi esclusivamente con un singolo oggetto JSON valido. Non usare Markdown. Non usare blocchi ```json. Non aggiungere spiegazioni o testo prima/dopo il JSON. Includi sempre: title, slug, excerpt, content, seo_title, seo_description, affiliate_shortcodes_used, affiliate_urls_used, media_used, warnings. content deve essere stringa JSON valida. Non generare disclosure affiliate generiche e non inserire frasi tipo “Questo articolo può contenere link affiliati...”. Non creare tag <a> senza href. Non usare shortcode come href. Se usi shortcode, inseriscili sia in content sia in affiliate_shortcodes_used. Se usi URL affiliati diretti, ogni href deve coincidere esattamente con affiliate_links[].affiliate_url e devi inserirlo in affiliate_urls_used; se non usi URL diretti, affiliate_urls_used deve essere vuoto. Usa immagini affiliate solo se pertinenti alla sezione: non inventare URL immagini, usa solo image_url presenti in affiliate_links[].image con can_use_in_content=true, non duplicare la stessa immagine e non forzare immagini dove non servono. Ogni immagine affiliata deve essere cliccabile con href uguale al relativo affiliate_url. Esempio immagine: <a href="{affiliate_url}" target="_blank" rel="nofollow sponsored noopener"><img class="aligncenter size-full" src="{image.image_url}" alt="{image.image_alt}" /></a>. Fallback alt: <a href="{affiliate_url}" target="_blank" rel="nofollow sponsored noopener"><img class="aligncenter size-full" src="{image.image_url}" alt="{title}" /></a>. Registra in media_used solo immagini affiliate effettivamente presenti nel contenuto finale con image_url, affiliate_link_id o id, affiliate_url, alt e source se disponibile. Se non usi shortcode/URL/media usa array vuoti. Non inventare campi.';
     }
 
     private static function build_draft_response_format() {
-        return array('type'=>'json_schema','name'=>'content_draft_generation','schema'=>array('type'=>'object','additionalProperties'=>false,'required'=>array('title','slug','excerpt','content','seo_title','seo_description','affiliate_shortcodes_used','affiliate_urls_used','media_used','warnings'),'properties'=>array('title'=>array('type'=>'string'),'slug'=>array('type'=>'string'),'excerpt'=>array('type'=>'string'),'content'=>array('type'=>'string'),'seo_title'=>array('type'=>'string'),'seo_description'=>array('type'=>'string'),'affiliate_shortcodes_used'=>array('type'=>'array','items'=>array('type'=>'string')),'affiliate_urls_used'=>array('type'=>'array','items'=>array('type'=>'string')),'media_used'=>array('type'=>'array','items'=>array('type'=>'string')),'warnings'=>array('type'=>'array','items'=>array('type'=>'string')))));
+        return array('type'=>'json_schema','name'=>'content_draft_generation','schema'=>array('type'=>'object','additionalProperties'=>false,'required'=>array('title','slug','excerpt','content','seo_title','seo_description','affiliate_shortcodes_used','affiliate_urls_used','media_used','warnings'),'properties'=>array('title'=>array('type'=>'string'),'slug'=>array('type'=>'string'),'excerpt'=>array('type'=>'string'),'content'=>array('type'=>'string'),'seo_title'=>array('type'=>'string'),'seo_description'=>array('type'=>'string'),'affiliate_shortcodes_used'=>array('type'=>'array','items'=>array('type'=>'string')),'affiliate_urls_used'=>array('type'=>'array','items'=>array('type'=>'string')),'media_used'=>array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>false,'required'=>array('image_url','affiliate_url'),'properties'=>array('image_url'=>array('type'=>'string'),'affiliate_link_id'=>array('type'=>'integer'),'id'=>array('type'=>'integer'),'affiliate_url'=>array('type'=>'string'),'alt'=>array('type'=>'string'),'source'=>array('type'=>'string')))),'warnings'=>array('type'=>'array','items'=>array('type'=>'string')))));
     }
 
     private static function map_openai_error_to_admin_message($res, $fallback='Risposta OpenAI fallita.') {
@@ -374,6 +374,15 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'Non usare Markdown o testo fuori dall’oggetto JSON.',
             'Non inventare fatti, prezzi, disponibilità, condizioni o link affiliati.',
             'Usa solo i link affiliati presenti in affiliate_links.',
+            'Non generare disclosure affiliate generiche e non inserire frasi tipo “Questo articolo può contenere link affiliati...” o “Se acquisti tramite questi link, potremmo ricevere una commissione...”.',
+            'Non creare tag <a> senza href.',
+            'Ogni link testuale affiliato diretto deve avere href uguale esattamente al relativo affiliate_url.',
+            'Ogni immagine affiliata deve essere racchiusa in un tag <a href="{affiliate_url}"> con target="_blank" e rel="nofollow sponsored noopener".',
+            'Non usare mai lo shortcode come href.',
+            'affiliate_urls_used deve includere solo gli URL affiliati diretti effettivamente usati negli href; se non usi URL diretti deve essere vuoto.',
+            'Se usi shortcode affiliati, compila affiliate_shortcodes_used e mantienilo separato da affiliate_urls_used.',
+            'Esempio HTML esatto per immagini affiliate: <a href="{affiliate_url}" target="_blank" rel="nofollow sponsored noopener"><img class="aligncenter size-full" src="{image.image_url}" alt="{image.image_alt}" /></a>',
+            'Fallback HTML esatto per immagini affiliate: <a href="{affiliate_url}" target="_blank" rel="nofollow sponsored noopener"><img class="aligncenter size-full" src="{image.image_url}" alt="{title}" /></a>',
         );
         $affiliate_rules = self::compact_rule_list(array_merge((array)($payload['affiliate_rules'] ?? array()), array($profile_rules['affiliate_rules'] ?? '')));
         $seo_rules = self::compact_rule_list(array_merge((array)($payload['seo_rules'] ?? array()), array($profile_rules['seo_rules'] ?? '')));
@@ -408,17 +417,49 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             if (!is_array($link)) { continue; }
             $image = is_array($link['image'] ?? null) ? $link['image'] : array();
             $url = esc_url_raw((string)($image['image_url'] ?? ($link['featured_image_url'] ?? '')));
-            if ($url === '' || !wp_http_validate_url($url)) { continue; }
+            if ($url !== '' && !wp_http_validate_url($url)) { $url = ''; }
+            $affiliate_url = esc_url_raw((string)($link['affiliate_url'] ?? ''));
+            if (($url === '' && $affiliate_url === '') || ($affiliate_url !== '' && !wp_http_validate_url($affiliate_url))) { continue; }
             $images[] = array(
                 'affiliate_link_id' => absint($link['id'] ?? ($link['affiliate_link_post_id'] ?? 0)),
+                'id' => absint($link['id'] ?? ($link['affiliate_link_post_id'] ?? 0)),
                 'attachment_id' => absint($link['featured_image_id'] ?? 0),
+                'title' => sanitize_text_field((string)($link['title'] ?? '')),
+                'affiliate_url' => $affiliate_url,
                 'url' => $url,
+                'image_url' => $url,
                 'alt' => sanitize_text_field((string)($image['image_alt'] ?? ($link['featured_image_alt'] ?? ''))),
                 'caption' => sanitize_text_field((string)($image['image_caption'] ?? ($link['featured_image_caption'] ?? ''))),
                 'source' => sanitize_text_field((string)($image['image_source'] ?? ($link['image_source'] ?? ''))),
             );
         }
         return $images;
+    }
+
+    private static function candidate_affiliate_records_from_ids($affiliate_ids) {
+        $records = array();
+        foreach (array_values(array_unique(array_filter(array_map('absint', (array)$affiliate_ids)))) as $id) {
+            $post = get_post($id);
+            if (!$post || $post->post_type !== 'affiliate_link') { continue; }
+            $affiliate_url = self::get_affiliate_url($id);
+            if ($affiliate_url === '') { continue; }
+            $image = class_exists('ALMA_AI_Content_Agent_Affiliate_Index') ? ALMA_AI_Content_Agent_Affiliate_Index::get_image_data($id) : array();
+            $image_url = esc_url_raw((string)($image['featured_image_url'] ?? ''));
+            if ($image_url !== '' && !wp_http_validate_url($image_url)) { $image_url = ''; }
+            $records[] = array(
+                'affiliate_link_id' => $id,
+                'id' => $id,
+                'attachment_id' => absint($image['featured_image_id'] ?? 0),
+                'title' => sanitize_text_field((string)$post->post_title),
+                'affiliate_url' => $affiliate_url,
+                'url' => $image_url,
+                'image_url' => $image_url,
+                'alt' => sanitize_text_field((string)($image['featured_image_alt'] ?? $post->post_title)),
+                'caption' => sanitize_text_field((string)($image['featured_image_caption'] ?? '')),
+                'source' => sanitize_text_field((string)($image['image_source'] ?? '')),
+            );
+        }
+        return $records;
     }
 
     private static function fetch_document_chunks($knowledge_item_id, $limit = 3) {
@@ -569,10 +610,15 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         $affiliate_rules = array(
             'Usare solo i link affiliati selezionati nel payload.',
             'Non inventare link affiliati.',
+            'Non generare disclosure affiliate generiche; vietate frasi tipo “Questo articolo può contenere link affiliati...” o varianti su commissione/senza costi aggiuntivi.',
             'Preferire shortcode WordPress per box/link affiliati.',
             'Usare affiliate_url solo per link testuali diretti quando necessario.',
+            'Non creare tag <a> senza href e non usare mai shortcode come href.',
+            'Ogni link testuale affiliato diretto deve avere href uguale al relativo affiliate_url.',
+            'Ogni immagine affiliata deve usare <a href="{affiliate_url}" target="_blank" rel="nofollow sponsored noopener"><img class="aligncenter size-full" src="{image.image_url}" alt="{image.image_alt}" /></a>.',
+            'Fallback immagine affiliata: <a href="{affiliate_url}" target="_blank" rel="nofollow sponsored noopener"><img class="aligncenter size-full" src="{image.image_url}" alt="{title}" /></a>.',
             'Compilare affiliate_shortcodes_used con gli shortcode realmente usati.',
-            'Se usi URL diretti, compilare affiliate_urls_used con gli URL realmente usati.',
+            'Se usi URL diretti, compilare affiliate_urls_used con gli URL realmente usati negli href; se non usi URL diretti, affiliate_urls_used deve essere vuoto.',
             'Non usare link non presenti nel payload.',
         );
         if (!empty($profile_payload['instruction_profile_rules']['affiliate_rules'])) { $affiliate_rules[] = $profile_payload['instruction_profile_rules']['affiliate_rules']; }
@@ -704,13 +750,14 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         if (!is_array($parsed)) { return self::fail('Draft JSON non valido', $res['model'] ?? '', 'idea:'.$idea_id); }
         $candidate_affiliate_ids = array_values(array_filter(array_map('absint', array_column((array)$context['candidate_affiliate_links'], 'link_id'))));
         $candidate_image_ids = array_values(array_filter(array_map('absint', array_column((array)$context['candidate_images'], 'attachment_id'))));
-        $clean = ALMA_AI_Content_Agent_Draft_Quality_Checker::validate_payload($parsed, $candidate_affiliate_ids, $candidate_image_ids);
+        $candidate_affiliate_records = self::candidate_affiliate_records_from_ids($candidate_affiliate_ids);
+        $clean = ALMA_AI_Content_Agent_Draft_Quality_Checker::validate_payload($parsed, $candidate_affiliate_ids, $candidate_image_ids, $candidate_affiliate_records);
         if (!is_array($clean) || !array_key_exists('title', $clean) || !array_key_exists('content', $clean)) return self::fail('QA output non valido.', $res['model'] ?? '', 'idea:'.$idea_id);
         if ($clean['title'] === '' || trim(wp_strip_all_tags($clean['content'])) === '') return self::fail('Output draft non valido dopo QA.', $res['model'] ?? '', 'idea:'.$idea_id);
         $post_id = wp_insert_post(array('post_type'=>'post','post_status'=>'draft','post_author'=>get_current_user_id(),'post_title'=>$clean['title'],'post_name'=>$clean['slug'],'post_excerpt'=>$clean['excerpt'],'post_content'=>$clean['content']), true);
         if (is_wp_error($post_id) || !$post_id) { return self::fail('Errore creazione bozza.', $res['model'] ?? '', 'idea:'.$idea_id); }
         if (!empty($clean['featured_image_id'])) set_post_thumbnail($post_id, $clean['featured_image_id']);
-        update_post_meta($post_id, '_alma_ai_agent_generated', 1); update_post_meta($post_id, '_alma_ai_agent_idea_id', $idea_id); update_post_meta($post_id, '_alma_ai_agent_brief_id', absint($brief['id'] ?? 0)); update_post_meta($post_id, '_alma_ai_agent_task', 'content_draft_generation'); update_post_meta($post_id, '_alma_ai_agent_model', sanitize_text_field($res['model'] ?? '')); update_post_meta($post_id, '_alma_ai_agent_instruction_profile_id', absint($brief['instruction_profile_id'] ?? $idea['instruction_profile_id'] ?? 0)); update_post_meta($post_id, '_alma_ai_agent_instruction_snapshot_hash', sanitize_text_field($brief['instruction_snapshot_hash'] ?? $idea['instruction_snapshot_hash'] ?? '')); update_post_meta($post_id, '_alma_ai_agent_affiliate_links_used', wp_json_encode($clean['affiliate_links_used'])); update_post_meta($post_id, '_alma_ai_agent_image_ids_used', wp_json_encode($clean['inline_image_ids'])); update_post_meta($post_id, '_alma_ai_agent_featured_image_id', absint($clean['featured_image_id'])); update_post_meta($post_id, '_alma_ai_agent_qa_warnings', wp_json_encode(array_merge((array)$clean['warnings'], (array)($parsed['warnings'] ?? array())))); update_post_meta($post_id, '_alma_ai_seo_title', sanitize_text_field($parsed['seo_title'] ?? '')); update_post_meta($post_id, '_alma_ai_meta_description', sanitize_text_field($parsed['meta_description'] ?? '')); update_post_meta($post_id, '_alma_ai_focus_keyword', sanitize_text_field($parsed['focus_keyword'] ?? '')); update_post_meta($post_id, '_alma_ai_generated_at', current_time('mysql')); update_post_meta($post_id, '_alma_ai_suggested_tags', wp_json_encode((array)($parsed['suggested_tags'] ?? array())));
+        update_post_meta($post_id, '_alma_ai_agent_generated', 1); update_post_meta($post_id, '_alma_ai_agent_idea_id', $idea_id); update_post_meta($post_id, '_alma_ai_agent_brief_id', absint($brief['id'] ?? 0)); update_post_meta($post_id, '_alma_ai_agent_task', 'content_draft_generation'); update_post_meta($post_id, '_alma_ai_agent_model', sanitize_text_field($res['model'] ?? '')); update_post_meta($post_id, '_alma_ai_agent_instruction_profile_id', absint($brief['instruction_profile_id'] ?? $idea['instruction_profile_id'] ?? 0)); update_post_meta($post_id, '_alma_ai_agent_instruction_snapshot_hash', sanitize_text_field($brief['instruction_snapshot_hash'] ?? $idea['instruction_snapshot_hash'] ?? '')); update_post_meta($post_id, '_alma_ai_agent_affiliate_links_used', wp_json_encode($clean['affiliate_links_used'])); update_post_meta($post_id, '_alma_ai_agent_affiliate_shortcodes_used', wp_json_encode((array)($clean['affiliate_shortcodes_used'] ?? array()))); update_post_meta($post_id, '_alma_ai_agent_affiliate_urls_used', wp_json_encode((array)($clean['affiliate_urls_used'] ?? array()))); update_post_meta($post_id, '_alma_ai_agent_media_used', wp_json_encode((array)($clean['media_used'] ?? array()))); update_post_meta($post_id, '_alma_ai_agent_image_ids_used', wp_json_encode($clean['inline_image_ids'])); update_post_meta($post_id, '_alma_ai_agent_featured_image_id', absint($clean['featured_image_id'])); update_post_meta($post_id, '_alma_ai_agent_qa_warnings', wp_json_encode(array_merge((array)$clean['warnings'], (array)($parsed['warnings'] ?? array())))); update_post_meta($post_id, '_alma_ai_seo_title', sanitize_text_field($parsed['seo_title'] ?? '')); update_post_meta($post_id, '_alma_ai_meta_description', sanitize_text_field($parsed['meta_description'] ?? '')); update_post_meta($post_id, '_alma_ai_focus_keyword', sanitize_text_field($parsed['focus_keyword'] ?? '')); update_post_meta($post_id, '_alma_ai_generated_at', current_time('mysql')); update_post_meta($post_id, '_alma_ai_suggested_tags', wp_json_encode((array)($parsed['suggested_tags'] ?? array())));
         ALMA_AI_Usage_Logger::log(array('task'=>'content_draft_generation','success'=>true,'model'=>$res['model'] ?? '','response_time'=>$res['response_time'] ?? null,'input_tokens'=>$res['usage']['input_tokens'] ?? null,'output_tokens'=>$res['usage']['output_tokens'] ?? null,'estimated_cost'=>$res['usage']['total_tokens'] ?? null,'reference_id'=>'post:'.$post_id));
         return array('success'=>true,'post_id'=>$post_id,'edit_url'=>get_edit_post_link($post_id, 'raw'),'warnings'=>array_values(array_merge((array)$clean['warnings'], (array)($parsed['warnings'] ?? array()))));
     }
@@ -821,6 +868,9 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         update_post_meta($post_id, '_alma_ai_agent_selected_media_ids', wp_json_encode(wp_list_pluck($ctx['media'], 'attachment_id')));
         update_post_meta($post_id, '_alma_ai_agent_affiliate_images_available', wp_json_encode($candidate_affiliate_images));
         update_post_meta($post_id, '_alma_ai_agent_affiliate_images_used', wp_json_encode((array)($clean['affiliate_images_used'] ?? array())));
+        update_post_meta($post_id, '_alma_ai_agent_affiliate_shortcodes_used', wp_json_encode((array)($clean['affiliate_shortcodes_used'] ?? array())));
+        update_post_meta($post_id, '_alma_ai_agent_affiliate_urls_used', wp_json_encode((array)($clean['affiliate_urls_used'] ?? array())));
+        update_post_meta($post_id, '_alma_ai_agent_media_used', wp_json_encode((array)($clean['media_used'] ?? array())));
         update_post_meta($post_id, '_alma_ai_agent_instruction_profile_id', absint($session['instruction_profile_id'] ?? ($profile['id'] ?? 0)));
         update_post_meta($post_id, '_alma_ai_agent_instruction_profile_name', sanitize_text_field($profile['profile_name'] ?? ($session['instruction_profile_name'] ?? '')));
         update_post_meta($post_id, '_alma_ai_agent_instruction_snapshot_hash', sanitize_text_field($session['instruction_snapshot_hash'] ?? ALMA_AI_Content_Agent_Instructions_Manager::snapshot_hash(wp_json_encode($profile))));

--- a/includes/class-ai-content-agent-draft-quality-checker.php
+++ b/includes/class-ai-content-agent-draft-quality-checker.php
@@ -1,55 +1,333 @@
 <?php
 if (!defined('ABSPATH')) { exit; }
 class ALMA_AI_Content_Agent_Draft_Quality_Checker {
+    private static function allowed_content_html() {
+        $allowed = function_exists('wp_kses_allowed_html') ? wp_kses_allowed_html('post') : array();
+        if (!is_array($allowed)) { $allowed = array(); }
+        $allowed['a'] = array_merge((array)($allowed['a'] ?? array()), array(
+            'href' => true,
+            'target' => true,
+            'rel' => true,
+            'class' => true,
+        ));
+        $allowed['img'] = array_merge((array)($allowed['img'] ?? array()), array(
+            'src' => true,
+            'alt' => true,
+            'class' => true,
+            'width' => true,
+            'height' => true,
+            'loading' => true,
+        ));
+        $allowed['figure'] = array_merge((array)($allowed['figure'] ?? array()), array(
+            'class' => true,
+        ));
+        return $allowed;
+    }
+
+    private static function sanitize_content_html($content) {
+        return wp_kses((string)$content, self::allowed_content_html(), wp_allowed_protocols());
+    }
+
+    private static function normalize_lookup_text($text) {
+        $text = html_entity_decode(wp_strip_all_tags((string)$text), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $text = remove_accents($text);
+        $text = strtolower($text);
+        $text = preg_replace('/[^a-z0-9]+/u', ' ', $text);
+        return trim(preg_replace('/\s+/', ' ', (string)$text));
+    }
+
+    private static function normalize_url_key($url) {
+        $url = html_entity_decode((string)$url, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $url = esc_url_raw(trim($url));
+        if ($url === '') { return ''; }
+        $parts = wp_parse_url($url);
+        if (!is_array($parts) || empty($parts['host'])) { return rtrim($url, '/'); }
+        $scheme = strtolower((string)($parts['scheme'] ?? 'https'));
+        $host = strtolower((string)$parts['host']);
+        $port = isset($parts['port']) ? ':' . (int)$parts['port'] : '';
+        $path = isset($parts['path']) ? preg_replace('#/+#', '/', (string)$parts['path']) : '';
+        $query = isset($parts['query']) ? '?' . (string)$parts['query'] : '';
+        return rtrim($scheme . '://' . $host . $port . $path . $query, '/');
+    }
+
+    private static function build_affiliate_link_index($candidate_affiliate_ids, $candidate_affiliate_images) {
+        $index = array(
+            'ids' => array_values(array_unique(array_filter(array_map('absint', (array)$candidate_affiliate_ids)))),
+            'by_image_url' => array(),
+            'by_image_key' => array(),
+            'by_title' => array(),
+            'by_affiliate_url' => array(),
+            'image_urls' => array(),
+        );
+
+        foreach ((array)$candidate_affiliate_images as $image) {
+            if (!is_array($image)) { continue; }
+            $image_url = esc_url_raw((string)($image['image_url'] ?? ($image['url'] ?? '')));
+            $affiliate_url = esc_url_raw((string)($image['affiliate_url'] ?? ''));
+            $id = absint($image['affiliate_link_id'] ?? ($image['id'] ?? 0));
+            $title = sanitize_text_field((string)($image['title'] ?? ''));
+            if ($affiliate_url === '' || !wp_http_validate_url($affiliate_url)) { continue; }
+
+            $record = array(
+                'id' => $id,
+                'affiliate_link_id' => $id,
+                'attachment_id' => absint($image['attachment_id'] ?? 0),
+                'title' => $title,
+                'affiliate_url' => $affiliate_url,
+                'image_url' => $image_url,
+                'alt' => sanitize_text_field((string)($image['alt'] ?? ($image['image_alt'] ?? ''))),
+                'source' => sanitize_text_field((string)($image['source'] ?? ($image['image_source'] ?? ''))),
+            );
+
+            $affiliate_key = self::normalize_url_key($affiliate_url);
+            if ($affiliate_key !== '') { $index['by_affiliate_url'][$affiliate_key] = $record; }
+            if ($image_url !== '' && wp_http_validate_url($image_url)) {
+                $index['image_urls'][$image_url] = $image_url;
+                $index['by_image_url'][$image_url] = $record;
+                $image_key = self::normalize_url_key($image_url);
+                if ($image_key !== '') { $index['by_image_key'][$image_key] = $record; }
+            }
+            $title_key = self::normalize_lookup_text($title);
+            if ($title_key !== '') { $index['by_title'][$title_key] = $record; }
+        }
+
+        return $index;
+    }
+
+    private static function remove_generic_affiliate_disclosures($content, &$warnings) {
+        $before = (string)$content;
+        $patterns = array(
+            '#<(?:p|div|aside|section)\b[^>]*>\s*(?:<[^>]+>\s*)*(?:Questo\s+articolo\s+(?:pu[oò]\s+contenere|contiene)\s+link\s+(?:affiliati|di\s+affiliazione)[\s\S]{0,260}?(?:commissione|senza\s+costi\s+aggiuntivi)[\s\S]{0,160}?)\s*</(?:p|div|aside|section)>#iu',
+            '#<(?:p|div|aside|section)\b[^>]*>\s*(?:<[^>]+>\s*)*(?:Se\s+acquisti\s+tramite\s+questi\s+link[\s\S]{0,220}?commissione[\s\S]{0,160}?)\s*</(?:p|div|aside|section)>#iu',
+            '#<(?:p|div|aside|section)\b[^>]*>\s*(?:<[^>]+>\s*)*(?:Potremmo\s+ricevere\s+una\s+commissione[\s\S]{0,180}?senza\s+costi\s+aggiuntivi[\s\S]{0,120}?)\s*</(?:p|div|aside|section)>#iu',
+            '#\bQuesto\s+articolo\s+(?:pu[oò]\s+contenere|contiene)\s+link\s+(?:affiliati|di\s+affiliazione)[^<\r\n.!?]*(?:[.!?]|$)#iu',
+            '#\bSe\s+acquisti\s+tramite\s+questi\s+link[^<\r\n.!?]*commissione[^<\r\n.!?]*(?:[.!?]|$)#iu',
+            '#\bPotremmo\s+ricevere\s+una\s+commissione[^<\r\n.!?]*senza\s+costi\s+aggiuntivi[^<\r\n.!?]*(?:[.!?]|$)#iu',
+        );
+        foreach ($patterns as $pattern) {
+            $content = preg_replace($pattern, '', (string)$content);
+        }
+        if ((string)$content !== $before) {
+            $warnings[] = 'Disclosure affiliata generica rimossa dal contenuto.';
+        }
+        return $content;
+    }
+
+    private static function find_record_by_image_src($src, $index) {
+        $src = esc_url_raw(html_entity_decode((string)$src, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        if ($src === '') { return array(); }
+        if (isset($index['by_image_url'][$src])) { return $index['by_image_url'][$src]; }
+        $key = self::normalize_url_key($src);
+        return $key !== '' && isset($index['by_image_key'][$key]) ? $index['by_image_key'][$key] : array();
+    }
+
+    private static function set_safe_affiliate_anchor_attrs($anchor, $href) {
+        $anchor->setAttribute('href', $href);
+        $anchor->setAttribute('target', '_blank');
+        $anchor->setAttribute('rel', 'nofollow sponsored noopener');
+    }
+
+    private static function unwrap_node($node) {
+        $parent = $node->parentNode;
+        if (!$parent) { return; }
+        while ($node->firstChild) {
+            $parent->insertBefore($node->firstChild, $node);
+        }
+        $parent->removeChild($node);
+    }
+
+    private static function dom_inner_html($dom) {
+        $html = '';
+        if (!$dom->documentElement) { return $html; }
+        foreach ($dom->documentElement->childNodes as $child) {
+            $html .= $dom->saveHTML($child);
+        }
+        return $html;
+    }
+
+    private static function repair_affiliate_anchors_with_dom($content, $index, &$warnings, &$added_urls) {
+        if (!class_exists('DOMDocument')) { return self::repair_affiliate_anchors_with_regex($content, $index, $warnings, $added_urls); }
+
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $previous = libxml_use_internal_errors(true);
+        $flags = 0;
+        if (defined('LIBXML_HTML_NOIMPLIED')) { $flags |= LIBXML_HTML_NOIMPLIED; }
+        if (defined('LIBXML_HTML_NODEFDTD')) { $flags |= LIBXML_HTML_NODEFDTD; }
+        $loaded = $dom->loadHTML('<div>' . mb_convert_encoding((string)$content, 'HTML-ENTITIES', 'UTF-8') . '</div>', $flags);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        if (!$loaded) { return $content; }
+
+        $anchors = array();
+        foreach ($dom->getElementsByTagName('a') as $anchor) { $anchors[] = $anchor; }
+        foreach ($anchors as $anchor) {
+            $href = trim((string)$anchor->getAttribute('href'));
+            if ($href !== '') { continue; }
+
+            $imgs = $anchor->getElementsByTagName('img');
+            if ($imgs->length > 0) {
+                $img = $imgs->item(0);
+                $record = self::find_record_by_image_src($img ? $img->getAttribute('src') : '', $index);
+                if (!empty($record['affiliate_url'])) {
+                    self::set_safe_affiliate_anchor_attrs($anchor, $record['affiliate_url']);
+                    $added_urls[] = $record['affiliate_url'];
+                    $warnings[] = 'Href affiliato aggiunto a immagine affiliata senza link.';
+                    continue;
+                }
+                self::unwrap_node($anchor);
+                $warnings[] = 'Link senza href rimosso perché non associabile a un link affiliato del payload.';
+                continue;
+            }
+
+            $text_key = self::normalize_lookup_text($anchor->textContent);
+            if ($text_key !== '' && isset($index['by_title'][$text_key])) {
+                $record = $index['by_title'][$text_key];
+                self::set_safe_affiliate_anchor_attrs($anchor, $record['affiliate_url']);
+                $added_urls[] = $record['affiliate_url'];
+                $warnings[] = 'Href affiliato aggiunto a link testuale senza href.';
+                continue;
+            }
+            self::unwrap_node($anchor);
+            $warnings[] = 'Link senza href rimosso perché non associabile a un link affiliato del payload.';
+        }
+
+        return self::dom_inner_html($dom);
+    }
+
+    private static function repair_affiliate_anchors_with_regex($content, $index, &$warnings, &$added_urls) {
+        // Fallback mirato: usato solo se DOMDocument non è disponibile nell'ambiente PHP.
+        $content = preg_replace_callback('#<a\b(?![^>]*\shref=)[^>]*>(\s*<img\b[^>]*\bsrc=["\']([^"\']+)["\'][^>]*>\s*)</a>#isu', function($matches) use ($index, &$warnings, &$added_urls) {
+            $record = self::find_record_by_image_src($matches[2], $index);
+            if (empty($record['affiliate_url'])) { $warnings[] = 'Link senza href rimosso perché non associabile a un link affiliato del payload.'; return $matches[1]; }
+            $added_urls[] = $record['affiliate_url'];
+            $warnings[] = 'Href affiliato aggiunto a immagine affiliata senza link.';
+            return '<a href="' . esc_url($record['affiliate_url']) . '" target="_blank" rel="nofollow sponsored noopener">' . $matches[1] . '</a>';
+        }, (string)$content);
+        $content = preg_replace_callback('#<a\b(?![^>]*\shref=)[^>]*>(.*?)</a>#isu', function($matches) use ($index, &$warnings, &$added_urls) {
+            $text_key = self::normalize_lookup_text($matches[1]);
+            if ($text_key !== '' && isset($index['by_title'][$text_key])) {
+                $record = $index['by_title'][$text_key];
+                $added_urls[] = $record['affiliate_url'];
+                $warnings[] = 'Href affiliato aggiunto a link testuale senza href.';
+                return '<a href="' . esc_url($record['affiliate_url']) . '" target="_blank" rel="nofollow sponsored noopener">' . $matches[1] . '</a>';
+            }
+            $warnings[] = 'Link senza href rimosso perché non associabile a un link affiliato del payload.';
+            return $matches[1];
+        }, (string)$content);
+        return $content;
+    }
+
+    private static function remove_bare_external_text_urls($content, $candidate_image_urls, $affiliate_url_index, &$warnings) {
+        $parts = preg_split('/(<[^>]+>)/', (string)$content, -1, PREG_SPLIT_DELIM_CAPTURE);
+        foreach ($parts as $i => $part) {
+            if ($part === '' || $part[0] === '<') { continue; }
+            $parts[$i] = preg_replace_callback('/https?:\/\/[^\s<>"\']+/i', function($m) use ($candidate_image_urls, $affiliate_url_index, &$warnings) {
+                $url = esc_url_raw($m[0]);
+                $key = self::normalize_url_key($url);
+                if (strpos($url, home_url()) === 0 || isset($candidate_image_urls[$url]) || ($key !== '' && isset($affiliate_url_index[$key]))) { return $m[0]; }
+                $warnings[] = 'URL grezzo rimosso per sicurezza QA.';
+                return '';
+            }, $part);
+        }
+        return implode('', $parts);
+    }
+
+    private static function collect_final_affiliate_usage($content, $index) {
+        $urls = array();
+        $media = array();
+        $images_used = array();
+        if (!class_exists('DOMDocument')) { return array($urls, $media, $images_used); }
+
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $previous = libxml_use_internal_errors(true);
+        $flags = 0;
+        if (defined('LIBXML_HTML_NOIMPLIED')) { $flags |= LIBXML_HTML_NOIMPLIED; }
+        if (defined('LIBXML_HTML_NODEFDTD')) { $flags |= LIBXML_HTML_NODEFDTD; }
+        $loaded = $dom->loadHTML('<div>' . mb_convert_encoding((string)$content, 'HTML-ENTITIES', 'UTF-8') . '</div>', $flags);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        if (!$loaded) { return array($urls, $media, $images_used); }
+
+        foreach ($dom->getElementsByTagName('a') as $anchor) {
+            $href = esc_url_raw(html_entity_decode((string)$anchor->getAttribute('href'), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+            $href_key = self::normalize_url_key($href);
+            if ($href_key === '' || !isset($index['by_affiliate_url'][$href_key])) { continue; }
+            $record = $index['by_affiliate_url'][$href_key];
+            $urls[$record['affiliate_url']] = $record['affiliate_url'];
+
+            foreach ($anchor->getElementsByTagName('img') as $img) {
+                $image_record = self::find_record_by_image_src($img->getAttribute('src'), $index);
+                if (empty($image_record['image_url']) || self::normalize_url_key($image_record['affiliate_url']) !== $href_key) { continue; }
+                $alt = sanitize_text_field((string)$img->getAttribute('alt'));
+                $entry = array(
+                    'image_url' => $image_record['image_url'],
+                    'affiliate_link_id' => absint($image_record['affiliate_link_id'] ?? 0),
+                    'id' => absint($image_record['id'] ?? ($image_record['affiliate_link_id'] ?? 0)),
+                    'affiliate_url' => $image_record['affiliate_url'],
+                    'alt' => $alt !== '' ? $alt : sanitize_text_field((string)($image_record['alt'] ?? '')),
+                    'source' => sanitize_text_field((string)($image_record['source'] ?? '')),
+                );
+                $media[$entry['image_url']] = $entry;
+                $images_used[$entry['image_url']] = array(
+                    'affiliate_link_id' => $entry['affiliate_link_id'],
+                    'attachment_id' => absint($image_record['attachment_id'] ?? 0),
+                    'url' => $entry['image_url'],
+                    'affiliate_url' => $entry['affiliate_url'],
+                    'alt' => $entry['alt'],
+                    'source' => $entry['source'],
+                );
+            }
+        }
+        return array(array_values($urls), array_values($media), array_values($images_used));
+    }
+
+    private static function dedupe_strings($items) {
+        $out = array();
+        foreach ((array)$items as $item) {
+            $item = is_scalar($item) ? trim((string)$item) : '';
+            if ($item !== '') { $out[$item] = $item; }
+        }
+        return array_values($out);
+    }
+
     public static function validate_payload($payload, $candidate_affiliate_ids = array(), $candidate_image_ids = array(), $candidate_affiliate_images = array()) {
         $warnings = array();
         $title = sanitize_text_field($payload['title'] ?? '');
         $excerpt = sanitize_textarea_field($payload['excerpt'] ?? '');
-        $content = wp_kses_post((string)($payload['content_html'] ?? ''));
+        $content = self::sanitize_content_html((string)($payload['content_html'] ?? ($payload['content'] ?? '')));
         if ($title === '') { $warnings[] = 'Titolo vuoto.'; }
         if (trim(wp_strip_all_tags($content)) === '') { $warnings[] = 'Contenuto vuoto.'; }
         if ($excerpt === '') { $excerpt = wp_trim_words(wp_strip_all_tags($content), 30); $warnings[] = 'Excerpt generato automaticamente.'; }
-        if (stripos($content, 'link affiliati') === false) {
-            $content = '<p>Questo articolo può contenere link affiliati: se acquisti tramite questi link, potremmo ricevere una commissione senza costi aggiuntivi per te.</p>' . $content;
-            $warnings[] = 'Disclosure affiliati aggiunta automaticamente dal plugin.';
-        }
+
+        $content = self::remove_generic_affiliate_disclosures($content, $warnings);
         $content = preg_replace('#<(script|iframe|embed)[^>]*>.*?</\1>#is', '', $content);
 
-        $candidate_image_urls = array();
-        $candidate_images_by_url = array();
-        foreach ((array)$candidate_affiliate_images as $image) {
-            if (!is_array($image)) { continue; }
-            $url = esc_url_raw((string)($image['url'] ?? ''));
-            if ($url === '' || !wp_http_validate_url($url)) { continue; }
-            $candidate_image_urls[$url] = $url;
-            $candidate_images_by_url[$url] = array(
-                'affiliate_link_id' => absint($image['affiliate_link_id'] ?? 0),
-                'attachment_id' => absint($image['attachment_id'] ?? 0),
-                'url' => $url,
-            );
-        }
-        foreach ((array)$payload['media_used'] as $media_url) {
-            $url = esc_url_raw((string)$media_url);
+        $index = self::build_affiliate_link_index($candidate_affiliate_ids, $candidate_affiliate_images);
+        $candidate_image_urls = $index['image_urls'];
+        foreach ((array)$payload['media_used'] as $media_item) {
+            $url = is_array($media_item) ? ($media_item['image_url'] ?? ($media_item['url'] ?? '')) : $media_item;
+            $url = esc_url_raw((string)$url);
             if ($url !== '' && isset($candidate_image_urls[$url])) { $candidate_image_urls[$url] = $url; }
         }
+
+        $added_urls = array();
+        $content = self::repair_affiliate_anchors_with_dom($content, $index, $warnings, $added_urls);
+        $content = self::sanitize_content_html($content);
 
         $content = preg_replace_callback('/<img\b[^>]*>/i', function($matches) use (&$warnings, $candidate_image_urls){
             $tag = $matches[0];
             if (!preg_match('/\ssrc=["\']([^"\']+)["\']/i', $tag, $m)) { $warnings[] = 'Immagine senza src rimossa.'; return ''; }
-            $src = esc_url_raw(html_entity_decode((string)$m[1]));
+            $src = esc_url_raw(html_entity_decode((string)$m[1], ENT_QUOTES | ENT_HTML5, 'UTF-8'));
             if ($src === '' || !isset($candidate_image_urls[$src])) { $warnings[] = 'Immagine non presente tra candidate rimossa.'; return ''; }
             if (preg_match('/\salt=["\']([^"\']*)["\']/i', $tag)) { return $tag; }
             return preg_replace('/<img\b/i', '<img alt=""', $tag, 1);
         }, $content);
 
-        $content = preg_replace_callback('/https?:\/\/[^\s<>"\']+/i', function($m) use (&$warnings, $candidate_image_urls){
-            $url = esc_url_raw($m[0]);
-            if (strpos($url, home_url()) === 0 || isset($candidate_image_urls[$url])) { return $m[0]; }
-            $warnings[] = 'URL grezzo rimosso per sicurezza QA.';
-            return '';
-        }, $content);
+        $content = self::remove_bare_external_text_urls($content, $candidate_image_urls, $index['by_affiliate_url'], $warnings);
+
         $used = array();
-        $content = preg_replace_callback('/\[affiliate_link\b([^\]]*)\]/i', function($matches) use (&$used, &$warnings, $candidate_affiliate_ids){
+        $shortcodes_used = array();
+        $content = preg_replace_callback('/\[affiliate_link\b([^\]]*)\]/i', function($matches) use (&$used, &$shortcodes_used, &$warnings, $candidate_affiliate_ids){
             $attrs = shortcode_parse_atts(trim((string)$matches[1]));
             $raw_id = $attrs['id'] ?? '';
             $id = is_numeric($raw_id) ? absint($raw_id) : 0;
@@ -57,6 +335,7 @@ class ALMA_AI_Content_Agent_Draft_Quality_Checker {
             $post = get_post($id);
             if (!$post || $post->post_type !== 'affiliate_link' || !in_array($id, $candidate_affiliate_ids, true) || !in_array($post->post_status, array('publish','private','draft','pending'), true)) { $warnings[] = 'Shortcode affiliato non valido rimosso (ID '.$id.').'; return ''; }
             $used[] = $id;
+            $shortcodes_used[] = $matches[0];
             return $matches[0];
         }, $content);
         $featured = absint($payload['featured_image_id'] ?? 0);
@@ -64,20 +343,29 @@ class ALMA_AI_Content_Agent_Draft_Quality_Checker {
         $inline = array_values(array_filter(array_map('absint', (array)($payload['inline_image_ids'] ?? array()))));
         $inline = array_values(array_filter($inline, function($id) use($candidate_image_ids){ return $id > 0 && in_array($id, $candidate_image_ids, true) && get_post_type($id)==='attachment'; }));
 
-        $affiliate_images_used = array();
-        preg_match_all('/<img\b[^>]*\ssrc=["\']([^"\']+)["\'][^>]*>/i', $content, $matches);
-        $image_use_counts = array_count_values(array_map('esc_url_raw', (array)($matches[1] ?? array())));
-        foreach ($image_use_counts as $url => $count) {
-            if (!isset($candidate_images_by_url[$url])) { continue; }
-            if ($count > 1) { $warnings[] = 'Immagine affiliata duplicata più volte: '.$url; }
-            $affiliate_images_used[] = $candidate_images_by_url[$url];
-        }
-
         if (preg_match('/placeholder(?:\.com|\.it)|via\.placeholder|placehold\.co|loremflickr|dummyimage/i', $content)) {
             $warnings[] = 'Placeholder immagine rilevato e rimosso.';
             $content = preg_replace('/https?:\/\/(?:[^\s<>"\']*(?:placeholder|placehold|dummyimage|loremflickr)[^\s<>"\']*)/i', '', $content);
         }
 
-        return array('title'=>$title,'slug'=>sanitize_title($payload['slug'] ?? $title),'excerpt'=>$excerpt,'content'=>$content,'featured_image_id'=>$featured,'inline_image_ids'=>$inline,'affiliate_links_used'=>array_values(array_unique($used)),'affiliate_images_used'=>array_values($affiliate_images_used),'warnings'=>array_values(array_unique($warnings)));
+        $content = self::sanitize_content_html($content);
+        list($affiliate_urls_used, $media_used, $affiliate_images_used) = self::collect_final_affiliate_usage($content, $index);
+        $affiliate_urls_used = self::dedupe_strings($affiliate_urls_used);
+        $shortcodes_used = self::dedupe_strings(array_merge((array)($payload['affiliate_shortcodes_used'] ?? array()), $shortcodes_used));
+
+        return array(
+            'title'=>$title,
+            'slug'=>sanitize_title($payload['slug'] ?? $title),
+            'excerpt'=>$excerpt,
+            'content'=>$content,
+            'featured_image_id'=>$featured,
+            'inline_image_ids'=>$inline,
+            'affiliate_links_used'=>array_values(array_unique($used)),
+            'affiliate_shortcodes_used'=>$shortcodes_used,
+            'affiliate_urls_used'=>$affiliate_urls_used,
+            'media_used'=>array_values($media_used),
+            'affiliate_images_used'=>array_values($affiliate_images_used),
+            'warnings'=>array_values(array_unique($warnings)),
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Evitare che l’AI produca disclosure affiliate generiche, <a> senza href, link testuali/immagini affiliate non allineate al payload e dati di uso affiliato incoerenti nel JSON finale. 
- Rafforzare il payload/instructional rules inviato a OpenAI per ridurre dipendenza dalla sola capacità del modello di rispettare le istruzioni. 
- Implementare controlli e correzioni locali (QA) per sanare automaticamente i problemi più comuni senza richiedere validazione manuale. 

### Description
- Aggiunte regole operative più vincolanti al payload OpenAI (Draft Builder) per vietare disclosure generiche, <a> senza href, shortcode usati come href e richiedere che ogni href corrisponda esattamente a `affiliate_links[].affiliate_url`, con esempi HTML esatti per immagini affiliate e fallback alt; file modificato: `includes/class-ai-content-agent-draft-builder.php`.
- Implementata rimozione automatica delle disclosure affiliate generiche dal solo campo `content` con warning dedicato; file modificato: `includes/class-ai-content-agent-draft-quality-checker.php`.
- Aggiunta logica DOM-based robusta (con fallback regex) che corregge `<a>` senza `href`: per immagini trova il record candidato dal payload e imposta `href`, `target` e `rel`; per link testuali normalizza il testo e, se corrisponde al titolo di un link affiliato, inserisce `href`, altrimenti rimuove il wrapper `<a>` preservando il contenuto; file modificato: `includes/class-ai-content-agent-draft-quality-checker.php`.
- Ricostruzione coerente di `affiliate_urls_used` e `media_used` a partire dal contenuto sanitizzato finale (solo URL effettivamente presenti come `href` e immagini cliccabili), e salvataggio dei meta della bozza aggiornati (`_alma_ai_agent_affiliate_shortcodes_used`, `_alma_ai_agent_affiliate_urls_used`, `_alma_ai_agent_media_used`); file modificato: `includes/class-ai-content-agent-draft-builder.php`.
- Rafforzata sanitizzazione HTML finale whitelistando in modo sicuro gli attributi consentiti per `<a>`, `<img>` e `<figure>` e prevenendo attributi pericolosi (onclick/onerror/style/javascript/data URL); file modificato: `includes/class-ai-content-agent-draft-quality-checker.php`.
- Esteso l’indice candidate images/records che il QA usa per trovare corrispondenze sicure (include title, affiliate_url, image_url, id, alt, source) senza cambiare la selezione dei candidati; file modificato: `includes/class-ai-content-agent-draft-builder.php`.
- Aggiornati versione plugin, `README.md` e `CHANGELOG.md` a `2.25.38` con descrizione delle novità; file modificati: `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`.

### Testing
- Eseguito fixture locale `php /tmp/alma-qa-test.php` che copre: disclosure prima dell’H1, disclosure nel corpo, immagine affiliata con <a> senza href (corretta), immagine con href già presente (preservata), link testuale affiliato senza href (corretto), link non associabile (wrapper rimosso), shortcode preservato, immagine non presente nel payload (rimossa), e sanitizzazione attributi pericolosi; tutti i casi hanno dato il comportamento atteso e i warning corretti.
- Eseguiti controlli di sintassi PHP: `php -l includes/class-ai-content-agent-draft-builder.php`, `php -l includes/class-ai-content-agent-draft-quality-checker.php` e `php -l affiliate-link-manager-ai.php` con esito OK.
- Eseguito controllo di coerenza `git diff --check` e verifiche rapide di integrazione nel flusso di generazione: payload normalizzato ora include le regole operative aggiornate e il QA riceve/usa i dati estesi per le correzioni locali.
- Nota: non sono stati introdotti download remoto, sideload di immagini, modifiche alla selezione candidati, ai provider Viator/GetYourGuide, né cambiamenti ai parametri degli URL affiliati o ai profili AI multi-attivi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2999931c8332b107fa475c20322d)