### PR TITLE
Improve internal link candidate relevance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.25.40 — AI Content Agent internal link relevance
+- La selezione dei link interni ora combina i tre campi delle Idee contenuto: `content_search_query` / Cerca contenuti, Titolo idea e `openai_prompt` / Prompt per OpenAI.
+- Aggiunta distinzione tra termini forti e termini deboli/generici, con stoplist travel filtrabile tramite `alma_ai_internal_link_stop_terms`.
+- Aggiunta soglia minima di pertinenza filtrabile tramite `alma_ai_internal_link_min_score`: i candidati sotto soglia non entrano in `internal_links` e non viene più forzato il riempimento fino a 8 risultati.
+- Aggiunti termini correlati geografici filtrabili tramite `alma_ai_internal_link_related_terms`, con piccola mappa iniziale `lecce => salento, puglia, otranto, gallipoli, galatina, leuca`.
+- Rafforzato lo scoring: match forti in titolo/slug/categorie/tag/excerpt pesano più della recenza, i termini deboli non bastano da soli e i candidati includono `score`, `matched_terms` e `reason`.
+- Migliorata la diagnostica debug con `internal_link_debug`/`internal_link_diagnostics` contenente `raw_terms`, `strong_terms`, `weak_terms`, `related_terms`, candidati trovati/passati e soglia minima.
+- Ridotto il rischio di link interni fuori contesto, preferendo `internal_links: []` quando non esistono candidati pertinenti alla destinazione richiesta.
+- Versione plugin aggiornata a `2.25.40`.
+
 ## 2.25.39 — AI Content Agent internal linking MVP
 - Aggiunto MVP internal linking per AI Content Agent: indice leggero `alma_ai_internal_link_index` dei post pubblicati con titolo, permalink assoluto, slug, excerpt, categorie, tag e date, senza indicizzare il contenuto completo e senza embeddings.
 - Aggiunto selettore deterministico di candidati link interni (massimo 8) basato su match in titolo, destinazione/keyword, slug, categorie/tag, excerpt e recenza, senza chiamate OpenAI.
@@ -112,7 +122,7 @@
 ## 2.25.25 — PR 8.25 Separate OpenAI Payload Download from Full Debug JSON
 - Corretto il download **Scarica JSON payload OpenAI**: ora esporta il payload compatto prodotto da `normalize_payload_for_openai()`, non il payload diagnostico completo.
 - Aggiunto il download separato **Scarica JSON debug completo**, con wrapper esplicito `debug_payload_full` + `openai_payload_normalized` per confrontare diagnostica interna e payload realmente inviato al modello.
-- Confermata esclusione dal payload OpenAI normalizzato di `content_search_query`, `theme`, `destination`, `selected_results_count`, `selection_context`, score/reason/provider/source/provenance, Source prompt, snapshot istruzioni, `internal_notes`, autori e timestamp amministrativi.
+- Confermata esclusione dal payload OpenAI normalizzato di `content_search_query`, `theme`, `destination`, `selected_results_count`, `selection_context`, score/reason/provider/source/provenance dei risultati sorgente, Source prompt, snapshot istruzioni, `internal_notes`, autori e timestamp amministrativi.
 - Rafforzata la sintesi del contesto Viator escludendo anche righe tecniche provider/source dal contesto breve dei link affiliati.
 - Versione plugin aggiornata a `2.25.25`.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## 2.25.40 — AI Content Agent internal link relevance
