### PR TITLE
Hotfix: GYG CSV modal AJAX diagnostics, timeout, healthcheck and simple fallback (2.28.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.28.1 — Hotfix GYG CSV modal AJAX diagnostics and fallback
+- Corretto il loading infinito del modale `gyg_csv` con stati progressivi, timeout AJAX e gestione esplicita di risposte non valide.
+- Aggiunta diagnostica AJAX sicura nel modale, console error admin limitato e health check `alma_gyg_csv_modal_healthcheck`.
+- Aggiunto fallback server-side “Apri importazione in modalità semplice” per importare una tipologia CSV senza dipendere dal modale AJAX.
+- Migliorato cache busting/enqueue JS admin: `assets/affiliate-sources.js` usa la versione `ALMA_VERSION` aggiornata a `2.28.1`.
+- Se il modale `gyg_csv` non carica le Tipologie Link Sothra, usare “Test caricamento modale” o “Apri importazione in modalità semplice”.
+- Versione plugin aggiornata a `2.28.1`.
+
 ## 2.28.0 — Persistent GetYourGuide CSV import sessions
 - Aggiunte sessioni CSV `gyg_csv` persistenti in `wp-content/uploads/alma-imports/gyg-csv/` con file CSV a nome non prevedibile, validazione estensione/MIME e protezioni `.htaccess`/`index.html` contro listing o esecuzione.
 - Aggiunte le tabelle `alma_gyg_csv_import_sessions` e `alma_gyg_csv_import_progress` via `dbDelta` per salvare token sicuri, colonne/summary CSV, mapping per tipologia, conteggi importati/aggiornati/già presenti/saltati/errori e cursore ultimo batch.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## 2.28.1 — Hotfix GYG CSV modal AJAX diagnostics and fallback
+- Corretto il loading infinito del modale `gyg_csv` con stati progressivi, timeout AJAX e gestione esplicita di risposte non valide.
+- Aggiunta diagnostica AJAX sicura nel modale, console error admin limitato e health check `alma_gyg_csv_modal_healthcheck`.
+- Aggiunto fallback server-side “Apri importazione in modalità semplice” per importare una tipologia CSV senza dipendere dal modale AJAX.
+- Migliorato cache busting/enqueue JS admin: `assets/affiliate-sources.js` usa la versione `ALMA_VERSION` aggiornata a `2.28.1`.
+- Se il modale `gyg_csv` non carica le Tipologie Link Sothra, usare “Test caricamento modale” o “Apri importazione in modalità semplice”.
+- Versione plugin aggiornata a `2.28.1`.
+
 ## 2.28.0 — GetYourGuide CSV persistente e riprendibile
 - Il provider `gyg_csv` salva ogni CSV caricato in modo persistente sotto `wp-content/uploads/alma-imports/gyg-csv/` con nome non prevedibile, validazione `.csv`/MIME e protezioni anti-listing/anti-esecuzione. La UI non mostra path server completi.
 - Le sessioni vengono registrate in database e sono visibili nella sezione **Sessioni CSV recenti** della pagina “Importa contenuti”: da lì è possibile riprendere Step 2/Step 3 senza ricaricare il file oppure eliminare la sessione. L’eliminazione rimuove sessione, progressi e file CSV, ma non elimina i Link affiliati già importati.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.28.0
+ * Version: 2.28.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.28.0');
+define('ALMA_VERSION', '2.28.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -746,7 +746,7 @@ class AffiliateManagerAI {
                 if (file_exists(ALMA_PLUGIN_DIR . 'assets/affiliate-sources.js')) {
                     wp_enqueue_script('alma-affiliate-sources', ALMA_PLUGIN_URL . 'assets/affiliate-sources.js', array('jquery'), ALMA_VERSION, true);
                     if ($this->source_manager && method_exists($this->source_manager, 'get_provider_presets')) {
-                        wp_localize_script('alma-affiliate-sources', 'almaSourcePresets', array('presets' => $this->source_manager->get_provider_presets(),'ajax_url'=>admin_url('admin-ajax.php'),'nonce'=>wp_create_nonce('alma_test_connection_nonce'),'gygNonce'=>wp_create_nonce('alma_gyg_csv_import_nonce')));
+                        wp_localize_script('alma-affiliate-sources', 'almaSourcePresets', array('presets' => $this->source_manager->get_provider_presets(),'ajax_url'=>admin_url('admin-ajax.php'),'nonce'=>wp_create_nonce('alma_test_connection_nonce'),'gygNonce'=>wp_create_nonce('alma_gyg_csv_import_nonce'),'gygJsVersion'=>ALMA_VERSION));
                     }
                 }
             }

--- a/assets/affiliate-sources.js
+++ b/assets/affiliate-sources.js
@@ -72,132 +72,81 @@ jQuery(function($){
 
 
 
+  var GYG_JS_VERSION = (window.almaSourcePresets && almaSourcePresets.gygJsVersion) || '2.28.1';
   var gygState = null;
+  if(window.console && console.info){ console.info('GYG CSV modal JS loaded: '+GYG_JS_VERSION); }
   function gygNonce(){ return (window.almaSourcePresets && almaSourcePresets.gygNonce) || ''; }
   function gygAjaxUrl(){ return (window.almaSourcePresets && almaSourcePresets.ajax_url) || (typeof ajaxurl !== 'undefined' ? ajaxurl : ''); }
   function gygEsc(v){ return $('<div/>').text(v == null ? '' : String(v)).html(); }
-  function gygClampQuantity(){
-    var $q = $('#alma-gyg-quantity'), value = parseInt($q.val(), 10) || 100;
-    value = Math.max(1, Math.min(1000, value));
-    $q.val(value);
-    return value;
-  }
-  function gygShowError(message){ $('.alma-gyg-modal-error').show().find('p').text(message || 'Errore importazione.'); }
+  function gygSafeExcerpt(text){ text = String(text || '').replace(/([A-Z]:)?[\\/][^\s<>"']+/g, '[path]'); return text.substring(0, 500); }
+  function gygClampQuantity(){ var $q = $('#alma-gyg-quantity'), value = parseInt($q.val(), 10) || 100; value = Math.max(1, Math.min(1000, value)); $q.val(value); return value; }
+  function gygSetStatus(status){ $('.alma-gyg-status').show().removeClass('notice-error notice-success').addClass(status === 'Errore caricamento.' ? 'notice-error' : 'notice-info').html('<p>'+gygEsc(status)+'</p>'); }
+  function gygShowError(message){ $('.alma-gyg-modal-error').show().find('p').first().text(message || 'Errore importazione.'); $('.alma-gyg-healthcheck,.alma-gyg-simple-link').show(); }
   function gygDisableImport(disabled){ $('.alma-gyg-start-import').prop('disabled', !!disabled); }
+  function gygClearError(){ $('.alma-gyg-modal-error').hide().find('p').first().text(''); $('.alma-gyg-diagnostics,.alma-gyg-health-result').remove(); $('.alma-gyg-healthcheck,.alma-gyg-simple-link').hide(); }
   function gygAjaxErrorMessage(xhr, fallback){
     var text = xhr && xhr.responseText ? String(xhr.responseText).trim() : '';
     if(text === '0'){ return 'Errore AJAX: action non registrata oppure capability insufficiente.'; }
     if(text === '-1'){ return 'Nonce non valido o scaduto. Ricarica la pagina e riprova.'; }
+    if(xhr && xhr.status === 403){ return 'HTTP 403: verifica di sicurezza o permessi non riusciti. Ricarica la pagina e riprova.'; }
+    if(xhr && xhr.status === 400){ return 'HTTP 400: richiesta non valida. Verifica dati sessione e ricarica la pagina.'; }
+    if(xhr && xhr.status >= 500){ return 'HTTP '+xhr.status+': errore server durante il caricamento del modale. Controlla i log PHP.'; }
+    if(xhr && xhr.statusText === 'timeout'){ return 'Timeout AJAX: nessuna risposta entro 20 secondi. Controlla Network / admin-ajax.php e log PHP.'; }
     if(xhr && xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.message){ return xhr.responseJSON.data.message; }
-    if(text){
-      try { var parsed = JSON.parse(text); if(parsed && parsed.data && parsed.data.message){ return parsed.data.message; } }
-      catch(e) { return 'Risposta non JSON dal server. Controlla i log PHP o ricarica la pagina.'; }
-    }
-    if(xhr && xhr.status === 403){ return 'Verifica di sicurezza o permessi non riusciti. Ricarica la pagina e riprova.'; }
-    if(xhr && xhr.status === 400){ return fallback || 'Richiesta non valida. Ricarica la pagina e riprova.'; }
-    if(xhr && xhr.status >= 500){ return 'Errore server durante il caricamento del modale. Riprova tra poco.'; }
-    return fallback || 'Errore di rete. Ricarica la pagina e riprova.';
+    if(text){ try { var parsed = JSON.parse(text); if(parsed && parsed.data && parsed.data.message){ return parsed.data.message; } } catch(e) { return 'Risposta HTML/non JSON dal server. Controlla Network / admin-ajax.php e log PHP.'; } }
+    return fallback || 'Risposta vuota o errore di rete. Ricarica la pagina e riprova.';
   }
   function gygDiagnostics(ctx, xhr, code, message){
     ctx = ctx || {}; xhr = xhr || {};
-    var html = '<div class="alma-gyg-diagnostics"><h3>Diagnostica caricamento</h3><dl>'+
-      '<dt>Action AJAX</dt><dd>'+gygEsc(ctx.action || 'alma_gyg_csv_prepare_import')+'</dd>'+
-      '<dt>HTTP status</dt><dd>'+gygEsc(xhr.status || 'n/d')+'</dd>'+
-      '<dt>Source ID</dt><dd>'+gygEsc(ctx.sourceId || 'n/d')+'</dd>'+
-      '<dt>Token presente</dt><dd>'+(ctx.token ? 'sì' : 'no')+'</dd>'+
-      '<dt>Tipologia attività</dt><dd>'+gygEsc(ctx.activityType || 'n/d')+'</dd>'+
-      '<dt>Codice errore</dt><dd>'+gygEsc(code || 'n/d')+'</dd>'+
-      '<dt>Messaggio errore</dt><dd>'+gygEsc(message || 'n/d')+'</dd>'+
-      '</dl></div>';
-    $('.alma-gyg-diagnostics').remove();
-    $('.alma-gyg-modal-error').after(html);
+    var responseText = xhr.responseText ? gygSafeExcerpt(xhr.responseText) : '';
+    var html = '<div class="alma-gyg-diagnostics"><h3>Diagnostica caricamento</h3><dl>'+ '<dt>Action AJAX</dt><dd>'+gygEsc(ctx.action || 'alma_gyg_csv_prepare_import')+'</dd>'+ '<dt>HTTP status</dt><dd>'+gygEsc(xhr.status || 'n/d')+'</dd>'+ '<dt>Source ID</dt><dd>'+gygEsc(ctx.sourceId || 'n/d')+'</dd>'+ '<dt>Token presente</dt><dd>'+(ctx.token ? 'sì' : 'no')+'</dd>'+ '<dt>Tipologia attività</dt><dd>'+gygEsc(ctx.activityType || 'n/d')+'</dd>'+ '<dt>Activity type hash presente</dt><dd>'+(ctx.activityHash ? 'sì' : 'no')+'</dd>'+ '<dt>Nonce presente</dt><dd>'+(gygNonce() ? 'sì' : 'no')+'</dd>'+ '<dt>Codice errore</dt><dd>'+gygEsc(code || 'n/d')+'</dd>'+ '<dt>Messaggio errore</dt><dd>'+gygEsc(message || 'n/d')+'</dd>'+(responseText ? '<dt>Estratto risposta</dt><dd><code>'+gygEsc(responseText)+'</code></dd>' : '')+'</dl></div>';
+    $('.alma-gyg-diagnostics').remove(); $('.alma-gyg-modal-error').after(html);
   }
-  function gygPrepareFailed(message, xhr, ctx, code){
-    $('.alma-gyg-summary').html('<p class="description">Impossibile caricare i dati del modale.</p>');
-    $('.alma-gyg-terms').html('<p class="description">Impossibile caricare le Tipologie Link Sothra. Il dettaglio errore è nella diagnostica.</p>');
-    $('.alma-gyg-preview').html('<p class="description">Anteprima non disponibile.</p>');
-    gygDisableImport(true);
-    gygShowError(message);
-    gygDiagnostics(ctx || (gygState || {}), xhr || {}, code, message);
-    if(window.console && console.error){ console.error('ALMA gyg_csv prepare import failed', {xhr:xhr, context:ctx || gygState, code:code, message:message}); }
-  }
-  function gygClearError(){ $('.alma-gyg-modal-error').hide().find('p').text(''); }
-  function gygOpen(){ $('#alma-gyg-import-modal').addClass('is-open').attr('aria-hidden','false'); $('body').addClass('alma-modal-open'); }
+  function gygSafePayload(ctx){ return {action:ctx.action, nonce_present:!!gygNonce(), source_id:ctx.sourceId, token_present:!!ctx.token, activity_type:ctx.activityType, activity_type_hash_present:!!ctx.activityHash}; }
+  function gygConsoleError(xhr, ctx, code, message, jsError){ if(window.console && console.error){ console.error('ALMA gyg_csv prepare import failed', {action:(ctx&&ctx.action)||'alma_gyg_csv_prepare_import', status:xhr&&xhr.status, responseText:gygSafeExcerpt(xhr&&xhr.responseText), payload:gygSafePayload(ctx||{}), code:code, message:message, jsError:jsError ? String(jsError.message || jsError) : ''}); } }
+  function gygPrepareFailed(message, xhr, ctx, code, jsError){ $('.alma-gyg-summary').html('<p class="description">Impossibile caricare i dati del modale.</p>'); $('.alma-gyg-terms').html('<p class="description">Impossibile caricare le Tipologie Link Sothra. Il dettaglio errore è nella diagnostica.</p>'); $('.alma-gyg-preview').html('<p class="description">Anteprima non disponibile.</p>'); gygDisableImport(true); gygSetStatus('Errore caricamento.'); gygShowError(message); gygDiagnostics(ctx || (gygState || {}), xhr || {}, code, message); gygConsoleError(xhr || {}, ctx || gygState || {}, code, message, jsError); }
+  function gygValidateBeforeAjax(ctx){ var missing=[]; if(!gygAjaxUrl()) missing.push('ajaxurl / ajax_url'); if(!gygNonce()) missing.push('gygNonce'); if(!ctx.sourceId || parseInt(ctx.sourceId,10)<1) missing.push('source_id'); if(!ctx.token) missing.push('token'); if(!ctx.activityType) missing.push('activity_type'); if(!ctx.activityHash) missing.push('activity_type_hash'); return missing; }
+  function gygOpen(){ $('#alma-gyg-import-modal').addClass('is-open').attr('aria-hidden','false'); $('body').addClass('alma-modal-open'); $('.alma-gyg-js-version').attr('data-gyg-js-version', GYG_JS_VERSION).text('GYG CSV modal JS loaded: '+GYG_JS_VERSION); }
   function gygClose(){ if(gygState && gygState.running){ return; } $('#alma-gyg-import-modal').removeClass('is-open').attr('aria-hidden','true'); $('body').removeClass('alma-modal-open'); }
-  function gygRenderPreview(items){
-    if(!items || !items.length){ $('.alma-gyg-preview').html('<p class="description">Nessun record disponibile per l’anteprima.</p>'); return; }
-    var html = '<table class="widefat striped"><thead><tr><th>Stato</th><th>URL originale</th><th>URL affiliato</th><th>Città</th><th>Regione</th><th>Descrizione breve</th></tr></thead><tbody>';
-    items.forEach(function(it){ html += '<tr><td>'+gygEsc(it.status||'')+'</td><td><code>'+gygEsc(it.original_url||'')+'</code></td><td><code>'+gygEsc(it.affiliate_url||'')+'</code></td><td>'+gygEsc(it.city||'—')+'</td><td>'+gygEsc(it.region||'—')+'</td><td>'+gygEsc(it.description||'')+'</td></tr>'; });
-    $('.alma-gyg-preview').html(html+'</tbody></table>');
-  }
-  function gygRenderTerms(terms, mapped){
-    mapped = mapped || [];
-    if(!terms || !terms.length){ $('.alma-gyg-terms').html('<p class="description">Nessuna Tipologia Link Sothra disponibile. Creane almeno una prima di importare.</p>'); gygDisableImport(true); return; }
-    var html = '<div class="alma-gyg-term-list">';
-    terms.forEach(function(t){ var checked = mapped.indexOf(parseInt(t.id,10)) !== -1 ? ' checked' : ''; html += '<label><input type="checkbox" name="alma_gyg_terms[]" value="'+parseInt(t.id,10)+'"'+checked+'> '+gygEsc(t.name)+'</label>'; });
-    $('.alma-gyg-terms').html(html+'</div>');
-  }
+  function gygRenderPreview(items){ if(!items || !items.length){ $('.alma-gyg-preview').html('<p class="description">Nessun record disponibile per l’anteprima.</p>'); return; } var html = '<table class="widefat striped"><thead><tr><th>Stato</th><th>URL originale</th><th>URL affiliato</th><th>Città</th><th>Regione</th><th>Descrizione breve</th></tr></thead><tbody>'; items.forEach(function(it){ html += '<tr><td>'+gygEsc(it.status||'')+'</td><td><code>'+gygEsc(it.original_url||'')+'</code></td><td><code>'+gygEsc(it.affiliate_url||'')+'</code></td><td>'+gygEsc(it.city||'—')+'</td><td>'+gygEsc(it.region||'—')+'</td><td>'+gygEsc(it.description||'')+'</td></tr>'; }); $('.alma-gyg-preview').html(html+'</tbody></table>'); }
+  function gygRenderTerms(terms, mapped){ mapped = mapped || []; if(!terms || !terms.length){ $('.alma-gyg-terms').html('<p class="description">Nessuna Tipologia Link Sothra disponibile nella tassonomia link_type. Crea almeno una Tipologia Link prima di importare.</p>'); gygDisableImport(true); return; } var html = '<div class="alma-gyg-term-list">'; terms.forEach(function(t){ var checked = mapped.indexOf(parseInt(t.id,10)) !== -1 ? ' checked' : ''; html += '<label><input type="checkbox" name="alma_gyg_terms[]" value="'+parseInt(t.id,10)+'"'+checked+'> '+gygEsc(t.name)+'</label>'; }); $('.alma-gyg-terms').html(html+'</div>'); }
   function gygSelectedTerms(){ return $('input[name="alma_gyg_terms[]"]:checked').map(function(){ return $(this).val(); }).get(); }
-  function gygSetProgress(processed, requested, status){
-    var pct = requested ? Math.min(100, Math.round(processed / requested * 100)) : 0;
-    $('.alma-progress-bar').css('width', pct+'%');
-    $('.alma-gyg-progress-status').text(status + ' ' + processed + ' / ' + requested + ' (' + pct + '%)');
-  }
-  function gygAppendLogs(logs){
-    if(!logs || !logs.length) return;
-    var $log = $('.alma-gyg-log');
-    if(!$log.find('ul').length) $log.html('<ul></ul>');
-    logs.forEach(function(msg){ $log.find('ul').append('<li>'+gygEsc(msg)+'</li>'); });
-  }
-  function gygRenderReport(){
-    var a = gygState.aggregate;
-    $('.alma-gyg-report').show().html('<h3>Report finale</h3><ul class="alma-gyg-report-list"><li><strong>Importati:</strong> '+a.imported+'</li><li><strong>Aggiornati:</strong> '+a.updated+'</li><li><strong>Già presenti:</strong> '+a.existing+'</li><li><strong>Saltati:</strong> '+a.skipped+'</li><li><strong>Errori:</strong> '+a.errors+'</li><li><strong>URL non validi:</strong> '+a.invalid_urls+'</li><li><strong>Record senza città:</strong> '+a.without_city+'</li><li><strong>Record senza regione:</strong> '+a.without_region+'</li><li><strong>Durata stimata:</strong> '+a.duration.toFixed(2)+'s</li></ul>');
-    $('.alma-gyg-import-more').show();
-  }
-  function gygImportNext(){
-    $.post(gygAjaxUrl(), {action:'alma_gyg_csv_import_batch', nonce:gygNonce(), source_id:gygState.sourceId, token:gygState.token, activity_type:gygState.activityType, activity_type_hash:gygState.activityHash, term_ids:gygState.termIds, quantity:gygState.quantity, cursor:gygState.cursor, update_existing:gygState.updateExisting ? 1 : 0})
-      .done(function(res){
-        if(!res || !res.success){ gygShowError((res && res.data && res.data.message) || 'Errore importazione.'); gygState.running=false; $('.alma-gyg-start-import').prop('disabled',false); return; }
-        var d=res.data, a=gygState.aggregate;
-        ['imported','updated','existing','skipped','errors','invalid_urls','without_city','without_region'].forEach(function(k){ a[k] += parseInt(d[k]||0,10); });
-        a.duration += parseFloat(d.duration||0); gygState.cursor = parseInt(d.next_cursor||gygState.cursor,10); gygAppendLogs(d.logs||[]);
-        if(d.mapping_label){ $('.alma-gyg-mapping-cell').filter(function(){ return String($(this).attr('data-activity-hash')||'') === String(gygState.activityHash||'') || String($(this).attr('data-activity-type')||'') === String(gygState.activityType); }).text(d.mapping_label); }
-        gygSetProgress(gygState.cursor, gygState.quantity, d.done ? 'Importazione completata:' : 'Importazione in corso:');
-        if(d.done){ gygState.running=false; $('.alma-gyg-start-import').prop('disabled',false).text('Avvia importazione'); gygRenderReport(); }
-        else { gygImportNext(); }
-      })
-      .fail(function(xhr){ var msg = gygAjaxErrorMessage(xhr, 'Errore di rete durante l’importazione.'); gygShowError(msg); if(window.console && console.error){ console.error('ALMA gyg_csv import batch failed', {status: xhr && xhr.status, message: msg}); } gygState.running=false; $('.alma-gyg-start-import').prop('disabled',false).text('Avvia importazione'); });
-  }
+  function gygSetProgress(processed, requested, status){ var pct = requested ? Math.min(100, Math.round(processed / requested * 100)) : 0; $('.alma-progress-bar').css('width', pct+'%'); $('.alma-gyg-progress-status').text(status + ' ' + processed + ' / ' + requested + ' (' + pct + '%)'); }
+  function gygAppendLogs(logs){ if(!logs || !logs.length) return; var $log = $('.alma-gyg-log'); if(!$log.find('ul').length) $log.html('<ul></ul>'); logs.forEach(function(msg){ $log.find('ul').append('<li>'+gygEsc(msg)+'</li>'); }); }
+  function gygRenderReport(){ var a = gygState.aggregate; $('.alma-gyg-report').show().html('<h3>Report finale</h3><ul class="alma-gyg-report-list"><li><strong>Importati:</strong> '+a.imported+'</li><li><strong>Aggiornati:</strong> '+a.updated+'</li><li><strong>Già presenti:</strong> '+a.existing+'</li><li><strong>Saltati:</strong> '+a.skipped+'</li><li><strong>Errori:</strong> '+a.errors+'</li><li><strong>URL non validi:</strong> '+a.invalid_urls+'</li><li><strong>Record senza città:</strong> '+a.without_city+'</li><li><strong>Record senza regione:</strong> '+a.without_region+'</li><li><strong>Durata stimata:</strong> '+a.duration.toFixed(2)+'s</li></ul>'); $('.alma-gyg-import-more').show(); }
+  function gygImportNext(){ $.ajax({url:gygAjaxUrl(), method:'POST', dataType:'json', timeout:20000, data:{action:'alma_gyg_csv_import_batch', nonce:gygNonce(), source_id:gygState.sourceId, token:gygState.token, activity_type:gygState.activityType, activity_type_hash:gygState.activityHash, term_ids:gygState.termIds, quantity:gygState.quantity, cursor:gygState.cursor, update_existing:gygState.updateExisting ? 1 : 0}}).done(function(res){ if(!res || !res.success){ gygShowError((res && res.data && res.data.message) || 'Errore importazione.'); gygState.running=false; $('.alma-gyg-start-import').prop('disabled',false); return; } var d=res.data, a=gygState.aggregate; ['imported','updated','existing','skipped','errors','invalid_urls','without_city','without_region'].forEach(function(k){ a[k] += parseInt(d[k]||0,10); }); a.duration += parseFloat(d.duration||0); gygState.cursor = parseInt(d.next_cursor||gygState.cursor,10); gygAppendLogs(d.logs||[]); if(d.mapping_label){ $('.alma-gyg-mapping-cell').filter(function(){ return String($(this).attr('data-activity-hash')||'') === String(gygState.activityHash||'') || String($(this).attr('data-activity-type')||'') === String(gygState.activityType); }).text(d.mapping_label); } gygSetProgress(gygState.cursor, gygState.quantity, d.done ? 'Importazione completata:' : 'Importazione in corso:'); if(d.done){ gygState.running=false; $('.alma-gyg-start-import').prop('disabled',false).text('Avvia importazione'); gygRenderReport(); } else { gygImportNext(); } }).fail(function(xhr){ var msg = gygAjaxErrorMessage(xhr, 'Errore di rete durante l’importazione.'); gygShowError(msg); gygState.running=false; $('.alma-gyg-start-import').prop('disabled',false).text('Avvia importazione'); }); }
   $(document).on('input change','#alma-gyg-quantity',gygClampQuantity);
   $(document).on('click','.alma-modal-close',function(e){ e.preventDefault(); gygClose(); });
   $(document).on('click','.alma-gyg-open-import',function(e){
     e.preventDefault(); gygClearError();
     var $btn=$(this), activityType=String($btn.attr('data-activity-type')||''), activityHash=String($btn.attr('data-activity-hash')||''), sourceId=$btn.attr('data-source-id'), token=$btn.attr('data-token');
     gygState = {sourceId:sourceId, token:token, activityType:activityType, activityHash:activityHash, running:false, action:'alma_gyg_csv_prepare_import'};
-    $('.alma-gyg-report').hide().empty(); $('.alma-gyg-log').html('<p class="description">Nessun errore o warning.</p>'); $('.alma-gyg-import-more').hide(); $('.alma-progress-bar').css('width','0%'); $('.alma-gyg-progress-wrap').hide();
-    $('.alma-gyg-diagnostics').remove(); $('.alma-gyg-summary').html('<p>Richiesta in corso…</p>'); $('.alma-gyg-terms').html('<p class="description">Richiesta Tipologie Link Sothra in corso…</p>'); $('.alma-gyg-preview').html('<p class="description">Caricamento anteprima…</p>'); gygDisableImport(true); gygOpen();
-    $.ajax({url:gygAjaxUrl(), method:'POST', dataType:'json', data:{action:'alma_gyg_csv_prepare_import', nonce:gygNonce(), source_id:sourceId, token:token, activity_type:activityType, activity_type_hash:activityHash}})
-      .done(function(res){
-        if(!res || !res.success){ var err=(res && res.data) || {}; gygPrepareFailed(err.message||'Impossibile preparare il modale.', {status:0, responseJSON:res}, gygState, err.code); return; }
+    $('.alma-gyg-simple-link').attr('href', $btn.attr('data-simple-url') || '#');
+    $('.alma-gyg-report').hide().empty(); $('.alma-gyg-log').html('<p class="description">Nessun errore o warning.</p>'); $('.alma-gyg-import-more').hide(); $('.alma-progress-bar').css('width','0%'); $('.alma-gyg-progress-wrap').hide(); $('.alma-gyg-diagnostics').remove();
+    $('.alma-gyg-summary').html('<p>Dati importazione in lettura…</p>'); $('.alma-gyg-terms').html('<p class="description">Tipologie Link Sothra non ancora caricate.</p>'); $('.alma-gyg-preview').html('<p class="description">Anteprima non ancora caricata.</p>'); gygDisableImport(true); gygOpen(); gygSetStatus('Modale aperto.');
+    gygSetStatus('Dati importazione letti.');
+    var missing = gygValidateBeforeAjax(gygState);
+    if(missing.length){ gygPrepareFailed('Dati mancanti prima della richiesta AJAX: '+missing.join(', ')+'.', {status:'n/d', responseText:''}, gygState, 'missing_client_data'); return; }
+    gygSetStatus('Richiesta AJAX in preparazione.');
+    var payload = {action:'alma_gyg_csv_prepare_import', nonce:gygNonce(), source_id:sourceId, token:token, activity_type:activityType, activity_type_hash:activityHash};
+    gygSetStatus('Richiesta AJAX inviata.');
+    $.ajax({url:gygAjaxUrl(), method:'POST', dataType:'json', timeout:20000, data:payload}).done(function(res, textStatus, xhr){
+      gygSetStatus('Risposta ricevuta.');
+      try {
+        if(res === 0 || res === '0'){ gygPrepareFailed('Risposta 0 da admin-ajax.php: action non registrata o permessi insufficienti.', xhr || {status:0,responseText:'0'}, gygState, 'ajax_zero'); return; }
+        if(res === -1 || res === '-1'){ gygPrepareFailed('Risposta -1 da admin-ajax.php: nonce non valido o scaduto.', xhr || {status:403,responseText:'-1'}, gygState, 'ajax_minus_one'); return; }
+        if(!res){ gygPrepareFailed('Risposta AJAX vuota.', xhr || {status:0,responseText:''}, gygState, 'empty_response'); return; }
+        if(!res.success){ var err=(res && res.data) || {}; gygPrepareFailed(err.message||'Impossibile preparare il modale.', xhr || {status:0, responseJSON:res}, gygState, err.code || 'json_success_false'); return; }
         var d=res.data || {}, c=d.counts||{}, terms=$.isArray(d.terms) ? d.terms : null;
-        if(!terms){ gygPrepareFailed('Risposta AJAX non valida: Tipologie Link Sothra mancanti.', {status:0, responseJSON:res}, gygState, 'missing_terms_payload'); return; }
-        if(!terms.length){ gygPrepareFailed('Nessuna Tipologia Link Sothra disponibile nella tassonomia link_type.', {status:200, responseJSON:res}, gygState, 'empty_terms'); return; }
+        if(!terms){ gygPrepareFailed('Risposta AJAX non valida: Tipologie Link Sothra mancanti.', xhr || {status:200, responseJSON:res}, gygState, 'missing_terms_payload'); return; }
+        if(!terms.length){ gygPrepareFailed('Nessuna Tipologia Link Sothra disponibile nella tassonomia link_type. Crea almeno una Tipologia Link.', xhr || {status:200, responseJSON:res}, gygState, 'empty_terms'); return; }
         var pr=d.progress||{}; $('.alma-gyg-summary').html('<dl class="alma-gyg-summary-grid"><dt>Tipologia CSV</dt><dd>'+gygEsc(d.activity_type)+'</dd><dt>Record totali</dt><dd>'+parseInt(c.total||0,10)+'</dd><dt>Record già importati</dt><dd>'+parseInt(c.existing||0,10)+'</dd><dt>Record ancora da importare</dt><dd>'+parseInt(c.remaining||0,10)+'</dd><dt>Progressi salvati</dt><dd>Importati '+parseInt(pr.imported_count||0,10)+' · aggiornati '+parseInt(pr.updated_count||0,10)+' · già presenti '+parseInt(pr.existing_count||0,10)+' · errori '+parseInt(pr.error_count||0,10)+'</dd><dt>Source attiva</dt><dd>'+(d.source_active?'Sì':'No')+'</dd><dt>Partner ID</dt><dd>'+gygEsc(d.partner_id||'—')+'</dd><dt>UTM medium</dt><dd>'+gygEsc(d.utm_medium||'—')+'</dd></dl>');
-        gygRenderTerms(terms,d.mapped_term_ids||[]); gygRenderPreview($.isArray(d.preview) ? d.preview : []); gygDisableImport(!terms.length);
-      })
-      .fail(function(xhr){ var msg = gygAjaxErrorMessage(xhr, 'Impossibile caricare le Tipologie Link Sothra. Controlla che la tassonomia delle tipologie esista e ricarica la pagina.'); var code=(xhr.responseJSON&&xhr.responseJSON.data&&xhr.responseJSON.data.code)||''; gygPrepareFailed(msg, xhr, gygState, code); });
+        gygRenderTerms(terms,d.mapped_term_ids||[]); gygRenderPreview($.isArray(d.preview) ? d.preview : []); gygDisableImport(false); gygSetStatus('Tipologie Link Sothra caricate.');
+      } catch(ex) { gygPrepareFailed('Eccezione JavaScript durante il rendering del modale: '+(ex.message || ex), xhr || {status:200,responseJSON:res}, gygState, 'render_exception', ex); }
+    }).fail(function(xhr){ var msg = gygAjaxErrorMessage(xhr, 'Impossibile caricare le Tipologie Link Sothra.'); var code=(xhr.responseJSON&&xhr.responseJSON.data&&xhr.responseJSON.data.code)||(xhr.statusText === 'timeout' ? 'timeout' : 'ajax_fail'); gygPrepareFailed(msg, xhr, gygState, code); });
   });
-  $(document).on('click','.alma-gyg-start-import',function(e){
-    e.preventDefault(); gygClearError();
-    if(!gygState || gygState.running) return;
-    var terms=gygSelectedTerms(); if(!terms.length){ gygShowError('Seleziona almeno una Tipologia Link Sothra prima di importare.'); return; }
-    var quantity=gygClampQuantity();
-    gygState.termIds=terms; gygState.quantity=quantity; gygState.cursor=0; gygState.updateExisting=$('input[name="alma_gyg_update_existing"]:checked').val()==='1'; gygState.running=true;
-    gygState.aggregate={imported:0,updated:0,existing:0,skipped:0,errors:0,invalid_urls:0,without_city:0,without_region:0,duration:0};
-    $('.alma-gyg-report').hide().empty(); $('.alma-gyg-log').html('<p class="description">Nessun errore o warning.</p>'); $('.alma-gyg-progress-wrap').show(); gygSetProgress(0, quantity, 'Preparazione importazione…');
-    $(this).prop('disabled',true).text('Importazione in corso…');
-    gygImportNext();
-  });
+  $(document).on('click','.alma-gyg-healthcheck',function(e){ e.preventDefault(); if(!gygState) return; var $btn=$(this).prop('disabled',true).text('Test in corso…'); $('.alma-gyg-health-result').remove(); $.ajax({url:gygAjaxUrl(), method:'POST', dataType:'json', timeout:20000, data:{action:'alma_gyg_csv_modal_healthcheck', nonce:gygNonce(), source_id:gygState.sourceId, token:gygState.token, activity_type:gygState.activityType, activity_type_hash:gygState.activityHash}}).done(function(res){ $('.alma-gyg-diagnostics').after('<div class="alma-gyg-health-result"><h3>Risultato health check</h3><pre>'+gygEsc(JSON.stringify(res, null, 2))+'</pre></div>'); }).fail(function(xhr){ $('.alma-gyg-diagnostics').after('<div class="alma-gyg-health-result"><h3>Risultato health check</h3><pre>'+gygEsc(gygSafeExcerpt(xhr && xhr.responseText))+'</pre></div>'); }).always(function(){ $btn.prop('disabled',false).text('Test caricamento modale'); }); });
+  $(document).on('click','.alma-gyg-start-import',function(e){ e.preventDefault(); gygClearError(); if(!gygState || gygState.running) return; var terms=gygSelectedTerms(); if(!terms.length){ gygShowError('Seleziona almeno una Tipologia Link Sothra prima di importare.'); return; } var quantity=gygClampQuantity(); gygState.termIds=terms; gygState.quantity=quantity; gygState.cursor=0; gygState.updateExisting=$('input[name="alma_gyg_update_existing"]:checked').val()==='1'; gygState.running=true; gygState.aggregate={imported:0,updated:0,existing:0,skipped:0,errors:0,invalid_urls:0,without_city:0,without_region:0,duration:0}; $('.alma-gyg-report').hide().empty(); $('.alma-gyg-log').html('<p class="description">Nessun errore o warning.</p>'); $('.alma-gyg-progress-wrap').show(); gygSetProgress(0, quantity, 'Preparazione importazione…'); $(this).prop('disabled',true).text('Importazione in corso…'); gygImportNext(); });
   $(document).on('click','.alma-gyg-import-more',function(e){ e.preventDefault(); $('.alma-gyg-report').hide().empty(); $('.alma-progress-bar').css('width','0%'); $('.alma-gyg-start-import').trigger('click'); });
 
   $(document).on('click','.alma-load-more-results',function(e){

--- a/includes/class-affiliate-source-manager.php
+++ b/includes/class-affiliate-source-manager.php
@@ -14,6 +14,7 @@ class ALMA_Affiliate_Source_Manager {
         add_action('wp_ajax_alma_test_source_connection', array($this, 'ajax_test_source_connection'));
         add_action('wp_ajax_alma_gyg_csv_prepare_import', array($this, 'ajax_gyg_csv_prepare_import'));
         add_action('wp_ajax_alma_gyg_csv_import_batch', array($this, 'ajax_gyg_csv_import_batch'));
+        add_action('wp_ajax_alma_gyg_csv_modal_healthcheck', array($this, 'ajax_gyg_csv_modal_healthcheck'));
         add_action('admin_post_alma_retry_affiliate_image', array($this, 'handle_single_image_retry'));
         add_action('admin_notices', array($this, 'render_image_retry_notice'));
     }
@@ -34,6 +35,7 @@ class ALMA_Affiliate_Source_Manager {
         if($view==='delete_confirmation'){ $this->render_delete_confirmation(); return; }
         if($view==='import_contents'){ $this->render_import_contents_page(); return; }
         if($view==='import_result'){ $this->render_import_result_page(); return; }
+        if($view==='gyg_csv_simple_import'){ $this->render_gyg_csv_simple_import_page(); return; }
         if($view==='ai_behavior'){ $this->render_ai_behavior_page(); return; }
         $editing_id=absint($_GET['edit_source']??0); $editing=$editing_id?$wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}alma_affiliate_sources WHERE id=%d",$editing_id),ARRAY_A):array(); if(!is_array($editing))$editing=array(); $sources_view=sanitize_key($_GET['alma_sources_view']??'active'); $where=($sources_view==='deleted')?' WHERE deleted_at IS NOT NULL':(($sources_view==='all')?'':' WHERE deleted_at IS NULL'); $rows=$this->sources_table_exists()?$wpdb->get_results("SELECT * FROM {$wpdb->prefix}alma_affiliate_sources{$where} ORDER BY id DESC LIMIT 100",ARRAY_A):array();
         $es=$this->decode_db_json($editing['settings']??''); $ec=$this->decode_db_json($editing['credentials']??''); $sel=json_decode($editing['destination_term_ids']??'',true); if(!is_array($sel))$sel=array(); if(empty($sel)&&!empty($editing['destination_term_id']))$sel=array((int)$editing['destination_term_id']);
@@ -128,6 +130,7 @@ class ALMA_Affiliate_Source_Manager {
         if($action==='gyg_csv_upload'){ $this->handle_gyg_csv_upload(); return; }
         if($action==='gyg_csv_save_mapping'){ $this->handle_gyg_csv_save_mapping(); return; }
         if($action==='gyg_csv_import_selected'){ $this->handle_gyg_csv_import_selected(); return; }
+        if($action==='gyg_csv_simple_import'){ $this->handle_gyg_csv_simple_import(); return; }
         if($action==='gyg_csv_delete_session'){ $this->handle_gyg_csv_delete_session(); return; }
         if($action==='import_selected_items'){ $this->handle_import_selected_items(); return; }
         if($action==='save_ai_behavior'){ $this->handle_save_ai_behavior(); return; }
@@ -209,7 +212,7 @@ class ALMA_Affiliate_Source_Manager {
         echo '</tbody></table>'; if(!$det['valid']){ echo '<div class="notice notice-error inline"><p>Mancano colonne obbligatorie: '.esc_html(implode(', ',$det['missing'])).'. Correggi il CSV e ricaricalo.</p></div></div></div>'; return; } echo '</div></div>';
         $summary=is_array($session['summary']??null)?$session['summary']:$svc->summarize($session['path'],$det['columns']); $mappings=is_array($settings['type_mappings']??null)?$settings['type_mappings']:array(); $progress_rows=$svc->get_progress_for_session(absint($session['id']??0));
         echo '<div class="postbox"><h2 class="hndle"><span>Step 3 — Riepilogo Tipologie attività</span></h2><div class="inside"><table class="widefat striped"><thead><tr><th>Tipologia attività CSV</th><th>Record</th><th>Mapping Sothra</th><th>Azione</th></tr></thead><tbody>';
-        foreach($summary['types'] as $type=>$count){ $hash=ALMA_Affiliate_Source_GYG_CSV_Importer::activity_type_hash($type); $progress=is_array($progress_rows[$hash]??null)?$progress_rows[$hash]:array(); $saved_terms=ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($progress['mapped_term_ids_json']??array()); $term_ids=!empty($saved_terms)?$saved_terms:ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($mappings[$type]??array()); $names=array(); foreach($term_ids as $tid){ $term=get_term($tid,'link_type'); if($term&&!is_wp_error($term)) $names[]=$term->name; } $done=absint($progress['imported_count']??0)+absint($progress['updated_count']??0)+absint($progress['existing_count']??0)+absint($progress['skipped_count']??0); $progress_label=$done>0?sprintf('Importati %d · aggiornati %d · già presenti %d · saltati %d · errori %d',absint($progress['imported_count']??0),absint($progress['updated_count']??0),absint($progress['existing_count']??0),absint($progress['skipped_count']??0),absint($progress['error_count']??0)):'Non iniziata'; echo '<tr><td>'.esc_html($type).'</td><td>'.(int)$count.'<br/><span class="description">'.esc_html($progress_label).'</span></td><td class="alma-gyg-mapping-cell" data-activity-type="'.esc_attr($type).'" data-activity-hash="'.esc_attr($hash).'">'.esc_html(!empty($names)?implode(', ',$names):'—').'</td><td><button type="button" class="button alma-gyg-open-import" data-source-id="'.(int)$source_id.'" data-token="'.esc_attr($token).'" data-activity-type="'.esc_attr($type).'" data-activity-hash="'.esc_attr($hash).'" data-total="'.(int)$count.'">Importa questa tipologia</button></td></tr>'; }
+        foreach($summary['types'] as $type=>$count){ $hash=ALMA_Affiliate_Source_GYG_CSV_Importer::activity_type_hash($type); $progress=is_array($progress_rows[$hash]??null)?$progress_rows[$hash]:array(); $saved_terms=ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($progress['mapped_term_ids_json']??array()); $term_ids=!empty($saved_terms)?$saved_terms:ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($mappings[$type]??array()); $names=array(); foreach($term_ids as $tid){ $term=get_term($tid,'link_type'); if($term&&!is_wp_error($term)) $names[]=$term->name; } $done=absint($progress['imported_count']??0)+absint($progress['updated_count']??0)+absint($progress['existing_count']??0)+absint($progress['skipped_count']??0); $progress_label=$done>0?sprintf('Importati %d · aggiornati %d · già presenti %d · saltati %d · errori %d',absint($progress['imported_count']??0),absint($progress['updated_count']??0),absint($progress['existing_count']??0),absint($progress['skipped_count']??0),absint($progress['error_count']??0)):'Non iniziata'; $simple_url=add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-affiliate-sources','alma_view'=>'gyg_csv_simple_import','source_id'=>$source_id,'gyg_csv_token'=>$token,'activity_type_hash'=>$hash),admin_url('edit.php')); echo '<tr><td>'.esc_html($type).'</td><td>'.(int)$count.'<br/><span class="description">'.esc_html($progress_label).'</span></td><td class="alma-gyg-mapping-cell" data-activity-type="'.esc_attr($type).'" data-activity-hash="'.esc_attr($hash).'">'.esc_html(!empty($names)?implode(', ',$names):'—').'</td><td><button type="button" class="button alma-gyg-open-import" data-source-id="'.(int)$source_id.'" data-token="'.esc_attr($token).'" data-activity-type="'.esc_attr($type).'" data-activity-hash="'.esc_attr($hash).'" data-simple-url="'.esc_url($simple_url).'" data-total="'.(int)$count.'">Importa questa tipologia</button> <a class="button" href="'.esc_url($simple_url).'">Apri importazione in modalità semplice</a></td></tr>'; }
         echo '</tbody></table><p class="description">Totale righe: '.(int)$summary['total'].' · URL non validi: '.(int)$summary['invalid_urls'].' · record senza città: '.(int)$summary['without_city'].' · record senza regione: '.(int)$summary['without_region'].'</p></div></div>';
         $this->render_gyg_csv_import_modal($source, $token);
     }
@@ -217,7 +220,7 @@ class ALMA_Affiliate_Source_Manager {
     private function render_gyg_csv_import_modal($source, $token){
         $settings=ALMA_Affiliate_Source_GYG_CSV_Importer::default_settings($this->decode_db_json($source['settings']??'{}'));
         $list_url=add_query_arg(array('post_type'=>'affiliate_link','alma_source_filter'=>(int)$source['id']),admin_url('edit.php'));
-        echo '<div id="alma-gyg-import-modal" class="alma-modal" aria-hidden="true"><div class="alma-modal-backdrop"></div><div class="alma-modal-panel" role="dialog" aria-modal="true" aria-labelledby="alma-gyg-modal-title"><button type="button" class="button-link alma-modal-close" aria-label="Chiudi">×</button><h2 id="alma-gyg-modal-title">Importazione GetYourGuide CSV</h2><div class="alma-gyg-modal-error notice notice-error inline" style="display:none"><p></p></div><div class="alma-gyg-summary"></div><h3>Associa a Tipologie Link Sothra</h3><div class="alma-gyg-terms"><p class="description">Caricamento tipologie…</p></div><p><label><strong>Quantità da importare</strong><br/><input type="number" id="alma-gyg-quantity" min="1" max="1000" value="100"/> <span class="description">Massimo 1000 record per importazione.</span></label></p><fieldset><legend class="screen-reader-text">Modalità deduplica</legend><p><label><input type="radio" name="alma_gyg_update_existing" value="0" checked> Importa solo nuovi record</label><br/><label><input type="radio" name="alma_gyg_update_existing" value="1"> Aggiorna anche record già importati</label></p></fieldset><h3>Anteprima sintetica</h3><div class="alma-gyg-preview"><p class="description">Apri una tipologia per caricare l’anteprima.</p></div><div class="alma-gyg-progress-wrap" style="display:none"><div class="alma-progress"><div class="alma-progress-bar" style="width:0%"></div></div><p class="alma-gyg-progress-status">Preparazione importazione…</p></div><div class="alma-gyg-report" style="display:none"></div><h3>Log errori</h3><div class="alma-gyg-log"><p class="description">Nessun errore o warning.</p></div><p class="submit"><button type="button" class="button button-primary alma-gyg-start-import">Avvia importazione</button> <button type="button" class="button alma-gyg-import-more" style="display:none">Importa altri record di questa tipologia</button> <a class="button" href="'.esc_url($list_url).'">Vai ai Link affiliati gyg_csv</a> <button type="button" class="button alma-modal-close">Chiudi</button></p><input type="hidden" class="alma-gyg-source-id" value="'.(int)$source['id'].'"/><input type="hidden" class="alma-gyg-token" value="'.esc_attr($token).'"/><input type="hidden" class="alma-gyg-partner" value="'.esc_attr($settings['partner_id']??'').'"/><input type="hidden" class="alma-gyg-utm" value="'.esc_attr($settings['utm_medium']??'online_publisher').'"/></div></div>';
+        echo '<div id="alma-gyg-import-modal" class="alma-modal" aria-hidden="true"><div class="alma-modal-backdrop"></div><div class="alma-modal-panel" role="dialog" aria-modal="true" aria-labelledby="alma-gyg-modal-title"><button type="button" class="button-link alma-modal-close" aria-label="Chiudi">×</button><h2 id="alma-gyg-modal-title">Importazione GetYourGuide CSV</h2><div class="alma-gyg-js-version" data-gyg-js-version="2.28.1" style="display:none">GYG CSV modal JS loaded: 2.28.1</div><div class="alma-gyg-modal-error notice notice-error inline" style="display:none"><p></p><p><button type="button" class="button alma-gyg-healthcheck" style="display:none">Test caricamento modale</button> <a class="button alma-gyg-simple-link" href="#" style="display:none">Apri importazione in modalità semplice</a></p></div><div class="alma-gyg-status notice notice-info inline"><p>Modale non ancora aperto.</p></div><div class="alma-gyg-summary"></div><h3>Associa a Tipologie Link Sothra</h3><div class="alma-gyg-terms"><p class="description">Caricamento tipologie…</p></div><p><label><strong>Quantità da importare</strong><br/><input type="number" id="alma-gyg-quantity" min="1" max="1000" value="100"/> <span class="description">Massimo 1000 record per importazione.</span></label></p><fieldset><legend class="screen-reader-text">Modalità deduplica</legend><p><label><input type="radio" name="alma_gyg_update_existing" value="0" checked> Importa solo nuovi record</label><br/><label><input type="radio" name="alma_gyg_update_existing" value="1"> Aggiorna anche record già importati</label></p></fieldset><h3>Anteprima sintetica</h3><div class="alma-gyg-preview"><p class="description">Apri una tipologia per caricare l’anteprima.</p></div><div class="alma-gyg-progress-wrap" style="display:none"><div class="alma-progress"><div class="alma-progress-bar" style="width:0%"></div></div><p class="alma-gyg-progress-status">Preparazione importazione…</p></div><div class="alma-gyg-report" style="display:none"></div><h3>Log errori</h3><div class="alma-gyg-log"><p class="description">Nessun errore o warning.</p></div><p class="submit"><button type="button" class="button button-primary alma-gyg-start-import">Avvia importazione</button> <button type="button" class="button alma-gyg-import-more" style="display:none">Importa altri record di questa tipologia</button> <a class="button" href="'.esc_url($list_url).'">Vai ai Link affiliati gyg_csv</a> <button type="button" class="button alma-modal-close">Chiudi</button></p><input type="hidden" class="alma-gyg-source-id" value="'.(int)$source['id'].'"/><input type="hidden" class="alma-gyg-token" value="'.esc_attr($token).'"/><input type="hidden" class="alma-gyg-partner" value="'.esc_attr($settings['partner_id']??'').'"/><input type="hidden" class="alma-gyg-utm" value="'.esc_attr($settings['utm_medium']??'online_publisher').'"/></div></div>';
     }
 
     private function render_gyg_csv_recent_sessions($source_id, $active_token = ''){
@@ -324,7 +327,7 @@ class ALMA_Affiliate_Source_Manager {
         if(!is_array($data)){ echo '<div class="notice notice-warning"><p>Nessun risultato disponibile.</p></div></div>'; return; }
         $r=$data['result'];
         if(is_wp_error($r)){ $source_id=(int)$data['source_id']; $base=add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-affiliate-sources'),admin_url('edit.php')); echo '<div class="notice notice-error"><p>'.esc_html($r->get_error_message()).'</p></div>'; echo '<p><a class="button" href="'.esc_url(add_query_arg(array('edit_source'=>$source_id),$base)).'">Torna alla Source</a> <a class="button button-primary" href="'.esc_url(add_query_arg(array('alma_view'=>'import_contents','source_id'=>$source_id,'load_preview'=>'1'),$base)).'">Nuova anteprima import</a> <a class="button" href="'.esc_url($base).'">Torna alla lista Sources</a></p></div>'; return; } $source_id=(int)$data['source_id']; $base=add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-affiliate-sources'),admin_url('edit.php'));
-        if(isset($r['imported']) || isset($r['already_present']) || isset($r['invalid_urls'])){ echo '<ul><li>Selezionati: '.intval($data['selected']).'</li><li>Importati: '.intval($r['imported']??0).'</li><li>Aggiornati: '.intval($r['updated']??0).'</li><li>Già presenti: '.intval($r['already_present']??0).'</li><li>Saltati: '.intval($r['skipped']??0).'</li><li>Errori: '.intval($r['errors']??0).'</li><li>URL non validi: '.intval($r['invalid_urls']??0).'</li><li>Record senza città: '.intval($r['without_city']??0).'</li><li>Record senza regione: '.intval($r['without_region']??0).'</li><li>Durata batch: '.esc_html((string)($r['duration']??0)).'s</li></ul>'; } else { echo '<ul><li>Selezionati: '.intval($data['selected']).'</li><li>Creati: '.intval($r['created']??0).'</li><li>Aggiornati: '.intval($r['updated']??0).'</li><li>Saltati: '.intval($r['skipped']??0).'</li><li>Errori: '.intval($r['errors']??0).'</li><li>Immagini importate: '.intval($r['image_imported']??0).'</li><li>Immagini riutilizzate: '.intval($r['image_reused']??0).'</li><li>Immagini non importate: '.intval($r['image_skipped']??0).'</li><li>Warning immagini: '.intval($r['image_failed']??0).'</li></ul>'; }
+        if(isset($r['imported']) || isset($r['already_present']) || isset($r['invalid_urls'])){ echo '<ul><li>Selezionati: '.intval($data['selected']).'</li><li>Importati: '.intval($r['imported']??0).'</li><li>Aggiornati: '.intval($r['updated']??0).'</li><li>Già presenti: '.intval($r['already_present']??($r['existing']??0)).'</li><li>Saltati: '.intval($r['skipped']??0).'</li><li>Errori: '.intval($r['errors']??0).'</li><li>URL non validi: '.intval($r['invalid_urls']??0).'</li><li>Record senza città: '.intval($r['without_city']??0).'</li><li>Record senza regione: '.intval($r['without_region']??0).'</li><li>Durata batch: '.esc_html((string)($r['duration']??0)).'s</li></ul>'; } else { echo '<ul><li>Selezionati: '.intval($data['selected']).'</li><li>Creati: '.intval($r['created']??0).'</li><li>Aggiornati: '.intval($r['updated']??0).'</li><li>Saltati: '.intval($r['skipped']??0).'</li><li>Errori: '.intval($r['errors']??0).'</li><li>Immagini importate: '.intval($r['image_imported']??0).'</li><li>Immagini riutilizzate: '.intval($r['image_reused']??0).'</li><li>Immagini non importate: '.intval($r['image_skipped']??0).'</li><li>Warning immagini: '.intval($r['image_failed']??0).'</li></ul>'; }
         echo '<p><a class="button button-primary" href="'.esc_url(add_query_arg(array('alma_view'=>'import_contents','source_id'=>$source_id,'load_preview'=>'1'),$base)).'">Nuova anteprima import</a> <a class="button" href="'.esc_url(add_query_arg('source_id',$source_id,$base)).'">Torna alla lista Sources</a></p></div>';
     }
 
@@ -470,6 +473,85 @@ class ALMA_Affiliate_Source_Manager {
 
     private function sources_table_exists(){ global $wpdb; $t=$wpdb->prefix.'alma_affiliate_sources'; return $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s',$t))===$t; }
 
+
+    private function get_gyg_csv_simple_context_from_request($method = 'GET') {
+        if (!current_user_can('manage_options')) return new WP_Error('forbidden', __('Permessi insufficienti.', 'affiliate-link-manager-ai'));
+        $input = strtoupper($method) === 'POST' ? $_POST : $_GET;
+        global $wpdb;
+        $source_id = absint($input['source_id'] ?? 0);
+        $token = sanitize_key($input['gyg_csv_token'] ?? ($input['token'] ?? ''));
+        $activity_hash = sanitize_text_field(wp_unslash($input['activity_type_hash'] ?? ''));
+        $source = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}alma_affiliate_sources WHERE id=%d", $source_id), ARRAY_A);
+        if (!is_array($source) || sanitize_key($source['provider_preset'] ?? '') !== 'gyg_csv') return new WP_Error('invalid_source', __('Source gyg_csv non valida.', 'affiliate-link-manager-ai'));
+        $svc = new ALMA_Affiliate_Source_GYG_CSV_Importer();
+        $session = $svc->get_session($token, $source_id);
+        if (is_wp_error($session)) return $session;
+        if (empty($session['path']) || !file_exists($session['path'])) return new WP_Error('csv_file_missing', __('File CSV persistente non trovato. Elimina la sessione e ricarica il CSV.', 'affiliate-link-manager-ai'));
+        $headers = $svc->get_headers($session['path']);
+        if (is_wp_error($headers)) return $headers;
+        $det = is_array($session['columns'] ?? null) ? $session['columns'] : $svc->detect_columns($headers);
+        if (empty($det['valid'])) return new WP_Error('missing_columns', __('Colonne obbligatorie mancanti nel CSV.', 'affiliate-link-manager-ai'));
+        $summary = is_array($session['summary'] ?? null) ? $session['summary'] : $svc->summarize($session['path'], $det['columns']);
+        $activity_type = '';
+        foreach ((array)($summary['types'] ?? array()) as $type => $count) {
+            if (hash_equals(ALMA_Affiliate_Source_GYG_CSV_Importer::activity_type_hash($type), $activity_hash)) { $activity_type = (string)$type; break; }
+        }
+        if ($activity_type === '') return new WP_Error('invalid_activity_type', __('Tipologia attività CSV non valida o non presente nella sessione.', 'affiliate-link-manager-ai'));
+        return array('source_id'=>$source_id,'token'=>$token,'activity_type'=>$activity_type,'activity_type_hash'=>$activity_hash,'source'=>$source,'svc'=>$svc,'session'=>$session,'columns'=>$det['columns'],'summary'=>$summary);
+    }
+
+    private function render_gyg_csv_simple_import_page() {
+        $ctx = $this->get_gyg_csv_simple_context_from_request('GET');
+        echo '<div class="wrap"><h1>Importazione gyg_csv in modalità semplice</h1>';
+        $back = add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-affiliate-sources','alma_view'=>'import_contents','source_id'=>absint($_GET['source_id'] ?? 0),'gyg_csv_token'=>sanitize_key($_GET['gyg_csv_token'] ?? '')), admin_url('edit.php'));
+        echo '<p><a class="button" href="'.esc_url($back).'">Torna allo Step 3</a></p>';
+        if (is_wp_error($ctx)) { echo '<div class="notice notice-error"><p>'.esc_html($ctx->get_error_message()).'</p></div></div>'; return; }
+        $taxonomy = $this->get_gyg_link_type_taxonomy();
+        $terms = taxonomy_exists($taxonomy) ? get_terms(array('taxonomy'=>$taxonomy,'hide_empty'=>false)) : array();
+        if (is_wp_error($terms) || !is_array($terms)) $terms = array();
+        $counts = $ctx['svc']->count_existing_for_type($ctx['session']['path'], $ctx['columns'], $ctx['activity_type'], $ctx['source']);
+        $progress = $ctx['svc']->get_progress(absint($ctx['session']['id'] ?? 0), $ctx['source_id'], $ctx['activity_type']);
+        $mapped = ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($progress['mapped_term_ids_json'] ?? array());
+        echo '<div class="postbox"><h2 class="hndle"><span>Riepilogo</span></h2><div class="inside"><ul><li><strong>Source:</strong> '.esc_html($ctx['source']['name'] ?? '').' (#'.(int)$ctx['source_id'].')</li><li><strong>Sessione:</strong> '.esc_html($ctx['session']['name'] ?? 'CSV').'</li><li><strong>Tipologia attività CSV:</strong> '.esc_html($ctx['activity_type']).'</li><li><strong>Record totali:</strong> '.intval($counts['total'] ?? 0).'</li><li><strong>Record già presenti:</strong> '.intval($counts['existing'] ?? 0).'</li><li><strong>Record ancora da importare:</strong> '.intval($counts['remaining'] ?? 0).'</li><li><strong>Tassonomia:</strong> link_type</li></ul></div></div>';
+        if (empty($terms)) { echo '<div class="notice notice-warning"><p>Nessuna Tipologia Link Sothra disponibile nella tassonomia link_type. Crea almeno una Tipologia Link prima di importare.</p></div></div>'; return; }
+        echo '<form method="post" class="postbox"><h2 class="hndle"><span>Avvia importazione semplice</span></h2><div class="inside">';
+        wp_nonce_field('alma_gyg_csv_simple_import', 'alma_gyg_csv_simple_nonce');
+        echo '<input type="hidden" name="action_type" value="gyg_csv_simple_import"/><input type="hidden" name="source_id" value="'.(int)$ctx['source_id'].'"/><input type="hidden" name="gyg_csv_token" value="'.esc_attr($ctx['token']).'"/><input type="hidden" name="activity_type_hash" value="'.esc_attr($ctx['activity_type_hash']).'"/>';
+        echo '<fieldset><legend><strong>Tipologie Link Sothra</strong></legend>';
+        foreach ($terms as $term) { $checked = in_array((int)$term->term_id, $mapped, true); echo '<label style="display:block;margin:.25em 0"><input type="checkbox" name="link_type_term_ids[]" value="'.(int)$term->term_id.'" '.checked($checked,true,false).'/> '.esc_html($term->name).'</label>'; }
+        echo '</fieldset><p><label><strong>Quantità</strong><br/><input type="number" name="quantity" min="1" max="1000" value="100"/> <span class="description">Massimo 1000.</span></label></p><p><label><input type="radio" name="update_existing" value="0" checked/> Importa solo nuovi record</label><br/><label><input type="radio" name="update_existing" value="1"/> Aggiorna anche record già importati</label></p><p><button class="button button-primary">Avvia importazione</button></p></div></form></div>';
+    }
+
+    private function handle_gyg_csv_simple_import() {
+        if (!current_user_can('manage_options')) wp_die('Unauthorized');
+        if (!wp_verify_nonce($_POST['alma_gyg_csv_simple_nonce'] ?? '', 'alma_gyg_csv_simple_import')) wp_die('Nonce non valido');
+        $ctx = $this->get_gyg_csv_simple_context_from_request('POST');
+        if (is_wp_error($ctx)) { set_transient('alma_import_result_'.get_current_user_id(), array('source_id'=>absint($_POST['source_id'] ?? 0),'selected'=>0,'result'=>$ctx), 5*MINUTE_IN_SECONDS); wp_safe_redirect(add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-affiliate-sources','alma_view'=>'import_result','source_id'=>absint($_POST['source_id'] ?? 0)), admin_url('edit.php'))); exit; }
+        $taxonomy = $this->get_gyg_link_type_taxonomy();
+        $term_ids = ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($_POST['link_type_term_ids'] ?? array());
+        foreach ($term_ids as $tid) { $term = get_term($tid, $taxonomy); if (!$term || is_wp_error($term)) { $term_ids = array(); break; } }
+        if (empty($term_ids)) { $result = new WP_Error('missing_terms', __('Seleziona almeno una Tipologia Link Sothra valida.', 'affiliate-link-manager-ai')); }
+        else {
+            $quantity = max(1, min(ALMA_Affiliate_Source_GYG_CSV_Importer::MAX_IMPORT_QUANTITY, absint($_POST['quantity'] ?? 100)));
+            $update_existing = !empty($_POST['update_existing']);
+            $aggregate = array('processed'=>0,'imported'=>0,'updated'=>0,'existing'=>0,'skipped'=>0,'errors'=>0,'invalid_urls'=>0,'without_city'=>0,'without_region'=>0,'duration'=>0,'logs'=>array(),'next_cursor'=>0,'done'=>false);
+            $cursor = 0;
+            do {
+                $batch = $ctx['svc']->import_batch($ctx['session']['path'], $ctx['columns'], $ctx['activity_type'], $ctx['source'], $term_ids, $quantity, $cursor, $update_existing);
+                if (is_wp_error($batch)) { $result = $batch; break; }
+                foreach (array('processed','imported','updated','existing','skipped','errors','invalid_urls','without_city','without_region') as $k) $aggregate[$k] += absint($batch[$k] ?? 0);
+                $aggregate['duration'] += (float)($batch['duration'] ?? 0);
+                $aggregate['logs'] = array_merge($aggregate['logs'], (array)($batch['logs'] ?? array()));
+                $cursor = absint($batch['next_cursor'] ?? $cursor);
+                $aggregate['next_cursor'] = $cursor; $aggregate['done'] = !empty($batch['done']);
+                $ctx['svc']->upsert_progress(absint($ctx['session']['id'] ?? 0), $ctx['source_id'], $ctx['activity_type'], $term_ids, $batch);
+            } while (empty($aggregate['done']) && $cursor < $quantity);
+            if (!isset($result)) $result = $aggregate;
+        }
+        set_transient('alma_import_result_'.get_current_user_id(), array('source_id'=>$ctx['source_id'],'selected'=>absint($_POST['quantity'] ?? 100),'result'=>$result), 5*MINUTE_IN_SECONDS);
+        wp_safe_redirect(add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-affiliate-sources','alma_view'=>'import_result','source_id'=>$ctx['source_id']), admin_url('edit.php'))); exit;
+    }
+
     private function get_gyg_link_type_taxonomy() { return 'link_type'; }
 
     private function send_gyg_ajax_context_error($error) {
@@ -491,6 +573,41 @@ class ALMA_Affiliate_Source_Manager {
         $det=is_array($session['columns']??null)?$session['columns']:$svc->detect_columns($headers); if(empty($det['valid'])) return new WP_Error('missing_columns',__('Colonne obbligatorie mancanti nel CSV.', 'affiliate-link-manager-ai'));
         if($activity_hash!=='' && !hash_equals(ALMA_Affiliate_Source_GYG_CSV_Importer::activity_type_hash($type), $activity_hash)) return new WP_Error('invalid_activity_hash',__('Tipologia attività CSV non valida. Ricarica la pagina e riprova.', 'affiliate-link-manager-ai'));
         return array('source_id'=>$source_id,'token'=>$token,'activity_type'=>$type,'activity_type_hash'=>ALMA_Affiliate_Source_GYG_CSV_Importer::activity_type_hash($type),'source'=>$source,'svc'=>$svc,'session'=>$session,'columns'=>$det['columns']);
+    }
+
+
+    public function ajax_gyg_csv_modal_healthcheck(){
+        $payload = array('plugin_version'=>defined('ALMA_VERSION') ? ALMA_VERSION : '', 'taxonomy'=>'link_type', 'checks'=>array());
+        $fail = function($code, $message, $status = 200) use (&$payload) { $payload['code']=$code; $payload['message']=$message; wp_send_json_error($payload, $status); };
+        if (!check_ajax_referer('alma_gyg_csv_import_nonce', 'nonce', false)) $fail('invalid_nonce', __('Nonce non valido o scaduto.', 'affiliate-link-manager-ai'));
+        if (!current_user_can('manage_options')) $fail('forbidden', __('Permessi insufficienti.', 'affiliate-link-manager-ai'));
+        global $wpdb;
+        $source_id = absint($_POST['source_id'] ?? 0);
+        $token = sanitize_key($_POST['token'] ?? '');
+        $payload['source_id'] = $source_id;
+        $payload['token_present'] = $token !== '';
+        $source = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}alma_affiliate_sources WHERE id=%d", $source_id), ARRAY_A);
+        $payload['checks']['source'] = is_array($source) && sanitize_key($source['provider_preset'] ?? '') === 'gyg_csv';
+        if (!$payload['checks']['source']) $fail('invalid_source', __('Source gyg_csv non valida.', 'affiliate-link-manager-ai'));
+        $svc = new ALMA_Affiliate_Source_GYG_CSV_Importer();
+        $session = $svc->get_session($token, $source_id);
+        $payload['checks']['session_token'] = !is_wp_error($session);
+        if (is_wp_error($session)) $fail($session->get_error_code(), $session->get_error_message());
+        $payload['session_id'] = absint($session['id'] ?? 0);
+        $payload['session_file_exists'] = !empty($session['path']) && file_exists($session['path']);
+        if (!$payload['session_file_exists']) $fail('csv_file_missing', __('File CSV persistente non trovato.', 'affiliate-link-manager-ai'));
+        $taxonomy = $this->get_gyg_link_type_taxonomy();
+        $payload['taxonomy_exists'] = taxonomy_exists($taxonomy);
+        $payload['link_type_terms_count'] = 0;
+        if ($payload['taxonomy_exists']) {
+            $terms = get_terms(array('taxonomy'=>$taxonomy,'hide_empty'=>false,'fields'=>'ids'));
+            $payload['link_type_terms_count'] = is_wp_error($terms) ? 0 : count((array)$terms);
+        }
+        $payload['prepare_action_registered'] = has_action('wp_ajax_alma_gyg_csv_prepare_import') ? true : false;
+        $payload['import_action_registered'] = has_action('wp_ajax_alma_gyg_csv_import_batch') ? true : false;
+        $payload['healthcheck_action_registered'] = has_action('wp_ajax_alma_gyg_csv_modal_healthcheck') ? true : false;
+        $payload['message'] = __('Health check modale gyg_csv completato.', 'affiliate-link-manager-ai');
+        wp_send_json_success($payload);
     }
 
     public function ajax_gyg_csv_prepare_import(){


### PR DESCRIPTION
### Motivation
- The GetYourGuide CSV import modal could remain in an indefinite loading state when the AJAX prepare call failed or returned invalid payloads, leaving users unable to select `link_type` terms.
- Add machine-readable and DOM-visible diagnostics so administrators can verify they are running the updated JS and quickly triage missing client/server data or nonce/capability problems.
- Provide a server-side fallback import path so imports remain operational even when the AJAX/modal flow fails, and ensure safe cache-busting of the admin JS via the plugin version.

### Description
- Hardened the admin JS `assets/affiliate-sources.js` with: visible diagnostic version (`GYG CSV modal JS loaded: 2.28.1`), client-side validation before AJAX, progressive modal states, a 20s AJAX timeout, exhaustive handling for `0`, `-1`, HTTP 400/403/5xx, non-JSON responses and JS render exceptions, safe truncated diagnostics in the modal and limited `console.error` payloads. (modified: `assets/affiliate-sources.js`)
- Improved enqueue/localize: bumped plugin version to `2.28.1` and pass `gygJsVersion` via `wp_localize_script` so the JS can show the loaded version and ALMA_VERSION is used for cache busting. (modified: `affiliate-link-manager-ai.php`)
- Added server-side modal health check AJAX action `alma_gyg_csv_modal_healthcheck` that validates nonce/capability/source/session/file/taxonomy and returns a safe JSON report, and wired a modal button to call it. (modified: `includes/class-affiliate-source-manager.php`, `assets/affiliate-sources.js`)
- Implemented a server-rendered fallback import page and handler (`gyg_csv_simple_import`) that uses the existing importer/progress logic, supports selecting `link_type` terms, quantity up to 1000, choice to update existing or import only new, nonce/capability checks and a final report; added links in Step 3 to open the simple import. (modified: `includes/class-affiliate-source-manager.php`)

### Testing
- Ran PHP syntax checks: `php -l affiliate-link-manager-ai.php`, `php -l includes/class-affiliate-source-manager.php`, `php -l includes/class-affiliate-source-gyg-csv-importer.php` — all passed.
- Ran JS syntax check: `node --check assets/affiliate-sources.js` — passed.
- Verified presence of AJAX actions and enqueue/localize keys via code search for `alma_gyg_csv_prepare_import`, `alma_gyg_csv_import_batch`, `alma_gyg_csv_modal_healthcheck`, `wp_enqueue_script('alma-affiliate-sources')` and `gygJsVersion` — confirmed.
- Ran `git diff --check` and basic repository checks — no whitespace or syntax issues detected.
- Result: automated checks succeeded; manual test instructions are in the plugin UI steps (open source, resume session, open modal, check DOM console message, exercise healthcheck and simple-mode import).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fddfeaa2108332a56b4c45c0620739)