### PR TITLE
Fix compact Trend source_test JSON & truncated_output handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
+## 2.33.2 - 2026-05-10
+- Aggiunto uno schema JSON compatto per il profilo `source_test`, separato dallo schema editoriale completo usato da `full_test`/`editorial_plan`.
+- Documentata e rinforzata la distinzione tra contenuti informativi analizzati dalla fonte, trend restituiti e idee editoriali generate.
+- Il `source_test` produce output diagnostico breve con limiti rigidi: massimo 2 trend, 2 idee contenuto, 3 citazioni, 3 warning, summary fino a 350 caratteri e descrizioni fino a 250 caratteri.
+- Migliorata la gestione `truncated_output` quando OpenAI termina con `status: incomplete` o `finish_reason: max_output_tokens`, distinguendola dagli errori JSON genericamente malformati.
+- Il retry `json_invalid_retry` ora usa prompt e schema compatti, `tool_choice: auto`, nessun `include`, mantiene `web_search` e conserva eventuali domini ammessi senza introdurre retry multipli.
+- I report tecnici includono categoria, modello, response id, status, finish reason, max output tokens, attempt label, tool choice, include, profilo, raw excerpt limitato e warning leggibili sul retry compatto.
+- Valori token consigliati per profilo: `source_test` circa 2200, retry compatto 1400-2200, `full_test` intermedio e `editorial_plan` più alto.
+- Versione plugin aggiornata a `2.33.2`.
+
 ## 2.33.1
+
 - Corretto il flag manuale del modello Trend: il valore legacy automatico `gpt-5.5` non viene più marcato come scelta manuale durante salvataggi ordinari della pagina impostazioni.
 - Il valore legacy `gpt-5.5` viene ignorato in modo idempotente finché l’admin non inserisce intenzionalmente un modello Trend; la UI mostra il campo modello vuoto e una nota dedicata quando il legacy è ignorato.
 - Rafforzato l’output JSON OpenAI del modulo Trend con Structured Outputs su Responses API tramite `text.format` JSON Schema, schema stabile e istruzioni esplicite solo-JSON.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
+## 2.33.2 - 2026-05-10
+- Aggiunto uno schema JSON compatto per il profilo `source_test`, separato dallo schema editoriale completo usato da `full_test`/`editorial_plan`.
+- Documentata e rinforzata la distinzione tra contenuti informativi analizzati dalla fonte, trend restituiti e idee editoriali generate.
+- Il `source_test` produce output diagnostico breve con limiti rigidi: massimo 2 trend, 2 idee contenuto, 3 citazioni, 3 warning, summary fino a 350 caratteri e descrizioni fino a 250 caratteri.
+- Migliorata la gestione `truncated_output` quando OpenAI termina con `status: incomplete` o `finish_reason: max_output_tokens`, distinguendola dagli errori JSON genericamente malformati.
+- Il retry `json_invalid_retry` ora usa prompt e schema compatti, `tool_choice: auto`, nessun `include`, mantiene `web_search` e conserva eventuali domini ammessi senza introdurre retry multipli.
+- I report tecnici includono categoria, modello, response id, status, finish reason, max output tokens, attempt label, tool choice, include, profilo, raw excerpt limitato e warning leggibili sul retry compatto.
+- Valori token consigliati per profilo: `source_test` circa 2200, retry compatto 1400-2200, `full_test` intermedio e `editorial_plan` più alto.
+- Versione plugin aggiornata a `2.33.2`.
+
 ## 2.33.1
+
 - Corretto il flag manuale del modello Trend: il valore legacy automatico `gpt-5.5` non viene più marcato come scelta manuale durante salvataggi ordinari della pagina impostazioni.
 - Il valore legacy `gpt-5.5` viene ignorato in modo idempotente finché l’admin non inserisce intenzionalmente un modello Trend; la UI mostra il campo modello vuoto e una nota dedicata quando il legacy è ignorato.
 - Rafforzato l’output JSON OpenAI del modulo Trend con Structured Outputs su Responses API tramite `text.format` JSON Schema, schema stabile e istruzioni esplicite solo-JSON.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.33.1
