### PR TITLE
Add Trend Idee contenuto admin module (v2.32.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.32.0 — Trend Idee contenuto
+- Aggiunto il nuovo modulo admin **Trend Idee contenuto** per analizzare fonti pubbliche sui trend di viaggio con OpenAI Web Search e generare report editoriali strutturati per Sothra.
+- Introdotte tabelle dedicate per configurazione fonti, report storici e log run; le fonti predefinite vengono inizializzate in modo idempotente su attivazione/upgrade.
+- Aggiunto registry iniziale di fonti Priorità 1 e Priorità 2 con domini ammessi, categoria, intervallo default, prompt specifico e stato abilitato.
+- La UI permette salvataggio prompt globale, prompt per fonte, enable/disable, intervallo giorni, test singola fonte, test completo e generazione manuale del piano editoriale.
+- Lo scheduler WP-Cron controlla solo fonti abilitate e scadute, aggiorna last/next run e usa transient lock per evitare run parallele; il caricamento admin/dashboard non avvia chiamate OpenAI.
+- I report salvano JSON validato, fonti, metriche predisposte per grafici, stato, modello e token quando disponibili; la vista report mostra sintesi, destinazioni, piano settimanale, bisogni, opportunità affiliate, rischi, fonti citate e JSON tecnico collassabile.
+- Aggiunto box **Trend Idee contenuto** nella dashboard principale del plugin con ultimo report, conteggi, top destinazioni, top idee, alert e link rapidi.
+- Versione plugin aggiornata a `2.32.0`.
+
 ## 2.31.0 — Filtro CSV GYG prima dell’importazione
 - Aggiunto il box **Filtra contenuti prima dell’importazione** nella schermata aperta dopo **Importa / continua**, sopra la tabella **Risultati Anteprima**.
 - La ricerca lavora sull’intero CSV normalizzato della sessione persistente, non solo sulla pagina visibile, e restituisce solo la pagina corrente per evitare rendering di migliaia di righe.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## 2.32.0 — Trend Idee contenuto
+- Aggiunto il nuovo modulo admin **Trend Idee contenuto** per analizzare fonti pubbliche sui trend di viaggio con OpenAI Web Search e generare report editoriali strutturati per Sothra.
+- Introdotte tabelle dedicate per configurazione fonti, report storici e log run; le fonti predefinite vengono inizializzate in modo idempotente su attivazione/upgrade.
+- Aggiunto registry iniziale di fonti Priorità 1 e Priorità 2 con domini ammessi, categoria, intervallo default, prompt specifico e stato abilitato.
+- La UI permette salvataggio prompt globale, prompt per fonte, enable/disable, intervallo giorni, test singola fonte, test completo e generazione manuale del piano editoriale.
+- Lo scheduler WP-Cron controlla solo fonti abilitate e scadute, aggiorna last/next run e usa transient lock per evitare run parallele; il caricamento admin/dashboard non avvia chiamate OpenAI.
+- I report salvano JSON validato, fonti, metriche predisposte per grafici, stato, modello e token quando disponibili; la vista report mostra sintesi, destinazioni, piano settimanale, bisogni, opportunità affiliate, rischi, fonti citate e JSON tecnico collassabile.
+- Aggiunto box **Trend Idee contenuto** nella dashboard principale del plugin con ultimo report, conteggi, top destinazioni, top idee, alert e link rapidi.
+- Versione plugin aggiornata a `2.32.0`.
+
 ## 2.31.0 — Filtro CSV GYG prima dell’importazione
 - Aggiunto il box **Filtra contenuti prima dell’importazione** nella schermata aperta dopo **Importa / continua**, sopra la tabella **Risultati Anteprima**.
 - La ricerca lavora sull’intero CSV normalizzato della sessione persistente, non solo sulla pagina visibile, e restituisce solo la pagina corrente per evitare rendering di migliaia di righe.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.31.0
+ * Version: 2.32.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.31.0');
+define('ALMA_VERSION', '2.32.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -54,6 +54,11 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-instructions-man
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-trend-radar-store.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-trend-radar-service.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-trend-radar-admin.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-trend-content-ideas-registry.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-trend-content-ideas-prompt-builder.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-trend-content-ideas-store.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-trend-content-ideas-service.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-trend-content-ideas-admin.php';
 
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-interface.php';
 require_once ALMA_PLUGIN_DIR . 'includes/providers/class-affiliate-source-provider-manual.php';
@@ -1309,6 +1314,17 @@ class AffiliateManagerAI {
             array('ALMA_AI_Trend_Radar_Admin', 'render_page')
         );
 
+
+        // Trend Idee contenuto
+        add_submenu_page(
+            self::AFFILIATE_LINK_PARENT_MENU,
+            __('Trend Idee contenuto', 'affiliate-link-manager-ai'),
+            __('Trend Idee contenuto', 'affiliate-link-manager-ai'),
+            'manage_options',
+            ALMA_Trend_Content_Ideas_Admin::SLUG,
+            array('ALMA_Trend_Content_Ideas_Admin', 'render_page')
+        );
+
         // Affiliate Chat AI
         add_submenu_page(
             'edit.php?post_type=affiliate_link',
@@ -1363,6 +1379,8 @@ class AffiliateManagerAI {
             'affiliate-chat-ai',
             'alma-affiliate-sources',
             self::AI_CONTENT_AGENT_MENU_SLUG,
+            ALMA_AI_Trend_Radar_Admin::SLUG,
+            ALMA_Trend_Content_Ideas_Admin::SLUG,
             'affiliate-link-manager-settings',
             'alma-css-editor',
         );
@@ -1399,6 +1417,12 @@ class AffiliateManagerAI {
                         case 'alma-affiliate-sources':
                             $item[0] = __('Affiliate Sources', 'affiliate-link-manager-ai');
                             break;
+                        case ALMA_AI_Trend_Radar_Admin::SLUG:
+                            $item[0] = __('Trend Radar', 'affiliate-link-manager-ai');
+                            break;
+                        case ALMA_Trend_Content_Ideas_Admin::SLUG:
+                            $item[0] = __('Trend Idee contenuto', 'affiliate-link-manager-ai');
+                            break;
                         case 'affiliate-link-manager-settings':
                             $item[0] = __('Impostazioni', 'affiliate-link-manager-ai');
                             break;
@@ -1409,6 +1433,14 @@ class AffiliateManagerAI {
                     $new[] = $item;
                     break;
                 }
+            }
+        }
+
+        $known = array();
+        foreach ($new as $item) { $known[] = $item[2]; }
+        foreach ($items as $item) {
+            if (!in_array($item[2], $known, true)) {
+                $new[] = $item;
             }
         }
 
@@ -1427,6 +1459,7 @@ class AffiliateManagerAI {
             <h1><?php _e('Dashboard Link - Affiliate Link Manager', 'affiliate-link-manager-ai'); ?></h1>
             <p style="font-size:14px;color:#666;">Versione <?php echo esc_html(ALMA_VERSION); ?></p>
             <div id="alma-dashboard-root"><p><?php _e('Caricamento statistiche dashboard…', 'affiliate-link-manager-ai'); ?></p></div>
+            <?php ALMA_Trend_Content_Ideas_Admin::dashboard_box(); ?>
         </div>
         <script>
         jQuery(function($){
@@ -3693,11 +3726,12 @@ class AffiliateManagerAI {
     public function activate() {
         ALMA_AI_Content_Agent_Store::install();
         ALMA_AI_Trend_Radar_Store::install();
+        ALMA_Trend_Content_Ideas_Store::install();
         $this->create_analytics_table();
         ALMA_AI_Usage_Logger::create_table();
         ALMA_Affiliate_Source_Manager::create_tables();
         $this->create_default_categories();
-        update_option('alma_db_schema_version', '3');
+        update_option('alma_db_schema_version', '4');
         update_option('alma_plugin_version', ALMA_VERSION);
         flush_rewrite_rules();
     }
@@ -3705,6 +3739,7 @@ class AffiliateManagerAI {
     public function deactivate() {
         // Rimuovi cron jobs
         wp_clear_scheduled_hook('alma_daily_optimization');
+        wp_clear_scheduled_hook(ALMA_Trend_Content_Ideas_Service::CRON_HOOK);
         foreach (ALMA_AI_Trend_Radar_Store::get_profiles() as $profile) {
             ALMA_AI_Trend_Radar_Service::clear_profile_schedule((int)$profile['id']);
         }
@@ -3716,10 +3751,11 @@ class AffiliateManagerAI {
         if (version_compare($installed_version, ALMA_VERSION, '<')) {
             ALMA_AI_Content_Agent_Store::install();
             ALMA_AI_Trend_Radar_Store::install();
+            ALMA_Trend_Content_Ideas_Store::install();
             $this->create_analytics_table();
             ALMA_AI_Usage_Logger::create_table();
             ALMA_Affiliate_Source_Manager::create_tables();
-            update_option('alma_db_schema_version', '3');
+            update_option('alma_db_schema_version', '4');
             update_option('alma_plugin_version', ALMA_VERSION);
         }
     }

--- a/includes/class-trend-content-ideas-admin.php
+++ b/includes/class-trend-content-ideas-admin.php
@@ -1,0 +1,72 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_Trend_Content_Ideas_Admin {
+    const SLUG = 'alma-trend-content-ideas';
+    const CAP = 'manage_options';
+
+    public static function init() { add_action('admin_post_alma_trend_content_action', array(__CLASS__, 'handle_action')); }
+    private static function url($args=array()) { return admin_url('edit.php?post_type=affiliate_link&page=' . self::SLUG . (empty($args)?'':'&' . http_build_query($args))); }
+    private static function action_url($args=array()) { return wp_nonce_url(add_query_arg(array_merge(array('action'=>'alma_trend_content_action'), $args), admin_url('admin-post.php')), 'alma_trend_content_action'); }
+
+    public static function render_page() {
+        if (!current_user_can(self::CAP)) { wp_die(esc_html__('Permessi insufficienti.', 'affiliate-link-manager-ai')); }
+        $notice = get_transient('alma_trend_content_notice_' . get_current_user_id()); delete_transient('alma_trend_content_notice_' . get_current_user_id());
+        $view_id = absint($_GET['report_id'] ?? 0);
+        echo '<div class="wrap alma-trend-content"><h1>Trend Idee contenuto</h1><p>Analizza fonti pubbliche sui trend di viaggio con OpenAI Web Search e genera report editoriali per Sothra. Nessuna bozza WordPress viene creata automaticamente.</p>';
+        if ($notice) { printf('<div class="notice notice-%s is-dismissible"><p>%s</p></div>', esc_attr($notice['type']), esc_html($notice['message'])); }
+        echo '<div class="notice notice-info"><p>Le chiamate OpenAI partono solo dai pulsanti di test/generazione o da WP Cron, mai durante il semplice caricamento della pagina.</p></div>';
+        if (!ALMA_Trend_Content_Ideas_Service::is_openai_ready()) { echo '<div class="notice notice-warning"><p>Configura la chiave OpenAI nelle impostazioni del plugin prima di eseguire test reali.</p></div>'; }
+        if ($view_id) { self::render_report($view_id); echo '</div>'; return; }
+        self::render_settings(); self::render_latest(); self::render_history(); echo '</div>';
+    }
+
+    private static function render_settings() {
+        $sources = ALMA_Trend_Content_Ideas_Store::get_sources(false);
+        $model = get_option(ALMA_Trend_Content_Ideas_Store::OPTION_MODEL, ''); $timeout = get_option(ALMA_Trend_Content_Ideas_Store::OPTION_TIMEOUT, 90);
+        echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '"><input type="hidden" name="action" value="alma_trend_content_action"><input type="hidden" name="do" value="save_settings">'; wp_nonce_field('alma_trend_content_action');
+        echo '<div class="postbox"><div class="inside"><h2>Configurazione generale</h2><table class="form-table"><tr><th><label for="global_prompt">Prompt globale</label></th><td><textarea id="global_prompt" name="global_prompt" class="large-text" rows="6">' . esc_textarea(get_option(ALMA_Trend_Content_Ideas_Store::OPTION_GLOBAL_PROMPT, ALMA_Trend_Content_Ideas_Prompt_Builder::default_global_prompt())) . '</textarea><p class="description">Questo testo viene combinato con istruzioni non modificabili e prompt specifici fonte.</p></td></tr><tr><th><label for="model">Modello OpenAI</label></th><td><input id="model" name="model" class="regular-text" value="' . esc_attr($model) . '" placeholder="Usa modello globale"><p class="description">Lascia vuoto per usare il modello configurato nelle impostazioni OpenAI del plugin.</p></td></tr><tr><th><label for="timeout">Timeout ricerca</label></th><td><input id="timeout" name="timeout" type="number" min="20" max="180" value="' . esc_attr($timeout) . '"> secondi</td></tr></table></div></div>';
+        echo '<div class="postbox"><div class="inside"><h2>Fonti trend</h2><p>Abilita le fonti da analizzare, scegli ogni quanti giorni controllarle e personalizza il prompt fonte.</p><table class="widefat striped"><thead><tr><th>Abilitata</th><th>Fonte</th><th>Priorità</th><th>Categoria</th><th>Intervallo</th><th>Ultima analisi</th><th>Prossima</th><th>Stato</th><th>Azioni</th></tr></thead><tbody>';
+        foreach ($sources as $src) { $key=$src['source_key']; $badge = $src['enabled'] ? 'success' : 'muted'; echo '<tr><td><input type="checkbox" name="sources[' . esc_attr($key) . '][enabled]" value="1" ' . checked((int)$src['enabled'],1,false) . '></td><td><strong>' . esc_html($src['name']) . '</strong><p class="description">' . esc_html($src['description']) . '</p><details><summary>Modifica prompt fonte</summary><textarea class="large-text" rows="4" name="sources[' . esc_attr($key) . '][custom_prompt]">' . esc_textarea($src['custom_prompt']) . '</textarea></details></td><td>' . (int)$src['priority'] . '</td><td>' . esc_html($src['category']) . '</td><td><input type="number" min="1" max="365" name="sources[' . esc_attr($key) . '][interval_days]" value="' . (int)$src['interval_days'] . '" style="width:80px"> giorni</td><td>' . esc_html($src['last_run_at'] ?: 'Mai') . '</td><td>' . esc_html($src['next_run_at'] ?: 'Non pianificata') . '</td><td><span class="alma-badge alma-badge-' . esc_attr($badge) . '">' . esc_html($src['status']) . '</span></td><td><a class="button button-small" href="' . esc_url(self::action_url(array('do'=>'run_source','source_key'=>$key))) . '">Testa fonte</a></td></tr>'; }
+        echo '</tbody></table><p><button class="button button-primary">Salva configurazione</button> <a class="button" href="' . esc_url(self::action_url(array('do'=>'run_all'))) . '">Esegui test completo adesso</a> <a class="button button-secondary" href="' . esc_url(self::action_url(array('do'=>'generate_plan'))) . '">Genera piano editoriale ora</a> <a class="button" href="#ultimo-report">Visualizza ultimo report</a></p></div></div></form>';
+        echo '<style>.alma-badge{display:inline-block;padding:3px 8px;border-radius:999px;background:#dcdcde}.alma-badge-success{background:#00a32a;color:#fff}.alma-badge-muted{background:#646970;color:#fff}.alma-report-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px}.alma-card{background:#fff;border:1px solid #c3c4c7;padding:14px}.alma-card h3{margin-top:0}.alma-pill{display:inline-block;padding:2px 7px;border-radius:999px;background:#f0f0f1;margin:2px}</style>';
+    }
+
+    public static function dashboard_box() {
+        $r = ALMA_Trend_Content_Ideas_Store::latest_report();
+        echo '<div class="postbox"><div class="inside"><h2>Trend Idee contenuto</h2>';
+        if (!$r) { echo '<p>Nessun report ancora generato.</p><p><a class="button" href="' . esc_url(self::url()) . '">Configura fonti</a></p></div></div>'; return; }
+        $data=ALMA_Trend_Content_Ideas_Store::decode_json($r['result_json']); $metrics=ALMA_Trend_Content_Ideas_Store::decode_json($r['metrics_json']); $dest=array_slice((array)($data['destinazioni_prioritarie']??array()),0,5); $ideas=array_slice((array)($data['piano_editoriale_settimanale']??array()),0,5); $alerts=array_slice((array)($data['alert']??array()),0,5);
+        echo '<p><strong>Ultimo report:</strong> ' . esc_html($r['created_at']) . ' — <strong>Stato:</strong> ' . esc_html($r['status']) . '</p><ul><li>Fonti analizzate: ' . (int)($metrics['count_fonti_analizzate']??0) . '</li><li>Destinazioni individuate: ' . (int)($metrics['count_destinazioni']??0) . '</li><li>Idee editoriali generate: ' . (int)($metrics['count_idee_editoriali']??0) . '</li></ul>';
+        echo '<h3>Top destinazioni</h3><ol>'; foreach($dest as $d){ echo '<li>' . esc_html($d['nome'] ?? '') . ' <small>' . esc_html($d['paese_o_area'] ?? '') . '</small></li>'; } echo '</ol><h3>Top idee contenuto</h3><ol>'; foreach($ideas as $i){ echo '<li>' . esc_html($i['titolo'] ?? '') . '</li>'; } echo '</ol>';
+        if($alerts){ echo '<h3>Alert principali</h3><ul>'; foreach($alerts as $a){ echo '<li>' . esc_html(is_scalar($a)?$a:wp_json_encode($a)) . '</li>'; } echo '</ul>'; }
+        echo '<p><a class="button button-primary" href="' . esc_url(self::url(array('report_id'=>(int)$r['id']))) . '">Apri report completo</a> <a class="button" href="' . esc_url(self::url()) . '">Configura fonti</a> <a class="button" href="' . esc_url(self::action_url(array('do'=>'run_all'))) . '">Esegui test ora</a></p></div></div>';
+    }
+
+    private static function render_latest() { echo '<div id="ultimo-report">'; self::dashboard_box(); echo '</div>'; }
+    private static function render_history() { $page=max(1,absint($_GET['paged']??1)); $reports=ALMA_Trend_Content_Ideas_Store::get_reports($page,10); echo '<div class="postbox"><div class="inside"><h2>Storico report</h2><table class="widefat striped"><thead><tr><th>Data</th><th>Titolo</th><th>Tipo</th><th>Stato</th><th>Sintesi</th><th>Azioni</th></tr></thead><tbody>'; if(!$reports){echo '<tr><td colspan="6">Nessun report salvato.</td></tr>';} foreach($reports as $r){ echo '<tr><td>'.esc_html($r['created_at']).'</td><td>'.esc_html($r['title']).'</td><td>'.esc_html($r['report_type']).'</td><td>'.esc_html($r['status']).'</td><td>'.esc_html(wp_trim_words($r['summary'],18)).'</td><td><a class="button button-small" href="'.esc_url(self::url(array('report_id'=>(int)$r['id']))).'">Apri</a></td></tr>'; } echo '</tbody></table></div></div>'; }
+
+    private static function render_report($id) {
+        $r=ALMA_Trend_Content_Ideas_Store::get_report($id); if(!$r){ echo '<div class="notice notice-error"><p>Report non trovato.</p></div>'; return; }
+        $data=ALMA_Trend_Content_Ideas_Store::decode_json($r['result_json']); $metrics=ALMA_Trend_Content_Ideas_Store::decode_json($r['metrics_json']);
+        echo '<p><a class="button" href="'.esc_url(self::url()).'">← Torna a Trend Idee contenuto</a></p><div class="postbox"><div class="inside"><h2>'.esc_html($r['title']).'</h2><p><strong>Data:</strong> '.esc_html($r['created_at']).' <strong>Stato:</strong> '.esc_html($r['status']).' <strong>Modello:</strong> '.esc_html($r['model']).'</p><p>'.esc_html($data['sintesi_generale']??'').'</p></div></div>';
+        echo '<div class="alma-report-grid">'; self::list_card('Fonti analizzate',(array)($data['fonti_analizzate']??array())); self::object_card('Destinazioni prioritarie',(array)($data['destinazioni_prioritarie']??array()),array('nome','paese_o_area','trend_score','confidence_score','motivazione')); self::object_card('Piano editoriale settimanale',(array)($data['piano_editoriale_settimanale']??array()),array('giorno_suggerito','titolo','tipo_contenuto','destinazione','priorita_editoriale','livello_confidenza','azione_consigliata')); self::object_card('Bisogni viaggiatori',(array)($data['bisogni_viaggiatori']??array()),array()); self::object_card('Opportunità affiliate',(array)($data['opportunita_affiliate']??array()),array()); self::object_card('Rischi e limiti',(array)($data['rischi_e_limiti']??array()),array()); echo '</div>';
+        echo '<div class="postbox"><div class="inside"><h2>Fonti citate</h2><ul>'; foreach((array)($data['fonti_citate']??array()) as $f){ $url=esc_url($f['url']??''); echo '<li>' . ($url?'<a href="'.$url.'" target="_blank" rel="noopener noreferrer">':'') . esc_html($f['titolo'] ?? ($f['fonte'] ?? $url)) . ($url?'</a>':'') . '</li>'; } echo '</ul></div></div>';
+        echo '<div class="postbox"><div class="inside"><h2>Metriche per grafici</h2><pre>'.esc_html(wp_json_encode($metrics, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE)).'</pre><details><summary>Sezione tecnica JSON</summary><pre>'.esc_html(wp_json_encode($data, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE)).'</pre></details></div></div>';
+    }
+
+    private static function list_card($title,$items){ echo '<div class="alma-card"><h3>'.esc_html($title).'</h3><ul>'; foreach($items as $it){ echo '<li>'.esc_html(is_scalar($it)?$it:wp_json_encode($it)).'</li>'; } echo '</ul></div>'; }
+    private static function stringify($value){ if (is_scalar($value) || $value === null) { return (string)$value; } $flat = array(); foreach ((array)$value as $item) { $flat[] = is_scalar($item) ? (string)$item : wp_json_encode($item, JSON_UNESCAPED_UNICODE); } return implode(', ', $flat); }
+    private static function object_card($title,$items,$fields){ echo '<div class="alma-card"><h3>'.esc_html($title).'</h3>'; if(!$items){echo '<p>Nessun dato.</p>';} foreach($items as $it){ echo '<div style="border-top:1px solid #dcdcde;padding:8px 0">'; if(is_array($it)){ $show=$fields?:array_keys($it); foreach($show as $f){ if(isset($it[$f])){ echo '<p><strong>'.esc_html($f).':</strong> '.esc_html(self::stringify($it[$f])).'</p>'; } } } else { echo '<p>'.esc_html($it).'</p>'; } echo '</div>'; } echo '</div>'; }
+
+    public static function handle_action() {
+        if (!current_user_can(self::CAP)) { wp_die(esc_html__('Permessi insufficienti.', 'affiliate-link-manager-ai')); }
+        check_admin_referer('alma_trend_content_action'); $do=sanitize_key($_REQUEST['do']??''); $type='success'; $msg='Operazione completata.'; $report_id=0;
+        if($do==='save_settings'){ ALMA_Trend_Content_Ideas_Store::save_settings($_POST); $msg='Configurazione Trend Idee contenuto salvata.'; }
+        elseif($do==='run_source'){ $r=ALMA_Trend_Content_Ideas_Service::run_source(sanitize_key($_GET['source_key']??''), 'test'); if(is_wp_error($r)){ $type='error'; $msg=$r->get_error_message(); $report_id=(int)($r->get_error_data()['report_id']??0); } else { $report_id=(int)$r['report_id']; $msg='Test fonte completato: '.$r['sources_count'].' fonte, durata '.$r['duration'].'s.'; } }
+        elseif($do==='run_all' || $do==='generate_plan'){ $r=ALMA_Trend_Content_Ideas_Service::run_enabled($do==='generate_plan'?'manual':'test'); if(is_wp_error($r)){ $type='error'; $msg=$r->get_error_message(); $report_id=(int)($r->get_error_data()['report_id']??0); } else { $report_id=(int)$r['report_id']; $msg=($do==='generate_plan'?'Piano editoriale generato':'Test completo completato').': '.$r['sources_count'].' fonti, stato '.$r['status'].', durata '.$r['duration'].'s.'; } }
+        set_transient('alma_trend_content_notice_' . get_current_user_id(), array('type'=>$type,'message'=>$msg), 120);
+        wp_safe_redirect($report_id ? self::url(array('report_id'=>$report_id)) : self::url()); exit;
+    }
+}
+ALMA_Trend_Content_Ideas_Admin::init();

--- a/includes/class-trend-content-ideas-prompt-builder.php
+++ b/includes/class-trend-content-ideas-prompt-builder.php
@@ -1,0 +1,51 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_Trend_Content_Ideas_Prompt_Builder {
+    public static function default_global_prompt() {
+        return 'Analizza trend di viaggio attuali e recenti utili per il sito Sothra, rivolto a viaggiatori italiani. Privilegia destinazioni, esperienze e bisogni concreti che possano generare contenuti editoriali pratici, autorevoli e monetizzabili tramite link affiliati pertinenti. Non copiare testi dalle fonti. Non inventare dati. Distingui sempre tra trend forte, medio e debole. Evidenzia bisogni pratici del viaggiatore: budget, periodo migliore, durata, trasporti, alloggi, sicurezza, esperienze, cosa prenotare prima.';
+    }
+
+    public static function system_prompt() {
+        return 'Sei il modulo Trend Idee contenuto di Sothra. Devi usare OpenAI Web Search solo sulle fonti/domìni ammessi quando indicati. Non copiare testi dalle fonti. Non inventare dati, numeri, link o citazioni. Se i dati sono parziali devi dichiararlo. Devi indicare livello di confidenza, fonti citate e limiti. Proponi contenuti per viaggiatori italiani e coerenti con Sothra. Proponi opportunità affiliate solo se pertinenti. Non generare bozze WordPress, post, HTML o contenuti da pubblicare automaticamente. Rispondi esclusivamente con JSON valido conforme allo schema richiesto.';
+    }
+
+    public static function build($sources, $run_type = 'manual') {
+        $global = get_option(ALMA_Trend_Content_Ideas_Store::OPTION_GLOBAL_PROMPT, self::default_global_prompt());
+        $source_lines = array();
+        foreach ($sources as $src) {
+            $domains = implode(', ', ALMA_Trend_Content_Ideas_Store::decode_json($src['allowed_domains'] ?? '[]'));
+            $source_lines[] = '- ' . $src['name'] . ' [' . $src['source_key'] . '] priorità ' . $src['priority'] . ', categoria ' . $src['category'] . ', domini: ' . $domains . '. Prompt fonte: ' . trim((string)$src['custom_prompt']);
+        }
+        return "Prompt globale admin:\n" . $global . "\n\nTipo run: " . sanitize_key($run_type) . "\nPeriodo: ultimi 30-90 giorni, privilegiando segnali recenti e verificabili.\n\nFonti abilitate da analizzare:\n" . implode("\n", $source_lines) . "\n\nOutput richiesto: JSON strutturato con i campi obbligatori dello schema. Ogni idea deve essere concreta, utile a viaggiatori italiani e non deve creare bozze WordPress.";
+    }
+
+    public static function response_schema() {
+        $text = array('type'=>'string');
+        $num = array('type'=>'number');
+        $arr = array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>true));
+        return array(
+            'type'=>'json_schema',
+            'name'=>'sothra_trend_idee_contenuto',
+            'strict'=>false,
+            'schema'=>array(
+                'type'=>'object','additionalProperties'=>true,
+                'properties'=>array(
+                    'sintesi_generale'=>$text,
+                    'fonti_analizzate'=>array('type'=>'array','items'=>$text),
+                    'destinazioni_prioritarie'=>array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>true,'properties'=>array('nome'=>$text,'paese_o_area'=>$text,'trend_score'=>$num,'confidence_score'=>$num,'fonti_collegate'=>array('type'=>'array','items'=>$text),'motivazione'=>$text,'target_viaggiatore'=>$text,'bisogni_pratici'=>array('type'=>'array','items'=>$text),'rischi'=>array('type'=>'array','items'=>$text),'opportunita_affiliate'=>array('type'=>'array','items'=>$text)))) ,
+                    'temi_editoriali'=>$arr,
+                    'piano_editoriale_settimanale'=>array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>true,'properties'=>array('giorno_suggerito'=>$text,'titolo'=>$text,'tipo_contenuto'=>$text,'destinazione'=>$text,'paese_o_area'=>$text,'intento_ricerca'=>$text,'motivazione_trend'=>$text,'bisogni_viaggiatore'=>array('type'=>'array','items'=>$text),'outline'=>array('type'=>'array','items'=>$text),'opportunita_affiliate'=>array('type'=>'array','items'=>$text),'fonti_da_citare'=>array('type'=>'array','items'=>$text),'priorita_editoriale'=>$text,'livello_confidenza'=>$text,'azione_consigliata'=>$text))),
+                    'opportunita_affiliate'=>$arr,
+                    'bisogni_viaggiatori'=>$arr,
+                    'rischi_e_limiti'=>$arr,
+                    'dati_per_grafici'=>array('type'=>'object','additionalProperties'=>true),
+                    'livello_confidenza'=>$text,
+                    'alert'=>array('type'=>'array','items'=>$text),
+                    'fonti_citate'=>array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>true,'properties'=>array('titolo'=>$text,'url'=>$text,'fonte'=>$text))),
+                ),
+                'required'=>array('sintesi_generale','fonti_analizzate','destinazioni_prioritarie','temi_editoriali','piano_editoriale_settimanale','opportunita_affiliate','bisogni_viaggiatori','rischi_e_limiti','dati_per_grafici','livello_confidenza','alert','fonti_citate'),
+            ),
+        );
+    }
+}

