### PR TITLE
Hotfix GYG CSV modal runtime fatals: add normalize_mapping_term_ids and count_existing_for_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.27.1 — Hotfix GetYourGuide CSV modal fatal
+- Corretto il fatal nello Step 3 `gyg_csv` causato dal metodo mancante di normalizzazione mapping Tipologia attività CSV → Tipologie Link Sothra.
+- Corretto il fatal in apertura del modale “Importa questa tipologia” causato dall’helper mancante per il conteggio record già importati.
+- Versione plugin aggiornata a `2.27.1`.
+
 ## 2.27.0 — GetYourGuide CSV modal import progressivo
 - Migliorato il flusso `gyg_csv` con modale admin sul pulsante “Importa questa tipologia”: riepilogo source, Partner ID, UTM medium, record totali/già importati/ancora da importare e anteprima sintetica limitata.
 - Aggiunta selezione multipla obbligatoria delle Tipologie Link Sothra, con mapping persistente per Tipologia attività CSV e colonna “Mapping Sothra” aggiornata con tutti i nomi salvati.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## 2.27.1 — Hotfix GetYourGuide CSV modal fatal
+- Corretto il fatal nello Step 3 `gyg_csv` causato dal metodo mancante di normalizzazione mapping Tipologia attività CSV → Tipologie Link Sothra.
+- Corretto il fatal in apertura del modale “Importa questa tipologia” causato dall’helper mancante per il conteggio record già importati.
+- Versione plugin aggiornata a `2.27.1`.
+
 ## 2.27.0 — GetYourGuide CSV modal import progressivo
 - Migliorato il flusso `gyg_csv` con modale admin sul pulsante “Importa questa tipologia”: riepilogo source, Partner ID, UTM medium, record totali/già importati/ancora da importare e anteprima sintetica limitata.
 - Aggiunta selezione multipla obbligatoria delle Tipologie Link Sothra, con mapping persistente per Tipologia attività CSV e colonna “Mapping Sothra” aggiornata con tutti i nomi salvati.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.27.0
