### PR TITLE
Enhance Trend content reports and dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.34.0 - 2026-05-10
+- Arricchito il modulo **Trend Idee contenuto**: `source_test` resta diagnostico e compatto, `full_test` usa uno schema più ampio per report utili a Sothra, `editorial_plan` diventa il profilo operativo per pianificazione editoriale.
+- `full_test` ora richiede, se i dati lo consentono, almeno 6 trend, 8 idee editoriali, 5 bisogni viaggiatori, 5 opportunità affiliate, 4 rischi/limiti e 6 citazioni, con warning espliciti quando le fonti non bastano.
+- `editorial_plan` richiede 10-20 idee, 7-14 contenuti settimanali, 8-12 opportunità affiliate, 8-12 bisogni viaggiatori e destinazioni reali quando disponibili, includendo priorità, intento di ricerca, categoria editoriale, CTA/link affiliato e fonti collegate.
+- Introdotte metriche fonti distinte: `count_fonti_configurate`, `count_fonti_interrogate`, `count_fonti_citate`, `count_fonti_saltate`, `count_fonti_senza_risultati`; `count_fonti_analizzate` resta per compatibilità come alias coerente di `count_fonti_interrogate`.
+- Chiarita la differenza tra fonti configurate (salvate in WordPress), interrogate/richieste (passate alla run Web Search) e citate (con URL/citazioni nel report), con dettaglio per fonte nella tabella del report.
+- Potenziata la box **Trend Idee contenuto** nella Bacheca WordPress: legge solo l’ultimo report salvato, mostra data/ora report, stato, modello, profilo runtime, metriche, top trend, destinazioni, idee, opportunità affiliate, bisogni, alert e link al report/generazione.
+- Ogni report salvato conserva data creazione, stato, modello, profilo runtime, metriche, JSON tecnico, sintesi, idee, destinazioni, opportunità affiliate, bisogni viaggiatori, citazioni e alert.
+- Migliorata la pagina report completa con sezioni per sintesi, metriche, fonti usate, trend, destinazioni/città, piano editoriale, bisogni, opportunità affiliate, rischi/limiti, fonti citate e JSON tecnico, con messaggi utili per sezioni vuote.
+- Le destinazioni prioritarie non vengono più popolate automaticamente con titoli generici di trend: devono essere città, località, regioni, paesi, aree geografiche o luoghi reali emersi dalle fonti.
+- Versione plugin aggiornata a `2.34.0`.
+
 ## 2.33.2 - 2026-05-10
 - Aggiunto uno schema JSON compatto per il profilo `source_test`, separato dallo schema editoriale completo usato da `full_test`/`editorial_plan`.
 - Documentata e rinforzata la distinzione tra contenuti informativi analizzati dalla fonte, trend restituiti e idee editoriali generate.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+## 2.34.0 - 2026-05-10
+- Arricchito il modulo **Trend Idee contenuto**: `source_test` resta diagnostico e compatto, `full_test` usa uno schema più ampio per report utili a Sothra, `editorial_plan` diventa il profilo operativo per pianificazione editoriale.
+- `full_test` ora richiede, se i dati lo consentono, almeno 6 trend, 8 idee editoriali, 5 bisogni viaggiatori, 5 opportunità affiliate, 4 rischi/limiti e 6 citazioni, con warning espliciti quando le fonti non bastano.
+- `editorial_plan` richiede 10-20 idee, 7-14 contenuti settimanali, 8-12 opportunità affiliate, 8-12 bisogni viaggiatori e destinazioni reali quando disponibili, includendo priorità, intento di ricerca, categoria editoriale, CTA/link affiliato e fonti collegate.
+- Introdotte metriche fonti distinte: `count_fonti_configurate`, `count_fonti_interrogate`, `count_fonti_citate`, `count_fonti_saltate`, `count_fonti_senza_risultati`; `count_fonti_analizzate` resta per compatibilità come alias coerente di `count_fonti_interrogate`.
+- Chiarita la differenza tra fonti configurate (salvate in WordPress), interrogate/richieste (passate alla run Web Search) e citate (con URL/citazioni nel report), con dettaglio per fonte nella tabella del report.
+- Potenziata la box **Trend Idee contenuto** nella Bacheca WordPress: legge solo l’ultimo report salvato, mostra data/ora report, stato, modello, profilo runtime, metriche, top trend, destinazioni, idee, opportunità affiliate, bisogni, alert e link al report/generazione.
+- Ogni report salvato conserva data creazione, stato, modello, profilo runtime, metriche, JSON tecnico, sintesi, idee, destinazioni, opportunità affiliate, bisogni viaggiatori, citazioni e alert.
+- Migliorata la pagina report completa con sezioni per sintesi, metriche, fonti usate, trend, destinazioni/città, piano editoriale, bisogni, opportunità affiliate, rischi/limiti, fonti citate e JSON tecnico, con messaggi utili per sezioni vuote.
+- Le destinazioni prioritarie non vengono più popolate automaticamente con titoli generici di trend: devono essere città, località, regioni, paesi, aree geografiche o luoghi reali emersi dalle fonti.
+- Versione plugin aggiornata a `2.34.0`.
+
 ## 2.33.2 - 2026-05-10
 - Aggiunto uno schema JSON compatto per il profilo `source_test`, separato dallo schema editoriale completo usato da `full_test`/`editorial_plan`.
 - Documentata e rinforzata la distinzione tra contenuti informativi analizzati dalla fonte, trend restituiti e idee editoriali generate.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.33.2