--- a/includes/class-trend-content-ideas-registry.php
+++ b/includes/class-trend-content-ideas-registry.php
@@ -1,0 +1,33 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_Trend_Content_Ideas_Registry {
+    public static function defaults() {
+        return array(
+            self::src('skyscanner','Skyscanner',1,'metasearch voli','skyscanner.it,skyscanner.net',7,1,'Analizza trend su voli, destinazioni emergenti, prezzi e stagionalità citati da Skyscanner.','Trend voli e destinazioni ricercate.'),
+            self::src('booking','Booking.com',1,'hotel e domanda alloggi','booking.com,news.booking.com,globalnews.booking.com',7,1,'Evidenzia trend su alloggi, destinazioni e comportamenti di prenotazione Booking.com.','Trend alloggi e prenotazioni.'),
+            self::src('expedia','Expedia',1,'OTA e pacchetti','expedia.com,expediagroup.com',7,1,'Cerca segnali Expedia su pacchetti, voli+hotel, famiglie e domanda internazionale.','Trend OTA e pacchetti viaggio.'),
+            self::src('hotels','Hotels.com',1,'hotel','hotels.com,expediagroup.com',10,1,'Analizza trend Hotels.com su hotel, servizi richiesti e destinazioni per soggiorni brevi.','Trend hotel e soggiorni.'),
+            self::src('vrbo','Vrbo',1,'case vacanza','vrbo.com,expediagroup.com',10,1,'Individua trend Vrbo su case vacanza, gruppi, famiglie e soggiorni lunghi.','Trend case vacanza.'),
+            self::src('airbnb_newsroom','Airbnb Newsroom',1,'case vacanza ed esperienze','airbnb.com,news.airbnb.com',7,1,'Analizza comunicati e report Airbnb su mete, esperienze e bisogni degli ospiti.','Newsroom Airbnb e trend ospitalità.'),
+            self::src('tripadvisor','Tripadvisor',1,'recensioni e ispirazione','tripadvisor.com,tripadvisor.mediaroom.com',7,1,'Trova trend Tripadvisor su attrazioni, ristorazione, destinazioni e preferenze viaggiatori.','Trend da recensioni e classifiche.'),
+            self::src('etc','European Travel Commission',1,'istituzionale Europa','etc-corporate.org,visiteurope.com',14,1,'Usa dati ETC per trend europei, mercati inbound e stagionalità.','Dati e report turismo Europa.'),
+            self::src('google_travel','Google Travel',1,'ricerche viaggio','google.com,travel.google',7,1,'Evidenzia segnali Google Travel su destinazioni, itinerari e bisogni di pianificazione.','Segnali Google Travel.'),
+            self::src('google_flights','Google Flights',1,'voli','google.com',7,1,'Analizza trend voli, prezzo, periodi e collegamenti utili ai viaggiatori italiani.','Segnali Google Flights.'),
+            self::src('lonely_planet','Lonely Planet',1,'editoriale travel','lonelyplanet.com',10,1,'Individua temi editoriali e destinazioni emergenti coerenti con guide pratiche.','Trend editoriali Lonely Planet.'),
+            self::src('time_out','Time Out',1,'city guide ed esperienze','timeout.com',10,1,'Cerca trend su città, quartieri, eventi e esperienze urbane monetizzabili.','Trend città e lifestyle travel.'),
+            self::src('travel_leisure','Travel + Leisure',1,'editoriale travel premium','travelandleisure.com',10,1,'Analizza trend su destinazioni, hotel, esperienze e liste editoriali internazionali.','Trend editoriali internazionali.'),
+            self::src('enit','ENIT',2,'istituzionale Italia','enit.it,italia.it',14,1,'Usa dati ENIT su turismo Italia, domanda estera e campagne destinazione.','Dati turismo Italia.'),
+            self::src('istat','ISTAT',2,'statistiche Italia','istat.it',30,1,'Cerca dati ISTAT recenti su viaggi, presenze, arrivi e spesa turistica.','Statistiche ufficiali Italia.'),
+            self::src('eurostat','Eurostat',2,'statistiche Europa','ec.europa.eu,eurostat.ec.europa.eu',30,1,'Usa dataset e news Eurostat per segnali macro sul turismo europeo.','Statistiche ufficiali UE.'),
+            self::src('un_tourism','UN Tourism',2,'istituzionale globale','unwto.org,un-tourism.org',30,1,'Analizza barometri e report UN Tourism per trend globali verificabili.','Dati turismo globale.'),
+            self::src('yougov','YouGov',2,'consumer insight','yougov.com,yougov.co.uk',21,1,'Individua insight YouGov su intenzioni, budget e preferenze dei viaggiatori.','Sondaggi e consumer insight.'),
+            self::src('data_appeal','Data Appeal',2,'destination intelligence','datappeal.io,thedataappealcompany.com',21,1,'Cerca insight Data Appeal su sentiment, reputazione destinazioni e domanda.','Destination intelligence.'),
+            self::src('pinterest_predicts','Pinterest Predicts',2,'ispirazione visuale','pinterestpredicts.com,pinterest.com',30,1,'Usa Pinterest Predicts per segnali aspirazionali, visual trend e micro-nicchie travel.','Trend previsionali Pinterest.'),
+        );
+    }
+
+    private static function src($key,$name,$priority,$category,$domains,$days,$enabled,$prompt,$description) {
+        return compact('key','name','priority','category','domains','days','enabled','prompt','description');
+    }
+}