+- La selezione dei link interni ora combina i tre campi delle Idee contenuto: `content_search_query` / Cerca contenuti, Titolo idea e `openai_prompt` / Prompt per OpenAI.
+- Aggiunta distinzione tra termini forti e termini deboli/generici, con stoplist travel filtrabile tramite `alma_ai_internal_link_stop_terms`.
+- Aggiunta soglia minima di pertinenza filtrabile tramite `alma_ai_internal_link_min_score`: i candidati sotto soglia non entrano in `internal_links` e non viene più forzato il riempimento fino a 8 risultati.
+- Aggiunti termini correlati geografici filtrabili tramite `alma_ai_internal_link_related_terms`, con piccola mappa iniziale `lecce => salento, puglia, otranto, gallipoli, galatina, leuca`.
+- Rafforzato lo scoring: match forti in titolo/slug/categorie/tag/excerpt pesano più della recenza, i termini deboli non bastano da soli e i candidati includono `score`, `matched_terms` e `reason`.
+- Migliorata la diagnostica debug con `internal_link_debug`/`internal_link_diagnostics` contenente `raw_terms`, `strong_terms`, `weak_terms`, `related_terms`, candidati trovati/passati e soglia minima.
+- Ridotto il rischio di link interni fuori contesto, preferendo `internal_links: []` quando non esistono candidati pertinenti alla destinazione richiesta.
+- Versione plugin aggiornata a `2.25.40`.
+
 ## 2.25.39 — AI Content Agent internal linking MVP
 - Aggiunto MVP internal linking per AI Content Agent: indice leggero `alma_ai_internal_link_index` dei post pubblicati con titolo, permalink assoluto, slug, excerpt, categorie, tag e date, senza indicizzare il contenuto completo e senza embeddings.
 - Aggiunto selettore deterministico di candidati link interni (massimo 8) basato su match in titolo, destinazione/keyword, slug, categorie/tag, excerpt e recenza, senza chiamate OpenAI.
@@ -263,14 +273,14 @@ Versione 2.25.31
 
 - Il pulsante **Scarica JSON payload OpenAI** genera ora il JSON normalizzato compatto prodotto da `normalize_payload_for_openai()`, cioè la struttura usata nel contesto inviato a OpenAI.
 - Aggiunto il pulsante separato **Scarica JSON debug completo**: il file contiene `payload_type`, `debug_payload_full` e `openai_payload_normalized`, così è esplicito quali dati restano solo diagnostici e quali dati entrano nel prompt OpenAI.
-- Il payload OpenAI esportabile resta privo di campi diagnostici/amministrativi (`content_search_query`, `theme`, `destination`, `selected_results_count`, `selection_context`, score/reason/provider/source/provenance, Source prompt, snapshot istruzioni, `internal_notes`, audit timestamps/autori) e mantiene `slug_required: true`.
+- Il payload OpenAI esportabile resta privo di campi diagnostici/amministrativi (`content_search_query`, `theme`, `destination`, `selected_results_count`, `selection_context`, score/reason/provider/source/provenance dei risultati sorgente, Source prompt, snapshot istruzioni, `internal_notes`, audit timestamps/autori) e mantiene `slug_required: true`.
 - Le regole duplicate restano deduplicate nelle sezioni finali `affiliate_rules`, `seo_rules`, `source_policies` ed `editorial_instructions.operational_rules`; il prompt personalizzato del profilo è disponibile in alto in `editorial_instructions.custom_prompt`.
 - Il contesto Viator nei link affiliati viene ulteriormente sintetizzato escludendo righe tecniche su provider/source oltre a product code, rating/recensioni e note operative.
 
 ## Novità 2.25.24 — PR 8.24 Compact OpenAI Draft Payload and JSON Diagnostics
 
 - Payload OpenAI della bozza da risultati selezionati normalizzato in sezioni compatte (`task`, `site`, `article_request`, `editorial_instructions`, `output_requirements`, `affiliate_links`, regole e warning).
-- Rimossi dal payload inviato al modello campi diagnostici/deduplicati come `theme`, `destination`, `selected_results_count`, score/reason/provider/source/provenance, prompt Source completi, snapshot istruzioni ridondanti e `internal_notes`.
+- Rimossi dal payload inviato al modello campi diagnostici/deduplicati come `theme`, `destination`, `selected_results_count`, score/reason/provider/source/provenance dei risultati sorgente, prompt Source completi, snapshot istruzioni ridondanti e `internal_notes`.
 - Separati payload completo di debug/download e payload effettivamente inviato a OpenAI.
 - `slug` ora obbligatorio nel contract JSON, con fallback locale sanificato dal titolo e warning non bloccante.
 - Diagnostica JSON più specifica per risposta vuota, probabile troncamento, JSON non parsabile/testo fuori oggetto, campi obbligatori mancanti e contenuto troppo corto.