+ * Version: 2.33.2
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.33.1');
+define('ALMA_VERSION', '2.33.2');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-trend-content-ideas-prompt-builder.php
+++ b/includes/class-trend-content-ideas-prompt-builder.php
@@ -7,7 +7,7 @@ class ALMA_Trend_Content_Ideas_Prompt_Builder {
     }
 
     public static function system_prompt() {
-        return 'Sei il modulo Trend Idee contenuto di Sothra. Devi usare OpenAI Web Search solo sulle fonti/domìni ammessi quando indicati. Per contenuti informativi si intendono risultati, pagine, articoli, comunicati, report o documenti informativi consultabili dalla ricerca web; non sono articoli WordPress generati, bozze o idee editoriali finali. Per ogni fonte rispetta max_contents_per_run: non analizzare né sintetizzare più di quel numero di contenuti informativi provenienti dalla fonte indicata durante una singola run. Il limite è per singola fonte e per singola run e non rappresenta il numero di idee editoriali da generare. Non copiare testi dalle fonti. Non inventare dati, numeri, link o citazioni. Se i dati sono parziali devi dichiararlo. Devi indicare livello di confidenza, fonti citate e limiti. Proponi contenuti per viaggiatori italiani e coerenti con Sothra. Proponi opportunità affiliate solo se pertinenti. Non generare bozze WordPress, post, HTML o contenuti da pubblicare automaticamente. Restituisci esclusivamente JSON valido conforme allo schema richiesto: nessun markdown, nessun blocco ```json, nessun testo prima o dopo il JSON. Se una fonte non produce risultati usa array vuoti e aggiungi warning. Non inventare URL, titoli, date o fonti.';
+        return 'Sei il modulo Trend Idee contenuto di Sothra. Devi usare OpenAI Web Search solo sulle fonti/domìni ammessi quando indicati. Per contenuti informativi si intendono risultati, pagine, articoli, comunicati, report o documenti informativi consultabili dalla ricerca web; non sono articoli WordPress generati, bozze o idee editoriali finali. Per ogni fonte rispetta max_contents_per_run: non analizzare né sintetizzare più di quel numero di contenuti informativi provenienti dalla fonte indicata durante una singola run. Il limite è per singola fonte e per singola run e non rappresenta il numero di trend restituiti o di idee editoriali generate. Non copiare testi dalle fonti. Non inventare dati, numeri, link o citazioni. Se i dati sono parziali devi dichiararlo. Devi indicare livello di confidenza, fonti citate e limiti. Proponi contenuti per viaggiatori italiani e coerenti con Sothra. Proponi opportunità affiliate solo se pertinenti. Non generare bozze WordPress, post, HTML o contenuti da pubblicare automaticamente. Restituisci esclusivamente JSON valido conforme allo schema richiesto: nessun markdown, nessun blocco ```json, nessun testo prima o dopo il JSON. Se una fonte non produce risultati usa array vuoti e aggiungi warning. Non inventare URL, titoli, date o fonti.';
     }
 
     public static function build($sources, $run_type = 'manual') {
@@ -19,7 +19,9 @@ class ALMA_Trend_Content_Ideas_Prompt_Builder {
             $priority = ALMA_Trend_Content_Ideas_Store::normalize_priority($src['priority'] ?? 2);
             $source_lines[] = '- ' . $src['name'] . ' [' . $src['source_key'] . '] priorità ' . $priority . ', max_contents_per_run ' . $max_contents . ', categoria ' . $src['category'] . ', domini: ' . $domains . '. Prompt fonte: ' . trim((string)$src['custom_prompt']);
         }
-        return "Prompt globale admin:\n" . $global . "\n\nTipo run: " . sanitize_key($run_type) . "\nPeriodo: ultimi 30-90 giorni, privilegiando segnali recenti e verificabili.\n\nDefinizione operativa: i contenuti informativi sono pagine, articoli, comunicati, report, documenti o risultati che puoi consultare/sintetizzare tramite Web Search; non sono bozze WordPress, articoli WordPress generati o idee editoriali finali. Per ogni fonte rispetta max_contents_per_run: non analizzare né sintetizzare più di quel numero di contenuti informativi della fonte indicata nella singola run.\n\nFonti abilitate da analizzare:\n" . implode("\n", $source_lines) . "\n\nOutput richiesto: restituisci esclusivamente JSON valido con i campi obbligatori dello schema, nessun markdown, nessun blocco ```json e nessun testo fuori dal JSON. Rispetta esattamente lo schema richiesto. Se una fonte non produce risultati usa array vuoti e aggiungi warning. Non inventare URL, titoli, date o fonti. Ogni idea deve essere concreta, utile a viaggiatori italiani e non deve creare bozze WordPress. Ricorda che priority definisce ordine/peso fonte e max_contents_per_run limita i contenuti informativi analizzati per fonte nella singola run, non il numero di articoli WordPress.";
+        $profile = self::profile_name($run_type, $sources);
+        $profile_instructions = self::profile_instructions($profile);
+        return "Prompt globale admin:\n" . $global . "\n\nTipo run: " . sanitize_key($run_type) . "\nProfilo runtime: " . $profile . "\nPeriodo: ultimi 30-90 giorni, privilegiando segnali recenti e verificabili.\n\nDefinizione operativa: i contenuti informativi sono pagine, articoli, comunicati, report, documenti o risultati che puoi consultare/sintetizzare tramite Web Search; non sono bozze WordPress, articoli WordPress generati o idee editoriali finali. Per ogni fonte rispetta max_contents_per_run: non analizzare né sintetizzare più di quel numero di contenuti informativi della fonte indicata nella singola run. Distingui sempre tra contenuti informativi analizzati, trend restituiti e idee editoriali restituite.\n\nFonti abilitate da analizzare:\n" . implode("\n", $source_lines) . "\n\n" . $profile_instructions . "\n\nOutput richiesto: restituisci esclusivamente JSON valido con i campi obbligatori dello schema, nessun markdown, nessun blocco ```json e nessun testo fuori dal JSON. Rispetta esattamente lo schema richiesto. Se una fonte non produce risultati usa array vuoti e aggiungi warning breve. Non inventare URL, titoli, date o fonti. Ogni idea deve essere concreta, utile a viaggiatori italiani e non deve creare bozze WordPress. Ricorda che priority definisce ordine/peso fonte e max_contents_per_run limita i contenuti informativi analizzati per fonte nella singola run, non il numero di articoli WordPress.";
     }
 
     public static function build_json_retry($sources, $run_type = 'manual') {
@@ -27,10 +29,55 @@ class ALMA_Trend_Content_Ideas_Prompt_Builder {
         foreach ($sources as $src) {
             $source_lines[] = '- ' . $src['name'] . ' [' . $src['source_key'] . '] priority ' . ALMA_Trend_Content_Ideas_Store::normalize_priority($src['priority'] ?? 2) . ', max_contents_per_run ' . ALMA_Trend_Content_Ideas_Store::normalize_max_contents_per_run($src['max_contents_per_run'] ?? 3);
         }
-        return "Retry JSON per run " . sanitize_key($run_type) . ". Restituisci SOLO JSON valido, senza markdown, senza blocchi ```json e senza testo prima o dopo. Rispetta esattamente lo schema. Se non hai dati sufficienti usa array vuoti e warnings. Non inventare URL, titoli, date o fonti. Fonti e limiti (max_contents_per_run = contenuti informativi, non articoli WordPress):\n" . implode("\n", $source_lines);
+        return "Retry compatto JSON per run " . sanitize_key($run_type) . ". Restituisci SOLO JSON valido, senza markdown, senza blocchi ```json e senza testo prima o dopo. Usa lo schema compatto source_test: status, summary, source_quality, trends, content_ideas, citations, warnings. summary massimo 350 caratteri; massimo 2 trend; massimo 2 idee; massimo 3 citazioni; massimo 3 warning; ogni descrizione trend massimo 250 caratteri; ogni descrizione idea massimo 250 caratteri. Niente spiegazioni discorsive lunghe, niente paragrafi estesi. Se non hai dati sufficienti usa array vuoti e warning breve. Non inventare URL, titoli, date o fonti. Fonti e limiti (max_contents_per_run = contenuti informativi analizzati, non trend restituiti o idee editoriali):\n" . implode("\n", $source_lines);
     }
 
-    public static function response_schema() {
+    private static function profile_name($run_type, $sources) {
+        if ($run_type === 'test' && count((array)$sources) <= 1) { return 'source_test'; }
+        if ($run_type === 'test') { return 'full_test'; }
+        return 'editorial_plan';
+    }
+
+    private static function profile_instructions($profile) {
+        if ($profile === 'source_test') {
+            return 'Profilo source_test: output diagnostico breve per testare una fonte. Analizza massimo 1 fonte salvo configurazioni già previste dal workflow. Restituisci solo i campi essenziali: status, summary, source_quality, trends, content_ideas, citations, warnings. summary massimo 350 caratteri. massimo 2 trend. massimo 2 idee. massimo 3 citazioni. massimo 3 warning. Ogni descrizione trend massimo 250 caratteri. Ogni descrizione idea massimo 250 caratteri. Niente spiegazioni discorsive lunghe. Niente paragrafi estesi. Niente markdown. Niente testo fuori dal JSON. Restituisci solo JSON valido. Se i dati non bastano, usa array vuoti e warning breve.';
+        }
+        if ($profile === 'full_test') {
+            return 'Profilo full_test: output intermedio per verificare più fonti abilitate. Mantieni sintesi e liste concise, ma includi i campi completi dello schema editoriale. Distingui contenuti informativi analizzati, trend restituiti e idee editoriali restituite.';
+        }
+        return 'Profilo editorial_plan: output editoriale più completo per pianificazione contenuti. Includi analisi, priorità, rischi, bisogni viaggiatori, opportunità affiliate e fonti citate rispettando lo schema editoriale completo.';
+    }
+
+    public static function response_schema($profile = 'editorial_plan') {
+        if ($profile === 'source_test' || $profile === 'json_invalid_retry') { return self::compact_source_test_schema(); }
+        return self::editorial_plan_schema();
+    }
+
+    private static function compact_source_test_schema() {
+        $text = array('type'=>'string');
+        $string_array = array('type'=>'array','maxItems'=>3,'items'=>$text);
+        return array(
+            'type'=>'json_schema',
+            'name'=>'sothra_trend_source_test_compact',
+            'strict'=>false,
+            'schema'=>array(
+                'type'=>'object',
+                'additionalProperties'=>false,
+                'properties'=>array(
+                    'status'=>$text,
+                    'summary'=>array('type'=>'string','maxLength'=>350),
+                    'source_quality'=>array('type'=>'object','additionalProperties'=>true,'properties'=>array('rating'=>$text,'notes'=>array('type'=>'string','maxLength'=>250))),
+                    'trends'=>array('type'=>'array','maxItems'=>2,'items'=>array('type'=>'object','additionalProperties'=>true,'properties'=>array('title'=>$text,'description'=>array('type'=>'string','maxLength'=>250),'confidence'=>$text))),
+                    'content_ideas'=>array('type'=>'array','maxItems'=>2,'items'=>array('type'=>'object','additionalProperties'=>true,'properties'=>array('title'=>$text,'description'=>array('type'=>'string','maxLength'=>250),'intent'=>$text))),
+                    'citations'=>array('type'=>'array','maxItems'=>3,'items'=>array('type'=>'object','additionalProperties'=>true,'properties'=>array('title'=>$text,'url'=>$text,'source'=>$text,'date'=>$text))),
+                    'warnings'=>$string_array,
+                ),
+                'required'=>array('status','summary','source_quality','trends','content_ideas','citations','warnings'),
+            ),
+        );
+    }
+
+    private static function editorial_plan_schema() {
         $text = array('type'=>'string');
         $num = array('type'=>'number');
         $string_array = array('type'=>'array','items'=>$text);

--- a/includes/class-trend-content-ideas-service.php
+++ b/includes/class-trend-content-ideas-service.php
@@ -11,6 +11,8 @@ class ALMA_Trend_Content_Ideas_Service {
     const LEGACY_MODEL_WARNING = 'Il modello Trend gpt-5.5 salvato da una versione precedente è stato ignorato: viene usato il modello globale OpenAI.';
     const TIMEOUT_RETRY_WARNING = 'Retry OpenAI alleggerito dopo timeout della ricerca web.';
     const JSON_RETRY_WARNING = 'Retry OpenAI eseguito perché la risposta precedente non era JSON valido.';
+    const TRUNCATED_OUTPUT_WARNING = 'La risposta AI è stata troncata per limite max_output_tokens.';
+    const TRUNCATED_OUTPUT_RETRY_WARNING = 'Retry OpenAI compatto eseguito dopo output troncato.';
 
     public static function init() {
         add_action(self::CRON_HOOK, array(__CLASS__, 'run_due_sources'));
@@ -65,7 +67,8 @@ class ALMA_Trend_Content_Ideas_Service {
                 }
                 if (is_wp_error($parsed)) {
                     $report = $parsed->get_error_data();
-                    return self::store_error_report($sources, $run_type, __('La risposta AI non era un JSON valido. Controlla il report tecnico per dettagli.', 'affiliate-link-manager-ai'), $started, wp_json_encode(array('attempts'=>$attempts,'warnings'=>$warnings,'runtime'=>$runtime,'json_error'=>$report)), $res['model'] ?? '', $runtime, $warnings);
+                    $message = self::json_error_user_message($report, $warnings);
+                    return self::store_error_report($sources, $run_type, $message, $started, wp_json_encode(array('attempts'=>$attempts,'warnings'=>$warnings,'runtime'=>$runtime,'json_error'=>$report)), $res['model'] ?? '', $runtime, $warnings);
                 }
             }
             $data = $parsed;
@@ -89,11 +92,13 @@ class ALMA_Trend_Content_Ideas_Service {
         return new WP_Error('trend_run_error', $message, array('report_id'=>$report_id));
     }
 
-    public static function validate_result($data) {
-        $required = array('status','summary','trends','content_ideas','citations','warnings','sintesi_generale','fonti_analizzate','destinazioni_prioritarie','temi_editoriali','piano_editoriale_settimanale','opportunita_affiliate','bisogni_viaggiatori','rischi_e_limiti','dati_per_grafici','livello_confidenza','alert','fonti_citate');
+    public static function validate_result($data, $schema_profile = 'editorial_plan') {
+        $is_compact = in_array($schema_profile, array('source_test','json_invalid_retry'), true);
+        $required = $is_compact ? array('status','summary','source_quality','trends','content_ideas','citations','warnings') : array('status','summary','trends','content_ideas','citations','warnings','sintesi_generale','fonti_analizzate','destinazioni_prioritarie','temi_editoriali','piano_editoriale_settimanale','opportunita_affiliate','bisogni_viaggiatori','rischi_e_limiti','dati_per_grafici','livello_confidenza','alert','fonti_citate');
         if (!is_array($data)) { return new WP_Error('invalid_json', __('JSON OpenAI non valido.', 'affiliate-link-manager-ai')); }
         foreach ($required as $key) { if (!array_key_exists($key, $data)) { return new WP_Error('incomplete_json', sprintf(__('JSON incompleto: manca %s.', 'affiliate-link-manager-ai'), $key)); } }
-        foreach (array('trends','content_ideas','citations','warnings','fonti_analizzate','destinazioni_prioritarie','temi_editoriali','piano_editoriale_settimanale','opportunita_affiliate','bisogni_viaggiatori','rischi_e_limiti','alert','fonti_citate') as $key) { if (!is_array($data[$key])) { return new WP_Error('incomplete_json', sprintf(__('JSON incompleto: %s deve essere un array.', 'affiliate-link-manager-ai'), $key)); } }
+        $array_keys = $is_compact ? array('trends','content_ideas','citations','warnings') : array('trends','content_ideas','citations','warnings','fonti_analizzate','destinazioni_prioritarie','temi_editoriali','piano_editoriale_settimanale','opportunita_affiliate','bisogni_viaggiatori','rischi_e_limiti','alert','fonti_citate');
+        foreach ($array_keys as $key) { if (!is_array($data[$key])) { return new WP_Error('incomplete_json', sprintf(__('JSON incompleto: %s deve essere un array.', 'affiliate-link-manager-ai'), $key)); } }
         return true;
     }
 
@@ -110,9 +115,10 @@ class ALMA_Trend_Content_Ideas_Service {
             $category = self::looks_truncated($res, $text) ? 'truncated_output' : 'malformed_json';
             return new WP_Error('invalid_json', __('JSON OpenAI non valido.', 'affiliate-link-manager-ai'), self::json_error_report($res, $attempt, $category, $text, $json_error));
         }
-        $valid = self::validate_result($decoded);
+        $schema_profile = sanitize_key((string)($attempt['schema_profile'] ?? 'editorial_plan'));
+        $valid = self::validate_result($decoded, $schema_profile);
         if (is_wp_error($valid)) { return new WP_Error($valid->get_error_code(), $valid->get_error_message(), self::json_error_report($res, $attempt, 'incomplete_schema', $text, $valid->get_error_message())); }
-        return $decoded;
+        return self::normalize_result_for_storage($decoded, $schema_profile);
     }
 
     private static function extract_response_text($res) {
@@ -140,11 +146,12 @@ class ALMA_Trend_Content_Ideas_Service {
         $raw = $res['raw_response'] ?? array();
         $status = strtolower((string)($raw['status'] ?? $res['status'] ?? ''));
         $reason = strtolower((string)($raw['incomplete_details']['reason'] ?? $raw['finish_reason'] ?? $res['finish_reason'] ?? ''));
-        return strpos($status, 'incomplete') !== false || strpos($reason, 'token') !== false || strpos($reason, 'length') !== false || (trim((string)$text) !== '' && !preg_match('/[}\]]\s*$/', trim((string)$text)));
+        return strpos($status, 'incomplete') !== false || strpos($reason, 'max_output_tokens') !== false || strpos($reason, 'token') !== false || strpos($reason, 'length') !== false || (trim((string)$text) !== '' && !preg_match('/[}\]]\s*$/', trim((string)$text)));
     }
 
     private static function json_error_report($res, $attempt=array(), $category='malformed_json', $text='', $warning='') {
         $raw = $res['raw_response'] ?? array();
+        if ($category !== 'truncated_output' && self::looks_truncated($res, $text !== '' ? $text : self::extract_response_text($res))) { $category = 'truncated_output'; }
         return array(
             'category'=>sanitize_key($category),
             'warning'=>sanitize_text_field((string)$warning),
@@ -157,7 +164,9 @@ class ALMA_Trend_Content_Ideas_Service {
             'max_output_tokens'=>absint($attempt['max_output_tokens'] ?? ($res['max_output_tokens'] ?? 0)),
             'tool_choice'=>sanitize_text_field((string)($attempt['tool_choice'] ?? '')),
             'include'=>array_values(array_map('sanitize_text_field', (array)($attempt['include'] ?? array()))),
+            'profile'=>sanitize_key((string)($attempt['profile'] ?? '')),
             'response_format_used'=>sanitize_text_field((string)($res['response_format_used'] ?? '')),
+            'suggestion'=>self::json_error_suggestion($category),
         );
     }
 
@@ -166,6 +175,84 @@ class ALMA_Trend_Content_Ideas_Service {
         $text = preg_replace('/sk-[A-Za-z0-9_\-]+/i', 'sk-[redacted]', $text);
         $text = wp_strip_all_tags($text);
         return mb_substr($text, 0, max(1, absint($limit)));
+    }
+
+
+    private static function normalize_result_for_storage($data, $schema_profile = 'editorial_plan') {
+        if (!in_array($schema_profile, array('source_test','json_invalid_retry'), true)) { return $data; }
+        $data['sintesi_generale'] = $data['sintesi_generale'] ?? ($data['summary'] ?? '');
+        $data['fonti_analizzate'] = $data['fonti_analizzate'] ?? array();
+        $data['destinazioni_prioritarie'] = $data['destinazioni_prioritarie'] ?? self::compact_trends_to_destinations($data['trends'] ?? array());
+        $data['temi_editoriali'] = $data['temi_editoriali'] ?? array();
+        $data['piano_editoriale_settimanale'] = $data['piano_editoriale_settimanale'] ?? self::compact_ideas_to_plan($data['content_ideas'] ?? array());
+        $data['opportunita_affiliate'] = $data['opportunita_affiliate'] ?? array();
+        $data['bisogni_viaggiatori'] = $data['bisogni_viaggiatori'] ?? array();
+        $data['rischi_e_limiti'] = $data['rischi_e_limiti'] ?? array();
+        $data['dati_per_grafici'] = $data['dati_per_grafici'] ?? array();
+        $data['livello_confidenza'] = $data['livello_confidenza'] ?? '';
+        $data['alert'] = $data['alert'] ?? ($data['warnings'] ?? array());
+        $data['fonti_citate'] = $data['fonti_citate'] ?? self::compact_citations_to_fonti_citate($data['citations'] ?? array());
+        return $data;
+    }
+
+    private static function compact_trends_to_destinations($trends) {
+        $out = array();
+        foreach ((array)$trends as $trend) {
+            if (!is_array($trend)) { continue; }
+            $out[] = array(
+                'nome'=>sanitize_text_field((string)($trend['title'] ?? '')),
+                'paese_o_area'=>'',
+                'trend_score'=>0,
+                'confidence_score'=>0,
+                'motivazione'=>sanitize_text_field((string)($trend['description'] ?? '')),
+            );
+        }
+        return $out;
+    }
+
+    private static function compact_ideas_to_plan($ideas) {
+        $out = array();
+        foreach ((array)$ideas as $idea) {
+            if (!is_array($idea)) { continue; }
+            $out[] = array(
+                'titolo'=>sanitize_text_field((string)($idea['title'] ?? '')),
+                'motivazione_trend'=>sanitize_text_field((string)($idea['description'] ?? '')),
+                'intento_ricerca'=>sanitize_text_field((string)($idea['intent'] ?? '')),
+            );
+        }
+        return $out;
+    }
+
+    private static function compact_citations_to_fonti_citate($citations) {
+        $out = array();
+        foreach ((array)$citations as $citation) {
+            if (!is_array($citation)) { continue; }
+            $out[] = array(
+                'titolo'=>sanitize_text_field((string)($citation['title'] ?? '')),
+                'url'=>esc_url_raw((string)($citation['url'] ?? '')),
+                'fonte'=>sanitize_text_field((string)($citation['source'] ?? '')),
+            );
+        }
+        return $out;
+    }
+
+    private static function is_truncated_error_report($report) {
+        if (!is_array($report)) { return false; }
+        return sanitize_key((string)($report['category'] ?? '')) === 'truncated_output'
+            || stripos((string)($report['status'] ?? ''), 'incomplete') !== false
+            || stripos((string)($report['finish_reason'] ?? ''), 'max_output_tokens') !== false;
+    }
+
+    private static function json_error_user_message($report, $warnings = array()) {
+        if (self::is_truncated_error_report($report) || in_array(self::TRUNCATED_OUTPUT_WARNING, (array)$warnings, true)) {
+            return __('La risposta AI è stata troncata perché troppo lunga per il limite token configurato. È stato tentato un retry compatto.', 'affiliate-link-manager-ai');
+        }
+        return __('La risposta AI non era un JSON valido. Controlla il report tecnico per dettagli.', 'affiliate-link-manager-ai');
+    }
+
+    private static function json_error_suggestion($category) {
+        if (sanitize_key((string)$category) !== 'truncated_output') { return ''; }
+        return __('Per ridurre il rischio di troncamento, abbassa la quantità contenuti della fonte, usa un modello più leggero o aumenta leggermente max output token.', 'affiliate-link-manager-ai');
     }
 
     public static function normalize_allowed_domains($domains, $limit = self::MAX_ALLOWED_DOMAINS) {
@@ -204,12 +291,12 @@ class ALMA_Trend_Content_Ideas_Service {
 
     public static function runtime_profile($run_type, $sources = array()) {
         if ($run_type === 'test' && count((array)$sources) <= 1) {
-            return array('name'=>'source_test','max_output_tokens'=>1800,'retry_max_output_tokens'=>900,'search_context_size'=>'low','include_sources'=>true,'tool_choice'=>'required');
+            return array('name'=>'source_test','max_output_tokens'=>2200,'retry_max_output_tokens'=>1600,'search_context_size'=>'low','include_sources'=>true,'tool_choice'=>'required');
         }
         if ($run_type === 'test') {
-            return array('name'=>'full_test','max_output_tokens'=>3500,'retry_max_output_tokens'=>1600,'search_context_size'=>'medium','include_sources'=>true,'tool_choice'=>'required');
+            return array('name'=>'full_test','max_output_tokens'=>3800,'retry_max_output_tokens'=>1800,'search_context_size'=>'medium','include_sources'=>true,'tool_choice'=>'required');
         }
-        return array('name'=>'editorial_plan','max_output_tokens'=>6000,'retry_max_output_tokens'=>3000,'search_context_size'=>'medium','include_sources'=>true,'tool_choice'=>'required');
+        return array('name'=>'editorial_plan','max_output_tokens'=>5200,'retry_max_output_tokens'=>2200,'search_context_size'=>'medium','include_sources'=>true,'tool_choice'=>'required');
     }
 
     public static function build_openai_request_args($sources, $run_type = 'manual', $with_filters = true, $tool_choice = 'required', $profile = null, $include_sources = null) {
@@ -220,11 +307,12 @@ class ALMA_Trend_Content_Ideas_Service {
             'model'=>self::model(),
             'system_prompt'=>ALMA_Trend_Content_Ideas_Prompt_Builder::system_prompt(),
             'user_prompt'=>ALMA_Trend_Content_Ideas_Prompt_Builder::build($sources, $run_type),
-            'response_format'=>ALMA_Trend_Content_Ideas_Prompt_Builder::response_schema(),
+            'response_format'=>ALMA_Trend_Content_Ideas_Prompt_Builder::response_schema($profile['name'] ?? 'editorial_plan'),
             'max_output_tokens'=>absint($profile['max_output_tokens'] ?? 3500),
             'timeout'=>absint(get_option(ALMA_Trend_Content_Ideas_Store::OPTION_TIMEOUT, 90)),
             'tools'=>array(self::build_web_search_tool($domains, $profile['search_context_size'] ?? 'medium')),
             'tool_choice'=>$tool_choice,
+            'runtime_profile'=>sanitize_key((string)($profile['name'] ?? 'editorial_plan')),
         );
         if ($include_sources) { $args['include'] = array('web_search_call.action.sources'); }
         return $args;
@@ -284,13 +372,19 @@ class ALMA_Trend_Content_Ideas_Service {
     private static function retry_invalid_json_response($sources, $run_type, $request, $parsed_error) {
         $base = is_array($request['last_args'] ?? null) ? $request['last_args'] : self::build_openai_request_args($sources, $run_type);
         $retry = $base;
-        $retry['system_prompt'] = ALMA_Trend_Content_Ideas_Prompt_Builder::system_prompt() . ' ' . self::JSON_RETRY_WARNING . ' Rispondi solo con JSON valido conforme allo schema, senza markdown o testo esterno.';
+        $is_truncated = self::is_truncated_error_report($parsed_error instanceof WP_Error ? $parsed_error->get_error_data() : array());
+        $retry['system_prompt'] = ALMA_Trend_Content_Ideas_Prompt_Builder::system_prompt() . ' ' . ($is_truncated ? self::TRUNCATED_OUTPUT_RETRY_WARNING : self::JSON_RETRY_WARNING) . ' Rispondi solo con JSON valido compatto conforme allo schema source_test, senza markdown o testo esterno.';
         $retry['user_prompt'] = ALMA_Trend_Content_Ideas_Prompt_Builder::build_json_retry($sources, $run_type);
-        $retry['max_output_tokens'] = max(900, min(absint($base['max_output_tokens'] ?? 3500), 2200));
+        $retry['response_format'] = ALMA_Trend_Content_Ideas_Prompt_Builder::response_schema('json_invalid_retry');
+        $retry['tool_choice'] = 'auto';
+        $retry['runtime_profile'] = 'json_invalid_retry';
+        $retry['max_output_tokens'] = max(1400, min(absint($base['max_output_tokens'] ?? 2200), 2200));
         unset($retry['include']);
         $attempts = (array)($request['attempts'] ?? array());
         $attempts[] = self::attempt_summary('json_invalid_retry', $retry);
-        $warnings = array_values(array_unique(array_merge((array)($request['warnings'] ?? array()), array(self::JSON_RETRY_WARNING))));
+        $retry_warning = $is_truncated ? self::TRUNCATED_OUTPUT_RETRY_WARNING : self::JSON_RETRY_WARNING;
+        $warning_set = $is_truncated ? array(self::TRUNCATED_OUTPUT_WARNING, $retry_warning) : array($retry_warning);
+        $warnings = array_values(array_unique(array_merge((array)($request['warnings'] ?? array()), $warning_set)));
         $res = ALMA_OpenAI_Service::request($retry);
         $warnings = self::merge_openai_warnings($warnings, $res);
         return array('executed'=>true,'response'=>$res,'attempts'=>$attempts,'warnings'=>$warnings);
@@ -313,7 +407,7 @@ class ALMA_Trend_Content_Ideas_Service {
         return $timeout_ms > 0 && $response_time >= max(1000, $timeout_ms - 2500);
     }
 
-    private static function attempt_summary($label, $args) { return array('label'=>$label,'tool'=>$args['tools'][0]['type'] ?? '','tool_choice'=>$args['tool_choice'] ?? '','allowed_domains'=>$args['tools'][0]['filters']['allowed_domains'] ?? array(),'include'=>$args['include'] ?? array(),'max_output_tokens'=>absint($args['max_output_tokens'] ?? 0),'sources_include_enabled'=>!empty($args['include'])); }
+    private static function attempt_summary($label, $args) { return array('label'=>$label,'tool'=>$args['tools'][0]['type'] ?? '','tool_choice'=>$args['tool_choice'] ?? '','allowed_domains'=>$args['tools'][0]['filters']['allowed_domains'] ?? array(),'include'=>$args['include'] ?? array(),'max_output_tokens'=>absint($args['max_output_tokens'] ?? 0),'sources_include_enabled'=>!empty($args['include']),'schema_profile'=>$label === 'json_invalid_retry' ? 'json_invalid_retry' : sanitize_key((string)($args['runtime_profile'] ?? 'editorial_plan')),'profile'=>sanitize_key((string)($args['runtime_profile'] ?? ''))); }
     private static function merge_openai_warnings($warnings, $res) { foreach ((array)($res['warnings'] ?? array()) as $warning) { $warnings[] = sanitize_text_field((string)$warning); } return array_values(array_unique(array_filter($warnings))); }
     private static function is_filters_unsupported_error($res) { $m = strtolower((string)($res['error'] ?? '')); return strpos($m, 'filters') !== false && (strpos($m, 'unsupported parameter') !== false || strpos($m, 'not supported') !== false || strpos($m, 'unknown parameter') !== false); }
     private static function is_tool_choice_unsupported($res) { $m = strtolower((string)($res['error'] ?? '')); return strpos($m, 'tool_choice') !== false && (strpos($m, 'unsupported') !== false || strpos($m, 'not supported') !== false); }


### PR DESCRIPTION
### Motivation
- The Trend Ideas module classified many responses as generic “JSON non valido” while the real cause was OpenAI responses truncated by `max_output_tokens` when using the `source_test` profile. 
- The `source_test` profile used an editorial-grade schema that produced overly large outputs for simple source diagnostics, increasing truncation risk.

### Description
- Added a compact JSON schema for `source_test` with only essential fields (`status`, `summary`, `source_quality`, `trends`, `content_ideas`, `citations`, `warnings`) and strict limits (max 2 trends, max 2 ideas, max 3 citations, `summary` ≤ 350 chars, descriptions ≤ 250 chars). (`includes/class-trend-content-ideas-prompt-builder.php`)
- Prompt builder now distinguishes `source_test`, `full_test` and `editorial_plan` and generates a stronger compact retry prompt for `json_invalid_retry`. (`includes/class-trend-content-ideas-prompt-builder.php`)
- The single `json_invalid_retry` was changed to run at most once with a compact schema, `tool_choice: auto`, `include` disabled, `web_search` preserved and allowed domains kept; it uses a shorter prompt and lower `max_output_tokens`. (`includes/class-trend-content-ideas-service.php`)
- Improved detection/classification of truncated outputs (`finish_reason: max_output_tokens`, `status: incomplete` or visibly cut JSON) and added clear user-facing messages and report fields (`category: truncated_output`, model, response id, finish reason, max output tokens, attempt label, tool_choice, include, profile, sanitized `raw_excerpt` ≤ 1500 chars) plus readable suggestions. (`includes/class-trend-content-ideas-service.php`)
- Tuned runtime token profiles to reasonable values (`source_test` ≈ 2200, compact retry 1400–2200, `full_test` intermediate, `editorial_plan` higher) and kept `max_contents_per_run` and source snapshot behavior unchanged. (`includes/class-trend-content-ideas-service.php`) 
- Bumped plugin version to `2.33.2` and updated `Version:` header and `ALMA_VERSION` constant, plus `README.md` and `CHANGELOG.md` docs for the new behavior. (`affiliate-link-manager-ai.php`, `README.md`, `CHANGELOG.md`)

### Testing
- Ran PHP lint on modified files with `php -l` and all checks passed for `affiliate-link-manager-ai.php`, `includes/class-trend-content-ideas-service.php`, `includes/class-trend-content-ideas-prompt-builder.php` and admin file. (passed)
- Executed static/unit-like Python assertions verifying the compact `source_test` schema differs from editorial schema, prompt limits (≤2 trends, ≤2 ideas, summary ≤350, descriptions ≤250), `json_invalid_retry` uses `tool_choice: auto` and disables `include`, truncated output is classified as `truncated_output`, report contains the truncation warning and retry warning, and `raw_excerpt` is limited to 1500 chars. (passed)
- Confirmed `web_search_preview` was not reintroduced and `web_search` remains configured as tool, and admin rendering does not start OpenAI calls. (passed)
- Ran repository checks including `rg` searches and `git diff --check`, which reported no syntax errors or whitespace problems. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ad9841448332b2fc76c31be30cc7)