--- a/includes/class-trend-content-ideas-service.php
+++ b/includes/class-trend-content-ideas-service.php
@@ -1,0 +1,108 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_Trend_Content_Ideas_Service {
+    const CRON_HOOK = 'alma_trend_content_ideas_cron';
+    const LOCK_KEY = 'alma_trend_content_ideas_lock';
+
+    public static function init() {
+        add_action(self::CRON_HOOK, array(__CLASS__, 'run_due_sources'));
+        if (!wp_next_scheduled(self::CRON_HOOK)) { wp_schedule_event(time() + HOUR_IN_SECONDS, 'hourly', self::CRON_HOOK); }
+    }
+
+    public static function is_openai_ready() { return trim((string)get_option('alma_openai_api_key', '')) !== ''; }
+
+    public static function run_due_sources() {
+        $sources = ALMA_Trend_Content_Ideas_Store::get_due_sources();
+        if (!$sources) { return array('status'=>'empty','message'=>'Nessuna fonte scaduta.'); }
+        return self::run_sources($sources, 'scheduled');
+    }
+
+    public static function run_source($source_key, $run_type = 'test') {
+        $src = ALMA_Trend_Content_Ideas_Store::get_source($source_key);
+        if (!$src) { return new WP_Error('missing_source', __('Fonte non trovata.', 'affiliate-link-manager-ai')); }
+        return self::run_sources(array($src), $run_type);
+    }
+
+    public static function run_enabled($run_type = 'manual') {
+        $sources = ALMA_Trend_Content_Ideas_Store::get_sources(true);
+        if (!$sources) { return new WP_Error('no_sources', __('Nessuna fonte abilitata.', 'affiliate-link-manager-ai')); }
+        return self::run_sources($sources, $run_type);
+    }
+
+    private static function run_sources($sources, $run_type) {
+        if (get_transient(self::LOCK_KEY)) { return new WP_Error('locked', __('Un’analisi trend è già in corso. Riprova tra qualche minuto.', 'affiliate-link-manager-ai')); }
+        set_transient(self::LOCK_KEY, 1, 15 * MINUTE_IN_SECONDS);
+        $started = current_time('mysql'); $start_time = microtime(true);
+        try {
+            if (!self::is_openai_ready()) { return self::store_error_report($sources, $run_type, 'OpenAI non configurato.', $started, 'openai_missing'); }
+            $domains = self::allowed_domains($sources);
+            $tools = array(array('type'=>'web_search_preview'));
+            if ($domains) { $tools[0]['filters'] = array('allowed_domains'=>$domains); }
+            $model = trim((string)get_option(ALMA_Trend_Content_Ideas_Store::OPTION_MODEL, '')) ?: get_option('alma_openai_model', 'gpt-5.4-mini');
+            $res = ALMA_OpenAI_Service::request(array(
+                'model'=>$model,
+                'system_prompt'=>ALMA_Trend_Content_Ideas_Prompt_Builder::system_prompt(),
+                'user_prompt'=>ALMA_Trend_Content_Ideas_Prompt_Builder::build($sources, $run_type),
+                'response_format'=>ALMA_Trend_Content_Ideas_Prompt_Builder::response_schema(),
+                'max_output_tokens'=>6000,
+                'timeout'=>absint(get_option(ALMA_Trend_Content_Ideas_Store::OPTION_TIMEOUT, 90)),
+                'tools'=>$tools,
+            ));
+            if (empty($res['success'])) { return self::store_error_report($sources, $run_type, $res['error'] ?? 'Errore OpenAI', $started, wp_json_encode($res)); }
+            $data = json_decode((string)$res['response'], true);
+            $valid = self::validate_result($data);
+            if (is_wp_error($valid)) { return self::store_error_report($sources, $run_type, $valid->get_error_message(), $started, $res['response']); }
+            $metrics = self::build_metrics($data, $sources);
+            $status = self::is_partial($data) ? 'partial' : 'success';
+            $report_id = ALMA_Trend_Content_Ideas_Store::insert_report(array(
+                'report_type'=>$run_type,'title'=>self::title_for($run_type, $sources),'period_start'=>gmdate('Y-m-d H:i:s', current_time('timestamp') - 90 * DAY_IN_SECONDS),'period_end'=>current_time('mysql'),'status'=>$status,'summary'=>$data['sintesi_generale'] ?? '',
+                'result'=>$data,'sources'=>self::source_snapshot($sources),'metrics'=>$metrics,'model'=>$res['model'] ?? $model,'tokens_used'=>self::tokens_used($res['usage'] ?? null),
+            ));
+            foreach ($sources as $src) { ALMA_Trend_Content_Ideas_Store::mark_source_ran($src['source_key'], true); ALMA_Trend_Content_Ideas_Store::log($src['source_key'], $run_type, $status, 'Analisi completata in ' . round(microtime(true)-$start_time, 1) . 's.', '', $report_id, $started); }
+            return array('success'=>true,'status'=>$status,'report_id'=>$report_id,'sources_count'=>count($sources),'duration'=>round(microtime(true)-$start_time,1),'sources'=>wp_list_pluck($sources, 'name'));
+        } finally { delete_transient(self::LOCK_KEY); }
+    }
+
+    private static function store_error_report($sources, $run_type, $message, $started, $raw='') {
+        $data = array('sintesi_generale'=>$message,'fonti_analizzate'=>array(),'destinazioni_prioritarie'=>array(),'temi_editoriali'=>array(),'piano_editoriale_settimanale'=>array(),'opportunita_affiliate'=>array(),'bisogni_viaggiatori'=>array(),'rischi_e_limiti'=>array(array('messaggio'=>$message)),'dati_per_grafici'=>array(),'livello_confidenza'=>'basso','alert'=>array($message),'fonti_citate'=>array());
+        $report_id = ALMA_Trend_Content_Ideas_Store::insert_report(array('report_type'=>$run_type,'title'=>self::title_for($run_type, $sources),'period_start'=>$started,'period_end'=>current_time('mysql'),'status'=>'error','summary'=>$message,'result'=>$data,'sources'=>self::source_snapshot($sources),'metrics'=>self::build_metrics($data,$sources),'model'=>get_option('alma_openai_model','')));
+        foreach ($sources as $src) { ALMA_Trend_Content_Ideas_Store::mark_source_ran($src['source_key'], false); ALMA_Trend_Content_Ideas_Store::log($src['source_key'], $run_type, 'error', $message, $raw, $report_id, $started); }
+        return new WP_Error('trend_run_error', $message, array('report_id'=>$report_id));
+    }
+
+    public static function validate_result($data) { $required=array('sintesi_generale','fonti_analizzate','destinazioni_prioritarie','temi_editoriali','piano_editoriale_settimanale','opportunita_affiliate','bisogni_viaggiatori','rischi_e_limiti','dati_per_grafici','livello_confidenza','alert','fonti_citate'); if(!is_array($data)){return new WP_Error('invalid_json', __('JSON OpenAI non valido.', 'affiliate-link-manager-ai'));} foreach($required as $key){ if(!array_key_exists($key,$data)){return new WP_Error('invalid_json', sprintf(__('JSON incompleto: manca %s.', 'affiliate-link-manager-ai'), $key));} } return true; }
+    private static function allowed_domains($sources) { $out=array(); foreach($sources as $src){ $out=array_merge($out, ALMA_Trend_Content_Ideas_Store::decode_json($src['allowed_domains'] ?? '[]')); } return array_values(array_unique(array_filter(array_map('sanitize_text_field',$out)))); }
+    private static function source_snapshot($sources) { return array_map(function($s){ return array('source_key'=>$s['source_key'],'name'=>$s['name'],'priority'=>(int)$s['priority'],'category'=>$s['category'],'allowed_domains'=>ALMA_Trend_Content_Ideas_Store::decode_json($s['allowed_domains'])); }, $sources); }
+    private static function title_for($run_type, $sources) { return ($run_type === 'test' ? 'Test Trend Idee contenuto' : 'Report Trend Idee contenuto') . ' - ' . count($sources) . ' fonti'; }
+    private static function tokens_used($usage) { return is_array($usage) && isset($usage['total_tokens']) ? absint($usage['total_tokens']) : null; }
+    private static function is_partial($data) { return !empty($data['alert']) || stripos((string)($data['livello_confidenza'] ?? ''), 'basso') !== false; }
+    public static function build_metrics($data, $sources) {
+        $dest = (array)($data['destinazioni_prioritarie'] ?? array());
+        $ideas = (array)($data['piano_editoriale_settimanale'] ?? array());
+        $affiliate = (array)($data['opportunita_affiliate'] ?? array());
+        $alerts = (array)($data['alert'] ?? array());
+        $risks = (array)($data['rischi_e_limiti'] ?? array());
+        $cat = array();
+        foreach ($sources as $s) { $cat[$s['category']] = ($cat[$s['category']] ?? 0) + 1; }
+        $areas = array(); $trend_scores = array(); $conf_scores = array();
+        foreach ($dest as $d) {
+            if (!is_array($d)) { continue; }
+            if (!empty($d['paese_o_area'])) { $areas[$d['paese_o_area']] = ($areas[$d['paese_o_area']] ?? 0) + 1; }
+            if (isset($d['trend_score'])) { $trend_scores[] = (float)$d['trend_score']; }
+            if (isset($d['confidence_score'])) { $conf_scores[] = (float)$d['confidence_score']; }
+        }
+        return array(
+            'count_fonti_analizzate'=>count($sources),
+            'count_idee_editoriali'=>count($ideas),
+            'count_destinazioni'=>count($dest),
+            'distribuzione_categoria_fonte'=>$cat,
+            'distribuzione_area_geografica'=>$areas,
+            'media_trend_score'=>$trend_scores ? round(array_sum($trend_scores) / count($trend_scores), 2) : 0,
+            'media_confidence_score'=>$conf_scores ? round(array_sum($conf_scores) / count($conf_scores), 2) : 0,
+            'count_opportunita_affiliate'=>count($affiliate),
+            'count_alert_rischi'=>count($alerts) + count($risks),
+        );
+    }
+}
+ALMA_Trend_Content_Ideas_Service::init();

