### PR TITLE
Hotfix gyg_csv modal loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.27.2 — Hotfix GetYourGuide CSV modal loading
+- Corretto il blocco del modale `gyg_csv` su “Caricamento tipologie…” quando il caricamento AJAX prepare fallisce o restituisce payload incompleto.
+- Migliorata la gestione errori AJAX del modale con messaggi leggibili, disattivazione sicura del pulsante import e log admin-side minimo.
+- Allineato il payload prepare import tra PHP e JavaScript includendo `terms`, `mapped_term_ids`, `counts`, `preview`, `activity_type`, `source_id`, `token` e `max_quantity`.
+- Verificata la tassonomia reale delle Tipologie Link: il flusso `gyg_csv` usa la tassonomia esistente `link_type` del CPT `affiliate_link`.
+- Versione plugin aggiornata a `2.27.2`.
+
 ## 2.27.1 — Hotfix GetYourGuide CSV modal fatal
 - Corretto il fatal nello Step 3 `gyg_csv` causato dal metodo mancante di normalizzazione mapping Tipologia attività CSV → Tipologie Link Sothra.
 - Corretto il fatal in apertura del modale “Importa questa tipologia” causato dall’helper mancante per il conteggio record già importati.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.27.1
+ * Version: 2.27.2
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.27.1');
+define('ALMA_VERSION', '2.27.2');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/assets/affiliate-sources.js
+++ b/assets/affiliate-sources.js
@@ -74,6 +74,7 @@ jQuery(function($){
 
   var gygState = null;
   function gygNonce(){ return (window.almaSourcePresets && almaSourcePresets.gygNonce) || ''; }
+  function gygAjaxUrl(){ return (window.almaSourcePresets && almaSourcePresets.ajax_url) || (typeof ajaxurl !== 'undefined' ? ajaxurl : ''); }
   function gygEsc(v){ return $('<div/>').text(v == null ? '' : String(v)).html(); }
   function gygClampQuantity(){
     var $q = $('#alma-gyg-quantity'), value = parseInt($q.val(), 10) || 100;
@@ -82,6 +83,25 @@ jQuery(function($){
     return value;
   }
   function gygShowError(message){ $('.alma-gyg-modal-error').show().find('p').text(message || 'Errore importazione.'); }
+  function gygDisableImport(disabled){ $('.alma-gyg-start-import').prop('disabled', !!disabled); }
+  function gygAjaxErrorMessage(xhr, fallback){
+    if(xhr && xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.message){ return xhr.responseJSON.data.message; }
+    if(xhr && xhr.responseText){
+      try { var parsed = JSON.parse(xhr.responseText); if(parsed && parsed.data && parsed.data.message){ return parsed.data.message; } } catch(e) {}
+    }
+    if(xhr && xhr.status === 403){ return 'Verifica di sicurezza non riuscita. Ricarica la pagina e riprova.'; }
+    if(xhr && xhr.status === 400){ return fallback || 'Richiesta non valida. Ricarica la pagina e riprova.'; }
+    if(xhr && xhr.status >= 500){ return 'Errore server durante il caricamento del modale. Riprova tra poco.'; }
+    return fallback || 'Errore di rete. Ricarica la pagina e riprova.';
+  }
+  function gygPrepareFailed(message, xhr){
+    $('.alma-gyg-summary').html('<p class="description">Impossibile caricare i dati del modale.</p>');
+    $('.alma-gyg-terms').html('<p class="description">Impossibile caricare le Tipologie Link Sothra. Controlla che la tassonomia delle tipologie esista e ricarica la pagina.</p>');
+    $('.alma-gyg-preview').html('<p class="description">Anteprima non disponibile.</p>');
+    gygDisableImport(true);
+    gygShowError(message);
+    if(window.console && console.error){ console.error('ALMA gyg_csv prepare import failed', {status: xhr && xhr.status, message: message}); }
+  }
   function gygClearError(){ $('.alma-gyg-modal-error').hide().find('p').text(''); }
   function gygOpen(){ $('#alma-gyg-import-modal').addClass('is-open').attr('aria-hidden','false'); $('body').addClass('alma-modal-open'); }
   function gygClose(){ if(gygState && gygState.running){ return; } $('#alma-gyg-import-modal').removeClass('is-open').attr('aria-hidden','true'); $('body').removeClass('alma-modal-open'); }
@@ -93,7 +113,7 @@ jQuery(function($){
   }
   function gygRenderTerms(terms, mapped){
     mapped = mapped || [];
-    if(!terms || !terms.length){ $('.alma-gyg-terms').html('<p class="description">Nessuna Tipologia Link Sothra disponibile.</p>'); return; }
+    if(!terms || !terms.length){ $('.alma-gyg-terms').html('<p class="description">Nessuna Tipologia Link Sothra disponibile. Creane almeno una prima di importare.</p>'); gygDisableImport(true); return; }
     var html = '<div class="alma-gyg-term-list">';
     terms.forEach(function(t){ var checked = mapped.indexOf(parseInt(t.id,10)) !== -1 ? ' checked' : ''; html += '<label><input type="checkbox" name="alma_gyg_terms[]" value="'+parseInt(t.id,10)+'"'+checked+'> '+gygEsc(t.name)+'</label>'; });
     $('.alma-gyg-terms').html(html+'</div>');
@@ -116,7 +136,7 @@ jQuery(function($){
     $('.alma-gyg-import-more').show();
   }
   function gygImportNext(){
-    $.post(ajaxurl, {action:'alma_gyg_csv_import_batch', nonce:gygNonce(), source_id:gygState.sourceId, token:gygState.token, activity_type:gygState.activityType, term_ids:gygState.termIds, quantity:gygState.quantity, cursor:gygState.cursor, update_existing:gygState.updateExisting ? 1 : 0})
+    $.post(gygAjaxUrl(), {action:'alma_gyg_csv_import_batch', nonce:gygNonce(), source_id:gygState.sourceId, token:gygState.token, activity_type:gygState.activityType, term_ids:gygState.termIds, quantity:gygState.quantity, cursor:gygState.cursor, update_existing:gygState.updateExisting ? 1 : 0})
       .done(function(res){
         if(!res || !res.success){ gygShowError((res && res.data && res.data.message) || 'Errore importazione.'); gygState.running=false; $('.alma-gyg-start-import').prop('disabled',false); return; }
         var d=res.data, a=gygState.aggregate;
@@ -127,7 +147,7 @@ jQuery(function($){
         if(d.done){ gygState.running=false; $('.alma-gyg-start-import').prop('disabled',false).text('Avvia importazione'); gygRenderReport(); }
         else { gygImportNext(); }
       })
-      .fail(function(xhr){ var msg = xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.message ? xhr.responseJSON.data.message : 'Errore di rete durante l’importazione.'; gygShowError(msg); gygState.running=false; $('.alma-gyg-start-import').prop('disabled',false).text('Avvia importazione'); });
+      .fail(function(xhr){ var msg = gygAjaxErrorMessage(xhr, 'Errore di rete durante l’importazione.'); gygShowError(msg); if(window.console && console.error){ console.error('ALMA gyg_csv import batch failed', {status: xhr && xhr.status, message: msg}); } gygState.running=false; $('.alma-gyg-start-import').prop('disabled',false).text('Avvia importazione'); });
   }
   $(document).on('input change','#alma-gyg-quantity',gygClampQuantity);
   $(document).on('click','.alma-modal-close',function(e){ e.preventDefault(); gygClose(); });
@@ -136,10 +156,16 @@ jQuery(function($){
     var $btn=$(this), activityType=String($btn.data('activity-type')||''), sourceId=$btn.data('source-id'), token=$btn.data('token');
     gygState = {sourceId:sourceId, token:token, activityType:activityType, running:false};
     $('.alma-gyg-report').hide().empty(); $('.alma-gyg-log').html('<p class="description">Nessun errore o warning.</p>'); $('.alma-gyg-import-more').hide(); $('.alma-progress-bar').css('width','0%'); $('.alma-gyg-progress-wrap').hide();
-    $('.alma-gyg-summary').html('<p>Caricamento dati modale…</p>'); gygOpen();
-    $.post(ajaxurl,{action:'alma_gyg_csv_prepare_import', nonce:gygNonce(), source_id:sourceId, token:token, activity_type:activityType})
-      .done(function(res){ if(!res || !res.success){ gygShowError((res && res.data && res.data.message)||'Impossibile preparare il modale.'); return; } var d=res.data, c=d.counts||{}; $('.alma-gyg-summary').html('<dl class="alma-gyg-summary-grid"><dt>Tipologia CSV</dt><dd>'+gygEsc(d.activity_type)+'</dd><dt>Record totali</dt><dd>'+parseInt(c.total||0,10)+'</dd><dt>Record già importati</dt><dd>'+parseInt(c.existing||0,10)+'</dd><dt>Record ancora da importare</dt><dd>'+parseInt(c.remaining||0,10)+'</dd><dt>Source attiva</dt><dd>'+(d.source_active?'Sì':'No')+'</dd><dt>Partner ID</dt><dd>'+gygEsc(d.partner_id||'—')+'</dd><dt>UTM medium</dt><dd>'+gygEsc(d.utm_medium||'—')+'</dd></dl>'); gygRenderTerms(d.terms,d.mapped_term_ids); gygRenderPreview(d.preview); })
-      .fail(function(xhr){ gygShowError((xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.message) || 'Errore di rete.'); });
+    $('.alma-gyg-summary').html('<p>Caricamento dati modale…</p>'); $('.alma-gyg-terms').html('<p class="description">Caricamento tipologie…</p>'); $('.alma-gyg-preview').html('<p class="description">Caricamento anteprima…</p>'); gygDisableImport(true); gygOpen();
+    $.ajax({url:gygAjaxUrl(), method:'POST', dataType:'json', data:{action:'alma_gyg_csv_prepare_import', nonce:gygNonce(), source_id:sourceId, token:token, activity_type:activityType}})
+      .done(function(res){
+        if(!res || !res.success){ gygPrepareFailed((res && res.data && res.data.message)||'Impossibile preparare il modale.', {status:0}); return; }
+        var d=res.data || {}, c=d.counts||{}, terms=$.isArray(d.terms) ? d.terms : null;
+        if(!terms){ gygPrepareFailed('Risposta AJAX non valida: Tipologie Link Sothra mancanti.', {status:0}); return; }
+        $('.alma-gyg-summary').html('<dl class="alma-gyg-summary-grid"><dt>Tipologia CSV</dt><dd>'+gygEsc(d.activity_type)+'</dd><dt>Record totali</dt><dd>'+parseInt(c.total||0,10)+'</dd><dt>Record già importati</dt><dd>'+parseInt(c.existing||0,10)+'</dd><dt>Record ancora da importare</dt><dd>'+parseInt(c.remaining||0,10)+'</dd><dt>Source attiva</dt><dd>'+(d.source_active?'Sì':'No')+'</dd><dt>Partner ID</dt><dd>'+gygEsc(d.partner_id||'—')+'</dd><dt>UTM medium</dt><dd>'+gygEsc(d.utm_medium||'—')+'</dd></dl>');
+        gygRenderTerms(terms,d.mapped_term_ids||[]); gygRenderPreview($.isArray(d.preview) ? d.preview : []); gygDisableImport(!terms.length);
+      })
+      .fail(function(xhr){ var msg = gygAjaxErrorMessage(xhr, 'Impossibile caricare le Tipologie Link Sothra. Controlla che la tassonomia delle tipologie esista e ricarica la pagina.'); gygPrepareFailed(msg, xhr); });
   });
   $(document).on('click','.alma-gyg-start-import',function(e){
     e.preventDefault(); gygClearError();

--- a/includes/class-affiliate-source-manager.php
+++ b/includes/class-affiliate-source-manager.php
@@ -433,9 +433,17 @@ class ALMA_Affiliate_Source_Manager {
 
     private function sources_table_exists(){ global $wpdb; $t=$wpdb->prefix.'alma_affiliate_sources'; return $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s',$t))===$t; }
 
+    private function get_gyg_link_type_taxonomy() { return 'link_type'; }
+
+    private function send_gyg_ajax_context_error($error) {
+        $code = is_wp_error($error) ? $error->get_error_code() : 'unknown_error';
+        $status = $code === 'forbidden' || $code === 'invalid_nonce' ? 403 : 400;
+        wp_send_json_error(array('message'=>is_wp_error($error) ? $error->get_error_message() : __('Errore AJAX gyg_csv.', 'affiliate-link-manager-ai'),'code'=>$code), $status);
+    }
+
     private function get_valid_gyg_ajax_context() {
         if (!current_user_can('manage_options')) return new WP_Error('forbidden', __('Permessi insufficienti.', 'affiliate-link-manager-ai'));
-        if (!check_ajax_referer('alma_gyg_csv_import_nonce', 'nonce', false)) return new WP_Error('invalid_nonce', __('Nonce non valido.', 'affiliate-link-manager-ai'));
+        if (!check_ajax_referer('alma_gyg_csv_import_nonce', 'nonce', false)) return new WP_Error('invalid_nonce', __('Verifica di sicurezza non riuscita. Ricarica la pagina e riprova.', 'affiliate-link-manager-ai'));
         global $wpdb;
         $source_id=absint($_POST['source_id']??0); $token=sanitize_key($_POST['token']??''); $type=sanitize_text_field(wp_unslash($_POST['activity_type']??''));
         $source=$wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}alma_affiliate_sources WHERE id=%d",$source_id),ARRAY_A);
@@ -447,31 +455,34 @@ class ALMA_Affiliate_Source_Manager {
     }
 
     public function ajax_gyg_csv_prepare_import(){
-        $ctx=$this->get_valid_gyg_ajax_context(); if(is_wp_error($ctx)) wp_send_json_error(array('message'=>$ctx->get_error_message(),'code'=>$ctx->get_error_code()),400);
+        $ctx=$this->get_valid_gyg_ajax_context(); if(is_wp_error($ctx)) $this->send_gyg_ajax_context_error($ctx);
         $settings=ALMA_Affiliate_Source_GYG_CSV_Importer::default_settings($this->decode_db_json($ctx['source']['settings']??'{}'));
-        $terms=get_terms(array('taxonomy'=>'link_type','hide_empty'=>false)); if(is_wp_error($terms)||!is_array($terms)) $terms=array();
+        $taxonomy=$this->get_gyg_link_type_taxonomy();
+        if(!taxonomy_exists($taxonomy)) wp_send_json_error(array('message'=>__('Impossibile caricare le Tipologie Link Sothra. Controlla che la tassonomia delle tipologie esista e ricarica la pagina.', 'affiliate-link-manager-ai'),'code'=>'missing_taxonomy'),500);
+        $terms=get_terms(array('taxonomy'=>$taxonomy,'hide_empty'=>false)); if(is_wp_error($terms)) wp_send_json_error(array('message'=>__('Impossibile caricare le Tipologie Link Sothra. Controlla che la tassonomia delle tipologie esista e ricarica la pagina.', 'affiliate-link-manager-ai'),'code'=>$terms->get_error_code()),500); if(!is_array($terms)) $terms=array();
         $term_data=array(); foreach($terms as $t){ $term_data[]=array('id'=>(int)$t->term_id,'name'=>$t->name); }
         $mapped=ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids(($settings['type_mappings'][$ctx['activity_type']]??array()));
         $counts=$ctx['svc']->count_existing_for_type($ctx['session']['path'],$ctx['columns'],$ctx['activity_type'],$ctx['source']);
         if (empty($counts['total'])) wp_send_json_error(array('message'=>__('Tipologia attività CSV non valida o non presente nella sessione.', 'affiliate-link-manager-ai'),'code'=>'invalid_activity_type'),400);
         $preview=$ctx['svc']->preview($ctx['session']['path'],$ctx['columns'],$ctx['activity_type'],$ctx['source'],array('show_existing'=>true,'limit'=>10));
         $preview=array_map(function($it){ return array('original_url'=>$it['original_url'],'affiliate_url'=>$it['affiliate_url'],'city'=>$it['city'],'region'=>$it['region'],'description'=>function_exists('mb_substr')?mb_substr($it['description'],0,140):substr($it['description'],0,140),'status'=>$it['post_id']>0?'già importato':'nuovo'); }, $preview);
-        wp_send_json_success(array('activity_type'=>$ctx['activity_type'],'source_name'=>$ctx['source']['name']??'','source_active'=>!empty($ctx['source']['is_active']),'partner_id'=>$settings['partner_id']??'','utm_medium'=>$settings['utm_medium']??'online_publisher','counts'=>$counts,'terms'=>$term_data,'mapped_term_ids'=>$mapped,'preview'=>$preview));
+        wp_send_json_success(array('activity_type'=>$ctx['activity_type'],'source_id'=>$ctx['source_id'],'token'=>$ctx['token'],'source_name'=>$ctx['source']['name']??'','source_active'=>!empty($ctx['source']['is_active']),'partner_id'=>$settings['partner_id']??'','utm_medium'=>$settings['utm_medium']??'online_publisher','counts'=>$counts,'terms'=>$term_data,'mapped_term_ids'=>$mapped,'preview'=>$preview,'max_quantity'=>ALMA_Affiliate_Source_GYG_CSV_Importer::MAX_IMPORT_QUANTITY));
     }
 
     public function ajax_gyg_csv_import_batch(){
-        $ctx=$this->get_valid_gyg_ajax_context(); if(is_wp_error($ctx)) wp_send_json_error(array('message'=>$ctx->get_error_message(),'code'=>$ctx->get_error_code()),400);
+        $ctx=$this->get_valid_gyg_ajax_context(); if(is_wp_error($ctx)) $this->send_gyg_ajax_context_error($ctx);
+        $taxonomy=$this->get_gyg_link_type_taxonomy();
         $quantity=max(1,min(ALMA_Affiliate_Source_GYG_CSV_Importer::MAX_IMPORT_QUANTITY,absint($_POST['quantity']??100)));
         $cursor=max(0,absint($_POST['cursor']??0)); $update_existing=!empty($_POST['update_existing']);
         $term_ids=ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($_POST['term_ids']??array());
         if(empty($term_ids)) wp_send_json_error(array('message'=>__('Seleziona almeno una Tipologia Link Sothra.', 'affiliate-link-manager-ai'),'code'=>'missing_terms'),400);
-        foreach($term_ids as $tid){ $term=get_term($tid,'link_type'); if(!$term||is_wp_error($term)) wp_send_json_error(array('message'=>__('Tipologia Sothra non valida.', 'affiliate-link-manager-ai'),'code'=>'invalid_term'),400); }
+        foreach($term_ids as $tid){ $term=get_term($tid,$taxonomy); if(!$term||is_wp_error($term)) wp_send_json_error(array('message'=>__('Tipologia Sothra non valida.', 'affiliate-link-manager-ai'),'code'=>'invalid_term'),400); }
         $counts=$ctx['svc']->count_existing_for_type($ctx['session']['path'],$ctx['columns'],$ctx['activity_type'],$ctx['source']);
         if (empty($counts['total'])) wp_send_json_error(array('message'=>__('Tipologia attività CSV non valida o non presente nella sessione.', 'affiliate-link-manager-ai'),'code'=>'invalid_activity_type'),400);
         global $wpdb; $settings=ALMA_Affiliate_Source_GYG_CSV_Importer::default_settings($this->decode_db_json($ctx['source']['settings']??'{}')); $settings['type_mappings'][$ctx['activity_type']]=$term_ids; $wpdb->update("{$wpdb->prefix}alma_affiliate_sources",array('settings'=>wp_json_encode($settings),'updated_at'=>current_time('mysql')),array('id'=>$ctx['source_id']));
         $result=$ctx['svc']->import_batch($ctx['session']['path'],$ctx['columns'],$ctx['activity_type'],$ctx['source'],$term_ids,$quantity,$cursor,$update_existing);
         if(is_wp_error($result)) wp_send_json_error(array('message'=>$result->get_error_message(),'code'=>$result->get_error_code()),400);
-        $names=array(); foreach($term_ids as $tid){ $term=get_term($tid,'link_type'); if($term&&!is_wp_error($term)) $names[]=$term->name; }
+        $names=array(); foreach($term_ids as $tid){ $term=get_term($tid,$taxonomy); if($term&&!is_wp_error($term)) $names[]=$term->name; }
         $result['mapping_label']=implode(', ',$names); $result['max_quantity']=ALMA_Affiliate_Source_GYG_CSV_Importer::MAX_IMPORT_QUANTITY;
         wp_send_json_success($result);
     }


### PR DESCRIPTION
### Motivation
- The GetYourGuide CSV import modal could remain stuck on “Caricamento tipologie…” when the prepare AJAX call failed or returned an incomplete payload, preventing mapping preselection, counts and preview from rendering. 
- Improve robustness of the `gyg_csv` prepare/import flow so the modal always clears loading placeholders, shows readable error messages, and disables import when terms are missing. 

### Description
- Add safer JS prepare/submit handling in `assets/affiliate-sources.js`: new helpers `gygAjaxUrl`, `gygAjaxErrorMessage`, `gygPrepareFailed`, `gygDisableImport`, switch to `$.ajax` for prepare, validate response keys (`terms`, `preview`, etc.), and disable/enable import button accordingly. 
- Harden batch import JS to use the localized AJAX endpoint and to show readable messages on HTTP 400/403/500, empty/invalid JSON and `success:false`. 
- Align PHP prepare/import payloads and checks in `includes/class-affiliate-source-manager.php`: introduce `get_gyg_link_type_taxonomy()` and `send_gyg_ajax_context_error()`, verify taxonomy existence, return `source_id`, `token` and `max_quantity` in `ajax_gyg_csv_prepare_import()`, and validate term IDs using the real taxonomy when importing. 
- Bump plugin version to `2.27.2` in `affiliate-link-manager-ai.php` and add a `2.27.2` entry to `CHANGELOG.md`. 
- Files modified: `assets/affiliate-sources.js`, `includes/class-affiliate-source-manager.php`, `affiliate-link-manager-ai.php`, `CHANGELOG.md`.

### Testing
- Ran `php -l` on modified PHP files: `php -l affiliate-link-manager-ai.php` and `php -l includes/class-affiliate-source-manager.php`, both returned no syntax errors. 
- Ran JS check `node --check assets/affiliate-sources.js`, which passed. 
- Performed repository grep validations to confirm AJAX action names and taxonomy usage with `rg` searches (AJAX actions `alma_gyg_csv_prepare_import` / `alma_gyg_csv_import_batch` are registered and used, taxonomy `link_type` is the real taxonomy), all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb6af3e048332bc4a3ce4a0553ec8)