### PR TITLE
Add AI Trend Radar module (WP‑Cron scheduler + OpenAI Responses integration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2.30.0 — AI Trend Radar
+- Aggiunto il modulo **AI Trend Radar** in **Affiliate Link Manager AI → Trend Radar** per eseguire ricerche web programmate con OpenAI e proporre trend editoriali travel/turismo per Sothra.
+- La sezione admin mostra report generati, card/azioni rapide, profili di ricerca, impostazioni pianificazione, log esecuzioni e avviso sul funzionamento di WP-Cron.
+- I profili permettono di configurare lingua, mercato target, tema, focus editoriale, query seed, fonti preferite/escluse, frequenza/orario, numero massimo trend, profondità, obiettivo editoriale e riepilogo email.
+- Lo scheduler usa WP-Cron con un evento per ogni profilo attivo, pulsante manuale “Esegui ricerca ora”, nonce/capability check e lock temporaneo anti doppia esecuzione. Per esecuzioni puntuali è consigliato un cron server reale che richiami `wp-cron.php`.
+- Il modulo riusa la configurazione OpenAI esistente, invia richieste Responses API con web search quando disponibile, richiede JSON strutturato, valida l’output e registra errori/log senza API key o dati sensibili.
+- Ogni report salva titolo trend, sintesi, perché ora, destinazioni, stagionalità, audience, punteggi normalizzati 1-10, titoli consigliati, keyword, outline, fonti, note fonte, link affiliati suggeriti, stato e data creazione.
+- Dopo la generazione viene eseguito un matching locale limitato sui Link Affiliati esistenti; all’AI viene passato solo un contesto compatto di candidati, mai l’intero database.
+- Bridge leggero con AI Content Agent: da un trend si può creare un’idea contenuto precompilata; se disponibile, è possibile anche creare una bozza articolo con sintesi, fonti, keyword, outline e link affiliati suggeriti.
+- Se OpenAI non è configurata, la UI mostra un avviso chiaro e disabilita l’esecuzione manuale; se web search/Responses API non è disponibile, l’errore viene salvato nei log e i profili restano gestibili.
+- Costi e limiti API: ogni esecuzione può consumare token e ricerche web OpenAI in base a modello, profondità, numero massimo trend e fonti analizzate; usare frequenze conservative e monitorare il billing OpenAI.
+- Versione plugin aggiornata a `2.30.0`.
+
 ## 2.29.0 — GetYourGuide CSV import server-rendered
 - Sostituito il flusso operativo `gyg_csv` basato su modale AJAX con la vista admin server-rendered `alma_view=gyg_csv_import_type`: lo Step 3 ora usa un link normale “Importa / continua” e non richiede JavaScript per caricare mapping, anteprima o import.
 - Aggiunta pagina PHP con validazione capability/source/preset/token/file/hash, riepilogo sessione persistente, dettagli tipologia CSV, checklist multipla delle Tipologie Link Sothra da `link_type`, quantità clampata a massimo 1000 e modalità deduplica.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+## 2.30.0 — AI Trend Radar
+- Aggiunto il modulo **AI Trend Radar** in **Affiliate Link Manager AI → Trend Radar** per eseguire ricerche web programmate con OpenAI e proporre trend editoriali travel/turismo per Sothra.
+- La sezione admin mostra report generati, card/azioni rapide, profili di ricerca, impostazioni pianificazione, log esecuzioni e avviso sul funzionamento di WP-Cron.
+- I profili permettono di configurare lingua, mercato target, tema, focus editoriale, query seed, fonti preferite/escluse, frequenza/orario, numero massimo trend, profondità, obiettivo editoriale e riepilogo email.
+- Lo scheduler usa WP-Cron con un evento per ogni profilo attivo, pulsante manuale “Esegui ricerca ora”, nonce/capability check e lock temporaneo anti doppia esecuzione. Per esecuzioni puntuali è consigliato un cron server reale che richiami `wp-cron.php`.
+- Il modulo riusa la configurazione OpenAI esistente, invia richieste Responses API con web search quando disponibile, richiede JSON strutturato, valida l’output e registra errori/log senza API key o dati sensibili.
+- Ogni report salva titolo trend, sintesi, perché ora, destinazioni, stagionalità, audience, punteggi normalizzati 1-10, titoli consigliati, keyword, outline, fonti, note fonte, link affiliati suggeriti, stato e data creazione.
+- Dopo la generazione viene eseguito un matching locale limitato sui Link Affiliati esistenti; all’AI viene passato solo un contesto compatto di candidati, mai l’intero database.
+- Bridge leggero con AI Content Agent: da un trend si può creare un’idea contenuto precompilata; se disponibile, è possibile anche creare una bozza articolo con sintesi, fonti, keyword, outline e link affiliati suggeriti.
+- Se OpenAI non è configurata, la UI mostra un avviso chiaro e disabilita l’esecuzione manuale; se web search/Responses API non è disponibile, l’errore viene salvato nei log e i profili restano gestibili.
+- Costi e limiti API: ogni esecuzione può consumare token e ricerche web OpenAI in base a modello, profondità, numero massimo trend e fonti analizzate; usare frequenze conservative e monitorare il billing OpenAI.
+- Versione plugin aggiornata a `2.30.0`.
+
 ## 2.29.0 — GetYourGuide CSV senza modale AJAX
 - Il flusso principale `gyg_csv` non usa più il modale AJAX: nello Step 3 il link **Importa / continua** apre la pagina admin normale `alma_view=gyg_csv_import_type`, renderizzata lato PHP.
 - L’import avviene con form POST WordPress, nonce, capability check e PRG redirect: ricaricare la pagina dopo il report non ripete il POST.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.29.0
+ * Version: 2.30.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.29.0');
+define('ALMA_VERSION', '2.30.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -51,6 +51,9 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-draft-quality-ch
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-draft-builder.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-result-usage.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-instructions-manager.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-ai-trend-radar-store.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-ai-trend-radar-service.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-ai-trend-radar-admin.php';
 
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-interface.php';
 require_once ALMA_PLUGIN_DIR . 'includes/providers/class-affiliate-source-provider-manual.php';
@@ -1293,6 +1296,16 @@ class AffiliateManagerAI {
             self::AI_CONTENT_AGENT_CAPABILITY,
             self::AI_CONTENT_AGENT_MENU_SLUG,
             array('ALMA_AI_Content_Agent_Admin', 'render_page')
+        );
+
+        // AI Trend Radar
+        add_submenu_page(
+            self::AFFILIATE_LINK_PARENT_MENU,
+            __('Trend Radar', 'affiliate-link-manager-ai'),
+            __('Trend Radar', 'affiliate-link-manager-ai'),
+            'manage_options',
+            ALMA_AI_Trend_Radar_Admin::SLUG,
+            array('ALMA_AI_Trend_Radar_Admin', 'render_page')
         );
 
         // Affiliate Chat AI
@@ -3678,6 +3691,7 @@ class AffiliateManagerAI {
      */
     public function activate() {
         ALMA_AI_Content_Agent_Store::install();
+        ALMA_AI_Trend_Radar_Store::install();
         $this->create_analytics_table();
         ALMA_AI_Usage_Logger::create_table();
         ALMA_Affiliate_Source_Manager::create_tables();
@@ -3690,6 +3704,9 @@ class AffiliateManagerAI {
     public function deactivate() {
         // Rimuovi cron jobs
         wp_clear_scheduled_hook('alma_daily_optimization');
+        foreach (ALMA_AI_Trend_Radar_Store::get_profiles() as $profile) {
+            ALMA_AI_Trend_Radar_Service::clear_profile_schedule((int)$profile['id']);
+        }
         flush_rewrite_rules();
     }
 
@@ -3697,6 +3714,7 @@ class AffiliateManagerAI {
         $installed_version = get_option('alma_plugin_version', '0.0.0');
         if (version_compare($installed_version, ALMA_VERSION, '<')) {
             ALMA_AI_Content_Agent_Store::install();
+            ALMA_AI_Trend_Radar_Store::install();
             $this->create_analytics_table();
             ALMA_AI_Usage_Logger::create_table();
             ALMA_Affiliate_Source_Manager::create_tables();

--- a/includes/class-ai-trend-radar-admin.php
+++ b/includes/class-ai-trend-radar-admin.php
@@ -1,0 +1,135 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_AI_Trend_Radar_Admin {
+    const SLUG = 'alma-ai-trend-radar';
+    const CAP = 'manage_options';
+
+    public static function init() {
+        add_action('admin_post_alma_trend_radar_action', array(__CLASS__, 'handle_action'));
+    }
+
+    public static function render_page() {
+        if (!current_user_can(self::CAP)) { wp_die(esc_html__('Permessi insufficienti.', 'affiliate-link-manager-ai')); }
+        $tab = sanitize_key($_GET['tab'] ?? 'reports');
+        $notice = get_transient('alma_trend_radar_notice_' . get_current_user_id()); delete_transient('alma_trend_radar_notice_' . get_current_user_id());
+        echo '<div class="wrap alma-trend-radar"><h1>AI Trend Radar</h1>';
+        if ($notice) { printf('<div class="notice notice-%s is-dismissible"><p>%s</p></div>', esc_attr($notice['type']), esc_html($notice['message'])); }
+        echo '<div class="notice notice-info"><p><strong>Nota WP-Cron:</strong> le esecuzioni programmate dipendono dal traffico del sito. Per orari puntuali configura un cron server reale che richiami wp-cron.php.</p></div>';
+        if (!ALMA_AI_Trend_Radar_Service::is_openai_ready()) { echo '<div class="notice notice-warning"><p>OpenAI non è configurata: “Esegui ricerca ora” è disabilitato finché non viene salvata una API key nelle impostazioni del plugin.</p></div>'; }
+        self::nav($tab);
+        if ($tab === 'profiles') { self::render_profiles(); }
+        elseif ($tab === 'settings') { self::render_settings(); }
+        elseif ($tab === 'logs') { self::render_logs(); }
+        else { self::render_reports(); }
+        echo '</div>';
+    }
+
+    private static function nav($tab) {
+        $base = admin_url('edit.php?post_type=affiliate_link&page=' . self::SLUG);
+        $tabs = array('reports'=>'Report trend','profiles'=>'Profili ricerca','settings'=>'Pianificazione','logs'=>'Log');
+        echo '<nav class="nav-tab-wrapper">'; foreach($tabs as $k=>$label){ printf('<a class="nav-tab %s" href="%s">%s</a>', $tab===$k?'nav-tab-active':'', esc_url($base.'&tab='.$k), esc_html($label)); } echo '</nav>';
+    }
+
+    private static function action_url($args=array()) { return wp_nonce_url(add_query_arg(array_merge(array('action'=>'alma_trend_radar_action'), $args), admin_url('admin-post.php')), 'alma_trend_radar_action'); }
+
+    private static function render_reports() {
+        $profiles = ALMA_AI_Trend_Radar_Store::get_profiles(); $first = !empty($profiles) ? (int)$profiles[0]['id'] : 0;
+        $total_reports = ALMA_AI_Trend_Radar_Store::count_reports();
+        $new_reports = ALMA_AI_Trend_Radar_Store::count_reports(array('status'=>'new'));
+        $interesting_reports = ALMA_AI_Trend_Radar_Store::count_reports(array('status'=>'interesting'));
+        echo '<div style="display:flex;gap:12px;margin:16px 0;flex-wrap:wrap;">';
+        foreach (array('Report totali'=>$total_reports, 'Da valutare'=>$new_reports, 'Interessanti'=>$interesting_reports) as $label=>$value) {
+            echo '<div class="card" style="max-width:220px;margin:0;"><h3 style="margin-top:0">'.esc_html($label).'</h3><p style="font-size:28px;margin:0"><strong>'.(int)$value.'</strong></p></div>';
+        }
+        echo '</div>';
+        echo '<div style="margin:16px 0;display:flex;gap:12px;align-items:center;">';
+        if (ALMA_AI_Trend_Radar_Service::is_openai_ready() && $first) { echo '<a class="button button-primary button-hero" href="'.esc_url(self::action_url(array('do'=>'run','profile_id'=>$first))).'">Esegui ricerca ora</a>'; }
+        else { echo '<button class="button button-primary button-hero" disabled>Esegui ricerca ora</button>'; }
+        echo '<a class="button" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page='.self::SLUG.'&tab=profiles')).'">Gestisci profili</a></div>';
+        $current_status = sanitize_key($_GET['status'] ?? '');
+        echo '<form method="get" style="margin:12px 0"><input type="hidden" name="post_type" value="affiliate_link"><input type="hidden" name="page" value="'.esc_attr(self::SLUG).'"><label>Filtro stato: <select name="status"><option value="">Tutti</option>';
+        foreach (array('new'=>'Nuovi','interesting'=>'Interessanti','idea_created'=>'Idea creata','draft_created'=>'Bozza creata','discarded'=>'Scartati') as $key=>$label) { echo '<option value="'.esc_attr($key).'" '.selected($current_status,$key,false).'>'.esc_html($label).'</option>'; }
+        echo '</select></label> <button class="button">Filtra</button></form>';
+        $page = max(1, absint($_GET['paged'] ?? 1));
+        $per_page = 20;
+        $reports = ALMA_AI_Trend_Radar_Store::get_reports(array('page'=>$page, 'per_page'=>$per_page, 'status'=>$current_status));
+        echo '<div class="postbox"><div class="inside"><h2>Report trend generati</h2><table class="widefat striped"><thead><tr><th>Trend</th><th>Priorità</th><th>SEO</th><th>Affiliate</th><th>Stato</th><th>Creato</th><th>Azioni rapide</th></tr></thead><tbody>';
+        if (!$reports) { echo '<tr><td colspan="7">Nessun report generato.</td></tr>'; }
+        foreach ($reports as $r) {
+            $priority = self::priority($r); $badge = $priority === 'alta' ? '#d63638' : ($priority === 'media' ? '#dba617' : '#00a32a');
+            echo '<tr><td><strong>'.esc_html($r['trend_title']).'</strong><p>'.esc_html(wp_trim_words($r['trend_summary'], 22)).'</p></td><td><span style="display:inline-block;padding:3px 8px;border-radius:10px;background:'.esc_attr($badge).';color:#fff;">'.esc_html($priority).'</span></td><td>'.(int)$r['seo_potential_score'].'/10</td><td>'.(int)$r['affiliate_potential_score'].'/10</td><td>'.esc_html($r['status']).'</td><td>'.esc_html($r['created_at']).'</td><td>';
+            echo '<a class="button button-small" href="'.esc_url(self::action_url(array('do'=>'idea','report_id'=>(int)$r['id']))).'">Crea idea contenuto</a> ';
+            if (class_exists('ALMA_AI_Content_Agent_Ideas')) { echo '<a class="button button-small" href="'.esc_url(self::action_url(array('do'=>'draft','report_id'=>(int)$r['id']))).'">Crea bozza articolo</a> '; }
+            echo '<a class="button button-small" href="'.esc_url(self::action_url(array('do'=>'interesting','report_id'=>(int)$r['id']))).'">Interessante</a> ';
+            echo '<a class="button button-small" href="'.esc_url(self::action_url(array('do'=>'discard','report_id'=>(int)$r['id']))).'">Scarta</a>';
+            echo '</td></tr><tr><td colspan="7"><details><summary>Dettagli, fonti e link affiliati suggeriti</summary>'.self::report_details($r).'</details></td></tr>';
+        }
+        echo '</tbody></table>';
+        $total = ALMA_AI_Trend_Radar_Store::count_reports(array('status'=>$current_status));
+        $pages = max(1, (int)ceil($total / $per_page));
+        if ($pages > 1) {
+            echo '<p class="tablenav-pages">';
+            for ($i=1; $i<=$pages; $i++) {
+                $url = admin_url('edit.php?post_type=affiliate_link&page=' . self::SLUG . '&paged=' . $i . ($current_status ? '&status=' . rawurlencode($current_status) : ''));
+                echo $i === $page ? ' <span class="button disabled">'.(int)$i.'</span> ' : ' <a class="button" href="'.esc_url($url).'">'.(int)$i.'</a> ';
+            }
+            echo '</p>';
+        }
+        echo '</div></div>';
+    }
+
+    private static function report_details($r) {
+        $fields = array('why_now'=>'Perché ora','destinations'=>'Destinazioni','seasonality'=>'Stagionalità','target_audience'=>'Audience','recommended_article_titles'=>'Titoli','suggested_keywords'=>'Keyword','suggested_outline'=>'Outline','source_urls'=>'Fonti','source_notes'=>'Note fonti','suggested_internal_affiliate_links'=>'Link affiliati suggeriti');
+        $html = '<dl>'; foreach($fields as $k=>$label){ $v=$r[$k]??''; $decoded=json_decode((string)$v,true); if(json_last_error()===JSON_ERROR_NONE){$v=wp_json_encode($decoded, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);} $html.='<dt><strong>'.esc_html($label).'</strong></dt><dd><pre style="white-space:pre-wrap">'.esc_html((string)$v).'</pre></dd>'; } return $html.'</dl>';
+    }
+
+    private static function priority($r) { $avg=((int)$r['seo_potential_score']+(int)$r['affiliate_potential_score']+(int)$r['urgency_score'])/3; return $avg>=8?'alta':($avg>=5?'media':'bassa'); }
+
+    private static function render_profiles() {
+        $edit_id=absint($_GET['profile_id']??0); $profile=$edit_id?ALMA_AI_Trend_Radar_Store::get_profile($edit_id):ALMA_AI_Trend_Radar_Store::defaults();
+        echo '<div class="postbox"><div class="inside"><h2>'.($edit_id?'Modifica profilo':'Nuovo profilo').'</h2><form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_trend_radar_action'); echo '<input type="hidden" name="action" value="alma_trend_radar_action"><input type="hidden" name="do" value="save_profile"><input type="hidden" name="profile_id" value="'.(int)$edit_id.'"><table class="form-table"><tbody>';
+        self::input('name','Nome profilo',$profile['name'],'text',true); self::checkbox('active','Attivo',$profile['active']); self::input('language','Lingua',$profile['language']); self::input('target_market','Mercato target',$profile['target_market']); self::input('main_theme','Tema principale',$profile['main_theme']); self::textarea('editorial_focus','Descrizione focus editoriale',$profile['editorial_focus']); self::textarea('seed_queries','Query seed',$profile['seed_queries']);
+        echo '<tr><th>Impostazioni avanzate</th><td><details><summary>Mostra opzioni avanzate</summary><table class="form-table">'; self::textarea('preferred_sources','Fonti preferite',$profile['preferred_sources']); self::textarea('excluded_sources','Fonti escluse',$profile['excluded_sources']); self::select('frequency','Frequenza esecuzione',$profile['frequency'],array('manual'=>'Manuale','hourly'=>'Ogni ora','twicedaily'=>'Due volte al giorno','daily'=>'Giornaliera','weekly'=>'Settimanale')); self::input('run_time','Orario esecuzione',$profile['run_time'],'time'); self::input('max_trends','Numero massimo trend',$profile['max_trends'],'number'); self::select('analysis_depth','Profondità analisi',$profile['analysis_depth'],array('rapido'=>'Rapido','standard'=>'Standard','approfondito'=>'Approfondito')); self::select('editorial_goal','Obiettivo editoriale',$profile['editorial_goal'],array('guida'=>'Guida','destinazione'=>'Destinazione','esperienza'=>'Esperienza','lista'=>'Lista','news'=>'News','itinerario'=>'Itinerario')); self::checkbox('email_summary','Invio email riepilogo',$profile['email_summary']); self::input('recipient_email','Email destinatario opzionale',$profile['recipient_email'],'email'); echo '</table></details></td></tr>';
+        echo '</tbody></table><p><button class="button button-primary">Salva profilo</button></p></form></div></div>';
+        $profiles=ALMA_AI_Trend_Radar_Store::get_profiles(); echo '<h2>Profili ricerca</h2><table class="widefat striped"><thead><tr><th>Nome</th><th>Stato</th><th>Frequenza</th><th>Prossima</th><th>Ultima</th><th>Azioni</th></tr></thead><tbody>'; foreach($profiles as $p){ echo '<tr><td>'.esc_html($p['name']).'</td><td>'.(!empty($p['active'])?'Attivo':'Disattivo').'</td><td>'.esc_html($p['frequency']).'</td><td>'.esc_html($p['next_run_at']).'</td><td>'.esc_html($p['last_run_at']).'</td><td><a class="button button-small" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page='.self::SLUG.'&tab=profiles&profile_id='.(int)$p['id'])).'">Modifica</a> <a class="button button-small" href="'.esc_url(self::action_url(array('do'=>'run','profile_id'=>(int)$p['id']))).'">Esegui ora</a> <a class="button button-small" href="'.esc_url(self::action_url(array('do'=>'delete_profile','profile_id'=>(int)$p['id']))).'">Elimina</a></td></tr>'; } echo '</tbody></table>';
+    }
+
+    private static function render_settings() { echo '<div class="postbox"><div class="inside"><h2>Pianificazione</h2><p>AI Trend Radar usa eventi singoli WP-Cron per ogni profilo attivo. Ogni profilo viene ripianificato dopo il salvataggio e al termine dell’esecuzione.</p><p>Per maggiore puntualità configura un cron server reale, ad esempio una chiamata periodica a <code>'.esc_html(site_url('wp-cron.php?doing_wp_cron')).'</code>.</p><p><a class="button" href="'.esc_url(self::action_url(array('do'=>'reschedule'))).'">Rigenera pianificazione profili attivi</a></p></div></div>'; }
+    private static function render_logs() { $logs=ALMA_AI_Trend_Radar_Store::get_logs(50); echo '<div class="postbox"><div class="inside"><h2>Log ultime esecuzioni</h2><table class="widefat striped"><thead><tr><th>Data</th><th>Profilo</th><th>Livello</th><th>Messaggio</th><th>Contesto</th></tr></thead><tbody>'; foreach($logs as $l){ echo '<tr><td>'.esc_html($l['created_at']).'</td><td>'.esc_html($l['profile_name']?:('#'.$l['profile_id'])).'</td><td>'.esc_html($l['level']).'</td><td>'.esc_html($l['message']).'</td><td><code>'.esc_html($l['context']).'</code></td></tr>'; } echo '</tbody></table></div></div>'; }
+
+    private static function input($name,$label,$value,$type='text',$required=false){ echo '<tr><th><label for="'.esc_attr($name).'">'.esc_html($label).'</label></th><td><input class="regular-text" type="'.esc_attr($type).'" id="'.esc_attr($name).'" name="'.esc_attr($name).'" value="'.esc_attr($value).'" '.($required?'required':'').'></td></tr>'; }
+    private static function textarea($name,$label,$value){ echo '<tr><th><label for="'.esc_attr($name).'">'.esc_html($label).'</label></th><td><textarea class="large-text" rows="3" id="'.esc_attr($name).'" name="'.esc_attr($name).'">'.esc_textarea($value).'</textarea></td></tr>'; }
+    private static function checkbox($name,$label,$value){ echo '<tr><th>'.esc_html($label).'</th><td><label><input type="checkbox" name="'.esc_attr($name).'" value="1" '.checked($value,1,false).'> Sì</label></td></tr>'; }
+    private static function select($name,$label,$value,$opts){ echo '<tr><th><label for="'.esc_attr($name).'">'.esc_html($label).'</label></th><td><select id="'.esc_attr($name).'" name="'.esc_attr($name).'">'; foreach($opts as $k=>$v){ echo '<option value="'.esc_attr($k).'" '.selected($value,$k,false).'>'.esc_html($v).'</option>'; } echo '</select></td></tr>'; }
+
+    public static function handle_action() {
+        if (!current_user_can(self::CAP)) { wp_die(esc_html__('Permessi insufficienti.', 'affiliate-link-manager-ai')); }
+        check_admin_referer('alma_trend_radar_action'); $do=sanitize_key($_REQUEST['do'] ?? ''); $type='success'; $msg='Operazione completata.';
+        if ($do==='save_profile') { $id=ALMA_AI_Trend_Radar_Store::save_profile($_POST, absint($_POST['profile_id']??0)); if(is_wp_error($id)){$type='error';$msg=$id->get_error_message();} else { ALMA_AI_Trend_Radar_Service::schedule_profile($id); $msg='Profilo salvato.'; } }
+        elseif ($do==='delete_profile') { $id=absint($_GET['profile_id']??0); ALMA_AI_Trend_Radar_Service::clear_profile_schedule($id); ALMA_AI_Trend_Radar_Store::delete_profile($id); $msg='Profilo eliminato.'; }
+        elseif ($do==='run') { $r=ALMA_AI_Trend_Radar_Service::run_profile(absint($_GET['profile_id']??0), true); if(is_wp_error($r)){$type='error';$msg=$r->get_error_message();} else {$msg='Ricerca completata: '.(int)$r['created'].' trend salvati.';} }
+        elseif ($do==='reschedule') { ALMA_AI_Trend_Radar_Service::reschedule_all(); $msg='Pianificazione rigenerata.'; }
+        elseif (in_array($do,array('interesting','discard'),true)) { ALMA_AI_Trend_Radar_Store::update_report_status(absint($_GET['report_id']??0), $do==='interesting'?'interesting':'discarded'); $msg='Trend aggiornato.'; }
+        elseif ($do==='idea') { $r=self::create_content_idea(absint($_GET['report_id']??0)); if(is_wp_error($r)){$type='error';$msg=$r->get_error_message();} else {$msg='Idea contenuto creata.';} }
+        elseif ($do==='draft') { $r=self::create_draft(absint($_GET['report_id']??0)); if(is_wp_error($r)){$type='error';$msg=$r->get_error_message();} else {$msg='Bozza articolo creata.';} }
+        set_transient('alma_trend_radar_notice_' . get_current_user_id(), array('type'=>$type,'message'=>$msg), 120);
+        wp_safe_redirect(admin_url('edit.php?post_type=affiliate_link&page='.self::SLUG)); exit;
+    }
+
+    private static function create_content_idea($report_id) {
+        if (!class_exists('ALMA_AI_Content_Agent_Ideas')) { return new WP_Error('missing_agent', 'AI Content Agent non disponibile.'); }
+        $r=ALMA_AI_Trend_Radar_Store::get_report($report_id); if(empty($r)){return new WP_Error('missing_report','Report non trovato.');}
+        $idea_id=ALMA_AI_Content_Agent_Ideas::create($r['trend_title']); if(!$idea_id){return new WP_Error('idea_error','Creazione idea non riuscita.');}
+        $prompt="Trend Radar Sothra\n\nSintesi: {$r['trend_summary']}\n\nPerché ora: {$r['why_now']}\n\nFonti: {$r['source_urls']}\n\nKeyword: {$r['suggested_keywords']}\n\nOutline: {$r['suggested_outline']}\n\nLink affiliati suggeriti: {$r['suggested_internal_affiliate_links']}";
+        update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_PROMPT, sanitize_textarea_field($prompt));
+        update_post_meta($idea_id, '_alma_trend_radar_report_id', $report_id); ALMA_AI_Trend_Radar_Store::update_report_status($report_id, 'idea_created'); return $idea_id;
+    }
+
+    private static function create_draft($report_id) {
+        $r=ALMA_AI_Trend_Radar_Store::get_report($report_id); if(empty($r)){return new WP_Error('missing_report','Report non trovato.');}
+        $content="<!-- wp:paragraph --><p>".esc_html($r['trend_summary'])."</p><!-- /wp:paragraph -->\n<!-- wp:heading --><h2>Perché parlarne ora</h2><!-- /wp:heading -->\n<!-- wp:paragraph --><p>".esc_html($r['why_now'])."</p><!-- /wp:paragraph -->\n<!-- wp:preformatted --><pre>Outline suggerito:\n".esc_html($r['suggested_outline'])."\n\nKeyword:\n".esc_html($r['suggested_keywords'])."\n\nFonti:\n".esc_html($r['source_urls'])."\n\nLink affiliati suggeriti:\n".esc_html($r['suggested_internal_affiliate_links'])."</pre><!-- /wp:preformatted -->";
+        $post_id=wp_insert_post(array('post_type'=>'post','post_status'=>'draft','post_title'=>sanitize_text_field($r['trend_title']),'post_content'=>$content,'post_author'=>get_current_user_id()), true); if(is_wp_error($post_id)){return $post_id;} update_post_meta($post_id,'_alma_trend_radar_report_id',$report_id); ALMA_AI_Trend_Radar_Store::update_report_status($report_id,'draft_created'); return $post_id;
+    }
+}
+ALMA_AI_Trend_Radar_Admin::init();

--- a/includes/class-ai-trend-radar-service.php
+++ b/includes/class-ai-trend-radar-service.php
@@ -1,0 +1,114 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_AI_Trend_Radar_Service {
+    const CRON_HOOK = 'alma_ai_trend_radar_run_profile';
+    const LOCK_PREFIX = 'alma_trend_radar_lock_';
+
+    public static function init() { add_action(self::CRON_HOOK, array(__CLASS__, 'run_profile'), 10, 1); }
+
+    public static function is_openai_ready() { return trim((string)get_option('alma_openai_api_key', '')) !== '' && class_exists('ALMA_OpenAI_Service'); }
+
+    public static function reschedule_all() { foreach (ALMA_AI_Trend_Radar_Store::get_profiles(true) as $p) { self::schedule_profile((int)$p['id']); } }
+
+    public static function schedule_profile($profile_id) {
+        $profile = ALMA_AI_Trend_Radar_Store::get_profile($profile_id); self::clear_profile_schedule($profile_id);
+        if (empty($profile) || empty($profile['active']) || $profile['frequency'] === 'manual') { ALMA_AI_Trend_Radar_Store::update_next_run($profile_id, null); return; }
+        $ts = self::next_timestamp($profile); wp_schedule_single_event($ts, self::CRON_HOOK, array((int)$profile_id)); ALMA_AI_Trend_Radar_Store::update_next_run($profile_id, gmdate('Y-m-d H:i:s', $ts + (int)(get_option('gmt_offset') * HOUR_IN_SECONDS)));
+    }
+
+    public static function clear_profile_schedule($profile_id) { wp_clear_scheduled_hook(self::CRON_HOOK, array((int)$profile_id)); }
+
+    private static function next_timestamp($profile) {
+        $now = current_time('timestamp'); $time = $profile['run_time'] ?: '09:00'; list($h,$m)=array_map('intval', explode(':', $time));
+        $candidate = mktime($h, $m, 0, (int)wp_date('n', $now), (int)wp_date('j', $now), (int)wp_date('Y', $now));
+        $freq = $profile['frequency'];
+        if ($freq === 'hourly') { return $now + HOUR_IN_SECONDS; }
+        if ($freq === 'twicedaily') { return $now + 12 * HOUR_IN_SECONDS; }
+        if ($candidate <= $now) { $candidate += DAY_IN_SECONDS; }
+        if ($freq === 'weekly') { while ((int)wp_date('N', $candidate) !== 1) { $candidate += DAY_IN_SECONDS; } }
+        return $candidate;
+    }
+
+    public static function run_profile($profile_id, $manual = false) {
+        $profile_id = absint($profile_id); $profile = ALMA_AI_Trend_Radar_Store::get_profile($profile_id);
+        if (empty($profile)) { return new WP_Error('profile_missing', __('Profilo Trend Radar non trovato.', 'affiliate-link-manager-ai')); }
+        if (empty($profile['active']) && !$manual) { return new WP_Error('profile_inactive', __('Profilo non attivo.', 'affiliate-link-manager-ai')); }
+        $lock_key = self::LOCK_PREFIX . $profile_id;
+        if (get_transient($lock_key)) { ALMA_AI_Trend_Radar_Store::log($profile_id, 'warning', 'Esecuzione saltata: lock profilo già attivo.'); return new WP_Error('locked', __('Esecuzione già in corso per questo profilo.', 'affiliate-link-manager-ai')); }
+        set_transient($lock_key, 1, 15 * MINUTE_IN_SECONDS);
+        try {
+            if (!self::is_openai_ready()) { ALMA_AI_Trend_Radar_Store::log($profile_id, 'error', 'OpenAI non configurata.'); return new WP_Error('openai_missing', __('OpenAI non è configurata.', 'affiliate-link-manager-ai')); }
+            ALMA_AI_Trend_Radar_Store::log($profile_id, 'info', 'Avvio ricerca trend.', array('manual'=>$manual));
+            $affiliate_context = self::affiliate_context($profile, 12);
+            $ai = self::call_openai($profile, $affiliate_context);
+            if (is_wp_error($ai)) { ALMA_AI_Trend_Radar_Store::log($profile_id, 'error', $ai->get_error_message(), array('code'=>$ai->get_error_code())); return $ai; }
+            $created = 0;
+            foreach ($ai as $trend) {
+                $trend = self::normalize_trend($trend);
+                if (empty($trend['trend_title'])) { continue; }
+                $trend['suggested_internal_affiliate_links'] = self::match_affiliate_links($trend, 8);
+                ALMA_AI_Trend_Radar_Store::insert_report($profile_id, $trend); $created++;
+            }
+            ALMA_AI_Trend_Radar_Store::mark_profile_ran($profile_id);
+            ALMA_AI_Trend_Radar_Store::log($profile_id, 'success', sprintf('Ricerca completata: %d trend salvati.', $created));
+            if (!empty($profile['email_summary'])) { self::send_summary($profile, $created); }
+            return array('success'=>true,'created'=>$created);
+        } finally {
+            delete_transient($lock_key);
+            if (!$manual) { self::schedule_profile($profile_id); }
+        }
+    }
+
+    private static function call_openai($profile, $affiliate_context) {
+        $schema = array('type'=>'json_schema','name'=>'trend_radar_report','schema'=>array('type'=>'object','additionalProperties'=>false,'properties'=>array('trends'=>array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>true))),'required'=>array('trends')));
+        $system = 'Sei AI Trend Radar per Sothra, magazine travel/turismo. Usa web search per trovare trend editoriali attuali. Rispondi solo JSON valido secondo schema. Punteggi sempre interi 1-10. Non inventare URL fonti.';
+        $prompt = "Genera fino a {$profile['max_trends']} trend editoriali travel/turismo.\nLingua: {$profile['language']}\nMercato target: {$profile['target_market']}\nTema: {$profile['main_theme']}\nFocus: {$profile['editorial_focus']}\nQuery seed: {$profile['seed_queries']}\nFonti preferite: {$profile['preferred_sources']}\nFonti escluse: {$profile['excluded_sources']}\nProfondità: {$profile['analysis_depth']}\nObiettivo editoriale: {$profile['editorial_goal']}\n\nPer ogni trend includi: trend_title, trend_summary, why_now, destinations, seasonality, target_audience, seo_potential_score, affiliate_potential_score, urgency_score, recommended_article_titles, suggested_keywords, suggested_outline, source_urls, source_notes, suggested_internal_affiliate_links, status, created_at.\n\nContesto compatto link affiliati locali candidati (usa solo se rilevante, non inventare link):\n" . wp_json_encode($affiliate_context);
+        $res = ALMA_OpenAI_Service::request(array('system_prompt'=>$system,'user_prompt'=>$prompt,'json_output'=>true,'response_format'=>$schema,'max_output_tokens'=>3500,'timeout'=>60,'tools'=>array(array('type'=>'web_search_preview'))));
+        if (empty($res['success'])) {
+            $code = $res['error_code'] ?? 'openai_error';
+            if ($code === 'response_format_unsupported' || $code === 'model_unsupported') { return new WP_Error($code, __('Web search/Responses API non disponibile per la configurazione corrente.', 'affiliate-link-manager-ai')); }
+            return new WP_Error($code, sanitize_text_field($res['error'] ?? __('Errore OpenAI.', 'affiliate-link-manager-ai')));
+        }
+        $data = json_decode((string)$res['response'], true);
+        if (!is_array($data) || !isset($data['trends']) || !is_array($data['trends'])) { return new WP_Error('invalid_json', __('JSON OpenAI non valido o incompleto.', 'affiliate-link-manager-ai')); }
+        return $data['trends'];
+    }
+
+    private static function normalize_trend($trend) {
+        $trend = is_array($trend) ? $trend : array();
+        foreach (array('seo_potential_score','affiliate_potential_score','urgency_score') as $s) { $trend[$s] = max(1, min(10, absint($trend[$s] ?? 1))); }
+        $trend['status'] = sanitize_key($trend['status'] ?? 'new') ?: 'new';
+        $trend['created_at'] = sanitize_text_field($trend['created_at'] ?? current_time('mysql'));
+        return $trend;
+    }
+
+    private static function affiliate_context($profile, $limit) {
+        $query = trim(implode(' ', array($profile['main_theme'], $profile['target_market'], $profile['seed_queries'])));
+        return self::find_affiliate_candidates($query, $limit);
+    }
+
+    private static function match_affiliate_links($trend, $limit) {
+        $parts = array($trend['trend_title'] ?? '', $trend['trend_summary'] ?? '', $trend['destinations'] ?? '', $trend['suggested_keywords'] ?? '');
+        return self::find_affiliate_candidates(wp_json_encode($parts), $limit);
+    }
+
+    private static function find_affiliate_candidates($query, $limit) {
+        global $wpdb; $terms = preg_split('/\s+/', strtolower(wp_strip_all_tags((string)$query))); $terms = array_values(array_filter(array_unique(array_map('sanitize_text_field', $terms)), function($t){ return strlen($t) > 3; })); $terms = array_slice($terms, 0, 8);
+        $where = "p.post_type='affiliate_link' AND p.post_status IN ('publish','draft')"; $params = array();
+        if ($terms) { $likes=array(); foreach($terms as $t){ $like='%'.$wpdb->esc_like($t).'%'; $likes[]='(p.post_title LIKE %s OR p.post_content LIKE %s OR pm.meta_value LIKE %s)'; array_push($params,$like,$like,$like); } $where .= ' AND (' . implode(' OR ', $likes) . ')'; }
+        $sql = "SELECT DISTINCT p.ID, p.post_title FROM {$wpdb->posts} p LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id=p.ID WHERE $where ORDER BY p.post_modified DESC LIMIT %d"; $params[] = max(1,min(20,absint($limit)));
+        $rows = $wpdb->get_results($wpdb->prepare($sql, $params), ARRAY_A); $out=array();
+        foreach ((array)$rows as $r) {
+            $id=(int)$r['ID']; $types=wp_get_object_terms($id,'link_type',array('fields'=>'names')); $url=get_post_meta($id,'_affiliate_url',true); $provider=get_post_meta($id,'_alma_provider',true); if($provider===''){$provider=get_post_meta($id,'_alma_source_provider',true);} 
+            $out[] = array('id'=>$id,'title'=>sanitize_text_field($r['post_title']),'url'=>esc_url_raw($url),'types'=>is_wp_error($types)?array():array_values($types),'provider'=>sanitize_text_field($provider));
+        }
+        return $out;
+    }
+
+    private static function send_summary($profile, $created) {
+        $to = is_email($profile['recipient_email']) ? $profile['recipient_email'] : get_option('admin_email'); if (!$to) { return; }
+        wp_mail($to, 'AI Trend Radar - riepilogo', sprintf("Profilo: %s\nTrend generati: %d\nData: %s", $profile['name'], $created, current_time('mysql')));
+    }
+}
+ALMA_AI_Trend_Radar_Service::init();

