### PR TITLE
Fix media index image detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.25.43 — Fix media index image detection
+- Corretta la ricostruzione dell’Indice Media: gli attachment vengono letti con stati WordPress compatibili, incluso `inherit`, e il riconoscimento immagini accetta tutti i MIME che iniziano con `image/`.
+- Il rebuild carica sempre il post completo prima di indicizzare, non scarta immagini con alt/caption/description vuoti, parent assente, metadata dimensioni mancanti o URL large/medium non disponibili, e salta solo immagini senza URL full.
+- Aggiunta diagnostica admin dettagliata con attachment processati, immagini rilevate, immagini indicizzate, non immagini saltati, attachment senza URL, errori insert/update e record rimossi; gli errori DB mostrano un warning sintetico basato su `wpdb->last_error`.
+- Rafforzata la verifica tabella: il rebuild tenta `install_table()` e restituisce un errore chiaro se la tabella media index non è disponibile.
+- Versione plugin aggiornata a `2.25.43`.
+
 ## 2.25.42 — AI Media Library index and affiliate media separation
 - Aggiunto indice leggero della Media Library per AI Content Agent nella tabella `alma_ai_media_index`, creato via dbDelta su attivazione/upgrade.
 - Indicizzati attachment immagine con title, alt, caption, description, filename, URL full/large/medium, dimensioni, mime type, parent post e testo aggregato di ricerca.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## 2.25.43 — Fix media index image detection
+- Corretta la ricostruzione dell’Indice Media: gli attachment vengono letti con stati WordPress compatibili, incluso `inherit`, e il riconoscimento immagini accetta tutti i MIME che iniziano con `image/`.
+- Il rebuild carica sempre il post completo prima di indicizzare, non scarta immagini con alt/caption/description vuoti, parent assente, metadata dimensioni mancanti o URL large/medium non disponibili, e salta solo immagini senza URL full.
+- Aggiunta diagnostica admin dettagliata con attachment processati, immagini rilevate, immagini indicizzate, non immagini saltati, attachment senza URL, errori insert/update e record rimossi; gli errori DB mostrano un warning sintetico basato su `wpdb->last_error`.
+- Rafforzata la verifica tabella: il rebuild tenta `install_table()` e restituisce un errore chiaro se la tabella media index non è disponibile.
+- Versione plugin aggiornata a `2.25.43`.
+
 ## 2.25.42 — AI Media Library index and affiliate media separation
 - Aggiunto indice leggero della Media Library per AI Content Agent nella tabella `alma_ai_media_index`, creato via dbDelta su attivazione/upgrade.
 - Indicizzati attachment immagine con title, alt, caption, description, filename, URL full/large/medium, dimensioni, mime type, parent post e testo aggregato di ricerca.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.42
