### PR TITLE
Add dashboard index update alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.25.47 — Dashboard index update alerts
+- Aggiunti alert operativi in alto nella Dashboard AI Content Agent per Link affiliati, Link interni e Media Library.
+- Gli alert mostrano stato, conteggi nuovi/modificati/obsoleti e totale indicizzato, con CTA per aggiornare solo i pendenti.
+- Aggiunti conteggi pending e sync incrementale per Link interni, confrontando post pubblicati con l’indice senza indicizzare il contenuto completo.
+- Aggiunti conteggi pending e sync incrementale per Media Library su attachment immagine, senza OCR, download o lettura file binari.
+- Riusata la sync incrementale esistente dei Link affiliati nella nuova UI alert.
+- Le ricostruzioni complete e reset/svuota indice restano disponibili nella sezione Manutenzione avanzata.
+- Versione plugin aggiornata a `2.25.47`.
+
 ## 2.25.46 — AI Content Agent dashboard UI operativa
 - Riorganizzata la dashboard **AI Content Agent** con quick actions in alto per Idee contenuto, creazione idea, Istruzioni AI e Stato/log.
 - Aggiunte card riepilogative per OpenAI, Idee contenuto, Link affiliati, Link interni, Media Library e Stato/log.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## 2.25.47 — Dashboard index update alerts
+- Aggiunti alert operativi in alto nella Dashboard AI Content Agent per Link affiliati, Link interni e Media Library.
+- Gli alert mostrano stato, conteggi nuovi/modificati/obsoleti e totale indicizzato, con CTA per aggiornare solo i pendenti.
+- Aggiunti conteggi pending e sync incrementale per Link interni, confrontando post pubblicati con l’indice senza indicizzare il contenuto completo.
+- Aggiunti conteggi pending e sync incrementale per Media Library su attachment immagine, senza OCR, download o lettura file binari.
+- Riusata la sync incrementale esistente dei Link affiliati nella nuova UI alert.
+- Le ricostruzioni complete e reset/svuota indice restano disponibili nella sezione Manutenzione avanzata.
+- Versione plugin aggiornata a `2.25.47`.
+
 ## 2.25.46 — AI Content Agent dashboard UI operativa
 - Riorganizzata la dashboard **AI Content Agent** con quick actions in alto per Idee contenuto, creazione idea, Istruzioni AI e Stato/log.
 - Aggiunte card riepilogative per OpenAI, Idee contenuto, Link affiliati, Link interni, Media Library e Stato/log.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.46
+ * Version: 2.25.47
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.46');
+define('ALMA_VERSION', '2.25.47');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -1055,3 +1055,77 @@ button:disabled {
     .alma-ai-agent-admin .alma-dashboard-actions form { width: 100%; }
     .alma-ai-agent-admin .alma-dashboard-actions .button { text-align: center; }
 }