+ * Version: 2.34.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.33.2');
+define('ALMA_VERSION', '2.34.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-trend-content-ideas-admin.php
+++ b/includes/class-trend-content-ideas-admin.php
@@ -5,7 +5,7 @@ class ALMA_Trend_Content_Ideas_Admin {
     const SLUG = 'alma-trend-content-ideas';
     const CAP = 'manage_options';
 
-    public static function init() { add_action('admin_post_alma_trend_content_action', array(__CLASS__, 'handle_action')); }
+    public static function init() { add_action('admin_post_alma_trend_content_action', array(__CLASS__, 'handle_action')); add_action('wp_dashboard_setup', array(__CLASS__, 'register_dashboard_widget'), 1); }
     private static function url($args=array()) { return admin_url('edit.php?post_type=affiliate_link&page=' . self::SLUG . (empty($args)?'':'&' . http_build_query($args))); }
     private static function action_url($args=array()) { return wp_nonce_url(add_query_arg(array_merge(array('action'=>'alma_trend_content_action'), $args), admin_url('admin-post.php')), 'alma_trend_content_action'); }
 
@@ -35,45 +35,104 @@ class ALMA_Trend_Content_Ideas_Admin {
             echo '<tr><td><input type="checkbox" name="sources[' . esc_attr($key) . '][enabled]" value="1" ' . checked((int)$src['enabled'],1,false) . '></td><td><strong>' . esc_html($src['name']) . '</strong><p class="description">' . esc_html($src['description']) . '</p><details><summary>Modifica prompt fonte</summary><textarea class="large-text" rows="4" name="sources[' . esc_attr($key) . '][custom_prompt]">' . esc_textarea($src['custom_prompt']) . '</textarea></details></td><td><input type="number" min="1" max="3" name="sources[' . esc_attr($key) . '][priority]" value="' . esc_attr($priority) . '" style="width:70px"><p class="description">1 alta, 2 media, 3 bassa.</p></td><td><input type="number" min="1" max="10" name="sources[' . esc_attr($key) . '][max_contents_per_run]" value="' . esc_attr($max_contents) . '" style="width:90px"><p class="description">Limite per fonte e per singola run.</p></td><td>' . esc_html($src['category']) . '</td><td><input type="number" min="1" max="365" name="sources[' . esc_attr($key) . '][interval_days]" value="' . (int)$src['interval_days'] . '" style="width:80px"> giorni</td><td>' . esc_html($src['last_run_at'] ?: 'Mai') . '</td><td>' . esc_html($src['next_run_at'] ?: 'Non pianificata') . '</td><td><span class="alma-badge alma-badge-' . esc_attr($badge) . '">' . esc_html($src['status']) . '</span></td><td><a class="button button-small" href="' . esc_url(self::action_url(array('do'=>'run_source','source_key'=>$key))) . '">Testa fonte</a></td></tr>';
         }
         echo '</tbody></table><p><button class="button button-primary">Salva configurazione</button> <a class="button" href="' . esc_url(self::action_url(array('do'=>'run_all'))) . '">Esegui test completo adesso</a> <a class="button button-secondary" href="' . esc_url(self::action_url(array('do'=>'generate_plan'))) . '">Genera piano editoriale ora</a> <a class="button" href="#ultimo-report">Visualizza ultimo report</a></p></div></div></form>';
-        echo '<style>.alma-badge{display:inline-block;padding:3px 8px;border-radius:999px;background:#dcdcde}.alma-badge-success{background:#00a32a;color:#fff}.alma-badge-muted{background:#646970;color:#fff}.alma-report-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px}.alma-card{background:#fff;border:1px solid #c3c4c7;padding:14px}.alma-card h3{margin-top:0}.alma-pill{display:inline-block;padding:2px 7px;border-radius:999px;background:#f0f0f1;margin:2px}</style>';
+        echo '<style>.alma-badge{display:inline-block;padding:3px 8px;border-radius:999px;background:#dcdcde}.alma-badge-success{background:#00a32a;color:#fff}.alma-badge-muted{background:#646970;color:#fff}.alma-report-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px}.alma-card{background:#fff;border:1px solid #c3c4c7;padding:14px}.alma-card h3{margin-top:0}.alma-pill{display:inline-block;padding:2px 7px;border-radius:999px;background:#f0f0f1;margin:2px}.alma-metric-cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:8px;margin:10px 0}.alma-metric-card{background:#f6f7f7;border:1px solid #dcdcde;border-radius:4px;padding:8px}.alma-metric-card strong{display:block;font-size:18px}.alma-dashboard-lists{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px}.alma-dashboard-lists h3{margin-bottom:4px}</style>';
     }
 
-    public static function dashboard_box() {
-        $r = ALMA_Trend_Content_Ideas_Store::latest_report();
-        echo '<div class="postbox"><div class="inside"><h2>Trend Idee contenuto</h2>';
-        if (!$r) { echo '<p>Nessun report ancora generato.</p><p><a class="button" href="' . esc_url(self::url()) . '">Configura fonti</a></p></div></div>'; return; }
-        $data=ALMA_Trend_Content_Ideas_Store::decode_json($r['result_json']); $metrics=ALMA_Trend_Content_Ideas_Store::decode_json($r['metrics_json']); $source_snapshot=ALMA_Trend_Content_Ideas_Store::decode_json($r['sources_json']); $dest=array_slice((array)($data['destinazioni_prioritarie']??array()),0,5); $ideas=array_slice((array)($data['piano_editoriale_settimanale']??array()),0,5); $alerts=array_slice((array)($data['alert']??array()),0,5);
-        echo '<p><strong>Ultimo report:</strong> ' . esc_html($r['created_at']) . ' — <strong>Stato:</strong> ' . esc_html($r['status']) . '</p><ul><li>Fonti analizzate: ' . (int)($metrics['count_fonti_analizzate']??0) . '</li><li>Destinazioni individuate: ' . (int)($metrics['count_destinazioni']??0) . '</li><li>Idee editoriali generate: ' . (int)($metrics['count_idee_editoriali']??0) . '</li></ul>';
-        echo '<h3>Top destinazioni</h3><ol>'; foreach($dest as $d){ echo '<li>' . esc_html($d['nome'] ?? '') . ' <small>' . esc_html($d['paese_o_area'] ?? '') . '</small></li>'; } echo '</ol><h3>Top idee contenuto</h3><ol>'; foreach($ideas as $i){ echo '<li>' . esc_html($i['titolo'] ?? '') . '</li>'; } echo '</ol>';
-        if($alerts){ echo '<h3>Alert principali</h3><ul>'; foreach($alerts as $a){ echo '<li>' . esc_html(is_scalar($a)?$a:wp_json_encode($a)) . '</li>'; } echo '</ul>'; }
-        echo '<p><a class="button button-primary" href="' . esc_url(self::url(array('report_id'=>(int)$r['id']))) . '">Apri report completo</a> <a class="button" href="' . esc_url(self::url()) . '">Configura fonti</a> <a class="button" href="' . esc_url(self::action_url(array('do'=>'run_all'))) . '">Esegui test ora</a></p></div></div>';
+    public static function register_dashboard_widget() {
+        if (!current_user_can(self::CAP)) { return; }
+        wp_add_dashboard_widget('alma_trend_content_ideas_dashboard_widget', __('Trend Idee contenuto', 'affiliate-link-manager-ai'), array(__CLASS__, 'dashboard_widget'), null, null, 'normal', 'high');
+        self::promote_dashboard_widget('alma_trend_content_ideas_dashboard_widget');
     }
+
+    public static function dashboard_widget() { self::dashboard_box(false); }
+
+    private static function promote_dashboard_widget($widget_id) {
+        global $wp_meta_boxes;
+        if (empty($wp_meta_boxes['dashboard']['normal']['high'][$widget_id])) { return; }
+        $widget = array($widget_id => $wp_meta_boxes['dashboard']['normal']['high'][$widget_id]);
+        unset($wp_meta_boxes['dashboard']['normal']['high'][$widget_id]);
+        $wp_meta_boxes['dashboard']['normal']['high'] = $widget + (array)$wp_meta_boxes['dashboard']['normal']['high'];
+    }
+
+    public static function dashboard_box($wrap_postbox = true) {
+        echo '<style>.alma-metric-cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:8px;margin:10px 0}.alma-metric-card{background:#f6f7f7;border:1px solid #dcdcde;border-radius:4px;padding:8px}.alma-metric-card strong{display:block;font-size:18px}.alma-dashboard-lists{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px}.alma-dashboard-lists h3{margin-bottom:4px}</style>';
+        $r = ALMA_Trend_Content_Ideas_Store::latest_report();
+        if ($wrap_postbox) { echo '<div class="postbox"><div class="inside"><h2>' . esc_html__('Trend Idee contenuto', 'affiliate-link-manager-ai') . '</h2>'; }
+        if (!$r) {
+            echo '<p>' . esc_html__('Nessun report Trend disponibile. Genera il primo report.', 'affiliate-link-manager-ai') . '</p><p><a class="button button-primary" href="' . esc_url(self::url()) . '">' . esc_html__('Vai a Trend Idee contenuto', 'affiliate-link-manager-ai') . '</a></p>';
+            if ($wrap_postbox) { echo '</div></div>'; }
+            return;
+        }
+        $data=ALMA_Trend_Content_Ideas_Store::decode_json($r['result_json']); $metrics=ALMA_Trend_Content_Ideas_Store::decode_json($r['metrics_json']);
+        $runtime=(array)($data['runtime']??array());
+        $trends=array_slice((array)($data['trends']??($data['trend_principali']??array())),0,5);
+        $dest=array_slice((array)($data['destinazioni_prioritarie']??array()),0,5);
+        $ideas=array_slice((array)($data['piano_editoriale_settimanale']??($data['content_ideas']??array())),0,5);
+        $affiliate=array_slice((array)($data['opportunita_affiliate']??array()),0,5);
+        $needs=array_slice((array)($data['bisogni_viaggiatori']??array()),0,5);
+        $alerts=array_slice((array)($data['alert']??($data['warnings']??array())),0,5);
+        echo '<p><strong>' . esc_html__('Data report:', 'affiliate-link-manager-ai') . '</strong> ' . esc_html($r['created_at']) . ' &nbsp; <strong>' . esc_html__('Stato:', 'affiliate-link-manager-ai') . '</strong> ' . esc_html($r['status']) . ' &nbsp; <strong>' . esc_html__('Modello:', 'affiliate-link-manager-ai') . '</strong> ' . esc_html($r['model']) . ' &nbsp; <strong>' . esc_html__('Profilo:', 'affiliate-link-manager-ai') . '</strong> ' . esc_html($runtime['runtime_profile'] ?? $r['report_type']) . '</p>';
+        self::render_metric_cards(array(
+            __('Fonti config.', 'affiliate-link-manager-ai')=>(int)($metrics['count_fonti_configurate']??0),
+            __('Citate/interr.', 'affiliate-link-manager-ai')=>(int)($metrics['count_fonti_citate']??0) . '/' . (int)($metrics['count_fonti_interrogate']??0),
+            __('Idee', 'affiliate-link-manager-ai')=>(int)($metrics['count_idee_editoriali']??0),
+            __('Destinazioni', 'affiliate-link-manager-ai')=>(int)($metrics['count_destinazioni']??0),
+            __('Affiliate', 'affiliate-link-manager-ai')=>(int)($metrics['count_opportunita_affiliate']??0),
+            __('Alert', 'affiliate-link-manager-ai')=>(int)($metrics['count_alert_rischi']??0),
+        ));
+        echo '<div class="alma-dashboard-lists">';
+        self::dashboard_list(__('Top trend', 'affiliate-link-manager-ai'), $trends, array('title','titolo','nome'));
+        self::dashboard_list(__('Top destinazioni/città', 'affiliate-link-manager-ai'), $dest, array('nome','paese_o_area'));
+        self::dashboard_list(__('Top idee editoriali', 'affiliate-link-manager-ai'), $ideas, array('titolo','title'));
+        self::dashboard_list(__('Opportunità affiliate', 'affiliate-link-manager-ai'), $affiliate, array('categoria','priorita'));
+        self::dashboard_list(__('Bisogni viaggiatori', 'affiliate-link-manager-ai'), $needs, array('bisogno','descrizione'));
+        self::dashboard_list(__('Alert principali', 'affiliate-link-manager-ai'), $alerts, array());
+        echo '</div>';
+        echo '<p><a class="button button-primary" href="' . esc_url(self::url(array('report_id'=>(int)$r['id']))) . '">' . esc_html__('Apri report completo', 'affiliate-link-manager-ai') . '</a> <a class="button" href="' . esc_url(self::action_url(array('do'=>'generate_plan'))) . '">' . esc_html__('Genera nuovo piano editoriale', 'affiliate-link-manager-ai') . '</a> <a class="button" href="' . esc_url(self::url()) . '">' . esc_html__('Vai a Trend Idee contenuto', 'affiliate-link-manager-ai') . '</a></p>';
+        if ($wrap_postbox) { echo '</div></div>'; }
+    }
+
+    private static function render_metric_cards($metrics) { echo '<div class="alma-metric-cards">'; foreach($metrics as $label=>$value){ echo '<div class="alma-metric-card"><strong>'.esc_html((string)$value).'</strong><span>'.esc_html($label).'</span></div>'; } echo '</div>'; }
+
+    private static function dashboard_list($title, $items, $fields=array()) { echo '<div><h3>'.esc_html($title).'</h3>'; if(!$items){ echo '<p><em>'.esc_html__('Nessun dato in questa run.', 'affiliate-link-manager-ai').'</em></p></div>'; return; } echo '<ol>'; foreach(array_slice((array)$items,0,5) as $item){ if(is_array($item)){ $parts=array(); foreach($fields as $field){ if(!empty($item[$field])){ $parts[]=self::stringify($item[$field]); } } $label=$parts?implode(' — ', $parts):self::stringify($item); } else { $label=(string)$item; } echo '<li>'.esc_html(wp_trim_words($label, 16)).'</li>'; } echo '</ol></div>'; }
 
     private static function render_latest() { echo '<div id="ultimo-report">'; self::dashboard_box(); echo '</div>'; }
     private static function render_history() { $page=max(1,absint($_GET['paged']??1)); $reports=ALMA_Trend_Content_Ideas_Store::get_reports($page,10); echo '<div class="postbox"><div class="inside"><h2>Storico report</h2><table class="widefat striped"><thead><tr><th>Data</th><th>Titolo</th><th>Tipo</th><th>Stato</th><th>Sintesi</th><th>Azioni</th></tr></thead><tbody>'; if(!$reports){echo '<tr><td colspan="6">Nessun report salvato.</td></tr>';} foreach($reports as $r){ echo '<tr><td>'.esc_html($r['created_at']).'</td><td>'.esc_html($r['title']).'</td><td>'.esc_html($r['report_type']).'</td><td>'.esc_html($r['status']).'</td><td>'.esc_html(wp_trim_words($r['summary'],18)).'</td><td><a class="button button-small" href="'.esc_url(self::url(array('report_id'=>(int)$r['id']))).'">Apri</a></td></tr>'; } echo '</tbody></table></div></div>'; }
 
     private static function render_report($id) {
-        $r=ALMA_Trend_Content_Ideas_Store::get_report($id); if(!$r){ echo '<div class="notice notice-error"><p>Report non trovato.</p></div>'; return; }
-        $data=ALMA_Trend_Content_Ideas_Store::decode_json($r['result_json']); $metrics=ALMA_Trend_Content_Ideas_Store::decode_json($r['metrics_json']); $source_snapshot=ALMA_Trend_Content_Ideas_Store::decode_json($r['sources_json']);
-        echo '<p><a class="button" href="'.esc_url(self::url()).'">← Torna a Trend Idee contenuto</a></p><div class="postbox"><div class="inside"><h2>'.esc_html($r['title']).'</h2><p><strong>Data:</strong> '.esc_html($r['created_at']).' <strong>Stato:</strong> '.esc_html($r['status']).' <strong>Modello:</strong> '.esc_html($r['model']).'</p><p>'.esc_html($data['sintesi_generale']??'').'</p>';
-        if (!empty($data['errore_tecnico'])) { echo '<details><summary>Dettaglio tecnico errore</summary><pre>'.esc_html((string)$data['errore_tecnico']).'</pre></details>'; }
+        $r=ALMA_Trend_Content_Ideas_Store::get_report($id); if(!$r){ echo '<div class="notice notice-error"><p>' . esc_html__('Report non trovato.', 'affiliate-link-manager-ai') . '</p></div>'; return; }
+        $data=ALMA_Trend_Content_Ideas_Store::decode_json($r['result_json']); $metrics=ALMA_Trend_Content_Ideas_Store::decode_json($r['metrics_json']); $source_snapshot=ALMA_Trend_Content_Ideas_Store::decode_json($r['sources_json']); $runtime=(array)($data['runtime']??array());
+        echo '<p><a class="button" href="'.esc_url(self::url()).'">' . esc_html__('← Torna a Trend Idee contenuto', 'affiliate-link-manager-ai') . '</a></p><div class="postbox"><div class="inside"><h2>'.esc_html($r['title']).'</h2><p><strong>' . esc_html__('Data report:', 'affiliate-link-manager-ai') . '</strong> '.esc_html($r['created_at']).' <strong>' . esc_html__('Stato:', 'affiliate-link-manager-ai') . '</strong> '.esc_html($r['status']).' <strong>' . esc_html__('Modello:', 'affiliate-link-manager-ai') . '</strong> '.esc_html($r['model']).' <strong>' . esc_html__('Profilo runtime:', 'affiliate-link-manager-ai') . '</strong> '.esc_html($runtime['runtime_profile'] ?? $r['report_type']).'</p><p>'.esc_html($data['sintesi_generale']??($data['summary']??'')).'</p>';
+        if (!empty($data['errore_tecnico'])) { echo '<details><summary>' . esc_html__('Dettaglio tecnico errore', 'affiliate-link-manager-ai') . '</summary><pre>'.esc_html((string)$data['errore_tecnico']).'</pre></details>'; }
         echo '</div></div>';
-        self::render_report_sources($source_snapshot, $data);
-        echo '<div class="alma-report-grid">'; self::list_card('Fonti analizzate',(array)($data['fonti_analizzate']??array())); self::object_card('Destinazioni prioritarie',(array)($data['destinazioni_prioritarie']??array()),array('nome','paese_o_area','trend_score','confidence_score','motivazione')); self::object_card('Piano editoriale settimanale',(array)($data['piano_editoriale_settimanale']??array()),array('giorno_suggerito','titolo','tipo_contenuto','destinazione','priorita_editoriale','livello_confidenza','azione_consigliata')); self::object_card('Bisogni viaggiatori',(array)($data['bisogni_viaggiatori']??array()),array()); self::object_card('Opportunità affiliate',(array)($data['opportunita_affiliate']??array()),array()); self::object_card('Rischi e limiti',(array)($data['rischi_e_limiti']??array()),array()); echo '</div>';
-        echo '<div class="postbox"><div class="inside"><h2>Fonti citate</h2><ul>'; foreach((array)($data['fonti_citate']??array()) as $f){ $url=esc_url($f['url']??''); echo '<li>' . ($url?'<a href="'.$url.'" target="_blank" rel="noopener noreferrer">':'') . esc_html($f['titolo'] ?? ($f['fonte'] ?? $url)) . ($url?'</a>':'') . '</li>'; } echo '</ul></div></div>';
-        if (!empty($data['fonti_web_search'])) { echo '<div class="postbox"><div class="inside"><h2>Fonti consultate da Web Search</h2><ul>'; foreach((array)$data['fonti_web_search'] as $f){ $url=esc_url($f['url']??''); echo '<li>' . ($url?'<a href="'.$url.'" target="_blank" rel="noopener noreferrer">':'') . esc_html($f['title'] ?? ($f['domain'] ?? $url)) . ($url?'</a>':'') . ' <small>' . esc_html($f['domain'] ?? '') . '</small></li>'; } echo '</ul></div></div>'; }
-        echo '<div class="postbox"><div class="inside"><h2>Metriche per grafici</h2><pre>'.esc_html(wp_json_encode($metrics, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE)).'</pre><details><summary>Sezione tecnica JSON</summary><pre>'.esc_html(wp_json_encode($data, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE)).'</pre></details></div></div>';
+        echo '<div class="postbox"><div class="inside"><h2>' . esc_html__('Metriche', 'affiliate-link-manager-ai') . '</h2>'; self::render_metric_cards(array(
+            __('Fonti configurate', 'affiliate-link-manager-ai')=>(int)($metrics['count_fonti_configurate']??0), __('Fonti interrogate', 'affiliate-link-manager-ai')=>(int)($metrics['count_fonti_interrogate']??0), __('Fonti citate', 'affiliate-link-manager-ai')=>(int)($metrics['count_fonti_citate']??0), __('Fonti saltate', 'affiliate-link-manager-ai')=>(int)($metrics['count_fonti_saltate']??0), __('Fonti senza dati', 'affiliate-link-manager-ai')=>(int)($metrics['count_fonti_senza_risultati']??0), __('Trend', 'affiliate-link-manager-ai')=>(int)($metrics['count_trend']??0), __('Idee', 'affiliate-link-manager-ai')=>(int)($metrics['count_idee_editoriali']??0), __('Destinazioni', 'affiliate-link-manager-ai')=>(int)($metrics['count_destinazioni']??0), __('Bisogni', 'affiliate-link-manager-ai')=>(int)($metrics['count_bisogni_viaggiatori']??0), __('Affiliate', 'affiliate-link-manager-ai')=>(int)($metrics['count_opportunita_affiliate']??0), __('Alert', 'affiliate-link-manager-ai')=>(int)($metrics['count_alert_rischi']??0))); echo '</div></div>';
+        self::render_report_sources($source_snapshot, $data, $metrics);
+        echo '<div class="alma-report-grid">';
+        self::object_card(__('Trend principali', 'affiliate-link-manager-ai'),(array)($data['trends']??($data['trend_principali']??array())),array('title','titolo','description','descrizione','confidence'));
+        self::object_card(__('Destinazioni/città', 'affiliate-link-manager-ai'),(array)($data['destinazioni_prioritarie']??array()),array('nome','tipo','paese_o_area','perche_rilevante','trend_collegati','idee_collegate','confidence_score'));
+        self::object_card(__('Piano editoriale', 'affiliate-link-manager-ai'),(array)($data['piano_editoriale_settimanale']??array()),array('giorno_suggerito','titolo','descrizione','categoria_editoriale','intento_ricerca','priorita','priorita_editoriale','suggerimento_cta_link_affiliato','opportunita_affiliate','fonti_collegate'));
+        self::object_card(__('Idee editoriali extra', 'affiliate-link-manager-ai'),(array)($data['idee_editoriali_extra']??$data['content_ideas']??array()),array('titolo','title','descrizione','description','categoria_editoriale','intento_ricerca','priorita','opportunita_affiliate','fonti_collegate','note_per_sothra'));
+        self::object_card(__('Bisogni viaggiatori', 'affiliate-link-manager-ai'),(array)($data['bisogni_viaggiatori']??array()),array('bisogno','descrizione','contenuti_utili','affiliate_possibili'));
+        self::object_card(__('Opportunità affiliate', 'affiliate-link-manager-ai'),(array)($data['opportunita_affiliate']??array()),array('categoria','esempi_servizi','idee_collegate','priorita','rischio_claim','nota_editoriale'));
+        self::object_card(__('Rischi e limiti', 'affiliate-link-manager-ai'),(array)($data['rischi_e_limiti']??array()),array());
+        echo '</div>';
+        self::render_citations_card($data);
+        echo '<div class="postbox"><div class="inside"><h2>' . esc_html__('JSON tecnico', 'affiliate-link-manager-ai') . '</h2><details open><summary>' . esc_html__('Metriche per grafici', 'affiliate-link-manager-ai') . '</summary><pre>'.esc_html(wp_json_encode($metrics, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE)).'</pre></details><details><summary>' . esc_html__('Risposta JSON normalizzata', 'affiliate-link-manager-ai') . '</summary><pre>'.esc_html(wp_json_encode($data, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE)).'</pre></details></div></div>';
     }
 
+    private static function render_citations_card($data) { echo '<div class="postbox"><div class="inside"><h2>' . esc_html__('Fonti citate', 'affiliate-link-manager-ai') . '</h2>'; $items=(array)($data['fonti_citate']??($data['citations']??array())); if(!$items){ echo '<p>'.esc_html__('Nessuna fonte citata emersa da questa run. Prova un piano editoriale completo o aumenta le fonti prioritarie.', 'affiliate-link-manager-ai').'</p>'; } else { echo '<ul>'; foreach($items as $f){ $url=esc_url($f['url']??''); echo '<li>' . ($url?'<a href="'.$url.'" target="_blank" rel="noopener noreferrer">':'') . esc_html($f['titolo'] ?? ($f['title'] ?? ($f['fonte'] ?? $url))) . ($url?'</a>':'') . ' <small>' . esc_html($f['fonte'] ?? ($f['source'] ?? '')) . '</small></li>'; } echo '</ul>'; } echo '</div></div>'; }
 
-    private static function render_report_sources($sources, $data) {
-        echo '<div class="postbox"><div class="inside"><h2>Fonti configurate nell’analisi</h2><table class="widefat striped"><thead><tr><th>Fonte</th><th>Priorità</th><th>Quantità contenuti configurata</th><th>Domini consentiti</th><th>Fonti consultate/citate</th></tr></thead><tbody>';
-        if (!$sources) { echo '<tr><td colspan="5">Nessuna configurazione fonte salvata nel report.</td></tr>'; }
+    private static function render_report_sources($sources, $data, $metrics=array()) {
+        $details = (array)($metrics['fonti_dettaglio'] ?? array());
+        echo '<div class="postbox"><div class="inside"><h2>' . esc_html__('Fonti usate', 'affiliate-link-manager-ai') . '</h2><table class="widefat striped"><thead><tr><th>' . esc_html__('Fonte configurata', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Interrogata', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Citata', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Senza dati', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Saltata', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Fonti consultate/citate', 'affiliate-link-manager-ai') . '</th></tr></thead><tbody>';
+        if (!$sources) { echo '<tr><td colspan="6">' . esc_html__('Nessuna configurazione fonte salvata nel report.', 'affiliate-link-manager-ai') . '</td></tr>'; }
         foreach ((array)$sources as $source) {
             $domains = (array)($source['normalized_allowed_domains'] ?? $source['allowed_domains'] ?? array());
-            $matched = self::matched_report_sources($domains, $data);
-            echo '<tr><td>' . esc_html($source['name'] ?? ($source['source_key'] ?? '')) . '</td><td>' . esc_html((string)ALMA_Trend_Content_Ideas_Store::normalize_priority($source['priority'] ?? 2)) . '</td><td>' . esc_html((string)ALMA_Trend_Content_Ideas_Store::normalize_max_contents_per_run($source['max_contents_per_run'] ?? 3)) . '</td><td>' . esc_html(implode(', ', $domains)) . '</td><td>';
-            if (!$matched) { echo 'Non disponibili'; }
+            $detail = self::source_detail_for($details, $source);
+            $matched = $detail && !empty($detail['matched_citations']) ? (array)$detail['matched_citations'] : self::matched_report_sources($domains, $data);
+            echo '<tr><td><strong>' . esc_html($source['name'] ?? ($source['source_key'] ?? '')) . '</strong><br><small>' . esc_html(implode(', ', $domains)) . '</small></td><td>' . esc_html(self::yes_no($detail['interrogated'] ?? true)) . '</td><td>' . esc_html(self::yes_no($detail['cited'] ?? !empty($matched))) . '</td><td>' . esc_html(self::yes_no($detail['without_results'] ?? empty($matched))) . '</td><td>' . esc_html(self::yes_no($detail['skipped'] ?? false)) . '</td><td>';
+            if (!$matched) { echo esc_html__('Nessuna citazione associata a questa fonte. Controlla le fonti citate globali sotto.', 'affiliate-link-manager-ai'); }
             foreach ($matched as $item) {
                 $url = esc_url($item['url'] ?? '');
                 echo '<p>' . ($url ? '<a href="' . $url . '" target="_blank" rel="noopener noreferrer">' : '') . esc_html($item['title'] ?? ($item['titolo'] ?? ($item['domain'] ?? $url))) . ($url ? '</a>' : '') . '</p>';
@@ -83,9 +142,12 @@ class ALMA_Trend_Content_Ideas_Admin {
         echo '</tbody></table></div></div>';
     }
 
+    private static function source_detail_for($details, $source) { foreach((array)$details as $detail){ if(($detail['source_key']??'') === ($source['source_key']??'')){ return $detail; } } return array(); }
+    private static function yes_no($value) { return $value ? __('Sì', 'affiliate-link-manager-ai') : __('No', 'affiliate-link-manager-ai'); }
+
     private static function matched_report_sources($domains, $data) {
         $matches = array(); $domains = array_map('strtolower', (array)$domains);
-        foreach (array_merge((array)($data['fonti_web_search'] ?? array()), (array)($data['fonti_citate'] ?? array())) as $item) {
+        foreach (array_merge((array)($data['fonti_web_search'] ?? array()), (array)($data['fonti_citate'] ?? array()), (array)($data['citations'] ?? array())) as $item) {
             if (!is_array($item)) { continue; }
             $domain = strtolower((string)($item['domain'] ?? $item['fonte'] ?? ''));
             if (!$domain && !empty($item['url'])) { $host = wp_parse_url((string)$item['url'], PHP_URL_HOST); $domain = strtolower((string)$host); }
@@ -99,8 +161,9 @@ class ALMA_Trend_Content_Ideas_Admin {
     }
 
     private static function list_card($title,$items){ echo '<div class="alma-card"><h3>'.esc_html($title).'</h3><ul>'; foreach($items as $it){ echo '<li>'.esc_html(is_scalar($it)?$it:wp_json_encode($it)).'</li>'; } echo '</ul></div>'; }
+    private static function empty_section_message($title){ $title=wp_strip_all_tags((string)$title); if(stripos($title, 'Opportun')!==false){ return __('Nessuna opportunità affiliata emersa da questa run. Prova un piano editoriale completo o aumenta le fonti prioritarie.', 'affiliate-link-manager-ai'); } if(stripos($title, 'Bisogni')!==false){ return __('Nessun bisogno viaggiatore specifico emerso da questa run. Prova un piano editoriale completo o fonti più dettagliate.', 'affiliate-link-manager-ai'); } if(stripos($title, 'Destin')!==false){ return __('Nessuna destinazione reale emersa dalle fonti: non vengono creati luoghi inventati.', 'affiliate-link-manager-ai'); } return __('Nessun dato emerso da questa run. Prova un profilo più completo o aumenta le fonti prioritarie.', 'affiliate-link-manager-ai'); }
     private static function stringify($value){ if (is_scalar($value) || $value === null) { return (string)$value; } $flat = array(); foreach ((array)$value as $item) { $flat[] = is_scalar($item) ? (string)$item : wp_json_encode($item, JSON_UNESCAPED_UNICODE); } return implode(', ', $flat); }
-    private static function object_card($title,$items,$fields){ echo '<div class="alma-card"><h3>'.esc_html($title).'</h3>'; if(!$items){echo '<p>Nessun dato.</p>';} foreach($items as $it){ echo '<div style="border-top:1px solid #dcdcde;padding:8px 0">'; if(is_array($it)){ $show=$fields?:array_keys($it); foreach($show as $f){ if(isset($it[$f])){ echo '<p><strong>'.esc_html($f).':</strong> '.esc_html(self::stringify($it[$f])).'</p>'; } } } else { echo '<p>'.esc_html($it).'</p>'; } echo '</div>'; } echo '</div>'; }
+    private static function object_card($title,$items,$fields){ echo '<div class="alma-card"><h3>'.esc_html($title).'</h3>'; if(!$items){echo '<p>'.esc_html(self::empty_section_message($title)).'</p>';} foreach($items as $it){ echo '<div style="border-top:1px solid #dcdcde;padding:8px 0">'; if(is_array($it)){ $show=$fields?:array_keys($it); foreach($show as $f){ if(isset($it[$f])){ echo '<p><strong>'.esc_html($f).':</strong> '.esc_html(self::stringify($it[$f])).'</p>'; } } } else { echo '<p>'.esc_html($it).'</p>'; } echo '</div>'; } echo '</div>'; }
 
     public static function handle_action() {
         if (!current_user_can(self::CAP)) { wp_die(esc_html__('Permessi insufficienti.', 'affiliate-link-manager-ai')); }

--- a/includes/class-trend-content-ideas-prompt-builder.php
+++ b/includes/class-trend-content-ideas-prompt-builder.php
@@ -7,7 +7,7 @@ class ALMA_Trend_Content_Ideas_Prompt_Builder {
     }
 
     public static function system_prompt() {
-        return 'Sei il modulo Trend Idee contenuto di Sothra. Devi usare OpenAI Web Search solo sulle fonti/domìni ammessi quando indicati. Per contenuti informativi si intendono risultati, pagine, articoli, comunicati, report o documenti informativi consultabili dalla ricerca web; non sono articoli WordPress generati, bozze o idee editoriali finali. Per ogni fonte rispetta max_contents_per_run: non analizzare né sintetizzare più di quel numero di contenuti informativi provenienti dalla fonte indicata durante una singola run. Il limite è per singola fonte e per singola run e non rappresenta il numero di trend restituiti o di idee editoriali generate. Non copiare testi dalle fonti. Non inventare dati, numeri, link o citazioni. Se i dati sono parziali devi dichiararlo. Devi indicare livello di confidenza, fonti citate e limiti. Proponi contenuti per viaggiatori italiani e coerenti con Sothra. Proponi opportunità affiliate solo se pertinenti. Non generare bozze WordPress, post, HTML o contenuti da pubblicare automaticamente. Restituisci esclusivamente JSON valido conforme allo schema richiesto: nessun markdown, nessun blocco ```json, nessun testo prima o dopo il JSON. Se una fonte non produce risultati usa array vuoti e aggiungi warning. Non inventare URL, titoli, date o fonti.';
+        return 'Sei il modulo Trend Idee contenuto di Sothra. Devi usare OpenAI Web Search solo sulle fonti/domìni ammessi quando indicati. Per contenuti informativi si intendono risultati, pagine, articoli, comunicati, report o documenti informativi consultabili dalla ricerca web; non sono articoli WordPress generati, bozze o idee editoriali finali. Distingui sempre fonti configurate, fonti richieste/interrogate, fonti effettivamente citate, fonti senza risultati e fonti saltate. Non considerare mai “fonti configurate” uguale a “fonti analizzate”. Per ogni fonte rispetta max_contents_per_run: non analizzare né sintetizzare più di quel numero di contenuti informativi provenienti dalla fonte indicata durante una singola run. Il limite è per singola fonte e per singola run e non rappresenta il numero di trend restituiti o di idee editoriali generate. Non copiare testi dalle fonti. Non inventare dati, numeri, link, città, destinazioni o citazioni. Estrai città, regioni, paesi, aree geografiche o luoghi reali solo se presenti nelle fonti. Le destinazioni_prioritarie devono essere luoghi reali: se non emergono luoghi reali lascia array vuoto e aggiungi warning. Se i dati sono parziali devi dichiararlo. Devi indicare livello di confidenza, fonti citate e limiti. Proponi contenuti per viaggiatori italiani e coerenti con Sothra. Collega le idee editoriali a opportunità affiliate pertinenti, bisogni viaggiatori, rischi e fonti collegate. Non generare bozze WordPress, post, HTML o contenuti da pubblicare automaticamente. Restituisci esclusivamente JSON valido conforme allo schema richiesto: nessun markdown, nessun blocco ```json, nessun testo prima o dopo il JSON. Se una fonte non produce risultati usa array vuoti e aggiungi warning. Non inventare URL, titoli, date o fonti.';
     }
 
     public static function build($sources, $run_type = 'manual') {
@@ -21,7 +21,7 @@ class ALMA_Trend_Content_Ideas_Prompt_Builder {
         }
         $profile = self::profile_name($run_type, $sources);
         $profile_instructions = self::profile_instructions($profile);
-        return "Prompt globale admin:\n" . $global . "\n\nTipo run: " . sanitize_key($run_type) . "\nProfilo runtime: " . $profile . "\nPeriodo: ultimi 30-90 giorni, privilegiando segnali recenti e verificabili.\n\nDefinizione operativa: i contenuti informativi sono pagine, articoli, comunicati, report, documenti o risultati che puoi consultare/sintetizzare tramite Web Search; non sono bozze WordPress, articoli WordPress generati o idee editoriali finali. Per ogni fonte rispetta max_contents_per_run: non analizzare né sintetizzare più di quel numero di contenuti informativi della fonte indicata nella singola run. Distingui sempre tra contenuti informativi analizzati, trend restituiti e idee editoriali restituite.\n\nFonti abilitate da analizzare:\n" . implode("\n", $source_lines) . "\n\n" . $profile_instructions . "\n\nOutput richiesto: restituisci esclusivamente JSON valido con i campi obbligatori dello schema, nessun markdown, nessun blocco ```json e nessun testo fuori dal JSON. Rispetta esattamente lo schema richiesto. Se una fonte non produce risultati usa array vuoti e aggiungi warning breve. Non inventare URL, titoli, date o fonti. Ogni idea deve essere concreta, utile a viaggiatori italiani e non deve creare bozze WordPress. Ricorda che priority definisce ordine/peso fonte e max_contents_per_run limita i contenuti informativi analizzati per fonte nella singola run, non il numero di articoli WordPress.";
+        return "Prompt globale admin:\n" . $global . "\n\nTipo run: " . sanitize_key($run_type) . "\nProfilo runtime: " . $profile . "\nPeriodo: ultimi 30-90 giorni, privilegiando segnali recenti e verificabili.\n\nDefinizioni operative:\n- contenuti informativi analizzati = pagine, articoli, comunicati, report, documenti o risultati consultati/sintetizzati tramite Web Search; non bozze WordPress o idee finali;\n- fonti configurate = elenco qui sotto salvato in WordPress;\n- fonti richieste/interrogate = fonti/domìni che provi a usare nella Web Search;\n- fonti effettivamente citate = fonti con URL o citazioni presenti nel JSON;\n- trend = segnali tematici emersi dai contenuti;\n- destinazioni = città, località, regioni, paesi, aree geografiche o luoghi reali citati dalle fonti;\n- idee editoriali = proposte operative per Sothra;\n- opportunità affiliate = categorie di servizi linkabili coerenti con le idee.\n\nPer ogni fonte rispetta max_contents_per_run: non analizzare né sintetizzare più di quel numero di contenuti informativi della fonte indicata nella singola run. Distingui sempre contenuti informativi analizzati, fonti configurate, fonti interrogate, fonti citate, trend restituiti, destinazioni e idee editoriali. Non considerare fonti configurate uguale a fonti analizzate. Se una fonte non produce dati o viene saltata, segnalalo chiaramente in warnings/fonti_saltate.\n\nFonti abilitate da analizzare:\n" . implode("\n", $source_lines) . "\n\n" . $profile_instructions . "\n\nOutput richiesto: restituisci esclusivamente JSON valido con i campi obbligatori dello schema, nessun markdown, nessun blocco ```json e nessun testo fuori dal JSON. Rispetta esattamente lo schema richiesto. Estrai nomi di città, regioni, paesi o aree quando presenti; non inventare destinazioni se non sono presenti. Collega ogni idea editoriale a bisogni viaggiatori, possibili affiliazioni, priorità editoriale, intento di ricerca e fonti collegate quando disponibili. Se i dati non bastano per raggiungere le quantità richieste, spiega perché nei warning. Ogni idea deve essere concreta, utile a viaggiatori italiani e non deve creare bozze WordPress. Ricorda che priority definisce ordine/peso fonte e max_contents_per_run limita i contenuti informativi analizzati per fonte nella singola run, non il numero di articoli WordPress.";
     }
 
     public static function build_json_retry($sources, $run_type = 'manual') {
@@ -40,16 +40,17 @@ class ALMA_Trend_Content_Ideas_Prompt_Builder {
 
     private static function profile_instructions($profile) {
         if ($profile === 'source_test') {
-            return 'Profilo source_test: output diagnostico breve per testare una fonte. Analizza massimo 1 fonte salvo configurazioni già previste dal workflow. Restituisci solo i campi essenziali: status, summary, source_quality, trends, content_ideas, citations, warnings. summary massimo 350 caratteri. massimo 2 trend. massimo 2 idee. massimo 3 citazioni. massimo 3 warning. Ogni descrizione trend massimo 250 caratteri. Ogni descrizione idea massimo 250 caratteri. Niente spiegazioni discorsive lunghe. Niente paragrafi estesi. Niente markdown. Niente testo fuori dal JSON. Restituisci solo JSON valido. Se i dati non bastano, usa array vuoti e warning breve.';
+            return 'Profilo source_test: output diagnostico breve per testare una fonte. Mantieni il report compatto: massimo 2 trend, massimo 2 idee contenuto, massimo 3 citazioni, massimo 3 warning. Restituisci solo i campi essenziali: status, summary, source_quality, trends, content_ideas, citations, warnings. summary massimo 350 caratteri. Ogni descrizione trend massimo 250 caratteri. Ogni descrizione idea massimo 250 caratteri. Niente spiegazioni discorsive lunghe. Niente paragrafi estesi. Niente markdown. Niente testo fuori dal JSON. Restituisci solo JSON valido. Se i dati non bastano, usa array vuoti e warning breve.';
         }
         if ($profile === 'full_test') {
-            return 'Profilo full_test: output intermedio per verificare più fonti abilitate. Mantieni sintesi e liste concise, ma includi i campi completi dello schema editoriale. Distingui contenuti informativi analizzati, trend restituiti e idee editoriali restituite.';
+            return 'Profilo full_test: genera un report utile a Sothra, non una sintesi minimalista. Mantieni struttura chiara e concisa, ma se i dati lo consentono includi almeno 6 trend, almeno 8 idee editoriali, almeno 5 bisogni viaggiatori, almeno 5 opportunità affiliate, almeno 4 rischi/limiti e almeno 6 citazioni. Includi destinazioni/città/aree geografiche quando presenti nelle fonti, ma non inventarle. Genera più idee se i dati lo consentono e non limitarti a 2 idee salvo dati insufficienti. Distingui fonti configurate, fonti interrogate, fonti citate, fonti saltate e fonti senza risultati. Segnala chiaramente nei warning se le fonti non producono dati o non bastano per raggiungere le quantità richieste.';
         }
-        return 'Profilo editorial_plan: output editoriale più completo per pianificazione contenuti. Includi analisi, priorità, rischi, bisogni viaggiatori, opportunità affiliate e fonti citate rispettando lo schema editoriale completo.';
+        return 'Profilo editorial_plan: output editoriale operativo per pianificazione contenuti. Se i dati lo consentono produci 10-20 idee editoriali totali, 7-14 contenuti nel piano settimanale, 8-12 opportunità affiliate, 8-12 bisogni viaggiatori e 10-20 destinazioni/città/aree reali disponibili nelle fonti. Per ogni contenuto includi priorità editoriale, intento di ricerca, categoria editoriale, suggerimento CTA/link affiliato e fonti collegate. Per ogni idea editoriale includi titolo, descrizione, destinazioni_collegate, categoria_editoriale, intento_ricerca, priorita, opportunita_affiliate, fonti_collegate e note_per_sothra. Per ogni opportunità affiliata includi categoria, esempi_servizi, idee_collegate, priorita, rischio_claim e nota_editoriale. Per ogni bisogno viaggiatore includi bisogno, descrizione, contenuti_utili e affiliate_possibili. Per ogni destinazione prioritaria includi nome, tipo, paese_o_area, perche_rilevante, trend_collegati, idee_collegate e confidence_score. Non riempire destinazioni_prioritarie con titoli di trend generici.';
     }
 
     public static function response_schema($profile = 'editorial_plan') {
         if ($profile === 'source_test' || $profile === 'json_invalid_retry') { return self::compact_source_test_schema(); }
+        if ($profile === 'full_test') { return self::full_test_schema(); }
         return self::editorial_plan_schema();
     }
 
@@ -77,14 +78,30 @@ class ALMA_Trend_Content_Ideas_Prompt_Builder {
         );
     }
 
+    private static function full_test_schema() {
+        $base = self::shared_rich_schema('sothra_trend_full_test');
+        $base['schema']['required'] = array('status','summary','source_quality','fonti_configurate','fonti_interrogate','fonti_citate','fonti_saltate','trends','destinazioni_prioritarie','temi_editoriali','piano_editoriale_settimanale','content_ideas','bisogni_viaggiatori','opportunita_affiliate','rischi_e_limiti','citations','warnings','dati_per_grafici');
+        return $base;
+    }
+
     private static function editorial_plan_schema() {
+        $base = self::shared_rich_schema('sothra_trend_editorial_plan');
+        $base['schema']['required'] = array('summary','scenario_editoriale','destinazioni_prioritarie','trend_principali','piano_editoriale_settimanale','idee_editoriali_extra','cluster_tematici','opportunita_affiliate','bisogni_viaggiatori','rischi_e_limiti','fonti_citate','dati_per_grafici','warnings');
+        return $base;
+    }
+
+    private static function shared_rich_schema($name) {
         $text = array('type'=>'string');
         $num = array('type'=>'number');
         $string_array = array('type'=>'array','items'=>$text);
-        $object_array = array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>true));
+        $rich_idea = array('type'=>'object','additionalProperties'=>true,'properties'=>array('titolo'=>$text,'descrizione'=>$text,'destinazioni_collegate'=>$string_array,'categoria_editoriale'=>$text,'intento_ricerca'=>$text,'priorita'=>$text,'priorita_editoriale'=>$text,'opportunita_affiliate'=>$string_array,'fonti_collegate'=>$string_array,'note_per_sothra'=>$text,'suggerimento_cta_link_affiliato'=>$text));
+        $destination = array('type'=>'object','additionalProperties'=>true,'properties'=>array('nome'=>$text,'tipo'=>$text,'paese_o_area'=>$text,'perche_rilevante'=>$text,'trend_collegati'=>$string_array,'idee_collegate'=>$string_array,'confidence_score'=>$num));
+        $affiliate = array('type'=>'object','additionalProperties'=>true,'properties'=>array('categoria'=>$text,'esempi_servizi'=>$string_array,'idee_collegate'=>$string_array,'priorita'=>$text,'rischio_claim'=>$text,'nota_editoriale'=>$text));
+        $need = array('type'=>'object','additionalProperties'=>true,'properties'=>array('bisogno'=>$text,'descrizione'=>$text,'contenuti_utili'=>$string_array,'affiliate_possibili'=>$string_array));
+        $citation = array('type'=>'object','additionalProperties'=>true,'properties'=>array('titolo'=>$text,'title'=>$text,'url'=>$text,'fonte'=>$text,'source'=>$text,'date'=>$text));
         return array(
             'type'=>'json_schema',
-            'name'=>'sothra_trend_idee_contenuto',
+            'name'=>$name,
             'strict'=>false,
             'schema'=>array(
                 'type'=>'object',
@@ -92,24 +109,30 @@ class ALMA_Trend_Content_Ideas_Prompt_Builder {
                 'properties'=>array(
                     'status'=>$text,
                     'summary'=>$text,
-                    'trends'=>$object_array,
-                    'content_ideas'=>$object_array,
-                    'citations'=>array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>true,'properties'=>array('title'=>$text,'url'=>$text,'source'=>$text,'date'=>$text))),
-                    'warnings'=>$string_array,
-                    'sintesi_generale'=>$text,
+                    'source_quality'=>array('type'=>'object','additionalProperties'=>true),
+                    'scenario_editoriale'=>$text,
+                    'fonti_configurate'=>$string_array,
+                    'fonti_interrogate'=>$string_array,
+                    'fonti_saltate'=>$string_array,
                     'fonti_analizzate'=>$string_array,
-                    'destinazioni_prioritarie'=>array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>true,'properties'=>array('nome'=>$text,'paese_o_area'=>$text,'trend_score'=>$num,'confidence_score'=>$num,'fonti_collegate'=>$string_array,'motivazione'=>$text,'target_viaggiatore'=>$text,'bisogni_pratici'=>$string_array,'rischi'=>$string_array,'opportunita_affiliate'=>$string_array))),
-                    'temi_editoriali'=>$object_array,
-                    'piano_editoriale_settimanale'=>array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>true,'properties'=>array('giorno_suggerito'=>$text,'titolo'=>$text,'tipo_contenuto'=>$text,'destinazione'=>$text,'paese_o_area'=>$text,'intento_ricerca'=>$text,'motivazione_trend'=>$text,'bisogni_viaggiatore'=>$string_array,'outline'=>$string_array,'opportunita_affiliate'=>$string_array,'fonti_da_citare'=>$string_array,'priorita_editoriale'=>$text,'livello_confidenza'=>$text,'azione_consigliata'=>$text))),
-                    'opportunita_affiliate'=>$object_array,
-                    'bisogni_viaggiatori'=>$object_array,
-                    'rischi_e_limiti'=>$object_array,
+                    'trends'=>array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>true)),
+                    'trend_principali'=>array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>true)),
+                    'destinazioni_prioritarie'=>array('type'=>'array','items'=>$destination),
+                    'temi_editoriali'=>array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>true)),
+                    'cluster_tematici'=>array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>true)),
+                    'piano_editoriale_settimanale'=>array('type'=>'array','items'=>$rich_idea),
+                    'content_ideas'=>array('type'=>'array','items'=>$rich_idea),
+                    'idee_editoriali_extra'=>array('type'=>'array','items'=>$rich_idea),
+                    'opportunita_affiliate'=>array('type'=>'array','items'=>$affiliate),
+                    'bisogni_viaggiatori'=>array('type'=>'array','items'=>$need),
+                    'rischi_e_limiti'=>array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>true)),
+                    'citations'=>array('type'=>'array','items'=>$citation),
+                    'warnings'=>$string_array,
                     'dati_per_grafici'=>array('type'=>'object','additionalProperties'=>true),
                     'livello_confidenza'=>$text,
                     'alert'=>$string_array,
