### PR TITLE
Fix AI media payload QA regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.25.48 — Fix AI media payload QA regressions
+- Corretta la validazione legacy di `featured_image_id`: quando `featured_image_candidates` è assente o vuoto resta valido il fallback su `candidate_image_ids` attachment.
+- Salvata nei meta della bozza selection-session la featured image scelta e validata da OpenAI con ID, URL risolto e source quando disponibili, senza applicare automaticamente `set_post_thumbnail`.
+- Applicato il limite massimo di immagini editoriali anche al contenuto HTML finale, rimuovendo le immagini editoriali eccedenti e mantenendo il default `max_editorial_media_used=5`.
+- Preservate le immagini affiliate valide provenienti da `affiliate_links[].image`: non contano nel limite editoriale e non vengono rimosse perché assenti da `media_candidates`.
+- Allineato `media_used` al contenuto finale: contiene solo immagini editoriali candidate rimaste nel contenuto, senza duplicati, senza immagini rimosse e senza immagini affiliate.
+- Versione plugin aggiornata a `2.25.48`.
+
 ## 2.25.47 — Dashboard index update alerts
 - Aggiunti alert operativi in alto nella Dashboard AI Content Agent per Link affiliati, Link interni e Media Library.
 - Gli alert mostrano stato, conteggi nuovi/modificati/obsoleti e totale indicizzato, con CTA per aggiornare solo i pendenti.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## 2.25.48 — Fix AI media payload QA regressions
+- Corretta la validazione legacy di `featured_image_id`: quando `featured_image_candidates` è assente o vuoto resta valido il fallback su `candidate_image_ids` attachment.
+- Salvata nei meta della bozza selection-session la featured image scelta e validata da OpenAI con ID, URL risolto e source quando disponibili, senza applicare automaticamente `set_post_thumbnail`.
+- Applicato il limite massimo di immagini editoriali anche al contenuto HTML finale, rimuovendo le immagini editoriali eccedenti e mantenendo il default `max_editorial_media_used=5`.
+- Preservate le immagini affiliate valide provenienti da `affiliate_links[].image`: non contano nel limite editoriale e non vengono rimosse perché assenti da `media_candidates`.
+- Allineato `media_used` al contenuto finale: contiene solo immagini editoriali candidate rimaste nel contenuto, senza duplicati, senza immagini rimosse e senza immagini affiliate.
+- Versione plugin aggiornata a `2.25.48`.
+
 ## 2.25.47 — Dashboard index update alerts
 - Aggiunti alert operativi in alto nella Dashboard AI Content Agent per Link affiliati, Link interni e Media Library.
 - Gli alert mostrano stato, conteggi nuovi/modificati/obsoleti e totale indicizzato, con CTA per aggiornare solo i pendenti.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.25.47
+ * Version: 2.25.48
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.25.47');
+define('ALMA_VERSION', '2.25.48');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -1218,12 +1218,32 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         update_post_meta($post_id, '_alma_ai_agent_selected_media_ids', wp_json_encode($candidate_image_ids));
         update_post_meta($post_id, '_alma_ai_agent_featured_image_candidates', wp_json_encode($featured_candidates));
         update_post_meta($post_id, '_alma_ai_agent_media_candidates', wp_json_encode($editorial_media_candidates));