+
+.alma-ai-agent-admin .alma-dashboard-alerts {
+    margin: 18px 0 22px;
+}
+.alma-ai-agent-admin .alma-dashboard-alerts-head {
+    margin-bottom: 10px;
+}
+.alma-ai-agent-admin .alma-dashboard-alerts-head h2 {
+    margin: 0 0 4px;
+}
+.alma-ai-agent-admin .alma-dashboard-alert {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    margin: 10px 0;
+    padding: 14px 16px;
+    border: 1px solid #dcdcde;
+    border-left: 4px solid #8c8f94;
+    background: #fff;
+    border-radius: 4px;
+}
+.alma-ai-agent-admin .alma-dashboard-alert--ok { border-left-color: #00a32a; }
+.alma-ai-agent-admin .alma-dashboard-alert--warning { border-left-color: #dba617; }
+.alma-ai-agent-admin .alma-dashboard-alert--error { border-left-color: #d63638; }
+.alma-ai-agent-admin .alma-dashboard-alert-icon {
+    flex: 0 0 28px;
+    min-width: 28px;
+    height: 28px;
+    border: 1px solid #c3c4c7;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    background: #f6f7f7;
+}
+.alma-ai-agent-admin .alma-dashboard-alert--ok .alma-dashboard-alert-icon { color: #008a20; }
+.alma-ai-agent-admin .alma-dashboard-alert--warning .alma-dashboard-alert-icon { color: #8a6100; }
+.alma-ai-agent-admin .alma-dashboard-alert--error .alma-dashboard-alert-icon { color: #b32d2e; }
+.alma-ai-agent-admin .alma-dashboard-alert-body {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+.alma-ai-agent-admin .alma-dashboard-alert-body h3 {
+    margin: 0 0 6px;
+}
+.alma-ai-agent-admin .alma-dashboard-alert-body p {
+    margin: 0 0 6px;
+}
+.alma-ai-agent-admin .alma-dashboard-alert-actions {
+    flex: 0 0 250px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+}
+.alma-ai-agent-admin .alma-dashboard-alert-actions form,
+.alma-ai-agent-admin .alma-dashboard-alert-actions form p {
+    margin: 0;
+}
+
+@media (max-width: 782px) {
+    .alma-ai-agent-admin .alma-dashboard-alert {
+        flex-direction: column;
+    }
+    .alma-ai-agent-admin .alma-dashboard-alert-actions {
+        flex-basis: auto;
+        width: 100%;
+    }
+    .alma-ai-agent-admin .alma-dashboard-alert-actions .button,
+    .alma-ai-agent-admin .alma-dashboard-alert-actions form {
+        width: 100%;
+    }
+}

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -68,6 +68,13 @@ class ALMA_AI_Content_Agent_Admin {
         } elseif ($do === 'rebuild_internal_link_index') {
             $stats = ALMA_AI_Content_Agent_Internal_Link_Index::rebuild_index(200);
             $result = array('success' => true, 'message' => sprintf('Indice link interni ricostruito: processati %d, indicizzati %d post pubblicati.', (int)$stats['processed'], (int)$stats['indexed']));
+        } elseif ($do === 'alma_sync_internal_links_pending') {
+            $stats = ALMA_AI_Content_Agent_Internal_Link_Index::sync_pending(300);
+            $result = array('success' => empty($stats['errors']), 'message' => sprintf('Indice link interni aggiornato: %d nuovi post, %d aggiornati, %d obsoleti rimossi, %d errori.', (int)($stats['new'] ?? 0), (int)($stats['modified'] ?? 0), (int)($stats['stale'] ?? 0), (int)($stats['errors'] ?? 0)));
+        } elseif ($do === 'alma_sync_media_pending') {
+            $stats = ALMA_AI_Content_Agent_Media_Index::sync_pending(300);
+            $result = array('success' => empty($stats['errors']), 'message' => sprintf('Indice media aggiornato: %d nuove immagini, %d immagini aggiornate, %d record obsoleti rimossi, %d errori.', (int)($stats['new'] ?? 0), (int)($stats['modified'] ?? 0), (int)($stats['stale'] ?? 0), (int)($stats['errors'] ?? 0)));
+
         } elseif ($do === 'index_affiliate_links') {
             $state = get_option('alma_ai_affiliate_index_state', array());
             $batch = ALMA_AI_Content_Agent_Affiliate_Index::index_batch(array('after_id'=>absint($state['last_processed_id'] ?? 0)));
@@ -331,6 +338,8 @@ class ALMA_AI_Content_Agent_Admin {
         echo '<a class="button" href="'.esc_url($log_url).'">Apri Stato/log</a>';
         echo '</div></section>';
 
+        self::render_dashboard_update_alerts($affiliate, $internal, $media);
+
         if ($openai !== 'Configurata') { echo '<div class="notice notice-warning inline"><p>OpenAI non è configurata.</p></div>'; }
         if (!empty($missing)) { echo '<div class="notice notice-info inline"><p>Tabelle mancanti: '.esc_html(implode(', ', $missing)).'. Alcuni dati possono risultare non disponibili.</p></div>'; }
 
@@ -364,6 +373,79 @@ class ALMA_AI_Content_Agent_Admin {
     private static function render_media_tab(){ global $wpdb; echo '<h2>Media Library</h2>'; if (self::is_table_missing('media_index')) { echo '<p><em>Tabella media_index mancante.</em></p>'; return; } $rows=$wpdb->get_results("SELECT id,attachment_id,file_name,alt_text,is_affiliate_media,is_editorial_candidate FROM ".ALMA_AI_Content_Agent_Store::table('media_index')." ORDER BY id DESC LIMIT 20",ARRAY_A); echo '<table class="widefat"><thead><tr><th>ID</th><th>Attachment ID</th><th>Filename</th><th>Alt text</th><th>Tipo</th><th>Preview</th></tr></thead><tbody>'; foreach($rows as $r){ $thumb=wp_get_attachment_image((int)$r['attachment_id'],array(60,60)); echo '<tr><td>'.(int)$r['id'].'</td><td>'.(int)$r['attachment_id'].'</td><td>'.esc_html($r['file_name']).'</td><td>'.esc_html($r['alt_text']).'</td><td>'.((int)$r['is_affiliate_media']?'Affiliato':((int)$r['is_editorial_candidate']?'Editoriale':'Escluso')).'</td><td>'.($thumb?$thumb:'-').'</td></tr>'; } echo '</tbody></table>'; }
     private static function render_reindex_tab(){ echo '<h2>Reindicizza</h2><div class="alma-agent-card"><p><label><input type="checkbox"> Articoli</label> <label><input type="checkbox"> Pagine</label> <label><input type="checkbox"> Affiliate Links</label> <label><input type="checkbox"> Documenti TXT</label> <label><input type="checkbox"> Fonti online AI</label> <label><input type="checkbox"> Media</label></p><p><button class="button button-primary" disabled>Reindicizza selezionati</button> Disponibile nella prossima fase.</p><ul><li>Elementi analizzati: Nessun dato</li><li>Elementi aggiornati: Nessun dato</li><li>Elementi saltati: Nessun dato</li><li>Errori: Nessun dato</li><li>Durata: Non disponibile</li><li>Link al log: vai a Stato/log</li></ul></div>'; self::action_form('reindex_knowledge','Reindicizza knowledge base'); self::render_media_index_status_box(); }
     private static function render_log_tab(){ global $wpdb; $missing=ALMA_AI_Content_Agent_Store::missing_tables(); $jobs=array(); if (!self::is_table_missing('jobs')) { $jobs=$wpdb->get_results("SELECT id,job_type,status,last_error,updated_at FROM ".ALMA_AI_Content_Agent_Store::table('jobs')." ORDER BY id DESC LIMIT 20",ARRAY_A); } $logs=ALMA_AI_Usage_Logger::get_recent_logs(20); echo '<h2>Stato/log</h2>'; self::render_affiliate_index_status_box(); self::render_media_index_status_box(); echo '<div class="alma-agent-grid"><div class="alma-agent-card"><h3>Job programmati</h3><p>Nessun dato</p></div><div class="alma-agent-card"><h3>Job in corso</h3><p>Nessun dato</p></div><div class="alma-agent-card"><h3>Job completati</h3><p>Nessun dato</p></div><div class="alma-agent-card"><h3>Job falliti</h3><p>Nessun dato</p></div><div class="alma-agent-card"><h3>Ultime chiamate AI</h3><p>'.(empty($logs)?'Nessun dato':'Disponibili sotto').'</p></div><div class="alma-agent-card"><h3>Errori recenti</h3><p>Nessun dato</p></div><div class="alma-agent-card"><h3>Bozze create</h3><p>'.count(ALMA_AI_Content_Agent_Store::get_agent_drafts(50)).'</p></div></div><p><strong>Tabelle mancanti:</strong> '.(empty($missing)?'Nessuna':esc_html(implode(', ',$missing))).'</p>'; if (self::is_table_missing('jobs')) { echo '<p><em>Tabella jobs mancante: sezione job non disponibile.</em></p>'; } echo '<h3>Ultimi job/errori</h3><table class="widefat"><thead><tr><th>ID</th><th>Tipo</th><th>Stato</th><th>Errore</th><th>Aggiornato</th></tr></thead><tbody>'; foreach($jobs as $j){ echo '<tr><td>'.(int)$j['id'].'</td><td>'.esc_html($j['job_type']).'</td><td><span class="alma-badge is-pending">'.esc_html($j['status']).'</span></td><td>'.esc_html($j['last_error']).'</td><td>'.esc_html($j['updated_at']).'</td></tr>'; } echo '</tbody></table>'; echo '<h3>Ultimi log AI</h3><table class="widefat"><thead><tr><th>Data</th><th>Task</th><th>Model</th><th>Successo</th><th>Errore</th></tr></thead><tbody>'; foreach($logs as $l){ echo '<tr><td>'.esc_html($l['created_at']).'</td><td>'.esc_html($l['task']).'</td><td>'.esc_html($l['model']).'</td><td>'.((int)$l['success']?'si':'no').'</td><td>'.esc_html($l['error_message']).'</td></tr>'; } echo '</tbody></table>'; }
+
+
+    private static function render_dashboard_update_alerts($affiliate, $internal, $media) {
+        $internal_pending = (array)($internal['pending'] ?? ALMA_AI_Content_Agent_Internal_Link_Index::get_pending_counts());
+        $media_pending = (array)($media['pending'] ?? ALMA_AI_Content_Agent_Media_Index::get_pending_counts());
+        $maintenance_url = '#alma-dashboard-maintenance-advanced';
+
+        echo '<section class="alma-dashboard-alerts" aria-labelledby="alma-dashboard-alerts-title"><div class="alma-dashboard-alerts-head"><h2 id="alma-dashboard-alerts-title">Aggiornamenti disponibili</h2><p class="description">Controlla contenuti nuovi, modificati o obsoleti negli indici usati dall’AI Content Agent. Le ricostruzioni complete restano in Manutenzione avanzata.</p></div>';
+
+        self::render_dashboard_update_alert(array(
+            'title' => 'Link affiliati',
+            'table_exists' => !empty($affiliate['table_exists']),
+            'new' => (int)($affiliate['missing_index'] ?? 0),
+            'modified' => (int)($affiliate['stale_index_records'] ?? 0),
+            'stale' => (int)($affiliate['orphan_index_records'] ?? 0) + (int)($affiliate['active_invalid_records'] ?? 0),
+            'indexed' => (int)($affiliate['indexed_active'] ?? 0),
+            'description' => 'Riuso della sync incrementale esistente per aggiornare link mancanti, modificati o non più validi.',
+            'button_do' => 'sync_affiliate_links_incremental',
+            'button_label' => 'Sync incrementale',
+            'maintenance_url' => $maintenance_url,
+        ));
+
+        self::render_dashboard_update_alert(array(
+            'title' => 'Link interni',
+            'table_exists' => !empty($internal_pending['table_exists']),
+            'new' => (int)($internal_pending['new'] ?? 0),
+            'modified' => (int)($internal_pending['modified'] ?? 0),
+            'stale' => (int)($internal_pending['stale'] ?? 0),
+            'indexed' => (int)($internal_pending['indexed'] ?? ($internal['indexed_count'] ?? 0)),
+            'description' => 'Confronta i post pubblicati con l’indice leggero, senza indicizzare il contenuto completo.',
+            'button_do' => 'alma_sync_internal_links_pending',
+            'button_label' => 'Aggiorna post nuovi/modificati',
+            'maintenance_url' => $maintenance_url,
+        ));
+
+        self::render_dashboard_update_alert(array(
+            'title' => 'Media Library',
+            'table_exists' => !empty($media_pending['table_exists']),
+            'new' => (int)($media_pending['new'] ?? 0),
+            'modified' => (int)($media_pending['modified'] ?? 0),
+            'stale' => (int)($media_pending['stale'] ?? 0),
+            'indexed' => (int)($media_pending['indexed_total'] ?? ($media['total'] ?? 0)),
+            'description' => 'Indicizza solo metadati degli attachment immagine: nessun OCR, download o lettura binaria.',
+            'button_do' => 'alma_sync_media_pending',
+            'button_label' => 'Aggiorna media nuovi/modificati',
+            'maintenance_url' => $maintenance_url,
+        ));
+
+        echo '</section>';
+    }
+
+    private static function render_dashboard_update_alert($args) {
+        $new = (int)($args['new'] ?? 0);
+        $modified = (int)($args['modified'] ?? 0);
+        $stale = (int)($args['stale'] ?? 0);
+        $indexed = (int)($args['indexed'] ?? 0);
+        $has_pending = ($new + $modified + $stale) > 0;
+        $table_exists = !empty($args['table_exists']);
+        $state_class = !$table_exists ? 'alma-dashboard-alert--error' : ($has_pending ? 'alma-dashboard-alert--warning' : 'alma-dashboard-alert--ok');
+        $icon = !$table_exists ? '✕' : ($has_pending ? '⚠' : '✓');
+        $status = !$table_exists ? 'Errore: tabella indice non disponibile' : ($has_pending ? 'Aggiornamenti disponibili' : 'Indice aggiornato');
+        $counts = sprintf('%d nuovi · %d modificati · %d obsoleti · %d indicizzati', $new, $modified, $stale, $indexed);
+
+        echo '<article class="alma-dashboard-alert '.esc_attr($state_class).'">';
+        echo '<div class="alma-dashboard-alert-icon" aria-hidden="true">'.esc_html($icon).'</div><div class="alma-dashboard-alert-body">';
+        echo '<h3>'.esc_html($args['title'] ?? '').'</h3><p><strong>'.esc_html($status).'</strong> · '.esc_html($counts).'</p><p class="description">'.esc_html($args['description'] ?? '').'</p>';
+        echo '</div><div class="alma-dashboard-alert-actions">';
+        if ($table_exists && $has_pending && !empty($args['button_do'])) { self::action_form($args['button_do'], $args['button_label'] ?? 'Aggiorna pendenti'); }
+        elseif ($table_exists) { echo '<button class="button" type="button" disabled>Indice aggiornato</button>'; }
+        else { echo '<button class="button" type="button" disabled>Azione non disponibile</button>'; }
+        echo '<a href="'.esc_url($args['maintenance_url'] ?? '#').'">Manutenzione avanzata / rebuild completo</a>';
+        echo '</div></article>';
+    }
 
     private static function get_affiliate_index_view_data() {
         $empty = array(
@@ -489,7 +571,7 @@ class ALMA_AI_Content_Agent_Admin {
     }
 
     private static function render_dashboard_maintenance_section($affiliate, $internal, $internal_state, $media) {
-        echo '<details class="alma-maintenance-advanced"><summary>Manutenzione avanzata</summary><p class="description">Strumenti tecnici per ricostruire indici o azzerare stati batch. Usali solo per manutenzione: non eliminano contenuti editoriali o Link affiliati reali.</p>';
+        echo '<details id="alma-dashboard-maintenance-advanced" class="alma-maintenance-advanced"><summary>Manutenzione avanzata</summary><p class="description">Strumenti tecnici per ricostruire indici o azzerare stati batch. Usali solo per manutenzione: non eliminano contenuti editoriali o Link affiliati reali.</p>';
         echo '<div class="alma-maintenance-grid">';
         echo '<section class="alma-maintenance-card"><h3>Indice Link affiliati</h3><ul><li>Record orfani: '.(int)$affiliate['orphan_index_records'].'</li><li>Record attivi non validi: '.(int)$affiliate['active_invalid_records'].'</li><li>Record indice inattivi: '.(int)$affiliate['inactive_index_records'].'</li><li>Mancanti dall’indice: '.(int)$affiliate['missing_index'].'</li><li>Da aggiornare: '.(int)$affiliate['stale_index_records'].'</li><li>Stato batch: '.esc_html($affiliate['batch_status']).'</li><li>Last processed ID: '.(int)($affiliate['batch']['last_processed_id'] ?? 0).'</li></ul>';
         if (!empty($affiliate['batch']['last_error'])) { echo '<p class="description"><strong>Ultimo errore batch:</strong> '.esc_html($affiliate['batch']['last_error']).'</p>'; }

--- a/includes/class-ai-content-agent-internal-link-index.php
+++ b/includes/class-ai-content-agent-internal-link-index.php
@@ -31,14 +31,90 @@ class ALMA_AI_Content_Agent_Internal_Link_Index {
         $exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table));
         $state = get_option(self::OPTION_STATE, array());
         if ($exists !== $table) {
-            return array('table_exists'=>false,'indexed_count'=>0,'last_rebuild_at'=>sanitize_text_field($state['last_rebuild_at'] ?? ''),'last_indexed_at'=>'');
+            return array('table_exists'=>false,'indexed_count'=>0,'last_rebuild_at'=>sanitize_text_field($state['last_rebuild_at'] ?? ''),'last_indexed_at'=>'','pending'=>self::empty_pending_counts(false, sanitize_text_field($state['last_rebuild_at'] ?? '')));
+
         }
         return array(
             'table_exists' => true,
             'indexed_count' => (int) $wpdb->get_var("SELECT COUNT(*) FROM $table WHERE post_status='publish'"),
             'last_rebuild_at' => sanitize_text_field($state['last_rebuild_at'] ?? ''),
             'last_indexed_at' => (string) $wpdb->get_var("SELECT MAX(indexed_at) FROM $table"),
+            'pending' => self::get_pending_counts(),
         );
+    }
+
+
+    private static function empty_pending_counts($table_exists = true, $last_rebuild_at = '') {
+        return array(
+            'table_exists' => (bool) $table_exists,
+            'new' => 0,
+            'modified' => 0,
+            'stale' => 0,
+            'indexed' => 0,
+            'last_rebuild_at' => sanitize_text_field($last_rebuild_at),
+            'last_indexed_at' => '',
+        );
+    }
+
+    private static function post_type_sql_placeholders($post_types) {
+        $post_types = array_values(array_filter(array_map('sanitize_key', (array) $post_types)));
+        return !empty($post_types) ? implode(',', array_fill(0, count($post_types), '%s')) : "''";
+    }
+
+    public static function get_pending_counts() {
+        global $wpdb;
+        $table = self::table_name();
+        $state = get_option(self::OPTION_STATE, array());
+        $exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table));
+        if ($exists !== $table) { return self::empty_pending_counts(false, sanitize_text_field($state['last_rebuild_at'] ?? '')); }
+        $post_types = self::supported_post_types();
+        if (empty($post_types)) { return self::empty_pending_counts(true, sanitize_text_field($state['last_rebuild_at'] ?? '')); }
+        $type_placeholders = self::post_type_sql_placeholders($post_types);
+
+        $indexed = (int) $wpdb->get_var("SELECT COUNT(*) FROM $table WHERE post_status='publish'");
+        $last_indexed_at = (string) $wpdb->get_var("SELECT MAX(indexed_at) FROM $table");
+        $new_sql = "SELECT COUNT(1) FROM {$wpdb->posts} p LEFT JOIN $table i ON i.post_id = p.ID WHERE p.post_type IN ($type_placeholders) AND p.post_status='publish' AND i.post_id IS NULL";
+        $modified_sql = "SELECT COUNT(1) FROM {$wpdb->posts} p INNER JOIN $table i ON i.post_id = p.ID WHERE p.post_type IN ($type_placeholders) AND p.post_status='publish' AND (i.indexed_at IS NULL OR p.post_modified_gmt > i.indexed_at)";
+        $stale_sql = "SELECT COUNT(1) FROM $table i LEFT JOIN {$wpdb->posts} p ON p.ID = i.post_id WHERE p.ID IS NULL OR p.post_type NOT IN ($type_placeholders) OR p.post_status <> 'publish'";
+
+        return array(
+            'table_exists' => true,
+            'new' => (int) $wpdb->get_var($wpdb->prepare($new_sql, $post_types)),
+            'modified' => (int) $wpdb->get_var($wpdb->prepare($modified_sql, $post_types)),
+            'stale' => (int) $wpdb->get_var($wpdb->prepare($stale_sql, $post_types)),
+            'indexed' => $indexed,
+            'last_rebuild_at' => sanitize_text_field($state['last_rebuild_at'] ?? ''),
+            'last_indexed_at' => $last_indexed_at,
+        );
+    }
+
+    public static function sync_pending($limit = 300) {
+        global $wpdb;
+        self::install_table();
+        $table = self::table_name();
+        $post_types = self::supported_post_types();
+        $limit = max(1, min(500, absint($limit)));
+        $result = array('new'=>0,'modified'=>0,'stale'=>0,'errors'=>0);
+        if (empty($post_types)) { return $result; }
+        $type_placeholders = self::post_type_sql_placeholders($post_types);
+
+        $new_sql = "SELECT p.ID FROM {$wpdb->posts} p LEFT JOIN $table i ON i.post_id = p.ID WHERE p.post_type IN ($type_placeholders) AND p.post_status='publish' AND i.post_id IS NULL ORDER BY p.ID ASC LIMIT %d";
+        $new_ids = $wpdb->get_col($wpdb->prepare($new_sql, array_merge($post_types, array($limit))));
+        foreach ((array) $new_ids as $post_id) {
+            if (self::index_post((int) $post_id)) { $result['new']++; } else { $result['errors']++; }
+        }
+
+        $remaining = max(1, $limit - count((array) $new_ids));
+        $modified_sql = "SELECT p.ID FROM {$wpdb->posts} p INNER JOIN $table i ON i.post_id = p.ID WHERE p.post_type IN ($type_placeholders) AND p.post_status='publish' AND (i.indexed_at IS NULL OR p.post_modified_gmt > i.indexed_at) ORDER BY p.ID ASC LIMIT %d";
+        $modified_ids = $wpdb->get_col($wpdb->prepare($modified_sql, array_merge($post_types, array($remaining))));
+        foreach ((array) $modified_ids as $post_id) {
+            if (self::index_post((int) $post_id)) { $result['modified']++; } else { $result['errors']++; }
+        }
+
+        $stale_sql = "DELETE i FROM $table i LEFT JOIN {$wpdb->posts} p ON p.ID = i.post_id WHERE p.ID IS NULL OR p.post_type NOT IN ($type_placeholders) OR p.post_status <> 'publish'";
+        $deleted = $wpdb->query($wpdb->prepare($stale_sql, $post_types));
+        if ($deleted === false) { $result['errors']++; } else { $result['stale'] = (int) $deleted; }
+        return $result;
     }
 
     public static function rebuild_index($per_page = 200) {

--- a/includes/class-ai-content-agent-media-index.php
+++ b/includes/class-ai-content-agent-media-index.php
@@ -260,7 +260,72 @@ class ALMA_AI_Content_Agent_Media_Index {
 
     public static function get_status() {
         global $wpdb; $table = self::table_name(); $exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table));
-        return array('table_exists'=>$exists === $table,'total'=>self::count_records(),'editorial'=>self::count_records('editorial'),'affiliate'=>self::count_records('affiliate'),'last_rebuild_at'=>get_option(self::OPTION_LAST_REBUILD_AT, ''));
+        return array('table_exists'=>$exists === $table,'total'=>self::count_records(),'editorial'=>self::count_records('editorial'),'affiliate'=>self::count_records('affiliate'),'last_rebuild_at'=>get_option(self::OPTION_LAST_REBUILD_AT, ''),'pending'=>self::get_pending_counts());
+    }
+
+
+    private static function valid_attachment_statuses() {
+        return array('inherit','private','publish','draft','pending','future');
+    }
+
+    private static function status_placeholders($statuses) {
+        $statuses = array_values(array_filter(array_map('sanitize_key', (array) $statuses)));
+        return !empty($statuses) ? implode(',', array_fill(0, count($statuses), '%s')) : "''";
+    }
+
+    public static function get_pending_counts() {
+        global $wpdb;
+        $table = self::table_name();
+        $exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table));
+        $last_rebuild = get_option(self::OPTION_LAST_REBUILD_AT, '');
+        $empty = array('table_exists'=>false,'new'=>0,'modified'=>0,'stale'=>0,'indexed_total'=>0,'indexed_editorial'=>0,'indexed_affiliate'=>0,'last_rebuild'=>$last_rebuild,'last_rebuild_at'=>$last_rebuild,'last_indexed_at'=>'');
+        if ($exists !== $table) { return $empty; }
+        $statuses = self::valid_attachment_statuses();
+        $status_placeholders = self::status_placeholders($statuses);
+        $new_sql = "SELECT COUNT(1) FROM {$wpdb->posts} p LEFT JOIN $table i ON i.attachment_id = p.ID WHERE p.post_type='attachment' AND p.post_status IN ($status_placeholders) AND p.post_mime_type LIKE 'image/%' AND i.attachment_id IS NULL";
+        $modified_sql = "SELECT COUNT(1) FROM {$wpdb->posts} p INNER JOIN $table i ON i.attachment_id = p.ID WHERE p.post_type='attachment' AND p.post_status IN ($status_placeholders) AND p.post_mime_type LIKE 'image/%' AND (i.indexed_at IS NULL OR p.post_modified_gmt > i.indexed_at)";
+        $stale_sql = "SELECT COUNT(1) FROM $table i LEFT JOIN {$wpdb->posts} p ON p.ID = i.attachment_id WHERE p.ID IS NULL OR p.post_type <> 'attachment' OR p.post_status NOT IN ($status_placeholders) OR p.post_mime_type NOT LIKE 'image/%'";
+        return array(
+            'table_exists'=>true,
+            'new'=>(int) $wpdb->get_var($wpdb->prepare($new_sql, $statuses)),
+            'modified'=>(int) $wpdb->get_var($wpdb->prepare($modified_sql, $statuses)),
+            'stale'=>(int) $wpdb->get_var($wpdb->prepare($stale_sql, $statuses)),
+            'indexed_total'=>self::count_records(),
+            'indexed_editorial'=>self::count_records('editorial'),
+            'indexed_affiliate'=>self::count_records('affiliate'),
+            'last_rebuild'=>$last_rebuild,
+            'last_rebuild_at'=>$last_rebuild,
+            'last_indexed_at'=>(string) $wpdb->get_var("SELECT MAX(indexed_at) FROM $table"),
+        );
+    }
+
+    public static function sync_pending($limit = 300) {
+        global $wpdb;
+        $schema = self::install_table();
+        $result = array('new'=>0,'modified'=>0,'stale'=>0,'errors'=>0,'schema'=>$schema);
+        if (empty($schema['success'])) { $result['errors'] = 1; return $result; }
+        $table = self::table_name();
+        $limit = max(1, min(500, absint($limit)));
+        $statuses = self::valid_attachment_statuses();
+        $status_placeholders = self::status_placeholders($statuses);
+
+        $new_sql = "SELECT p.ID FROM {$wpdb->posts} p LEFT JOIN $table i ON i.attachment_id = p.ID WHERE p.post_type='attachment' AND p.post_status IN ($status_placeholders) AND p.post_mime_type LIKE 'image/%' AND i.attachment_id IS NULL ORDER BY p.ID ASC LIMIT %d";
+        $new_ids = $wpdb->get_col($wpdb->prepare($new_sql, array_merge($statuses, array($limit))));
+        foreach ((array) $new_ids as $attachment_id) {
+            if (self::index_attachment((int) $attachment_id)) { $result['new']++; } else { $result['errors']++; }
+        }
+
+        $remaining = max(1, $limit - count((array) $new_ids));
+        $modified_sql = "SELECT p.ID FROM {$wpdb->posts} p INNER JOIN $table i ON i.attachment_id = p.ID WHERE p.post_type='attachment' AND p.post_status IN ($status_placeholders) AND p.post_mime_type LIKE 'image/%' AND (i.indexed_at IS NULL OR p.post_modified_gmt > i.indexed_at) ORDER BY p.ID ASC LIMIT %d";
+        $modified_ids = $wpdb->get_col($wpdb->prepare($modified_sql, array_merge($statuses, array($remaining))));
+        foreach ((array) $modified_ids as $attachment_id) {
+            if (self::index_attachment((int) $attachment_id)) { $result['modified']++; } else { $result['errors']++; }
+        }
+
+        $stale_sql = "DELETE i FROM $table i LEFT JOIN {$wpdb->posts} p ON p.ID = i.attachment_id WHERE p.ID IS NULL OR p.post_type <> 'attachment' OR p.post_status NOT IN ($status_placeholders) OR p.post_mime_type NOT LIKE 'image/%'";
+        $deleted = $wpdb->query($wpdb->prepare($stale_sql, $statuses));
+        if ($deleted === false) { $result['errors']++; } else { $result['stale'] = (int) $deleted; }
+        return $result;
     }
 
     private static function is_valid_image_attachment($attachment) {


### PR DESCRIPTION
### Motivation
- Rendere immediatamente visibili nella Dashboard AI Content Agent gli aggiornamenti incrementali sugli indici (Link affiliati, Link interni, Media Library) e offrire azioni sicure per processare solo i record pendenti senza ricostruire l’indice completo.
- Fornire conteggi sintetici `new` / `modified` / `stale` e stato operativo per guidare l’utente verso l’azione raccomandata mantenendo i rebuild completi in "Manutenzione avanzata".
- Evitare query pesanti e operazioni intrusive in caricamento: usare query `COUNT` mirate e azioni admin paginate/limitate per sync incrementali.
- Mantenere i controlli di sicurezza esistenti (`manage_options`, nonce `alma_ai_agent_action`) e riusare la sync incremental esistente per i link affiliati.

### Description
- Aggiunta della sezione di alert in alto sotto le quick actions con `render_dashboard_update_alerts()` e helper `render_dashboard_update_alert()` in `includes/class-ai-content-agent-admin.php` che mostra icona/stato, conteggi sintetici e CTA per sync incrementali; mantiene link a Manutenzione avanzata per i rebuild completi.
- Implementati i conteggi `pending` e la sync incrementale per Link interni con `get_pending_counts()` e `sync_pending()` in `includes/class-ai-content-agent-internal-link-index.php` che calcolano `new`, `modified`, `stale`, `indexed` e forniscono l’azione per indicizzare solo i pendenti.
- Implementati i conteggi `pending` e la sync incrementale per Media Library con `get_pending_counts()` e `sync_pending()` in `includes/class-ai-content-agent-media-index.php` limitati ad attachment immagine (MIME `image/%`) e che aggiornano solo metadati senza leggere file binari o fare OCR.
- Aggiunti admin handlers per le nuove azioni `alma_sync_internal_links_pending` e `alma_sync_media_pending` in `includes/class-ai-content-agent-admin.php`; la sync affiliati esistente (`sync_affiliate_links_incremental`) viene riutilizzata nella UI; aggiornati CSS (`assets/admin.css`) per classi prefissate `.alma-dashboard-alert*` e aggiornati `Version:` / `ALMA_VERSION` e documentazione (`README.md`, `CHANGELOG.md`) alla `2.25.47`.
- File principali modificati: `includes/class-ai-content-agent-admin.php`, `includes/class-ai-content-agent-internal-link-index.php`, `includes/class-ai-content-agent-media-index.php`, `assets/admin.css`, `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`.

### Testing
- Eseguiti controlli di sintassi PHP su file modificati con `php -l` e tutti sono passati senza errori (`affiliate-link-manager-ai.php`, `includes/class-ai-content-agent-admin.php`, `includes/class-ai-content-agent-internal-link-index.php`, `includes/class-ai-content-agent-media-index.php`).
- Eseguito `git diff --check` per warning/whitespace e non sono stati rilevati problemi.
- Non sono stati eseguiti test interattivi in ambiente WordPress (upload media, publish post, click CTA), ma il codice usa gli handler admin esistenti che richiedono `manage_options` e `alma_ai_agent_action` nonce per sicurezza; le azioni incrementali riportano admin notice con i conteggi risultati.
- Raccomandati test manuali in WordPress: verificare alert visibili nella Dashboard, creare/modificare/pubblicare post e media per confermare conteggi `new`/`modified`/`stale`, cliccare `Aggiorna` per ciascun alert e verificare che solo i record pendenti vengano processati e che i rebuild completi restino disponibili in Manutenzione avanzata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6c7cea2083328265a873b5867e03)