-                    'fonti_citate'=>array('type'=>'array','items'=>array('type'=>'object','additionalProperties'=>true,'properties'=>array('titolo'=>$text,'url'=>$text,'fonte'=>$text))),
+                    'fonti_citate'=>array('type'=>'array','items'=>$citation),
                 ),
-                'required'=>array('status','summary','trends','content_ideas','citations','warnings','sintesi_generale','fonti_analizzate','destinazioni_prioritarie','temi_editoriali','piano_editoriale_settimanale','opportunita_affiliate','bisogni_viaggiatori','rischi_e_limiti','dati_per_grafici','livello_confidenza','alert','fonti_citate'),
             ),
         );
     }

--- a/includes/class-trend-content-ideas-service.php
+++ b/includes/class-trend-content-ideas-service.php
@@ -93,11 +93,20 @@ class ALMA_Trend_Content_Ideas_Service {
     }
 
     public static function validate_result($data, $schema_profile = 'editorial_plan') {
+        $schema_profile = sanitize_key((string)$schema_profile);
         $is_compact = in_array($schema_profile, array('source_test','json_invalid_retry'), true);
-        $required = $is_compact ? array('status','summary','source_quality','trends','content_ideas','citations','warnings') : array('status','summary','trends','content_ideas','citations','warnings','sintesi_generale','fonti_analizzate','destinazioni_prioritarie','temi_editoriali','piano_editoriale_settimanale','opportunita_affiliate','bisogni_viaggiatori','rischi_e_limiti','dati_per_grafici','livello_confidenza','alert','fonti_citate');
+        if ($is_compact) {
+            $required = array('status','summary','source_quality','trends','content_ideas','citations','warnings');
+            $array_keys = array('trends','content_ideas','citations','warnings');
+        } elseif ($schema_profile === 'full_test') {
+            $required = array('status','summary','source_quality','fonti_configurate','fonti_interrogate','fonti_citate','fonti_saltate','trends','destinazioni_prioritarie','temi_editoriali','piano_editoriale_settimanale','content_ideas','bisogni_viaggiatori','opportunita_affiliate','rischi_e_limiti','citations','warnings','dati_per_grafici');
+            $array_keys = array('fonti_configurate','fonti_interrogate','fonti_citate','fonti_saltate','trends','destinazioni_prioritarie','temi_editoriali','piano_editoriale_settimanale','content_ideas','bisogni_viaggiatori','opportunita_affiliate','rischi_e_limiti','citations','warnings');
+        } else {
+            $required = array('summary','scenario_editoriale','destinazioni_prioritarie','trend_principali','piano_editoriale_settimanale','idee_editoriali_extra','cluster_tematici','opportunita_affiliate','bisogni_viaggiatori','rischi_e_limiti','fonti_citate','dati_per_grafici','warnings');
+            $array_keys = array('destinazioni_prioritarie','trend_principali','piano_editoriale_settimanale','idee_editoriali_extra','cluster_tematici','opportunita_affiliate','bisogni_viaggiatori','rischi_e_limiti','fonti_citate','warnings');
+        }
         if (!is_array($data)) { return new WP_Error('invalid_json', __('JSON OpenAI non valido.', 'affiliate-link-manager-ai')); }
         foreach ($required as $key) { if (!array_key_exists($key, $data)) { return new WP_Error('incomplete_json', sprintf(__('JSON incompleto: manca %s.', 'affiliate-link-manager-ai'), $key)); } }
-        $array_keys = $is_compact ? array('trends','content_ideas','citations','warnings') : array('trends','content_ideas','citations','warnings','fonti_analizzate','destinazioni_prioritarie','temi_editoriali','piano_editoriale_settimanale','opportunita_affiliate','bisogni_viaggiatori','rischi_e_limiti','alert','fonti_citate');
         foreach ($array_keys as $key) { if (!is_array($data[$key])) { return new WP_Error('incomplete_json', sprintf(__('JSON incompleto: %s deve essere un array.', 'affiliate-link-manager-ai'), $key)); } }
         return true;
     }
