### PR TITLE
Add GYG CSV preview filtering and selective import (v2.31.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2.31.0 — Filtro CSV GYG prima dell’importazione
+- Aggiunto il box **Filtra contenuti prima dell’importazione** nella schermata aperta dopo **Importa / continua**, sopra la tabella **Risultati Anteprima**.
+- La ricerca lavora sull’intero CSV normalizzato della sessione persistente, non solo sulla pagina visibile, e restituisce solo la pagina corrente per evitare rendering di migliaia di righe.
+- Disponibili filtri per parole chiave, campo di ricerca, modalità (almeno una parola, tutte le parole, frase esatta), città, regione, tipologia attività opzionale, stato importazione e risultati per pagina 25/50.
+- La città funziona anche senza tipologia selezionata; la tipologia è solo un filtro aggiuntivo e non limita da sola la ricerca globale nel file.
+- Lo stato importazione è gestito dalla select **Solo non importati / Mostra anche già importati / Solo già importati**, che sostituisce il vecchio comportamento a checkbox nella preview GYG CSV.
+- Aggiunti contatori per record totali, trovati, non importati, già importati, selezionati, selezionati non visibili e pagina corrente.
+- Aggiunte azioni **Seleziona risultati visibili**, **Deseleziona risultati visibili** e **Seleziona tutti i risultati filtrati** con conferma oltre 100 record; filtrare e selezionare non avvia mai l’import automaticamente.
+- La selezione resta basata su `external_id`, persiste al cambio filtro/pagina tramite UI admin, e l’import selettivo continua a passare al backend solo gli `external_id` scelti.
+- Aggiunto helper riusabile `ALMA_Affiliate_Source_Import_Record_Filter` per normalizzazione testo, parole chiave, filtri e paginazione, con log diagnostico sintetico e sicuro.
+- Note performance: la preview fa una scansione server-side della sessione CSV, batch query per lo stato già importato, nessuna chiamata OpenAI/API esterna e nessun payload CSV completo nei log.
+- Versione plugin aggiornata a `2.31.0`.
+
 ## 2.30.2 - 2026-05-09
 ### Fixed
 - Fixed GYG CSV selective import to process the exact selected `external_id` values instead of importing only the first compatible rows by count.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+## 2.31.0 — Filtro CSV GYG prima dell’importazione
+- Aggiunto il box **Filtra contenuti prima dell’importazione** nella schermata aperta dopo **Importa / continua**, sopra la tabella **Risultati Anteprima**.
+- La ricerca lavora sull’intero CSV normalizzato della sessione persistente, non solo sulla pagina visibile, e restituisce solo la pagina corrente per evitare rendering di migliaia di righe.
+- Disponibili filtri per parole chiave, campo di ricerca, modalità (almeno una parola, tutte le parole, frase esatta), città, regione, tipologia attività opzionale, stato importazione e risultati per pagina 25/50.
+- La città funziona anche senza tipologia selezionata; la tipologia è solo un filtro aggiuntivo e non limita da sola la ricerca globale nel file.
+- Lo stato importazione è gestito dalla select **Solo non importati / Mostra anche già importati / Solo già importati**, che sostituisce il vecchio comportamento a checkbox nella preview GYG CSV.
+- Aggiunti contatori per record totali, trovati, non importati, già importati, selezionati, selezionati non visibili e pagina corrente.
+- Aggiunte azioni **Seleziona risultati visibili**, **Deseleziona risultati visibili** e **Seleziona tutti i risultati filtrati** con conferma oltre 100 record; filtrare e selezionare non avvia mai l’import automaticamente.
+- La selezione resta basata su `external_id`, persiste al cambio filtro/pagina tramite UI admin, e l’import selettivo continua a passare al backend solo gli `external_id` scelti.
+- Aggiunto helper riusabile `ALMA_Affiliate_Source_Import_Record_Filter` per normalizzazione testo, parole chiave, filtri e paginazione, con log diagnostico sintetico e sicuro.
+- Note performance: la preview fa una scansione server-side della sessione CSV, batch query per lo stato già importato, nessuna chiamata OpenAI/API esterna e nessun payload CSV completo nei log.
+- Versione plugin aggiornata a `2.31.0`.
+
 ## 2.30.2 — Hotfix import CSV GYG selettivo e report coerente
 - Corretto l’import selettivo `gyg_csv`: i record selezionati vengono risolti tramite `external_id` e il backend importa esattamente quegli identificativi, inclusi record non consecutivi nel CSV.
 - Rafforzata la deduplica dei Link affiliati GYG: i match sono validi solo se puntano a post esistenti del CPT `affiliate_link` non cestinati; i riferimenti stale non bloccano più la creazione.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.30.2
+ * Version: 2.31.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.30.2');
+define('ALMA_VERSION', '2.31.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -79,6 +79,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-normalizer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-import-dedupe-service.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-media-sideload-service.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-importer.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-import-record-filter.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-gyg-csv-importer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-import-preview-service.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-manual-import-service.php';

--- a/assets/affiliate-sources.css
+++ b/assets/affiliate-sources.css
@@ -53,3 +53,20 @@ body.alma-modal-open{overflow:hidden}
 .alma-gyg-preview{overflow:auto}.alma-gyg-preview code{white-space:normal;word-break:break-word}
 .alma-gyg-report-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:8px;margin:0;padding:0;list-style:none}
 .alma-gyg-report-list li{padding:8px;border:1px solid #dcdcde;background:#f6f7f7}
+
+.alma-gyg-filter-box .inside,
+.alma-gyg-selective-import-form .inside {
+  padding: 12px 16px;
+}
+.alma-gyg-filter-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 10px 14px;
+  align-items: end;
+}
+.alma-gyg-filter-grid p { margin: 0; }
+.alma-gyg-filter-grid input[type="text"],
+.alma-gyg-filter-grid select { width: 100%; max-width: 100%; }
+.alma-gyg-selection-actions,
+.alma-gyg-pagination { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.alma-gyg-preview-table td code { font-size: 11px; }

--- a/assets/affiliate-sources.js
+++ b/assets/affiliate-sources.js
@@ -155,6 +155,56 @@ jQuery(function($){
     if(url){ window.location.href=url; }
   });
 
+
+  function gygSelectiveKey(){
+    var $form = $('.alma-gyg-selective-import-form');
+    if(!$form.length){ return ''; }
+    return 'alma_gyg_selected_'+($form.find('input[name="source_id"]').val()||'')+'_'+($form.find('input[name="gyg_csv_token"]').val()||'')+'_'+($form.find('input[name="activity_type_hash"]').val()||'');
+  }
+  function gygSelectedIds(){
+    var key = gygSelectiveKey(), ids = [];
+    if(key && window.sessionStorage){ try { ids = JSON.parse(sessionStorage.getItem(key) || '[]') || []; } catch(e){ ids = []; } }
+    $('.alma-gyg-row-select:checked').each(function(){ var v=String($(this).val()||''); if(v && ids.indexOf(v) === -1){ ids.push(v); } });
+    return ids;
+  }
+  function gygStoreSelected(ids){
+    ids = $.grep(ids || [], function(v, i){ return v && $.inArray(v, ids) === i; });
+    var key = gygSelectiveKey();
+    if(key && window.sessionStorage){ sessionStorage.setItem(key, JSON.stringify(ids)); }
+    $('.alma-gyg-selected-store').empty();
+    $.each(ids, function(_, id){ $('<input/>',{type:'hidden', name:'selected_external_ids[]', value:id}).appendTo('.alma-gyg-selected-store'); });
+    $('.alma-gyg-import-selected').prop('disabled', ids.length < 1);
+    $('.alma-gyg-no-selection-warning').toggle(ids.length < 1);
+    return ids;
+  }
+  function gygRefreshSelected(){
+    var ids = gygSelectedIds();
+    $('.alma-gyg-row-select').each(function(){ $(this).prop('checked', ids.indexOf(String($(this).val()||'')) !== -1); });
+    return gygStoreSelected(ids);
+  }
+  function gygAppendSelectedToContainer($container){
+    $container.find('input.alma-gyg-selected-query').remove();
+    $.each(gygStoreSelected(gygSelectedIds()), function(_, id){ $('<input/>',{type:'hidden', name:'selected_external_ids[]', value:id, 'class':'alma-gyg-selected-query'}).appendTo($container); });
+  }
+  function gygUrlWithSelected(url){
+    var ids = gygStoreSelected(gygSelectedIds()), sep = url.indexOf('?') === -1 ? '?' : '&';
+    $.each(ids, function(_, id){ url += sep + 'selected_external_ids[]=' + encodeURIComponent(id); sep='&'; });
+    return url;
+  }
+  gygRefreshSelected();
+  $(document).on('change', '.alma-gyg-row-select', function(){
+    var id = String($(this).val()||''), ids = gygSelectedIds(), idx = ids.indexOf(id);
+    if(this.checked && idx === -1){ ids.push(id); }
+    if(!this.checked && idx !== -1){ ids.splice(idx, 1); }
+    gygStoreSelected(ids);
+  });
+  $(document).on('click', '.alma-gyg-select-visible', function(e){ e.preventDefault(); var ids=gygSelectedIds(); $('.alma-gyg-row-select').each(function(){ var id=String($(this).val()||''); if(id && ids.indexOf(id)===-1){ ids.push(id); } $(this).prop('checked', true); }); gygStoreSelected(ids); });
+  $(document).on('click', '.alma-gyg-deselect-visible', function(e){ e.preventDefault(); var visible=[]; $('.alma-gyg-row-select').each(function(){ visible.push(String($(this).val()||'')); $(this).prop('checked', false); }); var ids=$.grep(gygSelectedIds(), function(id){ return visible.indexOf(id)===-1; }); gygStoreSelected(ids); });
+  $(document).on('click', '.alma-gyg-select-filtered', function(e){ e.preventDefault(); var ids=gygSelectedIds(), add=[]; $('.alma-gyg-filtered-id').each(function(){ var id=String($(this).val()||''); if(id){ add.push(id); } }); if(add.length > 100 && !window.confirm('Stai per selezionare '+add.length+' record filtrati. Confermi?')){ return; } $.each(add, function(_, id){ if(ids.indexOf(id)===-1){ ids.push(id); } }); $('.alma-gyg-row-select').prop('checked', true); gygStoreSelected(ids); });
+  $(document).on('submit', '.alma-gyg-filter-form', function(){ gygAppendSelectedToContainer($(this)); });
+  $(document).on('click', '.alma-gyg-pagination a, .alma-gyg-filter-box a.button', function(e){ e.preventDefault(); window.location.href = gygUrlWithSelected($(this).attr('href')); });
+  $(document).on('submit', '.alma-gyg-selective-import-form', function(e){ var ids=gygStoreSelected(gygSelectedIds()); if(ids.length < 1){ e.preventDefault(); window.alert('Seleziona almeno un contenuto prima di importare.'); } });
+
   renderProviderFields();
   toggleSearchHints();
   updateSelected();

--- a/includes/class-affiliate-source-gyg-csv-importer.php
+++ b/includes/class-affiliate-source-gyg-csv-importer.php
@@ -237,8 +237,8 @@ class ALMA_Affiliate_Source_GYG_CSV_Importer {
         $aliases = array(
             'url' => array('url'),
             'title' => array('titolo attivita', 'titolo attività', 'titolo_attivita', 'titolo', 'title', 'activity_title', 'activity title'),
-            'city' => array('citta', 'city'),
-            'region' => array('regione di appartenenza', 'regione', 'region'),
+            'city' => array('citta', 'città', 'city', 'destination', 'destinazione'),
+            'region' => array('regione di appartenenza', 'regione', 'region', 'country area', 'area paese'),
             'activity_type' => array('tipologia attivita', 'tipologia attività', 'activity type'),
             'description' => array('descrizione attivita', 'descrizione attività', 'descrizione', 'description'),
         );
@@ -416,6 +416,102 @@ class ALMA_Affiliate_Source_GYG_CSV_Importer {
         fclose($handle);
         arsort($summary['types']);
         return $summary;
+    }
+
+
+    private function existing_external_id_map($source_id, $external_ids) {
+        global $wpdb;
+        $source_id = (string)absint($source_id);
+        $ids = array_values(array_unique(array_filter(array_map('sanitize_text_field', (array)$external_ids))));
+        $map = array();
+        if ($source_id === '0' || empty($ids)) return $map;
+        foreach (array_chunk($ids, 500) as $chunk) {
+            $placeholders = implode(',', array_fill(0, count($chunk), '%s'));
+            $sql = "SELECT pm2.meta_value AS external_id, MAX(pm1.post_id) AS post_id FROM {$wpdb->postmeta} pm1 INNER JOIN {$wpdb->postmeta} pm2 ON pm1.post_id=pm2.post_id INNER JOIN {$wpdb->posts} p ON p.ID=pm1.post_id WHERE pm1.meta_key='_alma_source_id' AND pm1.meta_value=%s AND pm2.meta_key='_alma_external_id' AND pm2.meta_value IN ($placeholders) AND p.post_type='affiliate_link' AND p.post_status NOT IN ('trash','auto-draft') GROUP BY pm2.meta_value";
+            $rows = $wpdb->get_results($wpdb->prepare($sql, array_merge(array($source_id), $chunk)), ARRAY_A);
+            foreach ((array)$rows as $row) {
+                $eid = sanitize_text_field((string)($row['external_id'] ?? ''));
+                if ($eid !== '') $map[$eid] = absint($row['post_id'] ?? 0);
+            }
+        }
+        return $map;
+    }
+
+    public function filtered_preview($path, $columns, $source, $filters = array(), $selected_external_ids = array()) {
+        $filters = ALMA_Affiliate_Source_Import_Record_Filter::sanitize_filters($filters);
+        $settings = self::default_settings(json_decode((string)($source['settings'] ?? '{}'), true));
+        $partner_id = (string)($settings['partner_id'] ?? '');
+        $utm = (string)($settings['utm_medium'] ?? 'online_publisher');
+        $result = array(
+            'filters' => $filters,
+            'items' => array(),
+            'activity_types' => array(),
+            'total_records' => 0,
+            'filtered_before_status' => 0,
+            'found' => 0,
+            'new_count' => 0,
+            'imported_count' => 0,
+            'selected_count' => 0,
+            'selected_not_visible' => 0,
+            'page' => 1,
+            'per_page' => $filters['per_page'],
+            'total_pages' => 1,
+            'all_filtered_external_ids' => array(),
+        );
+        $selected = array_values(array_unique(array_filter(array_map('sanitize_text_field', (array)$selected_external_ids))));
+        $result['selected_count'] = count($selected);
+        $selected_map = array_fill_keys($selected, true);
+        $handle = fopen((string)$path, 'r');
+        if (!$handle) return $result;
+        $delimiter = $this->delimiter($path);
+        fgetcsv($handle, 0, $delimiter);
+        $candidates = array();
+        $candidate_ids = array();
+        while (($row = fgetcsv($handle, 0, $delimiter)) !== false) {
+            if ($this->is_empty_csv_row($row)) continue;
+            $item = $this->row_to_item($row, $columns, $source, $partner_id, $utm);
+            $result['total_records']++;
+            $type = (string)($item['activity_type'] ?? '');
+            if ($type !== '') $result['activity_types'][$type] = true;
+            if (!ALMA_Affiliate_Source_Import_Record_Filter::record_matches_text($item, $filters)) continue;
+            if (!ALMA_Affiliate_Source_Import_Record_Filter::record_matches_location_and_type($item, $filters)) continue;
+            $candidates[] = $item;
+            if (!empty($item['external_id'])) $candidate_ids[] = (string)$item['external_id'];
+        }
+        fclose($handle);
+        $result['activity_types'] = array_keys($result['activity_types']);
+        natcasesort($result['activity_types']);
+        $result['activity_types'] = array_values($result['activity_types']);
+        $result['filtered_before_status'] = count($candidates);
+        $existing = $this->existing_external_id_map(absint($source['id'] ?? 0), $candidate_ids);
+        $visible = array();
+        foreach ($candidates as $item) {
+            $eid = (string)($item['external_id'] ?? '');
+            $post_id = absint($existing[$eid] ?? 0);
+            $is_imported = $post_id > 0;
+            if ($is_imported) $result['imported_count']++; else $result['new_count']++;
+            if ($filters['status'] === 'new_only' && $is_imported) continue;
+            if ($filters['status'] === 'imported_only' && !$is_imported) continue;
+            $item['post_id'] = $post_id;
+            $item['status'] = $is_imported ? 'già importato' : 'nuovo';
+            $item['selected'] = isset($selected_map[$eid]);
+            $visible[] = $item;
+            if ($eid !== '') $result['all_filtered_external_ids'][] = $eid;
+        }
+        $result['found'] = count($visible);
+        $filtered_map = array_fill_keys($result['all_filtered_external_ids'], true);
+        foreach ($selected as $eid) {
+            if (!isset($filtered_map[$eid])) $result['selected_not_visible']++;
+        }
+        $page = ALMA_Affiliate_Source_Import_Record_Filter::paginate($visible, $filters['page'], $filters['per_page']);
+        $result['items'] = $page['items'];
+        $result['page'] = $page['page'];
+        $result['per_page'] = $page['per_page'];
+        $result['total_pages'] = $page['total_pages'];
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log(sprintf('[ALMA gyg_csv filter] total=%d found=%d page=%d per_page=%d selected=%d status=%s search_in=%s mode=%s type_set=%s city_set=%s region_set=%s keywords_set=%s', absint($result['total_records']), absint($result['found']), absint($result['page']), absint($result['per_page']), absint($result['selected_count']), sanitize_key($filters['status']), sanitize_key($filters['search_in']), sanitize_key($filters['keyword_mode']), $filters['activity_type'] !== '' ? 'yes' : 'no', $filters['city'] !== '' ? 'yes' : 'no', $filters['region'] !== '' ? 'yes' : 'no', $filters['keywords'] !== '' ? 'yes' : 'no'));
+        }
+        return $result;
     }
 
     public function preview($path, $columns, $activity_type, $source, $filters = array()) {

--- a/includes/class-affiliate-source-import-record-filter.php
+++ b/includes/class-affiliate-source-import-record-filter.php
@@ -1,0 +1,90 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_Affiliate_Source_Import_Record_Filter {
+    const STATUS_NEW = 'new';
+    const STATUS_IMPORTED = 'imported';
+
+    public static function normalize_text($value) {
+        $text = strtolower(wp_strip_all_tags((string)$value));
+        if (function_exists('remove_accents')) {
+            $text = remove_accents($text);
+        } else {
+            $text = strtr($text, array('à'=>'a','á'=>'a','â'=>'a','ä'=>'a','è'=>'e','é'=>'e','ê'=>'e','ë'=>'e','ì'=>'i','í'=>'i','î'=>'i','ï'=>'i','ò'=>'o','ó'=>'o','ô'=>'o','ö'=>'o','ù'=>'u','ú'=>'u','û'=>'u','ü'=>'u','ç'=>'c'));
+        }
+        $text = preg_replace('/\s+/', ' ', $text);
+        return trim((string)$text);
+    }
+
+    public static function normalize_keywords($keywords, $mode = 'any') {
+        $keywords = self::normalize_text($keywords);
+        if ($keywords === '') return array();
+        if ($mode === 'phrase') return array($keywords);
+        $parts = preg_split('/[\s,]+/', $keywords);
+        return array_values(array_unique(array_filter(array_map('trim', (array)$parts))));
+    }
+
+    public static function sanitize_filters($filters) {
+        $search_in_allowed = array('all','title','description','city','region','activity_type','affiliate_url');
+        $mode_allowed = array('any','all','phrase');
+        $status_allowed = array('new_only','with_imported','imported_only');
+        $per_page = absint($filters['per_page'] ?? 50);
+        if (!in_array($per_page, array(25, 50), true)) $per_page = 50;
+        return array(
+            'keywords' => sanitize_text_field(wp_unslash((string)($filters['keywords'] ?? ''))),
+            'search_in' => in_array(sanitize_key((string)($filters['search_in'] ?? 'all')), $search_in_allowed, true) ? sanitize_key((string)$filters['search_in']) : 'all',
+            'keyword_mode' => in_array(sanitize_key((string)($filters['keyword_mode'] ?? 'any')), $mode_allowed, true) ? sanitize_key((string)$filters['keyword_mode']) : 'any',
+            'city' => sanitize_text_field(wp_unslash((string)($filters['city'] ?? ''))),
+            'region' => sanitize_text_field(wp_unslash((string)($filters['region'] ?? ''))),
+            'activity_type' => sanitize_text_field(wp_unslash((string)($filters['activity_type'] ?? ''))),
+            'status' => in_array(sanitize_key((string)($filters['status'] ?? 'new_only')), $status_allowed, true) ? sanitize_key((string)$filters['status']) : 'new_only',
+            'page' => max(1, absint($filters['page'] ?? 1)),
+            'per_page' => $per_page,
+        );
+    }
+
+    public static function record_matches_text($item, $filters) {
+        $mode = (string)($filters['keyword_mode'] ?? 'any');
+        $keywords = self::normalize_keywords($filters['keywords'] ?? '', $mode);
+        if (empty($keywords)) return true;
+        $search_in = (string)($filters['search_in'] ?? 'all');
+        $fields = array(
+            'title' => $item['title'] ?? '',
+            'description' => $item['description'] ?? '',
+            'city' => $item['city'] ?? '',
+            'region' => $item['region'] ?? '',
+            'activity_type' => $item['activity_type'] ?? '',
+            'affiliate_url' => trim((string)($item['affiliate_url'] ?? '') . ' ' . (string)($item['original_url'] ?? '')),
+        );
+        $haystack = $search_in === 'all' ? implode(' ', $fields) : (string)($fields[$search_in] ?? '');
+        $haystack = self::normalize_text($haystack);
+        if ($mode === 'phrase') return $keywords[0] === '' || strpos($haystack, $keywords[0]) !== false;
+        $matches = 0;
+        foreach ($keywords as $word) {
+            if ($word !== '' && strpos($haystack, $word) !== false) $matches++;
+        }
+        return $mode === 'all' ? $matches === count($keywords) : $matches > 0;
+    }
+
+    public static function record_matches_location_and_type($item, $filters) {
+        $city = self::normalize_text($filters['city'] ?? '');
+        if ($city !== '' && strpos(self::normalize_text($item['city'] ?? ''), $city) === false && strpos(self::normalize_text($item['destination'] ?? ''), $city) === false) return false;
+        $region = self::normalize_text($filters['region'] ?? '');
+        if ($region !== '' && strpos(self::normalize_text($item['region'] ?? ''), $region) === false && strpos(self::normalize_text($item['country_area'] ?? ''), $region) === false) return false;
+        $type = self::normalize_text($filters['activity_type'] ?? '');
+        if ($type !== '' && self::normalize_text($item['activity_type'] ?? '') !== $type) return false;
+        return true;
+    }
+
+    public static function paginate($items, $page, $per_page) {
+        $total = count($items);
+        $pages = max(1, (int)ceil($total / max(1, $per_page)));
+        $page = min(max(1, (int)$page), $pages);
+        return array(
+            'items' => array_slice($items, ($page - 1) * $per_page, $per_page),
+            'page' => $page,
+            'per_page' => $per_page,
+            'total_pages' => $pages,
+        );
+    }
+}

--- a/includes/class-affiliate-source-manager.php
+++ b/includes/class-affiliate-source-manager.php
@@ -523,7 +523,19 @@ class ALMA_Affiliate_Source_Manager {
         $progress = $ctx['svc']->get_progress(absint($ctx['session']['id'] ?? 0), $ctx['source_id'], $ctx['activity_type']);
         $progress_terms = ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($progress['mapped_term_ids_json'] ?? array());
         $mapped = !empty($progress_terms) ? $progress_terms : ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids(($settings['type_mappings'][$ctx['activity_type']] ?? array()));
-        $preview = $ctx['svc']->preview($ctx['session']['path'], $ctx['columns'], $ctx['activity_type'], $ctx['source'], array('show_existing'=>true,'limit'=>10));
+        $filter_input = array(
+            'keywords' => $_GET['gyg_filter_keywords'] ?? '',
+            'search_in' => $_GET['gyg_filter_search_in'] ?? 'all',
+            'keyword_mode' => $_GET['gyg_filter_keyword_mode'] ?? 'any',
+            'city' => $_GET['gyg_filter_city'] ?? '',
+            'region' => $_GET['gyg_filter_region'] ?? '',
+            'activity_type' => $_GET['gyg_filter_activity_type'] ?? '',
+            'status' => $_GET['gyg_filter_status'] ?? 'new_only',
+            'per_page' => $_GET['gyg_filter_per_page'] ?? 50,
+            'page' => $_GET['gyg_filter_page'] ?? 1,
+        );
+        $selected_from_request = array_values(array_unique(array_filter(array_map('sanitize_text_field', (array)($_GET['selected_external_ids'] ?? array())))));
+        $preview = $ctx['svc']->filtered_preview($ctx['session']['path'], $ctx['columns'], $ctx['source'], $filter_input, $selected_from_request);
         $last_report = json_decode((string)($progress['last_report_json'] ?? ''), true);
         if (!is_array($last_report)) $last_report = array();
 
@@ -551,23 +563,58 @@ class ALMA_Affiliate_Source_Manager {
         echo '<tr><th>Da importare</th><td>'.absint($counts['remaining'] ?? 0).'</td></tr>';
         echo '</tbody></table></div></div>';
 
-        echo '<form method="post" class="postbox"><h2 class="hndle"><span>Importazione</span></h2><div class="inside">';
+        $filter = $preview['filters'];
+        $filter_base = array('post_type'=>'affiliate_link','page'=>'alma-affiliate-sources','alma_view'=>'gyg_csv_import_type','source_id'=>$ctx['source_id'],'gyg_csv_token'=>$ctx['token'],'activity_type_hash'=>$ctx['activity_type_hash']);
+        echo '<div class="postbox alma-gyg-filter-box"><h2 class="hndle"><span>Filtra contenuti prima dell’importazione</span></h2><div class="inside">';
+        echo '<p class="description">Usa questi filtri per cercare nel file e selezionare solo i contenuti da importare.</p>';
+        echo '<form method="get" class="alma-gyg-filter-form">';
+        foreach ($filter_base as $k=>$v) echo '<input type="hidden" name="'.esc_attr($k).'" value="'.esc_attr($v).'"/>';
+        echo '<input type="hidden" name="gyg_filter_page" value="1"/>';
+        echo '<div class="alma-gyg-filter-grid">';
+        echo '<p><label>Parole chiave<br/><input type="text" name="gyg_filter_keywords" value="'.esc_attr($filter['keywords']).'" placeholder="es. Lecce, barca"/></label></p>';
+        echo '<p><label>Cerca in<br/><select name="gyg_filter_search_in">';
+        $search_options=array('all'=>'Tutti i campi','title'=>'Titolo Attività','description'=>'Descrizione attività','city'=>'Città','region'=>'Regione','activity_type'=>'Tipologia attività','affiliate_url'=>'URL affiliato');
+        foreach($search_options as $value=>$label) echo '<option value="'.esc_attr($value).'" '.selected($filter['search_in'],$value,false).'>'.esc_html($label).'</option>';
+        echo '</select></label></p>';
+        echo '<p><label>Modalità ricerca<br/><select name="gyg_filter_keyword_mode">';
+        foreach(array('any'=>'contiene almeno una parola','all'=>'contiene tutte le parole','phrase'=>'frase esatta') as $value=>$label) echo '<option value="'.esc_attr($value).'" '.selected($filter['keyword_mode'],$value,false).'>'.esc_html($label).'</option>';
+        echo '</select></label></p>';
+        echo '<p><label>Città<br/><input type="text" name="gyg_filter_city" value="'.esc_attr($filter['city']).'"/></label></p>';
+        echo '<p><label>Regione<br/><input type="text" name="gyg_filter_region" value="'.esc_attr($filter['region']).'"/></label></p>';
+        echo '<p><label>Tipologia attività<br/><select name="gyg_filter_activity_type"><option value="">Tutte le tipologie</option>';
+        foreach((array)$preview['activity_types'] as $type) echo '<option value="'.esc_attr($type).'" '.selected($filter['activity_type'],$type,false).'>'.esc_html($type).'</option>';
+        echo '</select></label></p>';
+        echo '<p><label>Stato importazione<br/><select name="gyg_filter_status">';
+        foreach(array('new_only'=>'Solo non importati','with_imported'=>'Mostra anche già importati','imported_only'=>'Solo già importati') as $value=>$label) echo '<option value="'.esc_attr($value).'" '.selected($filter['status'],$value,false).'>'.esc_html($label).'</option>';
+        echo '</select></label></p>';
+        echo '<p><label>Risultati per pagina<br/><select name="gyg_filter_per_page"><option value="25" '.selected($filter['per_page'],25,false).'>25</option><option value="50" '.selected($filter['per_page'],50,false).'>50</option></select></label></p>';
+        echo '</div><p><button class="button button-primary">Applica filtro</button> <a class="button" href="'.esc_url($self_url).'">Pulisci filtro</a></p>';
+        echo '</form></div></div>';
+
+        $counter = sprintf('Record totali: %1$s · Trovati: %2$s · Non importati: %3$s · Già importati: %4$s · Selezionati: %5$s · Selezionati non visibili: %6$s · Pagina %7$s di %8$s', number_format_i18n($preview['total_records']), number_format_i18n($preview['found']), number_format_i18n($preview['new_count']), number_format_i18n($preview['imported_count']), number_format_i18n($preview['selected_count']), number_format_i18n($preview['selected_not_visible']), number_format_i18n($preview['page']), number_format_i18n($preview['total_pages']));
+        echo '<form method="post" class="postbox alma-gyg-selective-import-form"><h2 class="hndle"><span>Risultati Anteprima</span></h2><div class="inside">';
         wp_nonce_field('alma_gyg_csv_import_type', 'alma_gyg_csv_import_type_nonce');
         echo '<input type="hidden" name="action_type" value="gyg_csv_import_type"/><input type="hidden" name="source_id" value="'.(int)$ctx['source_id'].'"/><input type="hidden" name="gyg_csv_token" value="'.esc_attr($ctx['token']).'"/><input type="hidden" name="activity_type_hash" value="'.esc_attr($ctx['activity_type_hash']).'"/>';
+        echo '<p><strong>'.esc_html($counter).'</strong></p><div class="alma-gyg-selected-store"></div>';
         echo '<fieldset><legend><strong>Tipologie Link Sothra</strong></legend>';
-        if (empty($terms)) {
-            echo '<p class="description">Nessuna Tipologia Link Sothra disponibile. Creane almeno una prima di importare.</p>';
+        if (empty($terms)) echo '<p class="description">Nessuna Tipologia Link Sothra disponibile. Creane almeno una prima di importare.</p>'; else foreach ($terms as $term) { $checked = in_array((int)$term->term_id, $mapped, true); echo '<label style="display:block;margin:.25em 0"><input type="checkbox" name="link_type_term_ids[]" value="'.(int)$term->term_id.'" '.checked($checked,true,false).'/> '.esc_html($term->name).'</label>'; }
+        echo '</fieldset><fieldset><legend><strong>Modalità deduplica</strong></legend><p><label><input type="radio" name="update_existing" value="0" checked/> Importa solo nuovi record</label><br/><label><input type="radio" name="update_existing" value="1"/> Aggiorna anche record già importati</label></p></fieldset>';
+        echo '<p class="alma-gyg-selection-actions"><button type="button" class="button alma-gyg-select-visible">Seleziona risultati visibili</button> <button type="button" class="button alma-gyg-deselect-visible">Deseleziona risultati visibili</button> <button type="button" class="button alma-gyg-select-filtered" data-count="'.esc_attr($preview['found']).'">Seleziona tutti i risultati filtrati</button></p>';
+        foreach((array)$preview['all_filtered_external_ids'] as $eid) echo '<input type="hidden" class="alma-gyg-filtered-id" value="'.esc_attr($eid).'"/>';
+        if (empty($preview['items'])) {
+            echo '<div class="notice notice-warning inline"><p>Nessun contenuto trovato con i filtri applicati. Prova a rimuovere una parola chiave o cambiare modalità di ricerca.</p></div>';
         } else {
-            foreach ($terms as $term) { $checked = in_array((int)$term->term_id, $mapped, true); echo '<label style="display:block;margin:.25em 0"><input type="checkbox" name="link_type_term_ids[]" value="'.(int)$term->term_id.'" '.checked($checked,true,false).'/> '.esc_html($term->name).'</label>'; }
+            echo '<table class="widefat striped alma-gyg-preview-table"><thead><tr><th>Seleziona</th><th>Titolo Attività</th><th>URL affiliato</th><th>Città</th><th>Regione</th><th>Tipologia attività</th><th>Descrizione breve</th><th>Stato</th></tr></thead><tbody>';
+            foreach ($preview['items'] as $it) { $desc = function_exists('mb_substr') ? mb_substr((string)$it['description'], 0, 140) : substr((string)$it['description'], 0, 140); $eid=(string)$it['external_id']; echo '<tr'.(!empty($it['post_id'])?' class="alma-row-existing"':'').'><td><input class="alma-gyg-row-select" type="checkbox" value="'.esc_attr($eid).'" '.checked(!empty($it['selected']),true,false).'/></td><td>'.esc_html($it['title']!==''?$it['title']:'—').'<br/><code>'.esc_html(substr($eid,0,12)).'</code></td><td><a href="'.esc_url($it['affiliate_url']).'" target="_blank" rel="noopener noreferrer">Apri</a></td><td>'.esc_html($it['city']).'</td><td>'.esc_html($it['region']).'</td><td>'.esc_html($it['activity_type']).'</td><td>'.esc_html($desc).'</td><td>'.esc_html($it['status']).'</td></tr>'; }
+            echo '</tbody></table>';
         }
-        echo '</fieldset><p><label><strong>Quantità da importare</strong><br/><input type="number" name="quantity" min="1" max="1000" value="100"/> <span class="description">Massimo 1000 record per importazione.</span></label></p>';
-        echo '<fieldset><legend><strong>Modalità deduplica</strong></legend><p><label><input type="radio" name="update_existing" value="0" checked/> Importa solo nuovi record</label><br/><label><input type="radio" name="update_existing" value="1"/> Aggiorna anche record già importati</label></p></fieldset>';
-        if (empty($terms)) echo '<p><button class="button button-primary" disabled>Avvia importazione</button></p>'; else echo '<p><button class="button button-primary">Avvia importazione</button></p>';
+        $prev_args = array_merge($filter_base, array('gyg_filter_keywords'=>$filter['keywords'],'gyg_filter_search_in'=>$filter['search_in'],'gyg_filter_keyword_mode'=>$filter['keyword_mode'],'gyg_filter_city'=>$filter['city'],'gyg_filter_region'=>$filter['region'],'gyg_filter_activity_type'=>$filter['activity_type'],'gyg_filter_status'=>$filter['status'],'gyg_filter_per_page'=>$filter['per_page']));
+        $prev_url = add_query_arg(array_merge($prev_args,array('gyg_filter_page'=>max(1,$preview['page']-1))), admin_url('edit.php'));
+        $next_url = add_query_arg(array_merge($prev_args,array('gyg_filter_page'=>min($preview['total_pages'],$preview['page']+1))), admin_url('edit.php'));
+        echo '<p class="alma-gyg-pagination"><a class="button" href="'.esc_url($prev_url).'">precedente</a> <span>Pagina '.esc_html($preview['page']).' di '.esc_html($preview['total_pages']).'</span> <a class="button" href="'.esc_url($next_url).'">successiva</a></p>';
+        if (empty($terms)) echo '<p><button class="button button-primary alma-gyg-import-selected" disabled>Importa selezionati</button></p>'; else echo '<p><button class="button button-primary alma-gyg-import-selected">Importa selezionati</button> <span class="description alma-gyg-no-selection-warning">Se non ci sono record selezionati, seleziona almeno un contenuto prima dell’import.</span></p>';
         echo '</div></form>';
 
-        echo '<div class="postbox"><h2 class="hndle"><span>Anteprima sintetica</span></h2><div class="inside">';
-        if (empty($preview)) echo '<p class="description">Nessun record disponibile per l’anteprima.</p>'; else { echo '<table class="widefat striped"><thead><tr><th>URL originale</th><th>URL affiliato generato</th><th>Città</th><th>Regione</th><th>Descrizione breve</th><th>Stato</th></tr></thead><tbody>'; foreach ($preview as $it) { $desc = function_exists('mb_substr') ? mb_substr((string)$it['description'], 0, 140) : substr((string)$it['description'], 0, 140); echo '<tr><td><code>'.esc_html($it['original_url']).'</code></td><td><code>'.esc_html($it['affiliate_url']).'</code></td><td>'.esc_html($it['city']).'</td><td>'.esc_html($it['region']).'</td><td>'.esc_html($desc).'</td><td>'.esc_html(!empty($it['post_id']) ? 'già importato' : 'nuovo').'</td></tr>'; } echo '</tbody></table>'; }
-        echo '</div></div>';
 
         if (!empty($last_report)) { $this->render_gyg_csv_import_type_report($last_report, $back, $self_url, $list_url); }
         echo '</div>';
@@ -593,26 +640,16 @@ class ALMA_Affiliate_Source_Manager {
         $term_ids = ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($_POST['link_type_term_ids'] ?? array());
         foreach ($term_ids as $tid) { $term = get_term($tid, $taxonomy); if (!$term || is_wp_error($term)) { wp_safe_redirect(add_query_arg(array_merge($redirect_base, array('alma_gyg_error'=>'invalid_term')), admin_url('edit.php'))); exit; } }
         if (empty($term_ids)) { wp_safe_redirect(add_query_arg(array_merge($redirect_base, array('alma_gyg_error'=>'missing_terms')), admin_url('edit.php'))); exit; }
-        $quantity = max(1, min(ALMA_Affiliate_Source_GYG_CSV_Importer::MAX_IMPORT_QUANTITY, absint($_POST['quantity'] ?? 100)));
+        $selected = array_values(array_unique(array_filter(array_map('sanitize_text_field', (array)($_POST['selected_external_ids'] ?? array())))));
+        if (empty($selected)) { wp_safe_redirect(add_query_arg(array_merge($redirect_base, array('alma_gyg_error'=>'missing_selection')), admin_url('edit.php'))); exit; }
+        if (count($selected) > ALMA_Affiliate_Source_GYG_CSV_Importer::MAX_IMPORT_QUANTITY) $selected = array_slice($selected, 0, ALMA_Affiliate_Source_GYG_CSV_Importer::MAX_IMPORT_QUANTITY);
         $update_existing = isset($_POST['update_existing']) && (string)$_POST['update_existing'] === '1';
         global $wpdb;
         $settings = ALMA_Affiliate_Source_GYG_CSV_Importer::default_settings($this->decode_db_json($ctx['source']['settings'] ?? '{}'));
         $settings['type_mappings'][$ctx['activity_type']] = $term_ids;
         $wpdb->update("{$wpdb->prefix}alma_affiliate_sources", array('settings'=>wp_json_encode($settings),'updated_at'=>current_time('mysql')), array('id'=>$ctx['source_id']));
-        $progress = $ctx['svc']->get_progress(absint($ctx['session']['id'] ?? 0), $ctx['source_id'], $ctx['activity_type']);
-        $cursor = absint($progress['last_cursor'] ?? 0);
-        $target = $cursor + $quantity;
-        $aggregate = array('requested'=>$quantity,'selected'=>$quantity,'processed'=>0,'effective_processed'=>0,'imported'=>0,'updated'=>0,'existing'=>0,'skipped'=>0,'errors'=>0,'invalid_urls'=>0,'without_city'=>0,'without_region'=>0,'titles_read'=>0,'titles_saved'=>0,'titles_populated'=>0,'titles_missing'=>0,'ai_contexts_populated'=>0,'ai_contexts_skipped_manual_only'=>0,'ai_contexts_missing'=>0,'link_types_associated'=>0,'dedupe_matches_valid'=>0,'dedupe_matches_stale'=>0,'duration'=>0,'logs'=>array(),'next_cursor'=>$cursor,'done'=>false);
-        do {
-            $batch = $ctx['svc']->import_batch($ctx['session']['path'], $ctx['columns'], $ctx['activity_type'], $ctx['source'], $term_ids, $target, $cursor, $update_existing);
-            if (is_wp_error($batch)) { wp_safe_redirect(add_query_arg(array_merge($redirect_base, array('alma_gyg_error'=>$batch->get_error_code())), admin_url('edit.php'))); exit; }
-            foreach (array('processed','effective_processed','imported','updated','existing','skipped','errors','invalid_urls','without_city','without_region','titles_read','titles_saved','titles_populated','titles_missing','ai_contexts_populated','ai_contexts_skipped_manual_only','ai_contexts_missing','link_types_associated','dedupe_matches_valid','dedupe_matches_stale') as $k) $aggregate[$k] += absint($batch[$k] ?? 0);
-            $aggregate['duration'] += (float)($batch['duration'] ?? 0);
-            $aggregate['logs'] = array_merge($aggregate['logs'], (array)($batch['logs'] ?? array()));
-            $cursor = absint($batch['next_cursor'] ?? $cursor);
-            $aggregate['next_cursor'] = $cursor;
-            $aggregate['done'] = !empty($batch['done']);
-        } while (empty($aggregate['done']) && $aggregate['processed'] < $quantity);
+        $aggregate = $ctx['svc']->import_selected($ctx['session']['path'], $ctx['columns'], '', $ctx['source'], $selected, $term_ids, $update_existing);
+        if (is_wp_error($aggregate)) { wp_safe_redirect(add_query_arg(array_merge($redirect_base, array('alma_gyg_error'=>$aggregate->get_error_code())), admin_url('edit.php'))); exit; }
         $ctx['svc']->upsert_progress(absint($ctx['session']['id'] ?? 0), $ctx['source_id'], $ctx['activity_type'], $term_ids, $aggregate);
         wp_safe_redirect(add_query_arg(array_merge($redirect_base, array('alma_gyg_imported'=>1)), admin_url('edit.php'))); exit;
     }


### PR DESCRIPTION
### Motivation
- Rendere possibile filtrare e cercare i record del CSV nella schermata di anteprima (dopo “Importa / continua”) per consentire selezioni mirate prima dell’importazione. 
- Evitare rendering/client-side di migliaia di righe e mantenere performance e accuratezza della selezione su file grandi riusando lo stato già calcolato (external_id). 

### Description
- Aggiunto helper riusabile `ALMA_Affiliate_Source_Import_Record_Filter` che normalizza testo/parole chiave (case/accents-insensitive dove possibile), valida/sanitizza i filtri, applica ricerca keyword (modalità any/all/phrase), filtra per città/regione/tipologia, e fornisce paginazione server-side. (file: `includes/class-affiliate-source-import-record-filter.php`).
- Implementata preview filtrata server-side `filtered_preview(...)` in `ALMA_Affiliate_Source_GYG_CSV_Importer` che scansiona l’intero file della sessione persistente, costruisce la lista di candidati, esegue lookup batch dello stato “già importato” e restituisce solo la pagina corrente con contatori e lista di `all_filtered_external_ids`. Estesi anche alias di rilevamento colonne per città/regione (es. `destination`, `country area`). (file: `includes/class-affiliate-source-gyg-csv-importer.php`).
- Aggiornata la pagina admin di import (`render_gyg_csv_import_type_page`) per mostrare il box “Filtra contenuti prima dell’importazione” sopra la tabella Risultati Anteprima, i contatori riassuntivi, la paginazione, le azioni di selezione (seleziona visibili / deseleziona visibili / seleziona tutti filtrati con conferma >100) e il submit che invia solo gli `external_id` selezionati al backend. La logica server continua a chiamare l’import selettivo esistente passando gli `external_id`. (file: `includes/class-affiliate-source-manager.php`).
- JS/CSS admin: aggiunta gestione client per persistere la selezione su `external_id` in `sessionStorage`, reiniettare gli `selected_external_ids[]` nel form al submit/paginazione, azioni di selezione visibili/tutti, conferma per selezioni massicce e protezioni UX (non importare automaticamente, blocco import senza selezione). (files: `assets/affiliate-sources.js`, `assets/affiliate-sources.css`).
- Bump versione plugin a `2.31.0` e caricamento del nuovo helper nel bootstrap, aggiornati `README.md` e `CHANGELOG.md` con descrizione funzionalità e note performance. (file: `affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`).
- Sicurezza e validazione: capability checks, nonce per form, sanitizzazione/escaping input output, validazione `per_page`/page, e validazione degli `external_id` selezionati prima dell’import; nessuna chiamata OpenAI o API esterna introdotta.

### Testing
- Eseguiti controlli di sintassi PHP: `php -l` su `includes/class-affiliate-source-import-record-filter.php`, `includes/class-affiliate-source-gyg-csv-importer.php`, `includes/class-affiliate-source-manager.php` e `affiliate-link-manager-ai.php`; tutti i file risultano senza errori di sintassi. 
- Eseguito controllo sintassi JS: `node --check assets/affiliate-sources.js` risultando senza errori. 
- Eseguito `git diff --check` e `git diff --stat` per individuare whitespace/warnings; non sono stati riscontrati problemi bloccanti. 
- Nota: i test manuali end-to-end A–H indicati nella specifica (filtro città su tutto il file, parole chiave, paginazione e selezione persistente, seleziona tutti filtrati con conferma, import selettivo e regressione import 2.30.2) sono forniti come istruzioni di verifica, ma non sono stati eseguiti automaticamente in questo ambiente non interattivo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feeee2685c8332bdb00997a9bccf1a)