@@ -540,7 +550,7 @@ Nel flusso **Crea Bozza con OpenAI** da risultati selezionati, il payload effett
 - **Scarica JSON payload OpenAI** esporta il payload normalizzato realmente usato nel contesto OpenAI (`alma-ai-openai-payload-idea-*.json`).
 - **Scarica JSON debug completo** esporta un wrapper diagnostico (`alma-ai-debug-payload-idea-*.json`) con `debug_payload_full` per troubleshooting e `openai_payload_normalized` per confronto diretto.
 - I dati diagnostici o amministrativi restano disponibili solo in `debug_payload_full`, ma non vengono inviati a OpenAI.
-- Sono esclusi dal payload AI campi come `content_search_query`, `theme`, `destination`, `selected_results_count`, `selection_context`, score/reason/provider/source/provenance, prompt Source completi, snapshot istruzioni ridondanti, `internal_notes`, autori e timestamp amministrativi.
+- Sono esclusi dal payload AI campi come `content_search_query`, `theme`, `destination`, `selected_results_count`, `selection_context`, score/reason/provider/source/provenance dei risultati sorgente, prompt Source completi, snapshot istruzioni ridondanti, `internal_notes`, autori e timestamp amministrativi.
 - Il prompt personalizzato del profilo istruzioni viene esposto in alto dentro le istruzioni editoriali, insieme a tono, pubblico e stile.
 - Il contesto Viator viene sintetizzato in modo prudente, senza blocchi provider tecnici, rating/recensioni aggregate, product code o note operative lunghe.
 - Il contract JSON richiede sempre `title`, `slug`, `excerpt`, `content`, `seo_title`, `seo_description`, `affiliate_shortcodes_used`, `affiliate_urls_used`, `media_used` e `warnings`. Se lo slug manca o non è valido, viene generato/sanificato localmente senza bloccare la bozza.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.39');
+define('ALMA_VERSION', '2.25.40');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -381,6 +381,8 @@ class ALMA_AI_Content_Agent_Draft_Builder {
                 'excerpt' => self::compact_text((string)($link['excerpt'] ?? ''), 28),
                 'categories' => array_values(array_unique(array_filter(array_map('sanitize_text_field', (array)($link['categories'] ?? array()))))),
                 'tags' => array_values(array_unique(array_filter(array_map('sanitize_text_field', (array)($link['tags'] ?? array()))))),
+                'score' => absint($link['score'] ?? 0),
+                'matched_terms' => array_values(array_unique(array_filter(array_map('sanitize_text_field', (array)($link['matched_terms'] ?? array()))))),
                 'reason' => sanitize_text_field((string)($link['reason'] ?? '')),
             );
             if (count($internal_links) >= 8) { break; }
@@ -642,13 +644,26 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         if (empty($affiliate_links)) { $warnings[] = 'Nessun affiliate link selezionato.'; }
         if (empty($session['openai_prompt']) && empty($session['last_query']['temporary_instructions'])) { $warnings[] = 'Prompt OpenAI assente nella idea/sessione.'; }
 
+        $active_idea_title = '';
+        $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true));
+        if ($active_idea_id > 0 && class_exists('ALMA_AI_Content_Agent_Ideas')) {
+            $active_idea = ALMA_AI_Content_Agent_Ideas::get($active_idea_id);
+            $active_idea_title = sanitize_text_field((string)($active_idea['title'] ?? ''));
+        }
+        $content_search_query = sanitize_text_field($session['last_query']['content_search_query'] ?? ($session['last_query']['search_terms'] ?? ''));
+        $idea_title = $active_idea_title !== '' ? $active_idea_title : $content_search_query;
+        $openai_prompt = sanitize_textarea_field($session['openai_prompt'] ?? ($session['last_query']['openai_prompt'] ?? ($session['last_query']['temporary_instructions'] ?? '')));
+
         $internal_link_selection = ALMA_AI_Content_Agent_Internal_Link_Selector::select_candidates(array(
-            'idea' => $session['last_query']['content_search_query'] ?? '',
-            'keyword' => $session['last_query']['search_terms'] ?? ($session['last_query']['content_search_query'] ?? ''),
+            'content_search_query' => $content_search_query,
+            'search_query' => $content_search_query,
+            'idea' => $content_search_query,
+            'keyword' => $session['last_query']['search_terms'] ?? $content_search_query,
             'destination' => $session['last_query']['destination'] ?? '',
-            'prompt' => $session['openai_prompt'] ?? '',
-            'idea_title' => $session['last_query']['content_search_query'] ?? '',
-            'context' => wp_json_encode($selection_context),
+            'openai_prompt' => $openai_prompt,
+            'idea_prompt' => $openai_prompt,
+            'prompt' => $openai_prompt,
+            'idea_title' => $idea_title,
         ));
 
         $profile_payload = self::build_instruction_profile_payload($session, $warnings);