+        $selected_featured_id = absint($clean['featured_image_id'] ?? 0);
+        update_post_meta($post_id, '_alma_ai_agent_selected_featured_image_id', $selected_featured_id);
+        if ($selected_featured_id > 0) {
+            $selected_featured_url = function_exists('wp_get_attachment_image_url') ? wp_get_attachment_image_url($selected_featured_id, 'full') : '';
+            if (!$selected_featured_url && function_exists('wp_get_attachment_url')) { $selected_featured_url = wp_get_attachment_url($selected_featured_id); }
+            $selected_featured_source = '';
+            foreach (array_merge($featured_candidates, $editorial_media_candidates) as $featured_candidate) {
+                if (!is_array($featured_candidate) || absint($featured_candidate['attachment_id'] ?? 0) !== $selected_featured_id) { continue; }
+                $selected_featured_source = sanitize_text_field((string)($featured_candidate['source'] ?? ($featured_candidate['filename'] ?? '')));
+                break;
+            }
+            if ($selected_featured_url) { update_post_meta($post_id, '_alma_ai_agent_selected_featured_image_url', esc_url_raw($selected_featured_url)); }
+            else { delete_post_meta($post_id, '_alma_ai_agent_selected_featured_image_url'); }
+            if ($selected_featured_source !== '') { update_post_meta($post_id, '_alma_ai_agent_selected_featured_image_source', $selected_featured_source); }
+            else { delete_post_meta($post_id, '_alma_ai_agent_selected_featured_image_source'); }
+        } else {
+            delete_post_meta($post_id, '_alma_ai_agent_selected_featured_image_url');
+            delete_post_meta($post_id, '_alma_ai_agent_selected_featured_image_source');
+        }
         update_post_meta($post_id, '_alma_ai_agent_affiliate_images_available', wp_json_encode($candidate_affiliate_images));
         update_post_meta($post_id, '_alma_ai_agent_affiliate_images_used', wp_json_encode((array)($clean['affiliate_images_used'] ?? array())));
         update_post_meta($post_id, '_alma_ai_agent_affiliate_shortcodes_used', wp_json_encode((array)($clean['affiliate_shortcodes_used'] ?? array())));
         update_post_meta($post_id, '_alma_ai_agent_affiliate_urls_used', wp_json_encode((array)($clean['affiliate_urls_used'] ?? array())));
         update_post_meta($post_id, '_alma_ai_agent_internal_urls_used', wp_json_encode((array)($clean['internal_urls_used'] ?? array())));
         update_post_meta($post_id, '_alma_ai_agent_media_used', wp_json_encode((array)($clean['media_used'] ?? array())));
+        update_post_meta($post_id, '_alma_ai_agent_media_warnings', wp_json_encode((array)($clean['warnings'] ?? array())));
         update_post_meta($post_id, '_alma_ai_category_ids', wp_json_encode((array)($taxonomy_applied['category_ids'] ?? array())));
         update_post_meta($post_id, '_alma_ai_tag_ids', wp_json_encode((array)($taxonomy_applied['tag_ids'] ?? array())));
         update_post_meta($post_id, '_alma_ai_new_tags', wp_json_encode((array)($taxonomy_applied['new_tags'] ?? array())));

--- a/includes/class-ai-content-agent-draft-quality-checker.php
+++ b/includes/class-ai-content-agent-draft-quality-checker.php
@@ -356,6 +356,161 @@ class ALMA_AI_Content_Agent_Draft_Quality_Checker {
     }
 
 