--- a/includes/class-trend-content-ideas-store.php
+++ b/includes/class-trend-content-ideas-store.php
@@ -1,0 +1,105 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_Trend_Content_Ideas_Store {
+    const OPTION_GLOBAL_PROMPT = 'alma_trend_content_global_prompt';
+    const OPTION_MODEL = 'alma_trend_content_model';
+    const OPTION_TIMEOUT = 'alma_trend_content_timeout';
+
+    public static function table($name) { global $wpdb; return $wpdb->prefix . 'alma_trend_content_' . $name; }
+
+    public static function install() {
+        global $wpdb; require_once ABSPATH . 'wp-admin/includes/upgrade.php'; $c = $wpdb->get_charset_collate();
+        dbDelta("CREATE TABLE " . self::table('sources') . " (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            source_key VARCHAR(80) NOT NULL,
+            name VARCHAR(190) NOT NULL,
+            enabled TINYINT(1) NOT NULL DEFAULT 1,
+            priority TINYINT UNSIGNED NOT NULL DEFAULT 1,
+            category VARCHAR(120) NOT NULL DEFAULT '',
+            allowed_domains LONGTEXT NULL,
+            interval_days INT UNSIGNED NOT NULL DEFAULT 7,
+            last_run_at DATETIME NULL,
+            next_run_at DATETIME NULL,
+            custom_prompt LONGTEXT NULL,
+            description TEXT NULL,
+            status VARCHAR(30) NOT NULL DEFAULT 'active',
+            created_at DATETIME NOT NULL,
+            updated_at DATETIME NOT NULL,
+            PRIMARY KEY (id), UNIQUE KEY source_key (source_key), KEY enabled_next (enabled,next_run_at), KEY priority (priority)
+        ) $c;");
+        dbDelta("CREATE TABLE " . self::table('reports') . " (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            report_type VARCHAR(30) NOT NULL DEFAULT 'scheduled',
+            title VARCHAR(255) NOT NULL DEFAULT '',
+            period_start DATETIME NULL,
+            period_end DATETIME NULL,
+            status VARCHAR(30) NOT NULL DEFAULT 'success',
+            summary LONGTEXT NULL,
+            result_json LONGTEXT NULL,
+            sources_json LONGTEXT NULL,
+            metrics_json LONGTEXT NULL,
+            model VARCHAR(120) NOT NULL DEFAULT '',
+            tokens_used INT UNSIGNED NULL,
+            created_at DATETIME NOT NULL,
+            PRIMARY KEY (id), KEY type_created (report_type,created_at), KEY status_created (status,created_at)
+        ) $c;");
+        dbDelta("CREATE TABLE " . self::table('logs') . " (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            source_key VARCHAR(80) NOT NULL DEFAULT '',
+            report_id BIGINT UNSIGNED NULL,
+            run_type VARCHAR(30) NOT NULL DEFAULT 'scheduled',
+            status VARCHAR(30) NOT NULL DEFAULT 'info',
+            message TEXT NOT NULL,
+            raw_error LONGTEXT NULL,
+            started_at DATETIME NOT NULL,
+            completed_at DATETIME NULL,
+            PRIMARY KEY (id), KEY source_started (source_key,started_at), KEY report_id (report_id), KEY status_started (status,started_at)
+        ) $c;");
+        self::seed_sources();
+        if (get_option(self::OPTION_GLOBAL_PROMPT, null) === null) {
+            update_option(self::OPTION_GLOBAL_PROMPT, ALMA_Trend_Content_Ideas_Prompt_Builder::default_global_prompt());
+        }
+        if (get_option(self::OPTION_TIMEOUT, null) === null) { update_option(self::OPTION_TIMEOUT, 90); }
+    }
+
+    public static function seed_sources() {
+        global $wpdb; $now = current_time('mysql');
+        foreach (ALMA_Trend_Content_Ideas_Registry::defaults() as $src) {
+            $exists = (int)$wpdb->get_var($wpdb->prepare('SELECT id FROM ' . self::table('sources') . ' WHERE source_key=%s', $src['key']));
+            if ($exists) { continue; }
+            $wpdb->insert(self::table('sources'), array(
+                'source_key'=>sanitize_key($src['key']),'name'=>sanitize_text_field($src['name']),'enabled'=>(int)$src['enabled'],
+                'priority'=>absint($src['priority']),'category'=>sanitize_text_field($src['category']),'allowed_domains'=>wp_json_encode(self::domains_to_array($src['domains'])),
+                'interval_days'=>absint($src['days']),'next_run_at'=>gmdate('Y-m-d H:i:s', current_time('timestamp') + DAY_IN_SECONDS * absint($src['days'])),
+                'custom_prompt'=>sanitize_textarea_field($src['prompt']),'description'=>sanitize_text_field($src['description']),'status'=>'active','created_at'=>$now,'updated_at'=>$now,
+            ));
+        }
+    }
+
+    public static function get_sources($enabled_only = false) { global $wpdb; $where = $enabled_only ? ' WHERE enabled=1 AND status != "archived"' : ''; return $wpdb->get_results('SELECT * FROM ' . self::table('sources') . $where . ' ORDER BY priority ASC, name ASC', ARRAY_A); }
+    public static function get_due_sources() { global $wpdb; $now=current_time('mysql'); return $wpdb->get_results($wpdb->prepare('SELECT * FROM '.self::table('sources').' WHERE enabled=1 AND status != %s AND (next_run_at IS NULL OR next_run_at <= %s) ORDER BY priority ASC, next_run_at ASC', 'archived', $now), ARRAY_A); }
+    public static function get_source($key) { global $wpdb; $r=$wpdb->get_row($wpdb->prepare('SELECT * FROM '.self::table('sources').' WHERE source_key=%s', sanitize_key($key)), ARRAY_A); return is_array($r)?$r:array(); }
+
+    public static function save_settings($post) {
+        update_option(self::OPTION_GLOBAL_PROMPT, sanitize_textarea_field($post['global_prompt'] ?? ''));
+        update_option(self::OPTION_MODEL, sanitize_text_field($post['model'] ?? ''));
+        update_option(self::OPTION_TIMEOUT, max(20, min(180, absint($post['timeout'] ?? 90))));
+        global $wpdb; $sources = self::get_sources(false); $now=current_time('mysql');
+        foreach ($sources as $src) {
+            $key = $src['source_key']; $enabled = isset($post['sources'][$key]['enabled']) ? 1 : 0;
+            $interval = max(1, min(365, absint($post['sources'][$key]['interval_days'] ?? $src['interval_days'])));
+            $prompt = sanitize_textarea_field($post['sources'][$key]['custom_prompt'] ?? $src['custom_prompt']);
+            $wpdb->update(self::table('sources'), array('enabled'=>$enabled,'interval_days'=>$interval,'custom_prompt'=>$prompt,'updated_at'=>$now), array('source_key'=>$key));
+        }
+    }
+
+    public static function mark_source_ran($key, $ok = true) { global $wpdb; $src=self::get_source($key); if (!$src) { return; } $now=current_time('mysql'); $next=gmdate('Y-m-d H:i:s', current_time('timestamp') + DAY_IN_SECONDS * max(1, absint($src['interval_days']))); $wpdb->update(self::table('sources'), array('last_run_at'=>$now,'next_run_at'=>$next,'status'=>$ok?'active':'error','updated_at'=>$now), array('source_key'=>sanitize_key($key))); }
+    public static function insert_report($row) { global $wpdb; $data=array('report_type'=>sanitize_key($row['report_type']??'scheduled'),'title'=>sanitize_text_field($row['title']??''),'period_start'=>sanitize_text_field($row['period_start']??''),'period_end'=>sanitize_text_field($row['period_end']??''),'status'=>sanitize_key($row['status']??'success'),'summary'=>sanitize_textarea_field($row['summary']??''),'result_json'=>wp_json_encode($row['result']??array()),'sources_json'=>wp_json_encode($row['sources']??array()),'metrics_json'=>wp_json_encode($row['metrics']??array()),'model'=>sanitize_text_field($row['model']??''),'tokens_used'=>isset($row['tokens_used'])?absint($row['tokens_used']):null,'created_at'=>current_time('mysql')); $wpdb->insert(self::table('reports'), $data); return (int)$wpdb->insert_id; }
+    public static function get_reports($page=1,$per=10) { global $wpdb; $page=max(1,absint($page)); $per=max(1,min(50,absint($per))); return $wpdb->get_results($wpdb->prepare('SELECT id,report_type,title,status,summary,metrics_json,model,tokens_used,created_at FROM '.self::table('reports').' ORDER BY created_at DESC LIMIT %d OFFSET %d', $per, ($page-1)*$per), ARRAY_A); }
+    public static function get_report($id) { global $wpdb; $r=$wpdb->get_row($wpdb->prepare('SELECT * FROM '.self::table('reports').' WHERE id=%d', absint($id)), ARRAY_A); return is_array($r)?$r:array(); }
+    public static function latest_report() { global $wpdb; $r=$wpdb->get_row('SELECT * FROM '.self::table('reports').' ORDER BY created_at DESC LIMIT 1', ARRAY_A); return is_array($r)?$r:array(); }
+    public static function log($source_key,$run_type,$status,$message,$raw_error='',$report_id=null,$started_at='') { global $wpdb; $wpdb->insert(self::table('logs'), array('source_key'=>sanitize_key($source_key),'report_id'=>$report_id?absint($report_id):null,'run_type'=>sanitize_key($run_type),'status'=>sanitize_key($status),'message'=>sanitize_text_field($message),'raw_error'=>$raw_error?wp_strip_all_tags((string)$raw_error):null,'started_at'=>$started_at?:current_time('mysql'),'completed_at'=>current_time('mysql'))); }
+    public static function domains_to_array($domains) { return array_values(array_filter(array_map('trim', explode(',', (string)$domains)))); }
+    public static function decode_json($json) { $d=json_decode((string)$json,true); return is_array($d)?$d:array(); }
+}