--- a/includes/class-ai-trend-radar-store.php
+++ b/includes/class-ai-trend-radar-store.php
@@ -1,0 +1,154 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_AI_Trend_Radar_Store {
+    public static function table($name) { global $wpdb; return $wpdb->prefix . 'alma_trend_radar_' . $name; }
+
+    public static function install() {
+        global $wpdb; require_once ABSPATH . 'wp-admin/includes/upgrade.php'; $c = $wpdb->get_charset_collate();
+        dbDelta("CREATE TABLE " . self::table('profiles') . " (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            name VARCHAR(190) NOT NULL,
+            active TINYINT(1) NOT NULL DEFAULT 1,
+            language VARCHAR(20) NOT NULL DEFAULT 'it',
+            target_market VARCHAR(120) NOT NULL DEFAULT 'Italia',
+            main_theme VARCHAR(190) NOT NULL DEFAULT '',
+            editorial_focus TEXT NULL,
+            seed_queries TEXT NULL,
+            preferred_sources TEXT NULL,
+            excluded_sources TEXT NULL,
+            frequency VARCHAR(40) NOT NULL DEFAULT 'weekly',
+            run_time VARCHAR(5) NOT NULL DEFAULT '09:00',
+            max_trends INT UNSIGNED NOT NULL DEFAULT 5,
+            analysis_depth VARCHAR(20) NOT NULL DEFAULT 'standard',
+            editorial_goal VARCHAR(30) NOT NULL DEFAULT 'guida',
+            email_summary TINYINT(1) NOT NULL DEFAULT 0,
+            recipient_email VARCHAR(190) NOT NULL DEFAULT '',
+            next_run_at DATETIME NULL,
+            last_run_at DATETIME NULL,
+            created_at DATETIME NOT NULL,
+            updated_at DATETIME NOT NULL,
+            PRIMARY KEY (id), KEY active_next (active,next_run_at)
+        ) $c;");
+        dbDelta("CREATE TABLE " . self::table('reports') . " (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            profile_id BIGINT UNSIGNED NOT NULL DEFAULT 0,
+            trend_title TEXT NOT NULL,
+            trend_summary LONGTEXT NULL,
+            why_now LONGTEXT NULL,
+            destinations TEXT NULL,
+            seasonality VARCHAR(190) NOT NULL DEFAULT '',
+            target_audience TEXT NULL,
+            seo_potential_score TINYINT UNSIGNED NOT NULL DEFAULT 1,
+            affiliate_potential_score TINYINT UNSIGNED NOT NULL DEFAULT 1,
+            urgency_score TINYINT UNSIGNED NOT NULL DEFAULT 1,
+            recommended_article_titles LONGTEXT NULL,
+            suggested_keywords LONGTEXT NULL,
+            suggested_outline LONGTEXT NULL,
+            source_urls LONGTEXT NULL,
+            source_notes LONGTEXT NULL,
+            suggested_internal_affiliate_links LONGTEXT NULL,
+            status VARCHAR(30) NOT NULL DEFAULT 'new',
+            raw_json LONGTEXT NULL,
+            created_at DATETIME NOT NULL,
+            updated_at DATETIME NOT NULL,
+            PRIMARY KEY (id), KEY profile_created (profile_id,created_at), KEY status_created (status,created_at)
+        ) $c;");
+        dbDelta("CREATE TABLE " . self::table('logs') . " (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            profile_id BIGINT UNSIGNED NOT NULL DEFAULT 0,
+            level VARCHAR(20) NOT NULL DEFAULT 'info',
+            message TEXT NOT NULL,
+            context LONGTEXT NULL,
+            created_at DATETIME NOT NULL,
+            PRIMARY KEY (id), KEY profile_created (profile_id,created_at), KEY level_created (level,created_at)
+        ) $c;");
+    }
+
+    public static function defaults() {
+        return array('id'=>0,'name'=>'','active'=>1,'language'=>'it','target_market'=>'Italia','main_theme'=>'','editorial_focus'=>'','seed_queries'=>'','preferred_sources'=>'','excluded_sources'=>'','frequency'=>'weekly','run_time'=>'09:00','max_trends'=>5,'analysis_depth'=>'standard','editorial_goal'=>'guida','email_summary'=>0,'recipient_email'=>'');
+    }
+
+    public static function sanitize_profile($data) {
+        $allowed_depth = array('rapido','standard','approfondito');
+        $allowed_goal = array('guida','destinazione','esperienza','lista','news','itinerario');
+        $allowed_freq = array('manual','hourly','daily','twicedaily','weekly');
+        $run_time = preg_match('/^([01]\d|2[0-3]):[0-5]\d$/', (string)($data['run_time'] ?? '')) ? $data['run_time'] : '09:00';
+        return array(
+            'name'=>sanitize_text_field($data['name'] ?? ''),
+            'active'=>empty($data['active']) ? 0 : 1,
+            'language'=>sanitize_text_field($data['language'] ?? 'it'),
+            'target_market'=>sanitize_text_field($data['target_market'] ?? 'Italia'),
+            'main_theme'=>sanitize_text_field($data['main_theme'] ?? ''),
+            'editorial_focus'=>sanitize_textarea_field($data['editorial_focus'] ?? ''),
+            'seed_queries'=>sanitize_textarea_field($data['seed_queries'] ?? ''),
+            'preferred_sources'=>sanitize_textarea_field($data['preferred_sources'] ?? ''),
+            'excluded_sources'=>sanitize_textarea_field($data['excluded_sources'] ?? ''),
+            'frequency'=>in_array(($data['frequency'] ?? 'weekly'), $allowed_freq, true) ? $data['frequency'] : 'weekly',
+            'run_time'=>$run_time,
+            'max_trends'=>max(1, min(10, absint($data['max_trends'] ?? 5))),
+            'analysis_depth'=>in_array(($data['analysis_depth'] ?? 'standard'), $allowed_depth, true) ? $data['analysis_depth'] : 'standard',
+            'editorial_goal'=>in_array(($data['editorial_goal'] ?? 'guida'), $allowed_goal, true) ? $data['editorial_goal'] : 'guida',
+            'email_summary'=>empty($data['email_summary']) ? 0 : 1,
+            'recipient_email'=>sanitize_email($data['recipient_email'] ?? ''),
+        );
+    }
+
+    public static function save_profile($data, $id = 0) {
+        global $wpdb; $now = current_time('mysql'); $row = self::sanitize_profile($data); $row['updated_at'] = $now;
+        if ($row['name'] === '') { return new WP_Error('missing_name', __('Nome profilo obbligatorio.', 'affiliate-link-manager-ai')); }
+        if ($row['email_summary'] && $row['recipient_email'] !== '' && !is_email($row['recipient_email'])) { return new WP_Error('bad_email', __('Email destinatario non valida.', 'affiliate-link-manager-ai')); }
+        if ($id > 0) { $wpdb->update(self::table('profiles'), $row, array('id'=>absint($id))); return absint($id); }
+        $row['created_at'] = $now; $wpdb->insert(self::table('profiles'), $row); return (int)$wpdb->insert_id;
+    }
+
+    public static function get_profile($id) { global $wpdb; $r = $wpdb->get_row($wpdb->prepare('SELECT * FROM '.self::table('profiles').' WHERE id=%d', absint($id)), ARRAY_A); return is_array($r) ? array_merge(self::defaults(), $r) : array(); }
+    public static function get_profiles($active_only = false) { global $wpdb; $sql = 'SELECT * FROM '.self::table('profiles') . ($active_only ? ' WHERE active=1' : '') . ' ORDER BY active DESC, name ASC'; return $wpdb->get_results($sql, ARRAY_A); }
+    public static function delete_profile($id) { global $wpdb; return (bool)$wpdb->delete(self::table('profiles'), array('id'=>absint($id))); }
+    public static function update_next_run($id, $next) { global $wpdb; $wpdb->update(self::table('profiles'), array('next_run_at'=>$next, 'updated_at'=>current_time('mysql')), array('id'=>absint($id))); }
+    public static function mark_profile_ran($id) { global $wpdb; $wpdb->update(self::table('profiles'), array('last_run_at'=>current_time('mysql'), 'updated_at'=>current_time('mysql')), array('id'=>absint($id))); }
+
+    public static function insert_report($profile_id, $trend) {
+        global $wpdb; $now = current_time('mysql');
+        $row = self::sanitize_trend($trend); $row['profile_id'] = absint($profile_id); $row['created_at'] = $now; $row['updated_at'] = $now; $row['raw_json'] = wp_json_encode($trend);
+        $wpdb->insert(self::table('reports'), $row); return (int)$wpdb->insert_id;
+    }
+
+    public static function sanitize_trend($trend) {
+        $arr = is_array($trend) ? $trend : array();
+        $json_fields = array('destinations','recommended_article_titles','suggested_keywords','suggested_outline','source_urls','source_notes','suggested_internal_affiliate_links');
+        $row = array(
+            'trend_title'=>sanitize_text_field($arr['trend_title'] ?? ''),
+            'trend_summary'=>sanitize_textarea_field($arr['trend_summary'] ?? ''),
+            'why_now'=>sanitize_textarea_field($arr['why_now'] ?? ''),
+            'seasonality'=>sanitize_text_field($arr['seasonality'] ?? ''),
+            'target_audience'=>sanitize_textarea_field($arr['target_audience'] ?? ''),
+            'seo_potential_score'=>self::score($arr['seo_potential_score'] ?? 1),
+            'affiliate_potential_score'=>self::score($arr['affiliate_potential_score'] ?? 1),
+            'urgency_score'=>self::score($arr['urgency_score'] ?? 1),
+            'status'=>sanitize_key($arr['status'] ?? 'new'),
+        );
+        foreach ($json_fields as $f) { $row[$f] = wp_json_encode(self::sanitize_deep($arr[$f] ?? array())); }
+        return $row;
+    }
+
+    private static function score($v) { return max(1, min(10, absint($v))); }
+    private static function sanitize_deep($v) { if (is_array($v)) { return array_map(array(__CLASS__, 'sanitize_deep'), $v); } return is_scalar($v) ? sanitize_text_field((string)$v) : ''; }
+
+    public static function get_reports($args = array()) {
+        global $wpdb; $page=max(1,absint($args['page']??1)); $per=max(1,min(50,absint($args['per_page']??20))); $offset=($page-1)*$per; $where='WHERE 1=1'; $params=array();
+        if (!empty($args['status'])) { $where.=' AND status=%s'; $params[]=sanitize_key($args['status']); }
+        if (!empty($args['profile_id'])) { $where.=' AND profile_id=%d'; $params[]=absint($args['profile_id']); }
+        $sql='SELECT * FROM '.self::table('reports')." $where ORDER BY created_at DESC LIMIT %d OFFSET %d"; $params[]=$per; $params[]=$offset;
+        return $wpdb->get_results($wpdb->prepare($sql, $params), ARRAY_A);
+    }
+    public static function count_reports($args = array()) { global $wpdb; $where='WHERE 1=1'; $params=array(); if(!empty($args['status'])){$where.=' AND status=%s';$params[]=sanitize_key($args['status']);} $sql='SELECT COUNT(*) FROM '.self::table('reports')." $where"; return (int)($params ? $wpdb->get_var($wpdb->prepare($sql,$params)) : $wpdb->get_var($sql)); }
+    public static function get_report($id) { global $wpdb; $r=$wpdb->get_row($wpdb->prepare('SELECT * FROM '.self::table('reports').' WHERE id=%d',absint($id)),ARRAY_A); return is_array($r)?$r:array(); }
+    public static function update_report_status($id, $status) { global $wpdb; $allowed=array('new','interesting','discarded','idea_created','draft_created'); if(!in_array($status,$allowed,true)){return false;} return (bool)$wpdb->update(self::table('reports'), array('status'=>$status,'updated_at'=>current_time('mysql')), array('id'=>absint($id))); }
+
+    public static function log($profile_id, $level, $message, $context = array()) {
+        global $wpdb; unset($context['api_key'], $context['Authorization']);
+        $wpdb->insert(self::table('logs'), array('profile_id'=>absint($profile_id),'level'=>sanitize_key($level),'message'=>sanitize_text_field($message),'context'=>wp_json_encode(self::sanitize_deep($context)),'created_at'=>current_time('mysql')));
+    }
+    public static function get_logs($limit = 30) { global $wpdb; return $wpdb->get_results($wpdb->prepare('SELECT l.*, p.name AS profile_name FROM '.self::table('logs').' l LEFT JOIN '.self::table('profiles').' p ON p.id=l.profile_id ORDER BY l.created_at DESC LIMIT %d', max(1,min(100,absint($limit)))), ARRAY_A); }
+}

