### PR TITLE
Fix media index schema migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.25.44 — Fix media index schema migration
+- Allineato lo schema dichiarato di `alma_ai_media_index` alle colonne usate da insert/update, mantenendo `post_status` e tutte le colonne tecniche dell’indice media.
+- Aggiunta migrazione difensiva `ensure_schema()` per verificare le colonne esistenti con `SHOW COLUMNS` e aggiungere in sicurezza quelle mancanti con `ALTER TABLE`, senza affidarsi solo a `dbDelta()`.
+- Il rebuild dell’Indice Media aggiorna/verifica lo schema prima di processare gli attachment e si interrompe con errore admin chiaro se la tabella resta incompleta, evitando migliaia di insert/update destinati a fallire.
+- Aggiunta diagnostica sintetica quando vengono aggiunte colonne mancanti allo schema indice media.
+- Versione plugin aggiornata a `2.25.44`.
+
 ## 2.25.43 — Fix media index image detection
 - Corretta la ricostruzione dell’Indice Media: gli attachment vengono letti con stati WordPress compatibili, incluso `inherit`, e il riconoscimento immagini accetta tutti i MIME che iniziano con `image/`.
 - Il rebuild carica sempre il post completo prima di indicizzare, non scarta immagini con alt/caption/description vuoti, parent assente, metadata dimensioni mancanti o URL large/medium non disponibili, e salta solo immagini senza URL full.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## 2.25.44 — Fix media index schema migration
+- Allineato lo schema dichiarato di `alma_ai_media_index` alle colonne usate da insert/update, mantenendo `post_status` e tutte le colonne tecniche dell’indice media.
+- Aggiunta migrazione difensiva `ensure_schema()` per verificare le colonne esistenti con `SHOW COLUMNS` e aggiungere in sicurezza quelle mancanti con `ALTER TABLE`, senza affidarsi solo a `dbDelta()`.
+- Il rebuild dell’Indice Media aggiorna/verifica lo schema prima di processare gli attachment e si interrompe con errore admin chiaro se la tabella resta incompleta, evitando migliaia di insert/update destinati a fallire.
+- Aggiunta diagnostica sintetica quando vengono aggiunte colonne mancanti allo schema indice media.
+- Versione plugin aggiornata a `2.25.44`.
+
 ## 2.25.43 — Fix media index image detection
 - Corretta la ricostruzione dell’Indice Media: gli attachment vengono letti con stati WordPress compatibili, incluso `inherit`, e il riconoscimento immagini accetta tutti i MIME che iniziano con `image/`.
 - Il rebuild carica sempre il post completo prima di indicizzare, non scarta immagini con alt/caption/description vuoti, parent assente, metadata dimensioni mancanti o URL large/medium non disponibili, e salta solo immagini senza URL full.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.43