@@ -694,9 +709,9 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         return array_merge(array(
             'task'=>'create_article_draft_from_selected_sources',
             'site_context'=>array('site_name'=>get_bloginfo('name'),'language'=>get_bloginfo('language'),'generated_at'=>current_time('mysql')),
-            'user_inputs'=>array('content_search_query'=>sanitize_text_field($session['last_query']['content_search_query'] ?? ($session['last_query']['search_terms'] ?? '')),'theme'=>sanitize_text_field($session['last_query']['theme'] ?? ''),'destination'=>sanitize_text_field($session['last_query']['destination'] ?? ''),'openai_prompt'=>sanitize_textarea_field($session['openai_prompt'] ?? ($session['last_query']['temporary_instructions'] ?? ''))),
-            'idea_context'=>array('idea_title'=>sanitize_text_field($session['last_query']['content_search_query'] ?? ''),'idea_prompt'=>sanitize_textarea_field($session['openai_prompt'] ?? ''),'search_query'=>sanitize_text_field($session['last_query']['search_terms'] ?? ($session['last_query']['content_search_query'] ?? '')),'selected_results_count'=>count($selection_context)),
-            'openai_prompt'=>sanitize_textarea_field($session['openai_prompt'] ?? ($session['last_query']['temporary_instructions'] ?? '')),
+            'user_inputs'=>array('content_search_query'=>$content_search_query,'theme'=>sanitize_text_field($session['last_query']['theme'] ?? ''),'destination'=>sanitize_text_field($session['last_query']['destination'] ?? ''),'openai_prompt'=>$openai_prompt),
+            'idea_context'=>array('idea_title'=>$idea_title,'idea_prompt'=>$openai_prompt,'search_query'=>sanitize_text_field($session['last_query']['search_terms'] ?? $content_search_query),'selected_results_count'=>count($selection_context)),
+            'openai_prompt'=>$openai_prompt,
             'temporary_instructions'=>sanitize_textarea_field($session['last_query']['temporary_instructions'] ?? ''),
             'rules'=>array(
                 'output_json'=>true,
@@ -716,6 +731,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'internal_links'=>(array)($internal_link_selection['items'] ?? array()),
             'internal_link_rules'=>self::default_internal_link_rules(),
             'internal_link_diagnostics'=>(array)($internal_link_selection['diagnostics'] ?? array()),
+            'internal_link_debug'=>(array)($internal_link_selection['diagnostics'] ?? array()),
             'source_agent_prompts'=>$source_agent_prompts,
             'posts'=>array(),'documents'=>array(),'sources_online'=>array(),'pages'=>array(),'media'=>array(),
             'affiliate_rules'=>$affiliate_rules,

--- a/includes/class-ai-content-agent-internal-link-selector.php
+++ b/includes/class-ai-content-agent-internal-link-selector.php
@@ -9,16 +9,23 @@ class ALMA_AI_Content_Agent_Internal_Link_Selector {
         $args = is_array($args) ? $args : array();
         $table = ALMA_AI_Content_Agent_Internal_Link_Index::table_name();
         $exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table));
-        if ($exists !== $table) { return array('items'=>array(),'diagnostics'=>array('table_exists'=>false,'query_terms'=>array(),'candidates_found'=>0,'candidates_sent'=>0)); }
+        if ($exists !== $table) {
+            $empty_analysis = self::analyze_terms($args);
+            return array('items'=>array(),'diagnostics'=>array_merge(array('table_exists'=>false,'query_terms'=>array(),'candidates_found'=>0,'candidates_sent'=>0,'candidates_passed'=>0,'min_score'=>self::min_score()), $empty_analysis));
+        }
 
-        $terms = self::extract_terms($args);
+        $analysis = self::analyze_terms($args);
         $exclude_post_id = absint($args['exclude_post_id'] ?? 0);
-        $limit_scan = 80;
+        $min_score = self::min_score();
+        $limit_scan = 120;
         $rows = array();
-        if (!empty($terms)) {
+        $query_terms = !empty($analysis['strong_terms']) ? array_merge($analysis['strong_terms'], $analysis['related_terms']) : $analysis['raw_terms'];
+        $query_terms = array_values(array_unique(array_filter(array_map('sanitize_text_field', (array)$query_terms))));
+
+        if (!empty($query_terms)) {
             $likes = array();
             $params = array();
-            foreach (array_slice($terms, 0, 8) as $term) {
+            foreach (array_slice($query_terms, 0, 16) as $term) {
                 $like = '%' . $wpdb->esc_like($term) . '%';
                 $likes[] = '(search_text LIKE %s OR post_title LIKE %s OR post_slug LIKE %s)';
                 $params[] = $like; $params[] = $like; $params[] = $like;
@@ -28,21 +35,19 @@ class ALMA_AI_Content_Agent_Internal_Link_Selector {
             if ($exclude_post_id > 0) { array_unshift($params, $exclude_post_id); }
             $params[] = $limit_scan;
             $rows = $wpdb->get_results($wpdb->prepare($sql, $params), ARRAY_A);
+        } elseif ($exclude_post_id > 0) {
+            $rows = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table WHERE post_status='publish' AND post_id <> %d ORDER BY modified_at DESC LIMIT %d", $exclude_post_id, 30), ARRAY_A);
+        } else {
+            $rows = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table WHERE post_status='publish' ORDER BY modified_at DESC LIMIT %d", 30), ARRAY_A);
         }
-        if (empty($rows)) {
-            if ($exclude_post_id > 0) {
-                $rows = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table WHERE post_status='publish' AND post_id <> %d ORDER BY modified_at DESC LIMIT %d", $exclude_post_id, 30), ARRAY_A);
-            } else {
-                $rows = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table WHERE post_status='publish' ORDER BY modified_at DESC LIMIT %d", 30), ARRAY_A);
-            }
-        }
+
         $items = array();
         $seen = array();
         foreach ((array)$rows as $row) {
             $url = esc_url_raw((string)($row['permalink'] ?? ''));
             if ($url === '' || isset($seen[self::url_key($url)])) { continue; }
-            $score = self::score_row($row, $args, $terms);
-            if ($score['score'] < 8 && !empty($terms)) { continue; }
+            $score = self::score_row($row, $analysis);
+            if (empty($score['passes']) || $score['score'] < $min_score) { continue; }
             $seen[self::url_key($url)] = true;
             $items[] = array(
                 'id' => absint($row['post_id'] ?? 0),
@@ -52,6 +57,7 @@ class ALMA_AI_Content_Agent_Internal_Link_Selector {
                 'categories' => self::decode_string_list($row['categories_json'] ?? '[]'),
                 'tags' => self::decode_string_list($row['tags_json'] ?? '[]'),
                 'score' => (int)$score['score'],
+                'matched_terms' => array_values(array_unique(array_map('sanitize_text_field', (array)$score['matched_terms']))),
                 'reason' => sanitize_text_field($score['reason']),
             );
         }
@@ -60,47 +66,131 @@ class ALMA_AI_Content_Agent_Internal_Link_Selector {
             if ($s !== 0) { return $s; }
             return strcasecmp((string)$a['title'], (string)$b['title']);
         });
+        $passed_count = count($items);
         $items = array_slice($items, 0, self::MAX_CANDIDATES);
-        return array('items'=>$items,'diagnostics'=>array('table_exists'=>true,'query_terms'=>$terms,'candidates_found'=>count($rows),'candidates_sent'=>count($items),'reasons'=>wp_list_pluck($items, 'reason')));
+        $diagnostics = array_merge(array(
+            'table_exists' => true,
+            'query_terms' => $query_terms,
+            'candidates_found' => count($rows),
+            'candidates_sent' => count($items),
+            'candidates_passed' => $passed_count,
+            'min_score' => $min_score,
+            'reasons' => wp_list_pluck($items, 'reason'),
+        ), $analysis);
+        return array('items'=>$items,'diagnostics'=>$diagnostics);
     }
 
-    private static function extract_terms($args) {
-        $text = implode(' ', array(
-            $args['idea'] ?? '', $args['keyword'] ?? '', $args['destination'] ?? '', $args['prompt'] ?? '', $args['idea_title'] ?? '', $args['context'] ?? '',
-        ));
-        $text = remove_accents(strtolower(wp_strip_all_tags((string)$text)));
+    private static function analyze_terms($args) {
+        $sources = array(
+            $args['content_search_query'] ?? ($args['search_query'] ?? ($args['idea'] ?? '')),
+            $args['idea_title'] ?? '',
+            $args['openai_prompt'] ?? ($args['idea_prompt'] ?? ($args['prompt'] ?? '')),
+            $args['keyword'] ?? '',
+            $args['destination'] ?? '',
+        );
+        $text = self::norm(implode(' ', $sources));
         preg_match_all('/[a-z0-9]{3,}/u', $text, $m);
-        $stop = array_flip(array('con','per','una','uno','del','della','delle','degli','nel','nella','sul','sulla','come','cosa','vedere','guida','articolo','scrivi','crea','migliori','itinerario','visitare'));
-        $terms = array();
+        $stop_terms = self::stop_terms();
+        $raw = array();
+        $strong = array();
+        $weak = array();
         foreach ((array)($m[0] ?? array()) as $term) {
-            if (isset($stop[$term])) { continue; }
-            $terms[$term] = $term;
-            if (count($terms) >= 12) { break; }
+            if ($term === '') { continue; }
+            $raw[$term] = $term;
+            if (isset($stop_terms[$term])) { $weak[$term] = $term; continue; }
+            $strong[$term] = $term;
         }
-        return array_values($terms);
+        foreach (self::weak_phrases() as $phrase) {
+            if ($phrase !== '' && strpos(' ' . $text . ' ', ' ' . $phrase . ' ') !== false) { $weak[$phrase] = $phrase; }
+        }
+        $raw = array_slice(array_values($raw), 0, 24);
+        $strong = array_slice(array_values($strong), 0, 12);
+        $weak = array_slice(array_values($weak), 0, 18);
+        $related = self::related_terms($strong);
+        return array('raw_terms'=>$raw,'strong_terms'=>$strong,'weak_terms'=>$weak,'related_terms'=>$related);
     }
 
-    private static function score_row($row, $args, $terms) {
-        $title = self::norm($row['post_title'] ?? '');
-        $slug = self::norm($row['post_slug'] ?? '');
-        $excerpt = self::norm($row['post_excerpt'] ?? '');
-        $cats = self::norm(implode(' ', self::decode_string_list($row['categories_json'] ?? '[]')));
-        $tags = self::norm(implode(' ', self::decode_string_list($row['tags_json'] ?? '[]')));
-        $destination = self::norm($args['destination'] ?? '');
-        $keyword = self::norm($args['keyword'] ?? ($args['idea_title'] ?? ''));
-        $score = 0; $reasons = array();
-        if ($destination !== '' && strpos($title, $destination) !== false) { $score += 35; $reasons[] = 'Match destinazione nel titolo'; }
-        if ($keyword !== '' && strpos($title, $keyword) !== false) { $score += 30; $reasons[] = 'Match keyword nel titolo'; }
-        foreach ((array)$terms as $term) {
-            if ($term !== '' && strpos($title, $term) !== false) { $score += 18; $reasons[] = 'Match nel titolo'; }
-            if ($term !== '' && strpos($slug, $term) !== false) { $score += 10; $reasons[] = 'Match nello slug'; }
-            if ($term !== '' && (strpos($cats, $term) !== false || strpos($tags, $term) !== false)) { $score += 14; $reasons[] = 'Match categorie/tag'; }
-            if ($term !== '' && strpos($excerpt, $term) !== false) { $score += 7; $reasons[] = 'Match nell’excerpt'; }
+    private static function stop_terms() {
+        $terms = array('con','per','una','uno','del','della','delle','degli','dei','nel','nella','sul','sulla','tra','fra','che','questo','questa','questi','queste','come','cosa','fare','vedere','visitare','guida','guide','articolo','scrivi','crea','migliori','migliore','viaggio','viaggi','mete','meta','itinerario','itinerari','tour','esperienza','esperienze','destinazione','destinazioni','mese','periodo','estate','primavera','autunno','inverno','consigli','pratici','pratico','non','perdere','imperdibili','luglio','agosto','settembre','ottobre','novembre','dicembre','gennaio','febbraio','marzo','aprile','maggio','giugno');
+        $terms = (array) apply_filters('alma_ai_internal_link_stop_terms', $terms);
+        $normalized = array();
+        foreach ($terms as $term) {
+            $term = self::norm($term);
+            if ($term !== '') { $normalized[$term] = true; }
+        }
+        return $normalized;
+    }
+
+    private static function weak_phrases() {
+        return array('da non perdere','cosa vedere','cosa fare','consigli pratici');
+    }
+
+    private static function related_terms($strong_terms) {
+        $map = array('lecce'=>array('salento','puglia','otranto','gallipoli','galatina','leuca'));
+        $related = array();
+        foreach ((array)$strong_terms as $term) {
+            if (isset($map[$term])) {
+                foreach ($map[$term] as $rel) { $related[$rel] = $rel; }
+            }
+        }
+        $filtered = apply_filters('alma_ai_internal_link_related_terms', array_values($related), array_values((array)$strong_terms));
+        $out = array();
+        foreach ((array)$filtered as $term) {
+            $term = self::norm($term);
+            if ($term !== '' && !in_array($term, (array)$strong_terms, true)) { $out[$term] = $term; }
+        }
+        return array_slice(array_values($out), 0, 16);
+    }
+
+    private static function min_score() {
+        return max(1, absint(apply_filters('alma_ai_internal_link_min_score', 30)));
+    }
+
+    private static function score_row($row, $analysis) {
+        $fields = array(
+            'title' => self::norm($row['post_title'] ?? ''),
+            'slug' => self::norm($row['post_slug'] ?? ''),
+            'excerpt' => self::norm($row['post_excerpt'] ?? ''),
+            'tax' => self::norm(implode(' ', array_merge(self::decode_string_list($row['categories_json'] ?? '[]'), self::decode_string_list($row['tags_json'] ?? '[]')))),
+        );
+        $score = 0; $reasons = array(); $matched = array(); $has_required_match = false; $weak_matches = 0;
+        foreach ((array)($analysis['strong_terms'] ?? array()) as $term) {
+            $hit = false;
+            if (self::contains_term($fields['title'], $term)) { $score += 45; $reasons[] = 'Match forte nel titolo'; $hit = true; }
+            if (self::contains_term($fields['slug'], $term)) { $score += 35; $reasons[] = 'Match forte nello slug'; $hit = true; }
+            if (self::contains_term($fields['tax'], $term)) { $score += 35; $reasons[] = 'Match forte in categorie/tag'; $hit = true; }
+            if (self::contains_term($fields['excerpt'], $term)) { $score += 20; $reasons[] = 'Match forte nell’excerpt'; $hit = true; }
+            if ($hit) { $matched[$term] = $term; $has_required_match = true; }
+        }
+        foreach ((array)($analysis['related_terms'] ?? array()) as $term) {
+            $hit = false;
+            if (self::contains_term($fields['title'], $term)) { $score += 34; $reasons[] = 'Match correlato geografico nel titolo'; $hit = true; }
+            if (self::contains_term($fields['slug'], $term)) { $score += 28; $reasons[] = 'Match correlato geografico nello slug'; $hit = true; }
+            if (self::contains_term($fields['tax'], $term)) { $score += 30; $reasons[] = 'Match correlato geografico in categorie/tag'; $hit = true; }
+            if (self::contains_term($fields['excerpt'], $term)) { $score += 18; $reasons[] = 'Match correlato geografico nell’excerpt'; $hit = true; }
+            if ($hit) { $matched[$term] = $term; $has_required_match = true; }
+        }
+        foreach ((array)($analysis['weak_terms'] ?? array()) as $term) {
+            foreach ($fields as $field_text) {
+                if (self::contains_term($field_text, $term)) { $weak_matches++; break; }
+            }
+        }
+        if (empty($analysis['strong_terms']) && $weak_matches >= 2) {
+            $score += min(12, $weak_matches * 3);
+            $reasons[] = 'Match multipli su termini generici';
         }
         $modified = strtotime((string)($row['modified_at'] ?? ''));
-        if ($modified && $modified > strtotime('-18 months')) { $score += 3; $reasons[] = 'Post recente/modificato'; }
+        if ($modified && $modified > strtotime('-18 months') && $score > 0) { $score += 2; $reasons[] = 'Post recente/modificato'; }
+        $passes = !empty($analysis['strong_terms']) ? $has_required_match : ($score >= self::min_score());
         $reasons = array_values(array_unique($reasons));
-        return array('score'=>min(100, $score), 'reason'=>implode(' e ', array_slice($reasons, 0, 3)) ?: 'Post pubblicato recente');
+        return array('score'=>min(100, $score), 'passes'=>$passes, 'matched_terms'=>array_values($matched), 'reason'=>implode(' e ', array_slice($reasons, 0, 3)) ?: 'Nessun match pertinente');
+    }
+
+    private static function contains_term($haystack, $term) {
+        $haystack = ' ' . self::norm($haystack) . ' ';
+        $term = self::norm($term);
+        if ($term === '') { return false; }
+        return strpos($haystack, ' ' . $term . ' ') !== false;
     }
 
     private static function decode_string_list($json) {


### PR DESCRIPTION
### Motivation
- The internal link selector returned overly generic, out-of-context candidates for ideas like “Lecce”, so relevance, filtering and scoring need tightening. 
- The selector must base its search on the three Idea fields (`content_search_query` / search_query, idea title and OpenAI prompt) and distinguish strong vs weak terms to avoid proposing unrelated destinations. 
- Provide lightweight geographic related-terms and a minimal, filterable stoplist to keep travel-generic words from driving matches. 
- Keep backwards compatibility with existing internal_links payload, QA and draft generation flows while improving diagnostics for debugging. 

### Description
- Reworked term extraction to combine `content_search_query`/`search_query`, `idea_title` and `openai_prompt`/`idea_prompt`/`prompt` and normalize into `raw_terms`, `strong_terms` and `weak_terms`. (modified: `includes/class-ai-content-agent-internal-link-selector.php`) 
- Added a filterable stoplist `alma_ai_internal_link_stop_terms`, related-terms hook `alma_ai_internal_link_related_terms` with a small initial map (e.g. `lecce => salento,puglia,otranto,gallipoli,galatina,leuca`) and a filterable minimum score `alma_ai_internal_link_min_score`. (modified: `includes/class-ai-content-agent-internal-link-selector.php`) 
- Implemented stricter scoring that requires at least one strong-term match in title/slug/categories/tags/excerpt (weak terms alone don’t qualify unless multiple weak matches exist), favors title/slug/category matches over recency, and returns `score`, `matched_terms` and `reason` per candidate. (modified: `includes/class-ai-content-agent-internal-link-selector.php`) 
- Selector now returns diagnostics including `internal_link_debug` / `internal_link_diagnostics`: `raw_terms`, `strong_terms`, `weak_terms`, `related_terms`, `candidates_found`, `candidates_passed` and `min_score`; draft builder forwards the three idea fields and includes debug into the debug payload; OpenAI payload keeps candidate `score`, `matched_terms` and `reason` but diagnostics remain separated. (modified: `includes/class-ai-content-agent-draft-builder.php`) 
- Limited scan/SQL logic extended to consider related & strong terms and avoid artificial filling of results; final results are capped to 8 but not artificially completed with weak matches. (modified: `includes/class-ai-content-agent-internal-link-selector.php`, `includes/class-ai-content-agent-draft-builder.php`) 
- Bumped plugin version and updated documentation with the change summary. (modified: `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`) 

### Testing
- Ran targeted relevance checks via PHP reflection that exercise `analyze_terms` and `score_row` for the Lecce / generic / Parigi scenarios and the checks passed (validated strong/weak/related term extraction and that unrelated posts fail threshold). 
- Performed PHP lint on modified files with `php -l` which produced no syntax errors for `includes/class-ai-content-agent-internal-link-selector.php`, `includes/class-ai-content-agent-draft-builder.php`, and `affiliate-link-manager-ai.php`. 
- Verified payload/diagnostics generation by creating debug payloads from the Draft Builder and confirmed `internal_link_debug` / `internal_link_diagnostics` contain `raw_terms`, `strong_terms`, `weak_terms`, `related_terms`, `candidates_found`, `candidates_passed` and `min_score`. 
- Ran `git diff --check` to ensure no whitespace/index issues and confirmed all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3d8db5808332a0ec355be9a5b727)