+ * Version: 2.27.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.27.0');
+define('ALMA_VERSION', '2.27.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-affiliate-source-gyg-csv-importer.php
+++ b/includes/class-affiliate-source-gyg-csv-importer.php
@@ -63,6 +63,36 @@ class ALMA_Affiliate_Source_GYG_CSV_Importer {
         return $settings;
     }
 
+
+    public static function normalize_mapping_term_ids($value) {
+        $ids = array();
+        $collect = function($item) use (&$collect, &$ids) {
+            if ($item === null || $item === false || $item === '') {
+                return;
+            }
+            if (is_array($item)) {
+                foreach ($item as $child) {
+                    $collect($child);
+                }
+                return;
+            }
+            if (is_string($item) && strpos($item, ',') !== false) {
+                foreach (explode(',', $item) as $part) {
+                    $collect($part);
+                }
+                return;
+            }
+            if (is_numeric($item)) {
+                $id = (int)$item;
+                if ($id > 0) {
+                    $ids[] = $id;
+                }
+            }
+        };
+        $collect($value);
+        return array_values(array_unique($ids));
+    }
+
     public static function normalize_header($header) {
         $header = strtolower(trim((string)$header));
         $header = strtr($header, array('à'=>'a','á'=>'a','è'=>'e','é'=>'e','ì'=>'i','í'=>'i','ò'=>'o','ó'=>'o','ù'=>'u','ú'=>'u'));
@@ -244,6 +274,108 @@ class ALMA_Affiliate_Source_GYG_CSV_Importer {
             '_alma_ai_visibility' => 'available',
         );
         return array('post_title'=>sanitize_text_field($title !== '' ? $title : __('GetYourGuide attività', 'affiliate-link-manager-ai')), 'post_content'=>wp_kses_post($item['description']), 'featured_image_url'=>'', 'affiliate_url'=>esc_url_raw($item['affiliate_url']), 'original_url'=>esc_url_raw($item['original_url']), 'meta'=>$meta, 'raw_item'=>$item);
+    }
+
+
+    private function is_empty_csv_row($row) {
+        if (!is_array($row)) {
+            return true;
+        }
+        foreach ($row as $value) {
+            if (trim((string)$value) !== '') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public function count_existing_for_type($path, $columns, $activity_type, $source) {
+        $counts = array(
+            'total' => 0,
+            'existing' => 0,
+            'remaining' => 0,
+            'new' => 0,
+            'invalid' => 0,
+            'invalid_urls' => 0,
+            'missing_description' => 0,
+            'error_code' => '',
+            'message' => '',
+        );
+
+        $source_id = absint($source['id'] ?? 0);
+        if ($source_id <= 0) {
+            $counts['error_code'] = 'invalid_source';
+            $counts['message'] = __('Source gyg_csv non valida.', 'affiliate-link-manager-ai');
+            return $counts;
+        }
+
+        $columns = is_array($columns) ? $columns : array();
+        foreach (array('url', 'activity_type', 'description') as $required_column) {
+            if (!isset($columns[$required_column])) {
+                $counts['error_code'] = 'missing_columns';
+                $counts['message'] = __('Colonne obbligatorie mancanti nel CSV.', 'affiliate-link-manager-ai');
+                return $counts;
+            }
+        }
+
+        $path = (string)$path;
+        if ($path === '' || !is_readable($path)) {
+            $counts['error_code'] = 'csv_open';
+            $counts['message'] = __('Impossibile leggere il CSV.', 'affiliate-link-manager-ai');
+            return $counts;
+        }
+
+        $settings = self::default_settings(json_decode((string)($source['settings'] ?? '{}'), true));
+        $partner_id = (string)($settings['partner_id'] ?? '');
+        $utm = (string)($settings['utm_medium'] ?? 'online_publisher');
+        $source_for_count = $source;
+        $source_for_count['provider_preset'] = 'gyg_csv';
+        $source_for_count['provider'] = 'gyg_csv';
+        $dedupe = new ALMA_Affiliate_Source_Import_Dedupe_Service();
+
+        $handle = fopen($path, 'r');
+        if (!$handle) {
+            $counts['error_code'] = 'csv_open';
+            $counts['message'] = __('Impossibile leggere il CSV.', 'affiliate-link-manager-ai');
+            return $counts;
+        }
+
+        $activity_type = sanitize_text_field((string)$activity_type);
+        $delimiter = $this->delimiter($path);
+        fgetcsv($handle, 0, $delimiter);
+        while (($row = fgetcsv($handle, 0, $delimiter)) !== false) {
+            if ($this->is_empty_csv_row($row)) {
+                continue;
+            }
+            $item = $this->row_to_item($row, $columns, $source_for_count, $partner_id, $utm);
+            if ($activity_type !== '' && $item['activity_type'] !== $activity_type) {
+                continue;
+            }
+
+            $counts['total']++;
+            if ($item['original_url'] === '' || !wp_http_validate_url($item['original_url']) || $item['affiliate_url'] === '') {
+                $counts['invalid']++;
+                $counts['invalid_urls']++;
+                continue;
+            }
+            if ($item['description'] === '') {
+                $counts['invalid']++;
+                $counts['missing_description']++;
+                continue;
+            }
+
+            $normalized = $this->normalize_item($item, $source_for_count);
+            $match = $dedupe->find_match($normalized, 'skip_existing');
+            if (!empty($match['post_id'])) {
+                $counts['existing']++;
+            } else {
+                $counts['remaining']++;
+                $counts['new']++;
+            }
+        }
+        fclose($handle);
+
+        return $counts;
     }
 
     public function import_batch($path, $columns, $activity_type, $source, $term_ids, $quantity, $cursor = 0, $update_existing = false, $batch_size = self::AJAX_BATCH_SIZE) {


### PR DESCRIPTION
### Motivation
- Fix two P1 runtime fatals in the GetYourGuide CSV flow caused by missing methods referenced from the import UI and AJAX: a mapping normalizer and a CSV-count helper. 
- Preserve existing UI/flow, keep deduplication semantics (`source_id + external_id`) and maintain backward compatibility with single-term and multi-term mappings.

### Description
- Added `public static function normalize_mapping_term_ids($value)` to `ALMA_Affiliate_Source_GYG_CSV_Importer`, which accepts single IDs, numeric strings, CSV strings, arrays (including associative/JSON-decoded), null/empty and returns a deduped array of positive integers. 
- Added `public function count_existing_for_type($path, $columns, $activity_type, $source)` (and a small private helper `is_empty_csv_row`) to `ALMA_Affiliate_Source_GYG_CSV_Importer`; it streams the CSV, filters rows by activity type, builds items with existing `row_to_item()` / `normalize_item()`, reuses `ALMA_Affiliate_Source_Import_Dedupe_Service` for dedupe checks, and returns counts including `total`, `existing`, `remaining`/`new`, `invalid`, `invalid_urls`, `missing_description`, and optional error metadata without creating/updating any CPT. 
- Hardened `count_existing_for_type` to return safe results or error codes for missing file/columns/unreadable path and to skip empty CSV rows; it avoids any fatal. 
- Bumped plugin version to `2.27.1` and added a hotfix entry to `CHANGELOG.md` and `README.md`.
- Files modified: `includes/class-affiliate-source-gyg-csv-importer.php`, `affiliate-link-manager-ai.php`, `CHANGELOG.md`, `README.md`.

### Testing
- Ran PHP lint on core files: `php -l includes/class-affiliate-source-gyg-csv-importer.php && php -l includes/class-affiliate-source-manager.php && php -l affiliate-link-manager-ai.php` — all returned "No syntax errors detected". 
- Executed a smoke PHP runtime test that verifies `normalize_mapping_term_ids()` behavior and `count_existing_for_type()` call against a temporary CSV: the one-line test ran and printed `ok`; the test used the command shown in the rollout (invoked via `php -r` and requiring the importer and dedupe service). 
- Searched repository to confirm usages: `rg -n "normalize_mapping_term_ids|count_existing_for_type" . --glob '!vendor' --glob '!node_modules'` — confirmed call sites updated and methods present. 
- Commit created: `Hotfix GYG CSV modal runtime fatals`; all automated checks executed in the rollout succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb052c8dc833299c067cfd0d8f979)