+ * Version: 2.25.44
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.43');
+define('ALMA_VERSION', '2.25.44');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -41,20 +41,30 @@ class ALMA_AI_Content_Agent_Admin {
             $result = array('success' => true, 'message' => sprintf('Reindex knowledge completato: %d elementi.', (int)$count));
         } elseif ($do === 'reindex_media') {
             $stats = ALMA_AI_Content_Agent_Media_Index::rebuild_index(100);
-            $message = sprintf(
-                'Indice media ricostruito: processati %d attachment, immagini rilevate %d, indicizzati %d, non immagini saltati %d, senza URL %d, errori %d, rimossi %d record non validi.',
-                (int)($stats['processed'] ?? 0),
-                (int)($stats['detected_images'] ?? 0),
-                (int)($stats['indexed'] ?? 0),
-                (int)($stats['non_images_skipped'] ?? 0),
-                (int)($stats['missing_url'] ?? 0),
-                (int)($stats['errors'] ?? 0),
-                (int)($stats['deleted'] ?? 0)
-            );
-            if (!empty($stats['error_messages'])) {
-                $message .= ' Warning DB: ' . implode(' | ', array_map('sanitize_text_field', (array)$stats['error_messages']));
+            if (!empty($stats['schema_error'])) {
+                $schema = is_array($stats['schema'] ?? null) ? $stats['schema'] : array();
+                $detail = sanitize_text_field($schema['error'] ?? implode(' | ', (array)($stats['error_messages'] ?? array())));
+                $message = 'Indice media non aggiornato: schema tabella incompleto. Dettaglio DB: ' . ($detail !== '' ? $detail : 'errore schema non disponibile.');
+                $result = array('success' => false, 'message' => $message);
+            } else {
+                $message = sprintf(
+                    'Indice media ricostruito: processati %d attachment, immagini rilevate %d, indicizzati %d, non immagini saltati %d, senza URL %d, errori %d, rimossi %d record non validi.',
+                    (int)($stats['processed'] ?? 0),
+                    (int)($stats['detected_images'] ?? 0),
+                    (int)($stats['indexed'] ?? 0),
+                    (int)($stats['non_images_skipped'] ?? 0),
+                    (int)($stats['missing_url'] ?? 0),
+                    (int)($stats['errors'] ?? 0),
+                    (int)($stats['deleted'] ?? 0)
+                );
+                if (!empty($stats['schema']['added_columns'])) {
+                    $message .= ' Schema indice media aggiornato: aggiunte colonne mancanti.';
+                }
+                if (!empty($stats['error_messages'])) {
+                    $message .= ' Warning DB: ' . implode(' | ', array_map('sanitize_text_field', (array)$stats['error_messages']));
+                }
+                $result = array('success' => empty($stats['errors']), 'message' => $message);
             }
-            $result = array('success' => empty($stats['errors']), 'message' => $message);
         } elseif ($do === 'rebuild_internal_link_index') {
             $stats = ALMA_AI_Content_Agent_Internal_Link_Index::rebuild_index(200);
             $result = array('success' => true, 'message' => sprintf('Indice link interni ricostruito: processati %d, indicizzati %d post pubblicati.', (int)$stats['processed'], (int)$stats['indexed']));

--- a/includes/class-ai-content-agent-media-index.php
+++ b/includes/class-ai-content-agent-media-index.php
@@ -25,7 +25,90 @@ class ALMA_AI_Content_Agent_Media_Index {
         global $wpdb;
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         $c = $wpdb->get_charset_collate();
-        dbDelta("CREATE TABLE " . self::table_name() . " (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,attachment_id BIGINT UNSIGNED NOT NULL,post_status VARCHAR(20) NOT NULL DEFAULT 'inherit',mime_type VARCHAR(120) NOT NULL DEFAULT '',title TEXT NULL,alt_text TEXT NULL,caption TEXT NULL,description LONGTEXT NULL,file_name VARCHAR(255) NOT NULL DEFAULT '',url_full TEXT NULL,url_large TEXT NULL,url_medium TEXT NULL,width INT UNSIGNED NOT NULL DEFAULT 0,height INT UNSIGNED NOT NULL DEFAULT 0,post_parent BIGINT UNSIGNED NOT NULL DEFAULT 0,attached_post_title TEXT NULL,media_origin VARCHAR(60) NOT NULL DEFAULT 'editorial',media_role VARCHAR(80) NOT NULL DEFAULT 'editorial_image',provider VARCHAR(80) NOT NULL DEFAULT '',source_id VARCHAR(190) NOT NULL DEFAULT '',external_id VARCHAR(190) NOT NULL DEFAULT '',related_post_id BIGINT UNSIGNED NOT NULL DEFAULT 0,related_post_type VARCHAR(60) NOT NULL DEFAULT '',is_affiliate_media TINYINT(1) NOT NULL DEFAULT 0,is_editorial_candidate TINYINT(1) NOT NULL DEFAULT 1,search_text LONGTEXT NULL,created_at DATETIME NULL,modified_at DATETIME NULL,indexed_at DATETIME NULL,PRIMARY KEY (id),UNIQUE KEY attachment_id (attachment_id),KEY post_status (post_status),KEY mime_type (mime_type),KEY post_parent (post_parent),KEY media_origin (media_origin),KEY media_role (media_role),KEY is_affiliate_media (is_affiliate_media),KEY is_editorial_candidate (is_editorial_candidate),KEY related_post (related_post_id, related_post_type),KEY indexed_at (indexed_at)) $c;");
+        dbDelta("CREATE TABLE " . self::table_name() . " (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,attachment_id BIGINT UNSIGNED NOT NULL,post_status VARCHAR(20) NOT NULL DEFAULT '',mime_type VARCHAR(120) NOT NULL DEFAULT '',title TEXT NULL,alt_text TEXT NULL,caption TEXT NULL,description LONGTEXT NULL,file_name VARCHAR(255) NOT NULL DEFAULT '',url_full TEXT NULL,url_large TEXT NULL,url_medium TEXT NULL,width INT UNSIGNED NOT NULL DEFAULT 0,height INT UNSIGNED NOT NULL DEFAULT 0,post_parent BIGINT UNSIGNED NOT NULL DEFAULT 0,attached_post_title TEXT NULL,media_origin VARCHAR(60) NOT NULL DEFAULT 'editorial',media_role VARCHAR(80) NOT NULL DEFAULT 'editorial_image',provider VARCHAR(80) NOT NULL DEFAULT '',source_id VARCHAR(190) NOT NULL DEFAULT '',external_id VARCHAR(190) NOT NULL DEFAULT '',related_post_id BIGINT UNSIGNED NOT NULL DEFAULT 0,related_post_type VARCHAR(60) NOT NULL DEFAULT '',is_affiliate_media TINYINT(1) NOT NULL DEFAULT 0,is_editorial_candidate TINYINT(1) NOT NULL DEFAULT 1,search_text LONGTEXT NULL,created_at DATETIME NULL,modified_at DATETIME NULL,indexed_at DATETIME NULL,PRIMARY KEY (id),UNIQUE KEY attachment_id (attachment_id),KEY post_status (post_status),KEY mime_type (mime_type),KEY post_parent (post_parent),KEY media_origin (media_origin),KEY media_role (media_role),KEY is_affiliate_media (is_affiliate_media),KEY is_editorial_candidate (is_editorial_candidate),KEY related_post (related_post_id, related_post_type),KEY indexed_at (indexed_at)) $c;");
+        return self::ensure_schema();
+    }
+
+    public static function maybe_upgrade_schema() {
+        return self::ensure_schema();
+    }
+
+    public static function expected_columns() {
+        return array(
+            'attachment_id' => 'BIGINT UNSIGNED NOT NULL DEFAULT 0',
+            'post_status' => "VARCHAR(20) NOT NULL DEFAULT ''",
+            'mime_type' => "VARCHAR(120) NOT NULL DEFAULT ''",
+            'title' => 'TEXT NULL',
+            'alt_text' => 'TEXT NULL',
+            'caption' => 'TEXT NULL',
+            'description' => 'LONGTEXT NULL',
+            'file_name' => "VARCHAR(255) NOT NULL DEFAULT ''",
+            'url_full' => 'TEXT NULL',
+            'url_large' => 'TEXT NULL',
+            'url_medium' => 'TEXT NULL',
+            'width' => 'INT UNSIGNED NOT NULL DEFAULT 0',
+            'height' => 'INT UNSIGNED NOT NULL DEFAULT 0',
+            'post_parent' => 'BIGINT UNSIGNED NOT NULL DEFAULT 0',
+            'attached_post_title' => 'TEXT NULL',
+            'media_origin' => "VARCHAR(60) NOT NULL DEFAULT 'editorial'",
+            'media_role' => "VARCHAR(80) NOT NULL DEFAULT 'editorial_image'",
+            'provider' => "VARCHAR(80) NOT NULL DEFAULT ''",
+            'source_id' => "VARCHAR(190) NOT NULL DEFAULT ''",
+            'external_id' => "VARCHAR(190) NOT NULL DEFAULT ''",
+            'related_post_id' => 'BIGINT UNSIGNED NOT NULL DEFAULT 0',
+            'related_post_type' => "VARCHAR(60) NOT NULL DEFAULT ''",
+            'is_affiliate_media' => 'TINYINT(1) NOT NULL DEFAULT 0',
+            'is_editorial_candidate' => 'TINYINT(1) NOT NULL DEFAULT 1',
+            'search_text' => 'LONGTEXT NULL',
+            'created_at' => 'DATETIME NULL',
+            'modified_at' => 'DATETIME NULL',
+            'indexed_at' => 'DATETIME NULL',
+        );
+    }
+
+    public static function ensure_schema() {
+        global $wpdb;
+        $table = self::table_name();
+        $table_exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table));
+        if ($table_exists !== $table) {
+            return array('success'=>false,'added_columns'=>array(),'missing_columns'=>array_keys(self::expected_columns()),'checked_columns'=>array_keys(self::expected_columns()),'error'=>'Tabella media_index non disponibile.');
+        }
+
+        $wpdb->last_error = '';
+        $existing = $wpdb->get_results('SHOW COLUMNS FROM `' . str_replace('`', '``', $table) . '`', ARRAY_A);
+        if (!is_array($existing)) {
+            return array('success'=>false,'added_columns'=>array(),'missing_columns'=>array_keys(self::expected_columns()),'checked_columns'=>array_keys(self::expected_columns()),'error'=>sanitize_text_field($wpdb->last_error ?: 'SHOW COLUMNS non riuscito.'));
+        }
+
+        $existing_columns = array();
+        foreach ($existing as $column) {
+            if (!empty($column['Field'])) { $existing_columns[(string)$column['Field']] = true; }
+        }
+
+        $added = array();
+        $errors = array();
+        foreach (self::expected_columns() as $column => $definition) {
+            if (isset($existing_columns[$column])) { continue; }
+            $wpdb->last_error = '';
+            $ok = $wpdb->query('ALTER TABLE `' . str_replace('`', '``', $table) . '` ADD COLUMN `' . str_replace('`', '``', $column) . '` ' . $definition);
+            if ($ok === false) {
+                $errors[] = $column . ': ' . sanitize_text_field($wpdb->last_error ?: 'ALTER TABLE non riuscito.');
+                continue;
+            }
+            $added[] = $column;
+            $existing_columns[$column] = true;
+        }
+
+        $missing = array();
+        foreach (array_keys(self::expected_columns()) as $column) {
+            if (!isset($existing_columns[$column])) { $missing[] = $column; }
+        }
+
+        $success = empty($missing) && empty($errors);
+        $error = '';
+        if (!$success) { $error = implode(' | ', array_merge($errors, array_map('sanitize_text_field', $missing))); }
+        if (!empty($added)) { error_log('ALMA media index schema updated: added missing columns ' . implode(', ', array_map('sanitize_key', $added))); }
+        return array('success'=>$success,'added_columns'=>$added,'missing_columns'=>$missing,'checked_columns'=>array_keys(self::expected_columns()),'error'=>$error);
     }
 
     public static function handle_attachment_change($attachment_id) { self::index_attachment(absint($attachment_id)); }