+ * Version: 2.25.43
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.42');
+define('ALMA_VERSION', '2.25.43');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -41,7 +41,20 @@ class ALMA_AI_Content_Agent_Admin {
             $result = array('success' => true, 'message' => sprintf('Reindex knowledge completato: %d elementi.', (int)$count));
         } elseif ($do === 'reindex_media') {
             $stats = ALMA_AI_Content_Agent_Media_Index::rebuild_index(100);
-            $result = array('success' => true, 'message' => sprintf('Indice media ricostruito: processati %d attachment, indicizzati %d, rimossi %d record non validi.', (int)$stats['processed'], (int)$stats['indexed'], (int)$stats['deleted']));
+            $message = sprintf(
+                'Indice media ricostruito: processati %d attachment, immagini rilevate %d, indicizzati %d, non immagini saltati %d, senza URL %d, errori %d, rimossi %d record non validi.',
+                (int)($stats['processed'] ?? 0),
+                (int)($stats['detected_images'] ?? 0),
+                (int)($stats['indexed'] ?? 0),
+                (int)($stats['non_images_skipped'] ?? 0),
+                (int)($stats['missing_url'] ?? 0),
+                (int)($stats['errors'] ?? 0),
+                (int)($stats['deleted'] ?? 0)
+            );
+            if (!empty($stats['error_messages'])) {
+                $message .= ' Warning DB: ' . implode(' | ', array_map('sanitize_text_field', (array)$stats['error_messages']));
+            }
+            $result = array('success' => empty($stats['errors']), 'message' => $message);
         } elseif ($do === 'rebuild_internal_link_index') {
             $stats = ALMA_AI_Content_Agent_Internal_Link_Index::rebuild_index(200);
             $result = array('success' => true, 'message' => sprintf('Indice link interni ricostruito: processati %d, indicizzati %d post pubblicati.', (int)$stats['processed'], (int)$stats['indexed']));

--- a/includes/class-ai-content-agent-media-index.php
+++ b/includes/class-ai-content-agent-media-index.php
@@ -50,19 +50,53 @@ class ALMA_AI_Content_Agent_Media_Index {
     public static function rebuild_index($batch_size = 100) {
         global $wpdb;
         self::install_table();
-        $batch_size = max(10, min(250, absint($batch_size)));
-        $processed = 0; $indexed = 0; $deleted = 0; $paged = 1; $seen = array();
-        do {
-            $q = new WP_Query(array('post_type'=>'attachment','post_mime_type'=>'image','post_status'=>'inherit','posts_per_page'=>$batch_size,'paged'=>$paged,'fields'=>'ids','orderby'=>'ID','order'=>'ASC','no_found_rows'=>true));
-            $ids = is_array($q->posts) ? array_map('absint', $q->posts) : array();
-            foreach ($ids as $attachment_id) {
-                $processed++; $seen[] = $attachment_id;
-                if (self::index_attachment($attachment_id)) { $indexed++; }
-            }
-            $paged++;
-        } while (count($ids) === $batch_size);
-
         $table = self::table_name();
+        $table_exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table));
+        if ($table_exists !== $table) {
+            return array('processed'=>0,'detected_images'=>0,'indexed'=>0,'non_images_skipped'=>0,'missing_url'=>0,'errors'=>1,'error_messages'=>array('Tabella media_index non disponibile dopo install_table().'),'deleted'=>0,'batch_size'=>max(10, min(250, absint($batch_size))));
+        }
+
+        $batch_size = max(10, min(250, absint($batch_size)));
+        $processed = 0; $detected_images = 0; $indexed = 0; $non_images_skipped = 0; $missing_url = 0; $errors = 0; $deleted = 0; $last_id = 0; $seen = array(); $error_messages = array();
+        $valid_statuses = array('inherit','private','publish','draft','pending','future');
+        $status_placeholders = implode(',', array_fill(0, count($valid_statuses), '%s'));
+        do {
+            $params = array_merge($valid_statuses, array($last_id, $batch_size));
+            $posts = $wpdb->get_results($wpdb->prepare("SELECT ID, post_mime_type, post_status, (post_mime_type LIKE 'image/%') AS is_image_mime FROM {$wpdb->posts} WHERE post_type = 'attachment' AND post_status IN ($status_placeholders) AND ID > %d ORDER BY ID ASC LIMIT %d", $params));
+            $posts = is_array($posts) ? $posts : array();
+            foreach ($posts as $attachment_stub) {
+                $attachment_id = absint($attachment_stub->ID ?? 0);
+                if ($attachment_id < 1) { continue; }
+                $last_id = $attachment_id;
+                $processed++;
+                $post = get_post($attachment_id);
+                if (!self::is_valid_image_attachment($post)) {
+                    $non_images_skipped++;
+                    self::delete_attachment($attachment_id);
+                    continue;
+                }
+
+                $detected_images++;
+                $seen[] = $attachment_id;
+                $url_full = wp_get_attachment_url($attachment_id);
+                if (!$url_full) {
+                    $missing_url++;
+                    self::delete_attachment($attachment_id);
+                    continue;
+                }
+
+                $index_result = self::index_attachment($attachment_id, $post);
+                if ($index_result) {
+                    $indexed++;
+                } else {
+                    $errors++;
+                    if (!empty($wpdb->last_error)) {
+                        $error_messages[] = sanitize_text_field($wpdb->last_error);
+                    }
+                }
+            }
+        } while (count($posts) === $batch_size);
+
         $rows = $wpdb->get_col("SELECT attachment_id FROM $table");
         foreach ((array)$rows as $attachment_id) {
             if (!in_array((int)$attachment_id, $seen, true) && !self::is_valid_image_attachment((int)$attachment_id)) {
@@ -70,15 +104,18 @@ class ALMA_AI_Content_Agent_Media_Index {
             }
         }
         update_option(self::OPTION_LAST_REBUILD_AT, current_time('mysql'), false);
-        return array('processed'=>$processed,'indexed'=>$indexed,'deleted'=>$deleted,'batch_size'=>$batch_size);
+        return array('processed'=>$processed,'detected_images'=>$detected_images,'indexed'=>$indexed,'non_images_skipped'=>$non_images_skipped,'missing_url'=>$missing_url,'errors'=>$errors,'error_messages'=>array_values(array_unique(array_slice($error_messages, 0, 3))),'deleted'=>$deleted,'batch_size'=>$batch_size);
     }
 
-    public static function index_attachment($attachment_id) {
+    public static function index_attachment($attachment_id, $post = null) {
         global $wpdb;
         $attachment_id = absint($attachment_id);
-        if (!self::is_valid_image_attachment($attachment_id)) { self::delete_attachment($attachment_id); return false; }
-        $post = get_post($attachment_id);
+        $post = $post instanceof WP_Post ? $post : get_post($attachment_id);
+        if (!self::is_valid_image_attachment($post)) { self::delete_attachment($attachment_id); return false; }
+        $url_full = wp_get_attachment_url($attachment_id);
+        if (!$url_full) { self::delete_attachment($attachment_id); return false; }
         $meta = wp_get_attachment_metadata($attachment_id);
+        $meta = is_array($meta) ? $meta : array();
         $file = get_attached_file($attachment_id);
         $file_name = sanitize_file_name(wp_basename((string)$file));
         if ($file_name === '') { $file_name = sanitize_file_name(wp_basename((string)get_post_meta($attachment_id, '_wp_attached_file', true))); }
@@ -94,7 +131,7 @@ class ALMA_AI_Content_Agent_Media_Index {
             'caption'=>sanitize_text_field($post->post_excerpt),
             'description'=>wp_kses_post($post->post_content),
             'file_name'=>$file_name,
-            'url_full'=>esc_url_raw((string)wp_get_attachment_url($attachment_id)),
+            'url_full'=>esc_url_raw((string)$url_full),
             'url_large'=>esc_url_raw((string)wp_get_attachment_image_url($attachment_id, 'large')),
             'url_medium'=>esc_url_raw((string)wp_get_attachment_image_url($attachment_id, 'medium')),
             'width'=>absint($meta['width'] ?? 0),
@@ -116,7 +153,11 @@ class ALMA_AI_Content_Agent_Media_Index {
             'indexed_at'=>current_time('mysql'),
         );
         $exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM " . self::table_name() . " WHERE attachment_id=%d", $attachment_id));
-        return $exists ? (false !== $wpdb->update(self::table_name(), $row, array('attachment_id'=>$attachment_id))) : (false !== $wpdb->insert(self::table_name(), $row));
+        $ok = $exists ? (false !== $wpdb->update(self::table_name(), $row, array('attachment_id'=>$attachment_id))) : (false !== $wpdb->insert(self::table_name(), $row));
+        if (!$ok && !empty($wpdb->last_error)) {
+            error_log('ALMA media index insert/update failed: ' . sanitize_text_field($wpdb->last_error));
+        }
+        return $ok;
     }
 
     public static function delete_attachment($attachment_id) {
@@ -140,9 +181,10 @@ class ALMA_AI_Content_Agent_Media_Index {
         return array('table_exists'=>$exists === $table,'total'=>self::count_records(),'editorial'=>self::count_records('editorial'),'affiliate'=>self::count_records('affiliate'),'last_rebuild_at'=>get_option(self::OPTION_LAST_REBUILD_AT, ''));
     }
 
-    private static function is_valid_image_attachment($attachment_id) {
-        $post = get_post($attachment_id);
-        return $post && $post->post_type === 'attachment' && $post->post_status !== 'trash' && strpos((string)$post->post_mime_type, 'image/') === 0;
+    private static function is_valid_image_attachment($attachment) {
+        $post = $attachment instanceof WP_Post ? $attachment : get_post(absint($attachment));
+        if (!$post || $post->post_type !== 'attachment' || $post->post_status === 'trash') { return false; }
+        return strpos(strtolower((string)$post->post_mime_type), 'image/') === 0;
     }
 
     private static function classify($attachment_id) {


### PR DESCRIPTION
### Motivation
- Risolvere il bug per cui il rebuild dell’Indice Media processava molti `attachment` ma indicizzava 0 immagini restituendo messaggi come “processati 11633 attachment, indicizzati 0”.
- La causa era una logica di scoperta/riconoscimento immagine troppo fragile che usava query in modalità `fields => ids` e filtri non adeguati su `post_status`/`post_mime_type` e poi scartava i post senza metadata completi.
- L’obiettivo è far sì che il rebuild trovi gli attachment corretti (incluso `inherit`), riconosca qualsiasi `post_mime_type` che inizia con `image/` e indicizzi anche immagini con metadata mancanti o alt/caption vuoti.

### Description
- Aggiornata la procedura di rebuild `ALMA_AI_Content_Agent_Media_Index::rebuild_index()` per usare una query paginata su `{$wpdb->posts}` che include stati compatibili (`inherit`, `private`, `publish`, `draft`, `pending`, `future`) e carica i campi necessari prima di decidere; la funzione ora verifica anche l’esistenza della tabella dopo `install_table()` e restituisce errore chiaro se la tabella non è disponibile.
- Migliorato il riconoscimento immagine con `is_valid_image_attachment()` che accetta un `WP_Post` o un ID e considera indicizzabile ogni attachment il cui `post_mime_type` inizia con `image/` (copre `image/jpeg`, `image/png`, `image/webp`, `image/gif`, `image/avif`, ecc.).
- Modificata la firma `index_attachment()` per accettare un parametro opzionale `$post`, caricare sempre il `WP_Post` completo con `get_post()` quando necessario, normalizzare `wp_get_attachment_metadata()` come array e non rifiutare immagini per metadata mancanti; gli URL `large/medium` mancanti non impediscono l’indicizzazione, mentre manca l’`url_full` causa lo skip del record.
- Aggiunta diagnostica e logging: il rebuild ora ritorna e l’admin mostra contatori estesi (`processed`, `detected_images`, `indexed`, `non_images_skipped`, `missing_url`, `errors`, `deleted`) e, in caso di errori DB, viene catturato un warning sintetico basato su `$wpdb->last_error` (loggato con `error_log()` senza esporre dati sensibili).
- File modificati: `includes/class-ai-content-agent-media-index.php`, `includes/class-ai-content-agent-admin.php`, `affiliate-link-manager-ai.php` (versione), `README.md`, `CHANGELOG.md`.
- Versioning: header plugin e costante `ALMA_VERSION` aggiornate a `2.25.43` e documentazione aggiornata.

### Testing
- Eseguito `php -l includes/class-ai-content-agent-media-index.php` con esito OK.
- Eseguito `php -l includes/class-ai-content-agent-admin.php` con esito OK.
- Eseguito `php -l affiliate-link-manager-ai.php` con esito OK.
- Eseguito `git diff --check` (nessun warning) e commit della modifica; questi controlli sono passati correttamente.
- Test reali richiesti (da eseguire su sito WordPress con Media Library reale): ricostruire indice via admin e verificare che `indicizzati` > 0, verificare indicizzazione di `image/jpeg` con `alt` vuoto, indicizzazione di attachment con `post_status = inherit`, e che file non immagine (es. PDF) siano saltati; questi test manuali non sono eseguibili nel container e devono essere eseguiti in ambiente WordPress reale.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc57da21888332976eabddb44a070a)