+
+    private static function editorial_record_by_src($src, $editorial_index) {
+        $url = esc_url_raw(html_entity_decode((string)$src, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        if ($url === '') { return null; }
+        if (isset($editorial_index['by_url'][$url])) { return $editorial_index['by_url'][$url]; }
+        $key = self::normalize_url_key($url);
+        if ($key !== '' && isset($editorial_index['by_key'][$key])) { return $editorial_index['by_key'][$key]; }
+        return null;
+    }
+
+    private static function affiliate_record_by_src($src, $affiliate_index) {
+        return self::find_record_by_image_src($src, $affiliate_index);
+    }
+
+    private static function dom_inner_html_from_root($dom, $root) {
+        $html = '';
+        foreach ($root->childNodes as $child) {
+            $html .= $dom->saveHTML($child);
+        }
+        return $html;
+    }
+
+    private static function remove_node_safely($node) {
+        if (!$node || !$node->parentNode) { return; }
+        $target = $node;
+        $parent = $node->parentNode;
+        while ($parent && strtolower((string)$parent->nodeName) !== 'div') {
+            if (strtolower((string)$parent->nodeName) === 'figure') { $target = $parent; break; }
+            $parent = $parent->parentNode;
+        }
+        $container = $target->parentNode;
+        if ($container) { $container->removeChild($target); }
+        foreach (array('p', 'div', 'span') as $tag) {
+            if (!$container || strtolower((string)$container->nodeName) === 'div') { break; }
+            $text = trim((string)$container->textContent);
+            if ($text !== '' || $container->getElementsByTagName('img')->length > 0) { break; }
+            $empty = $container;
+            $container = $empty->parentNode;
+            if ($container) { $container->removeChild($empty); }
+        }
+    }
+
+    private static function enforce_editorial_media_limit_in_content($content, $editorial_index, $affiliate_index, $max_editorial_media_used, &$warnings) {
+        $max = max(0, min(5, absint($max_editorial_media_used)));
+        $retained = array();
+        $seen = array();
+        $removed = 0;
+
+        if (!class_exists('DOMDocument')) {
+            $editorial_seen = 0;
+            $content = preg_replace_callback('/<img\b[^>]*>/i', function($matches) use ($editorial_index, $affiliate_index, $max, &$retained, &$seen, &$removed, &$editorial_seen) {
+                $tag = $matches[0];
+                if (!preg_match('/\ssrc=["\']([^"\']+)["\']/i', $tag, $m)) { return $tag; }
+                if (self::affiliate_record_by_src($m[1], $affiliate_index)) { return $tag; }
+                $record = self::editorial_record_by_src($m[1], $editorial_index);
+                if (!$record) { return $tag; }
+                $editorial_seen++;
+                if ($editorial_seen > $max) { $removed++; return ''; }
+                $key = (string)$record['attachment_id'];
+                if (!isset($seen[$key])) { $seen[$key] = true; $retained[] = $record; }
+                return $tag;
+            }, (string)$content);
+            if ($removed > 0) { $warnings[] = 'Rimosse ' . $removed . ' immagini editoriali oltre il limite massimo di ' . $max . '.'; }
+            return array($content, $retained);
+        }
+
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $previous = libxml_use_internal_errors(true);
+        $flags = 0;
+        if (defined('LIBXML_HTML_NOIMPLIED')) { $flags |= LIBXML_HTML_NOIMPLIED; }
+        if (defined('LIBXML_HTML_NODEFDTD')) { $flags |= LIBXML_HTML_NODEFDTD; }
+        $loaded = $dom->loadHTML('<div id="alma-media-root">' . mb_convert_encoding((string)$content, 'HTML-ENTITIES', 'UTF-8') . '</div>', $flags);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        if (!$loaded) { return array($content, $retained); }
+        $root = $dom->getElementById('alma-media-root');
+        if (!$root) { return array($content, $retained); }
+
+        $images = array();
+        foreach ($root->getElementsByTagName('img') as $img) { $images[] = $img; }
+        $editorial_seen = 0;
+        foreach ($images as $img) {
+            $src = $img->getAttribute('src');
+            if (self::affiliate_record_by_src($src, $affiliate_index)) { continue; }
+            $record = self::editorial_record_by_src($src, $editorial_index);
+            if (!$record) { continue; }
+            $editorial_seen++;
+            if ($editorial_seen > $max) {
+                $removed++;
+                self::remove_node_safely($img);
+                continue;
+            }
+            $key = (string)$record['attachment_id'];
+            if (!isset($seen[$key])) { $seen[$key] = true; $retained[] = $record; }
+        }
+        if ($removed > 0) { $warnings[] = 'Rimosse ' . $removed . ' immagini editoriali oltre il limite massimo di ' . $max . '.'; }
+        return array(self::dom_inner_html_from_root($dom, $root), $retained);
+    }
+
+    private static function normalize_editorial_media_used_for_content($payload_media_used, $editorial_index, $retained_editorial_media, $max_editorial_media_used, &$warnings) {
+        $max = max(0, min(5, absint($max_editorial_media_used)));
+        $retained_ids = array();
+        foreach ((array)$retained_editorial_media as $record) {
+            if (is_array($record) && !empty($record['attachment_id'])) { $retained_ids[absint($record['attachment_id'])] = true; }
+        }
+        $placements = array();
+        $declared_ids = array();
+        foreach ((array)$payload_media_used as $media_item) {
+            if (!is_array($media_item)) { continue; }
+            if (!empty($media_item['affiliate_url']) || !empty($media_item['affiliate_link_id'])) { continue; }
+            $id = absint($media_item['attachment_id'] ?? 0);
+            $url = esc_url_raw((string)($media_item['url'] ?? ($media_item['image_url'] ?? '')));
+            $record = null;
+            if ($id > 0 && isset($editorial_index['media_ids'][$id])) { $record = $editorial_index['media_ids'][$id]; }
+            if (!$record && $url !== '') { $record = self::editorial_record_by_src($url, $editorial_index); }
+            if (!$record) { $warnings[] = 'Media editoriale non candidato rimosso da media_used.'; continue; }
+            $declared_id = absint($record['attachment_id']);
+            $declared_ids[$declared_id] = true;
+            if (!isset($retained_ids[$declared_id])) { $warnings[] = 'Media editoriale non presente nel contenuto finale rimosso da media_used.'; continue; }
+            if (!isset($placements[$declared_id])) { $placements[$declared_id] = sanitize_text_field((string)($media_item['placement'] ?? '')); }
+        }
+
+        $items = array();
+        $seen = array();
+        foreach ((array)$retained_editorial_media as $record) {
+            if (!is_array($record)) { continue; }
+            $id = absint($record['attachment_id'] ?? 0);
+            if ($id < 1 || isset($seen[$id])) { continue; }
+            $seen[$id] = true;
+            if (!isset($declared_ids[$id])) { $warnings[] = 'Immagine editoriale candidata presente nel contenuto finale aggiunta a media_used.'; }
+            $items[] = array(
+                'attachment_id' => $id,
+                'url' => esc_url_raw((string)($record['url'] ?? '')),
+                'placement' => sanitize_text_field((string)($placements[$id] ?? '')),
+            );
+            if (count($items) >= $max) { break; }
+        }
+        return $items;
+    }
+
+    private static function validate_featured_image_id($featured, $candidate_image_ids, $editorial_index, &$warnings) {
+        $featured = absint($featured);
+        if ($featured < 1) { return 0; }
+        $has_featured_candidates = !empty($editorial_index['featured_ids']);
+        if ($has_featured_candidates) {
+            if (!empty($editorial_index['featured_ids'][$featured]) && get_post_type($featured) === 'attachment') { return $featured; }
+            $warnings[] = 'featured_image_id non presente in featured_image_candidates: azzerato.';
+            return 0;
+        }
+        $legacy_ids = array_values(array_unique(array_filter(array_map('absint', (array)$candidate_image_ids))));
+        if (in_array($featured, $legacy_ids, true) && get_post_type($featured) === 'attachment') { return $featured; }
+        $warnings[] = 'featured_image_id non presente nei candidati legacy: azzerato.';
+        return 0;
+    }
+
     private static function build_internal_link_index($candidate_internal_links) {
         $index = array('by_url_key'=>array(), 'urls'=>array(), 'home_host'=>'');
         $home = wp_parse_url(home_url('/'));
@@ -479,7 +634,7 @@ class ALMA_AI_Content_Agent_Draft_Quality_Checker {
         $index = self::build_affiliate_link_index($candidate_affiliate_ids, $candidate_affiliate_images);
         $editorial_index = self::build_editorial_media_index($featured_image_candidates, $media_candidates);
         $candidate_image_urls = array_merge($index['image_urls'], $editorial_index['urls']);
-        foreach ((array)$payload['media_used'] as $media_item) {
+        foreach ((array)($payload['media_used'] ?? array()) as $media_item) {
             $url = is_array($media_item) ? ($media_item['image_url'] ?? ($media_item['url'] ?? '')) : $media_item;
             $url = esc_url_raw((string)$url);
             if ($url !== '' && isset($candidate_image_urls[$url])) { $candidate_image_urls[$url] = $url; }
@@ -517,8 +672,7 @@ class ALMA_AI_Content_Agent_Draft_Quality_Checker {
             $shortcodes_used[] = $matches[0];
             return $matches[0];
         }, $content);
-        $featured = absint($payload['featured_image_id'] ?? 0);
-        if ($featured && (empty($editorial_index['featured_ids'][$featured]) || get_post_type($featured) !== 'attachment')) { $warnings[]='featured_image_id non presente in featured_image_candidates: azzerato.'; $featured=0; }
+        $featured = self::validate_featured_image_id($payload['featured_image_id'] ?? 0, $candidate_image_ids, $editorial_index, $warnings);
         $inline = array_values(array_filter(array_map('absint', (array)($payload['inline_image_ids'] ?? array()))));
         $inline = array_values(array_filter($inline, function($id) use($candidate_image_ids){ return $id > 0 && in_array($id, $candidate_image_ids, true) && get_post_type($id)==='attachment'; }));
 
@@ -528,9 +682,11 @@ class ALMA_AI_Content_Agent_Draft_Quality_Checker {
         }
 
         $content = self::sanitize_content_html($content);
-        $editorial_media_used = self::normalize_editorial_media_used((array)($payload['media_used'] ?? array()), $editorial_index, $max_editorial_media_used, $warnings);
+        list($content, $retained_editorial_media) = self::enforce_editorial_media_limit_in_content($content, $editorial_index, $index, $max_editorial_media_used, $warnings);
+        $content = self::sanitize_content_html($content);
+        $editorial_media_used = self::normalize_editorial_media_used_for_content((array)($payload['media_used'] ?? array()), $editorial_index, $retained_editorial_media, $max_editorial_media_used, $warnings);
         list($affiliate_urls_used, $affiliate_media_used, $affiliate_images_used) = self::collect_final_affiliate_usage($content, $index);
-        $media_used = array_merge($editorial_media_used, (array)$affiliate_media_used);
+        $media_used = $editorial_media_used;
         $affiliate_urls_used = self::dedupe_strings($affiliate_urls_used);
         $shortcodes_used = self::dedupe_strings(array_merge((array)($payload['affiliate_shortcodes_used'] ?? array()), $shortcodes_used));
 


### PR DESCRIPTION
### Motivation
- Correggere le regressioni QA introdotte dall’aggiunta di `featured_image_candidates`/`media_candidates` garantendo retrocompatibilità con il flusso legacy e preservando il comportamento delle immagini affiliate.
- Salvare la featured image selezionata da OpenAI nei meta della bozza selection-session senza applicare automaticamente `set_post_thumbnail` nel nuovo flusso.
- Applicare il limite massimo di immagini editoriali anche al contenuto HTML finale e riallineare `media_used` al contenuto effettivamente salvato.

### Description
- Ripristinata e migliorata la validazione legacy di `featured_image_id` in `ALMA_AI_Content_Agent_Draft_Quality_Checker::validate_payload()` con la nuova funzione `validate_featured_image_id()` che: usa `featured_image_candidates` se presenti, altrimenti fa fallback su `candidate_image_ids`, preserva attachment legacy e aggiunge warning distinti. (file modificato: `includes/class-ai-content-agent-draft-quality-checker.php`)
- Implementato enforcement del limite editoriale anche sul contenuto HTML con rimozione delle immagini editoriali eccedenti in ordine di apparizione, rimozione sicura di interi `<figure>` quando opportuno, preservazione delle immagini affiliate e raccolta degli elementi editoriali trattenuti; aggiunte funzioni helper per ricerca record editoriali/affiliate e rimozione sicura dei nodi. (file modificato: `includes/class-ai-content-agent-draft-quality-checker.php`)
- Allineamento di `media_used`: introdotta logica che normalizza `media_used` in base alle immagini editoriali effettivamente rimaste nel contenuto finale (rimuove non candidati, rimuove duplicati, rispetta il limite e non include immagini affiliate). (file modificato: `includes/class-ai-content-agent-draft-quality-checker.php`)
- Persistenza meta della featured image selezionata nella selection-session: il builder salva `_alma_ai_agent_selected_featured_image_id`, `_alma_ai_agent_selected_featured_image_url` e `_alma_ai_agent_selected_featured_image_source` (salva l’ID validato sempre; URL/source risolti quando disponibili; non applica `set_post_thumbnail` in questo flusso). Aggiunto anche `_alma_ai_agent_media_warnings` per diagnostica. (file modificato: `includes/class-ai-content-agent-draft-builder.php`)
- Aggiornata versione plugin e costante `ALMA_VERSION` a `2.25.48` e documentazione in `README.md` e `CHANGELOG.md`. (file modificati: `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`)
- Non sono stati cambiati flussi non richiesti: `includes/class-ai-content-agent-media-selector.php` e la logica di applicazione automatica della featured image nei flussi legacy non sono stati modificati qui.

### Testing
- Eseguito script di test funzionale sintetico `php /tmp/alma_media_qa_test.php` che verifica: preservazione legacy `featured_image_id` senza `featured_image_candidates`; preservazione `featured_image_id` quando presente in `featured_image_candidates`; azzeramento e warning per ID non candidati; contenuto con 7 immagini editoriali ridotto a 5; immagini affiliate preservate; `media_used` allineato alle 5 immagini editoriali rimaste. Risultato: tutti i test inclusi nello script PASS.
- Lint PHP sui file modificati: `php -l includes/class-ai-content-agent-draft-quality-checker.php`, `php -l includes/class-ai-content-agent-draft-builder.php`, `php -l affiliate-link-manager-ai.php` — nessun errore di sintassi rilevato.
- Controllo statico `git diff --check` eseguito per whitespace/issue, nessun problema rilevato.
- Nota: test end-to-end su WordPress (DB, post meta effettivamente salvati nell’installazione) non è stato eseguito in questo ambiente container limitato, ma la persistenza dei meta è inserita immediatamente dopo `wp_insert_post()` nel flusso selection-session e copre i meta richiesti.

Modifiche principali (file): `includes/class-ai-content-agent-draft-quality-checker.php`, `includes/class-ai-content-agent-draft-builder.php`, `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6e2e76ec8332b1c5ec89ada031cf)