@@ -49,11 +132,10 @@ class ALMA_AI_Content_Agent_Media_Index {
 
     public static function rebuild_index($batch_size = 100) {
         global $wpdb;
-        self::install_table();
+        $schema = self::install_table();
         $table = self::table_name();
-        $table_exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table));
-        if ($table_exists !== $table) {
-            return array('processed'=>0,'detected_images'=>0,'indexed'=>0,'non_images_skipped'=>0,'missing_url'=>0,'errors'=>1,'error_messages'=>array('Tabella media_index non disponibile dopo install_table().'),'deleted'=>0,'batch_size'=>max(10, min(250, absint($batch_size))));
+        if (empty($schema['success'])) {
+            return array('processed'=>0,'detected_images'=>0,'indexed'=>0,'non_images_skipped'=>0,'missing_url'=>0,'errors'=>1,'error_messages'=>array($schema['error'] ?: 'Schema tabella media_index incompleto.'),'deleted'=>0,'batch_size'=>max(10, min(250, absint($batch_size))),'schema_error'=>true,'schema'=>$schema);
         }
 
         $batch_size = max(10, min(250, absint($batch_size)));
@@ -104,7 +186,7 @@ class ALMA_AI_Content_Agent_Media_Index {
             }
         }
         update_option(self::OPTION_LAST_REBUILD_AT, current_time('mysql'), false);