### PR DESCRIPTION
### Motivation
- Introdurre un modulo admin chiamato "Trend Idee contenuto" che analizzi automaticamente fonti pubbliche sui trend di viaggio usando OpenAI Web Search e produca report editoriali strutturati utili a Sothra. 
- Fornire UI amministrativa per abilitare/disabilitare fonti, configurare intervalli, prompt globali e per fonte, eseguire test manuali e conservare report storici senza modificare le feature esistenti del plugin.
- Preparare dati normalizzati per futuri grafici e integrare WP-Cron e meccanismi di lock per evitare esecuzioni parallele.

### Description
- Aggiunte classi e file per il nuovo modulo: `includes/class-trend-content-ideas-registry.php`, `includes/class-trend-content-ideas-store.php`, `includes/class-trend-content-ideas-prompt-builder.php`, `includes/class-trend-content-ideas-service.php`, `includes/class-trend-content-ideas-admin.php` che implementano registry fonti, installazione tabelle (`sources`, `reports`, `logs`), prompt builder con schema JSON e servizio di esecuzione/cron/lock e UI admin.
- Integrata chiamata a OpenAI Responses API tramite l'esistente `ALMA_OpenAI_Service` usando `tools` con `web_search_preview` e filtro `allowed_domains` quando disponibile; la risposta richiesta è sempre JSON strutturato e validato secondo lo schema definito in `ALMA_Trend_Content_Ideas_Prompt_Builder::response_schema()`.
- Implementata logica scheduler: evento WP-Cron orario per controllare fonti scadute, transient lock anti-run parallele, aggiornamento `last_run_at`/`next_run_at`, gestione errori/report di fallback e salvataggio metriche normalizzate per grafici.
- Modificato file principale per includere le nuove classi, aggiungere la voce di menu admin "Trend Idee contenuto", mostrare un box sintetico nella dashboard principale del plugin, eseguire `dbDelta` all'install/upgrade e incrementare la versione del plugin a `2.32.0` e lo schema DB a `4`.

### Testing
- Eseguiti controlli di sintassi PHP con `php -l` su tutti i file PHP aggiunti/modificati (lint): esito **successo** per tutti i file.
- Verifica registry fonti: eseguito script PHP che carica `ALMA_Trend_Content_Ideas_Registry::defaults()` e conferma la presenza delle 20 fonti attese e l'unicità delle chiavi: esito **successo**.
- Verifica schema prompt/response: eseguito controllo PHP su `ALMA_Trend_Content_Ideas_Prompt_Builder::response_schema()` per la presenza dei campi richiesti (`sintesi_generale`, `fonti_analizzate`, `destinazioni_prioritarie`, `piano_editoriale_settimanale`, `fonti_citate`): esito **successo**.
- Nota su test funzionali runtime: non è stato possibile eseguire attivazione reale del plugin, WP-Cron o chiamate verso OpenAI perché non è disponibile una istanza WordPress attiva né una API key OpenAI nell'ambiente di sviluppo; pertanto i test di integrazione live e le chiamate Web Search devono essere verificate manualmente in ambiente WordPress con API key configurata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0094748764833281fe86d5d1b77774)