@@ -179,35 +188,48 @@ class ALMA_Trend_Content_Ideas_Service {
 
 
     private static function normalize_result_for_storage($data, $schema_profile = 'editorial_plan') {
-        if (!in_array($schema_profile, array('source_test','json_invalid_retry'), true)) { return $data; }
-        $data['sintesi_generale'] = $data['sintesi_generale'] ?? ($data['summary'] ?? '');
-        $data['fonti_analizzate'] = $data['fonti_analizzate'] ?? array();
-        $data['destinazioni_prioritarie'] = $data['destinazioni_prioritarie'] ?? self::compact_trends_to_destinations($data['trends'] ?? array());
-        $data['temi_editoriali'] = $data['temi_editoriali'] ?? array();
-        $data['piano_editoriale_settimanale'] = $data['piano_editoriale_settimanale'] ?? self::compact_ideas_to_plan($data['content_ideas'] ?? array());
-        $data['opportunita_affiliate'] = $data['opportunita_affiliate'] ?? array();
-        $data['bisogni_viaggiatori'] = $data['bisogni_viaggiatori'] ?? array();
-        $data['rischi_e_limiti'] = $data['rischi_e_limiti'] ?? array();
-        $data['dati_per_grafici'] = $data['dati_per_grafici'] ?? array();
-        $data['livello_confidenza'] = $data['livello_confidenza'] ?? '';
-        $data['alert'] = $data['alert'] ?? ($data['warnings'] ?? array());
-        $data['fonti_citate'] = $data['fonti_citate'] ?? self::compact_citations_to_fonti_citate($data['citations'] ?? array());
+        $schema_profile = sanitize_key((string)$schema_profile);
+        if ($schema_profile === 'editorial_plan') {
+            $data['status'] = $data['status'] ?? 'success';
+            $data['trends'] = $data['trends'] ?? ($data['trend_principali'] ?? array());
+            $data['content_ideas'] = $data['content_ideas'] ?? array_values(array_merge((array)($data['piano_editoriale_settimanale'] ?? array()), (array)($data['idee_editoriali_extra'] ?? array())));
+            $data['citations'] = $data['citations'] ?? ($data['fonti_citate'] ?? array());
+            $data['sintesi_generale'] = $data['sintesi_generale'] ?? ($data['summary'] ?? '');
+            $data['temi_editoriali'] = $data['temi_editoriali'] ?? ($data['cluster_tematici'] ?? array());
+            $data['alert'] = $data['alert'] ?? ($data['warnings'] ?? array());
+            $data['livello_confidenza'] = $data['livello_confidenza'] ?? '';
+            $data['fonti_analizzate'] = $data['fonti_analizzate'] ?? ($data['fonti_citate'] ?? array());
+        } elseif ($schema_profile === 'full_test') {
+            $data['sintesi_generale'] = $data['sintesi_generale'] ?? ($data['summary'] ?? '');
+            $data['trend_principali'] = $data['trend_principali'] ?? ($data['trends'] ?? array());
+            $data['fonti_analizzate'] = $data['fonti_analizzate'] ?? ($data['fonti_interrogate'] ?? array());
+            $data['alert'] = $data['alert'] ?? ($data['warnings'] ?? array());
+            $data['livello_confidenza'] = $data['livello_confidenza'] ?? '';
+        } elseif (in_array($schema_profile, array('source_test','json_invalid_retry'), true)) {
+            $data['sintesi_generale'] = $data['sintesi_generale'] ?? ($data['summary'] ?? '');
+            $data['fonti_analizzate'] = $data['fonti_analizzate'] ?? array();
+            $data['destinazioni_prioritarie'] = $data['destinazioni_prioritarie'] ?? array();
+            if (empty($data['destinazioni_prioritarie']) && !empty($data['trends'])) {
+                $data['warnings'][] = __('Le destinazioni prioritarie non sono state derivate automaticamente dai titoli dei trend: servono luoghi reali presenti nelle fonti.', 'affiliate-link-manager-ai');
+            }
+            $data['temi_editoriali'] = $data['temi_editoriali'] ?? array();
+            $data['piano_editoriale_settimanale'] = $data['piano_editoriale_settimanale'] ?? self::compact_ideas_to_plan($data['content_ideas'] ?? array());
+            $data['opportunita_affiliate'] = $data['opportunita_affiliate'] ?? array();
+            $data['bisogni_viaggiatori'] = $data['bisogni_viaggiatori'] ?? array();
+            $data['rischi_e_limiti'] = $data['rischi_e_limiti'] ?? array();
+            $data['dati_per_grafici'] = $data['dati_per_grafici'] ?? array();
+            $data['livello_confidenza'] = $data['livello_confidenza'] ?? '';
+            $data['alert'] = $data['alert'] ?? ($data['warnings'] ?? array());
+            $data['fonti_citate'] = $data['fonti_citate'] ?? self::compact_citations_to_fonti_citate($data['citations'] ?? array());
+        }
+        $data['warnings'] = array_values(array_unique(array_filter((array)($data['warnings'] ?? array()))));
+        $data['alert'] = array_values(array_unique(array_filter((array)($data['alert'] ?? $data['warnings']))));
         return $data;
     }
 
     private static function compact_trends_to_destinations($trends) {
-        $out = array();
-        foreach ((array)$trends as $trend) {
-            if (!is_array($trend)) { continue; }
-            $out[] = array(
-                'nome'=>sanitize_text_field((string)($trend['title'] ?? '')),
-                'paese_o_area'=>'',
-                'trend_score'=>0,
-                'confidence_score'=>0,
-                'motivazione'=>sanitize_text_field((string)($trend['description'] ?? '')),
-            );
-        }
-        return $out;
+        // Deliberately do not convert generic trend titles into destinations: destinations must be real places returned by the model from sources.
+        return array();
     }
 
     private static function compact_ideas_to_plan($ideas) {
@@ -294,9 +316,9 @@ class ALMA_Trend_Content_Ideas_Service {
             return array('name'=>'source_test','max_output_tokens'=>2200,'retry_max_output_tokens'=>1600,'search_context_size'=>'low','include_sources'=>true,'tool_choice'=>'required');
         }
         if ($run_type === 'test') {
-            return array('name'=>'full_test','max_output_tokens'=>3800,'retry_max_output_tokens'=>1800,'search_context_size'=>'medium','include_sources'=>true,'tool_choice'=>'required');
+            return array('name'=>'full_test','max_output_tokens'=>4600,'retry_max_output_tokens'=>2000,'search_context_size'=>'medium','include_sources'=>true,'tool_choice'=>'required');
         }
-        return array('name'=>'editorial_plan','max_output_tokens'=>5200,'retry_max_output_tokens'=>2200,'search_context_size'=>'medium','include_sources'=>true,'tool_choice'=>'required');
+        return array('name'=>'editorial_plan','max_output_tokens'=>6400,'retry_max_output_tokens'=>2400,'search_context_size'=>'medium','include_sources'=>true,'tool_choice'=>'required');
     }
 
     public static function build_openai_request_args($sources, $run_type = 'manual', $with_filters = true, $tool_choice = 'required', $profile = null, $include_sources = null) {
@@ -482,9 +504,13 @@ class ALMA_Trend_Content_Ideas_Service {
     public static function build_metrics($data, $sources) {
         $dest = (array)($data['destinazioni_prioritarie'] ?? array());
         $ideas = (array)($data['piano_editoriale_settimanale'] ?? array());
+        if (!$ideas) { $ideas = (array)($data['content_ideas'] ?? array()); }
         $affiliate = (array)($data['opportunita_affiliate'] ?? array());
-        $alerts = (array)($data['alert'] ?? array());
+        $needs = (array)($data['bisogni_viaggiatori'] ?? array());
+        $alerts = (array)($data['alert'] ?? ($data['warnings'] ?? array()));
         $risks = (array)($data['rischi_e_limiti'] ?? array());
+        $trends = (array)($data['trends'] ?? ($data['trend_principali'] ?? array()));
+        $source_usage = self::build_source_usage($data, $sources);
         $cat = array();
         foreach ($sources as $s) { $cat[$s['category']] = ($cat[$s['category']] ?? 0) + 1; }
         $areas = array(); $trend_scores = array(); $conf_scores = array();
@@ -495,16 +521,98 @@ class ALMA_Trend_Content_Ideas_Service {
             if (isset($d['confidence_score'])) { $conf_scores[] = (float)$d['confidence_score']; }
         }
         return array(
-            'count_fonti_analizzate'=>count($sources),
+            'count_fonti_configurate'=>$source_usage['counts']['configured'],
+            'count_fonti_interrogate'=>$source_usage['counts']['interrogated'],
+            'count_fonti_citate'=>$source_usage['counts']['cited'],
+            'count_fonti_saltate'=>$source_usage['counts']['skipped'],
+            'count_fonti_senza_risultati'=>$source_usage['counts']['without_results'],
+            'count_fonti_analizzate'=>$source_usage['counts']['interrogated'],
+            'count_trend'=>count($trends),
             'count_idee_editoriali'=>count($ideas),
             'count_destinazioni'=>count($dest),
+            'count_bisogni_viaggiatori'=>count($needs),
+            'count_opportunita_affiliate'=>count($affiliate),
+            'count_alert_rischi'=>count($alerts) + count($risks),
+            'fonti_dettaglio'=>$source_usage['sources'],
             'distribuzione_categoria_fonte'=>$cat,
             'distribuzione_area_geografica'=>$areas,
             'media_trend_score'=>$trend_scores ? round(array_sum($trend_scores) / count($trend_scores), 2) : 0,
             'media_confidence_score'=>$conf_scores ? round(array_sum($conf_scores) / count($conf_scores), 2) : 0,
-            'count_opportunita_affiliate'=>count($affiliate),
-            'count_alert_rischi'=>count($alerts) + count($risks),
         );
     }
+
+    private static function build_source_usage($data, $sources) {
+        $sources = self::normalize_sources($sources);
+        $cited_items = array_merge((array)($data['fonti_web_search'] ?? array()), (array)($data['fonti_citate'] ?? array()), (array)($data['citations'] ?? array()));
+        $configured_names = self::strings_lower((array)($data['fonti_configurate'] ?? array()));
+        $interrogated_names = self::strings_lower((array)($data['fonti_interrogate'] ?? $data['fonti_analizzate'] ?? array()));
+        $skipped_names = self::strings_lower((array)($data['fonti_saltate'] ?? array()));
+        $details = array(); $counts = array('configured'=>count($sources),'interrogated'=>0,'cited'=>0,'skipped'=>0,'without_results'=>0);
+        $default_interrogated = sanitize_key((string)($data['status'] ?? 'success')) !== 'error';
+        foreach ($sources as $source) {
+            $domains = self::normalize_allowed_domains($source['normalized_allowed_domains'] ?? ALMA_Trend_Content_Ideas_Store::decode_json($source['allowed_domains'] ?? '[]'));
+            $name = (string)($source['name'] ?? $source['source_key'] ?? '');
+            $source_key = (string)($source['source_key'] ?? '');
+            $is_skipped = self::source_named_in($name, $source_key, $skipped_names);
+            $is_interrogated = !$is_skipped && (($default_interrogated && empty($interrogated_names)) || self::source_named_in($name, $source_key, $interrogated_names) || self::source_named_in($name, $source_key, $configured_names));
+            $matches = self::match_items_to_domains($cited_items, $domains, $name);
+            $is_cited = !empty($matches);
+            if ($is_interrogated) { $counts['interrogated']++; }
+            if ($is_cited) { $counts['cited']++; }
+            if ($is_skipped) { $counts['skipped']++; }
+            if ($is_interrogated && !$is_cited) { $counts['without_results']++; }
+            $details[] = array(
+                'source_key'=>$source_key,
+                'name'=>$name,
+                'configured'=>true,
+                'interrogated'=>$is_interrogated,
+                'cited'=>$is_cited,
+                'without_results'=>$is_interrogated && !$is_cited,
+                'skipped'=>$is_skipped,
+                'matched_citations'=>array_slice($matches, 0, 5),
+            );
+        }
+        return array('counts'=>$counts,'sources'=>$details);
+    }
+
+    private static function strings_lower($items) {
+        $out = array();
+        foreach ($items as $item) {
+            if (is_array($item)) { $item = $item['name'] ?? $item['nome'] ?? $item['fonte'] ?? $item['source'] ?? wp_json_encode($item); }
+            $item = strtolower(trim(wp_strip_all_tags((string)$item)));
+            if ($item !== '') { $out[] = $item; }
+        }
+        return $out;
+    }
+
+    private static function source_named_in($name, $source_key, $haystack) {
+        $name = strtolower((string)$name); $source_key = strtolower((string)$source_key);
+        foreach ((array)$haystack as $item) {
+            if ($item === '') { continue; }
+            if ($item === $name || $item === $source_key || strpos($item, $name) !== false || ($source_key !== '' && strpos($item, $source_key) !== false)) { return true; }
+        }
+        return false;
+    }
+
+    private static function match_items_to_domains($items, $domains, $source_name = '') {
+        $matches = array(); $domains = array_map(function($d){ return preg_replace('/^www\./', '', strtolower((string)$d)); }, (array)$domains);
+        foreach ((array)$items as $item) {
+            if (!is_array($item)) { continue; }
+            $domain = strtolower((string)($item['domain'] ?? $item['fonte'] ?? $item['source'] ?? ''));
+            if (!$domain && !empty($item['url'])) { $domain = strtolower((string)wp_parse_url((string)$item['url'], PHP_URL_HOST)); }
+            $domain = preg_replace('/^www\./', '', $domain);
+            $matched = false;
+            foreach ($domains as $allowed) {
+                if ($allowed !== '' && ($domain === $allowed || substr($domain, -strlen('.' . $allowed)) === '.' . $allowed)) { $matched = true; break; }
+            }
+            if (!$matched && $source_name !== '') {
+                $source = strtolower((string)($item['fonte'] ?? $item['source'] ?? $item['title'] ?? $item['titolo'] ?? ''));
+                $matched = $source !== '' && strpos($source, strtolower($source_name)) !== false;
+            }
+            if ($matched) { $matches[] = $item; }
+        }
+        return $matches;
+    }
+
 }
 ALMA_Trend_Content_Ideas_Service::init();


### PR DESCRIPTION
### Motivation
- Il report `full_test` risultava troppo scarno e la metrica sulle fonti era ambigua tra fonti configurate e fonti effettivamente usate/citate.
- È necessario fornire report più operativi per Sothra (`full_test` ed `editorial_plan`) senza sacrificare il profilo diagnostico compatto `source_test`.
- La box nella Bacheca WordPress doveva mostrare rapidamente il report più recente con metriche chiare e link operativi senza avviare chiamate OpenAI.

### Description
- Aggiornato il prompt builder in `includes/class-trend-content-ideas-prompt-builder.php` per distinguere chiaramente `fonti configurate`, `fonti interrogate`, `fonti citate`, `fonti saltate` e richieste specifiche per `full_test` e `editorial_plan` mantenendo `source_test` compatto.
- Introdotti/aggiornati gli schemi JSON ricchi per `full_test` e `editorial_plan` (nuovo `full_test_schema` e `shared_rich_schema`) mentre `source_test` resta con limiti stretti; lo schema include campi per `fonti_configurate`, `fonti_interrogate`, `fonti_citate`, `fonti_saltate`, `destinazioni_prioritarie`, `opportunita_affiliate`, `bisogni_viaggiatori` e `dati_per_grafici`.
- Implementata logica di metriche e mappatura fonti in `includes/class-trend-content-ideas-service.php` con nuovi contatori: `count_fonti_configurate`, `count_fonti_interrogate`, `count_fonti_citate`, `count_fonti_saltate`, `count_fonti_senza_risultati` e alias `count_fonti_analizzate` = `count_fonti_interrogate`, più funzione `build_source_usage()` per dettaglio per fonte e matching domini/citazioni.
- Potenziata l'interfaccia admin/dashboard in `includes/class-trend-content-ideas-admin.php` per registrare il widget con priorità alta, leggere solo l'ultimo report salvato, mostrare data/ora, stato, modello, profilo runtime, metriche in card compatte, top trend/destinazioni/idee/opportunità/bisogni/alert e link rapidi; migliorata la pagina report completa con sezioni arricchite e messaggi utili per sezioni vuote.
- Piccola regolazione runtime: aumentati i token target per profili ricchi (`full_test` max_output_tokens 4600, `editorial_plan` max_output_tokens 6400) mentre `source_test` rimane compatto; mantenuto `web_search` come tool e nessuna chiamata OpenAI durante rendering admin/dashboard.
- Bumped version plugin a `2.34.0` e aggiornati `README.md` e `CHANGELOG.md` con le modifiche rilevanti.

### Testing
- Eseguito `php -l` su i file modificati (`affiliate-link-manager-ai.php`, `includes/class-trend-content-ideas-admin.php`, `includes/class-trend-content-ideas-prompt-builder.php`, `includes/class-trend-content-ideas-service.php`) e non sono stati rilevati errori di sintassi (successo).
- Eseguito test statico/unit-like personalizzato `python3 /tmp/trend_static_tests.py` che verifica presenza di nuove regole di prompt, schemi, metriche e assenza di `web_search_preview`; tutti i controlli sono passati (successo).
- Verificata assenza di `web_search_preview` e presenza di `web_search` come tool via `rg`; risultato conforme (successo).
- Eseguito `git diff --check` per whitespace/issue diff e non sono stati rilevati problemi (successo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b67259e88332a30553e2b69ba367)