--- a/includes/class-openai-service.php
+++ b/includes/class-openai-service.php
@@ -24,6 +24,9 @@ class ALMA_OpenAI_Service {
         $input[] = array('role'=>'user','content'=>array(array('type'=>'input_text','text'=>(string)($args['user_prompt'] ?? ''))));
 
         $body = array('model'=>$model,'input'=>$input,'max_output_tokens'=>$max_output_tokens);
+        if (!empty($args['tools']) && is_array($args['tools'])) {
+            $body['tools'] = $args['tools'];
+        }
         if ($temperature >= 0 && $temperature <= 2) { $body['temperature'] = $temperature; }
 
         $response_format_used = 'none';


### PR DESCRIPTION
### Motivation
- Aggiungere un modulo amministrativo “AI Trend Radar” per eseguire ricerche web programmate via OpenAI e generare report di trend editoriali travel/turismo per Sothra. 
- Permettere schedulazione per profili di ricerca, matching locale con link affiliati e integrazione leggera con l’AI Content Agent senza duplicare la gestione delle API. 

### Description
- Aggiunte tabelle e store dedicati per profili, report e log in `includes/class-ai-trend-radar-store.php` con sanitizzazione, normalizzazione punteggi 1–10 e funzioni CRUD/paginazione. 
- Implementato servizio scheduler `ALMA_AI_Trend_Radar_Service` in `includes/class-ai-trend-radar-service.php` che usa WP‑Cron per profilo, gestisce lock temporaneo anti‑doppia esecuzione, richieste strutturate a OpenAI (Responses API / web search quando disponibile), validazione JSON, gestione errori e matching locale limitato dei link affiliati. 
- Aggiunta UI admin `Affiliate Link Manager AI → Trend Radar` in `includes/class-ai-trend-radar-admin.php` con report list, card riepilogative, filtro/paginazione, profili di ricerca, impostazioni pianificazione, log, pulsante manuale `Esegui ricerca ora` (nonce + capability) e azioni rapide: crea idea contenuto, crea bozza (se AI Content Agent disponibile), segna/scarta. 
- Riutilizzo della configurazione OpenAI esistente e piccola estensione di `ALMA_OpenAI_Service::request` (`includes/class-openai-service.php`) per accettare parametri `tools` (utile per web search preview), evitando duplicazione della gestione API key. 
- Registrazione del modulo nel bootstrap del plugin: include files nuovi, sottomenu admin, installazione tabelle in activation/update e pulizia schedule alla deattivazione; versione plugin aggiornata a `2.30.0`. 
- Documentazione aggiornata in `README.md` e `CHANGELOG.md` con nota su WP‑Cron vs cron reale, costi API e workflow trend→idea. 

### Testing
- Eseguiti controlli di sintassi PHP: `php -l includes/class-ai-trend-radar-store.php`, `php -l includes/class-ai-trend-radar-service.php`, `php -l includes/class-ai-trend-radar-admin.php`, `php -l includes/class-openai-service.php`, `php -l affiliate-link-manager-ai.php` — tutti senza errori. 
- Verificato `git diff --check` e `git diff --stat` per le modifiche; nessun whitespace/errori mostrati. 
- Commit delle modifiche pronto per review (creato il commit con message: "Add AI Trend Radar module"). 
- Raccomandazione test manuale veloce: attivare il plugin, visitare `Affiliate Link Manager AI → Trend Radar`, creare un profilo, provare `Esegui ricerca ora` con/ senza API key OpenAI e verificare creazione report, log e azioni rapide (consulta i file nuovi per istruzioni UI e hook).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fede019668833287a570fed8ac7bdd)