-        return array('processed'=>$processed,'detected_images'=>$detected_images,'indexed'=>$indexed,'non_images_skipped'=>$non_images_skipped,'missing_url'=>$missing_url,'errors'=>$errors,'error_messages'=>array_values(array_unique(array_slice($error_messages, 0, 3))),'deleted'=>$deleted,'batch_size'=>$batch_size);
+        return array('processed'=>$processed,'detected_images'=>$detected_images,'indexed'=>$indexed,'non_images_skipped'=>$non_images_skipped,'missing_url'=>$missing_url,'errors'=>$errors,'error_messages'=>array_values(array_unique(array_slice($error_messages, 0, 3))),'deleted'=>$deleted,'batch_size'=>$batch_size,'schema'=>$schema);
     }
 
     public static function index_attachment($attachment_id, $post = null) {


### PR DESCRIPTION
### Motivation
- The media index rebuild was failing with DB errors because `alma_ai_media_index` lacked columns (notably `post_status`) expected by insert/update code, causing every insert/update to error out.
- Ensure the plugin does not process thousands of attachments when the media index schema is incomplete and provide a clear admin diagnostic when schema migration fails.

### Description
- Updated `includes/class-ai-content-agent-media-index.php` to keep `dbDelta()` but return into and call a new defensive `ensure_schema()` that verifies and adds missing columns via `SHOW COLUMNS` + `ALTER TABLE` and exposes `maybe_upgrade_schema()` for upgrades.
- Aligned the declared table schema to include all columns used by insert/update (including `post_status`, `attachment_id`, `mime_type`, `title`, `alt_text`, `caption`, `description`, `file_name`, `url_full`, `url_large`, `url_medium`, `width`, `height`, `post_parent`, `attached_post_title`, `media_origin`, `media_role`, `provider`, `source_id`, `external_id`, `related_post_id`, `related_post_type`, `is_affiliate_media`, `is_editorial_candidate`, `search_text`, `created_at`, `modified_at`, `indexed_at`).
- Before starting the rebuild, `rebuild_index()` now runs `install_table()`/`ensure_schema()` and aborts with a structured error if the schema cannot be made complete, and the rebuild result now contains schema diagnostics (added/missing columns and error text) when relevant.
- Updated admin action handling in `includes/class-ai-content-agent-admin.php` to show a clear admin message when schema is incomplete and to report when missing columns were automatically added, and bumped plugin `Version`/`ALMA_VERSION` to `2.25.44` and updated `README.md`/`CHANGELOG.md`.

### Testing
- Ran `php -l includes/class-ai-content-agent-media-index.php` with no syntax errors detected.
- Ran `php -l includes/class-ai-content-agent-admin.php` and `php -l affiliate-link-manager-ai.php` with no syntax errors detected.
- Ran `git diff --check` and no whitespace/patch problems were reported.
- Manual WordPress integration tests were requested but not executed in this environment; recommended manual steps are: run the media rebuild via admin, verify the DB warning `Unknown column 'post_status'` is gone, confirm `indexed > 0`, check affiliate/editorial counts, and re-run rebuild to confirm idempotent behavior when columns already exist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5a9779288332ac1237a6cb3edae3)