### PR TITLE
Hardening AJAX, public AI chat rate limit and external URL validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.36.0 - 2026-06-01
+- Hardening tecnico degli endpoint AJAX admin/editoriali con controlli coerenti di nonce, capability, sanitizzazione input ed escaping dei payload JSON dove applicabile.
+- Aggiunto rate limit configurabile via filtro `alma_affiliate_chat_rate_limit` per la chat AI pubblica, con risposta JSON leggibile e logging redatto degli eventi bloccati.
+- Introdotta validazione anti-SSRF centralizzata per URL esterni usati da provider Custom/Generic API e sideload immagini remote: solo HTTP/HTTPS, host obbligatorio, blocco localhost, loopback, IP privati e link-local, redirect limitati.
+- Nessuna modifica ai flussi utente principali, shortcode, CPT/tassonomie o import CSV GetYourGuide server-rendered.
+- Versione plugin aggiornata a `2.36.0`.
+
 ## 2.35.0 - 2026-05-10
 - Corretto il bug delle metriche fonti Trend: `fonti_analizzate` non deriva più da `fonti_citate`; per `editorial_plan` senza `fonti_interrogate` il report usa lo snapshot runtime delle fonti incluse nella run.
 - Le metriche distinguono fonti configurate, interrogate, citate, saltate, senza risultati, non raggiungibili e da verificare. `count_fonti_analizzate` resta solo per compatibilità come alias di `count_fonti_interrogate`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## 2.36.0 - 2026-06-01
+- Hardening tecnico degli endpoint AJAX admin/editoriali con controlli coerenti di nonce, capability, sanitizzazione input ed escaping dei payload JSON dove applicabile.
+- Aggiunto rate limit configurabile via filtro `alma_affiliate_chat_rate_limit` per la chat AI pubblica, con risposta JSON leggibile e logging redatto degli eventi bloccati.
+- Introdotta validazione anti-SSRF centralizzata per URL esterni usati da provider Custom/Generic API e sideload immagini remote: solo HTTP/HTTPS, host obbligatorio, blocco localhost, loopback, IP privati e link-local, redirect limitati.
+- Nessuna modifica ai flussi utente principali, shortcode, CPT/tassonomie o import CSV GetYourGuide server-rendered.
+- Versione plugin aggiornata a `2.36.0`.
+
 ## 2.35.0 - 2026-05-10
 - Corretto il bug delle metriche fonti Trend: `fonti_analizzate` non deriva più da `fonti_citate`; per `editorial_plan` senza `fonti_interrogate` il report usa lo snapshot runtime delle fonti incluse nella run.
 - Le metriche distinguono fonti configurate, interrogate, citate, saltate, senza risultati, non raggiungibili e da verificare. `count_fonti_analizzate` resta solo per compatibilità come alias di `count_fonti_interrogate`.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.35.0
+ * Version: 2.36.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.35.0');
+define('ALMA_VERSION', '2.36.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -60,6 +60,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-trend-content-ideas-store.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-trend-content-ideas-service.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-trend-content-ideas-admin.php';
 
+require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-url-validator.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-interface.php';
 require_once ALMA_PLUGIN_DIR . 'includes/providers/class-affiliate-source-provider-manual.php';
 require_once ALMA_PLUGIN_DIR . 'includes/providers/class-affiliate-source-provider-csv.php';
@@ -410,35 +411,95 @@ class AffiliateManagerAI {
         return ob_get_clean();
     }
 
-    public function ajax_affiliate_chat() {
-        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'alma_affiliate_chat')) {
-            wp_send_json_error(__('Nonce non valida', 'affiliate-link-manager-ai'));
+
+    private function ajax_require_nonce($action, $field = 'nonce') {
+        $nonce = isset($_POST[$field]) ? sanitize_text_field(wp_unslash($_POST[$field])) : '';
+        if (!$nonce || !wp_verify_nonce($nonce, $action)) {
+            wp_send_json_error(array('message' => __('Verifica di sicurezza non riuscita.', 'affiliate-link-manager-ai')), 403);
+        }
+    }
+
+    private function ajax_require_capability($capability, $args = array()) {
+        $allowed = empty($args) ? current_user_can($capability) : current_user_can($capability, $args[0]);
+        if (!$allowed) {
+            wp_send_json_error(array('message' => __('Permessi insufficienti.', 'affiliate-link-manager-ai')), 403);
+        }
+    }
+
+    private function get_affiliate_chat_rate_limit_key() {
+        $ip = $this->get_user_ip();
+        if (!filter_var($ip, FILTER_VALIDATE_IP)) {
+            $ip = 'unknown';
+        }
+        $ua = isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])) : '';
+        $ua = function_exists('mb_substr') ? mb_substr($ua, 0, 120) : substr($ua, 0, 120);
+        return 'alma_chat_rl_' . hash('sha256', $ip . '|' . $ua);
+    }
+
+    private function check_affiliate_chat_rate_limit() {
+        if (is_user_logged_in() && current_user_can('edit_posts')) {
+            return true;
         }
 
-        $query = sanitize_text_field($_POST['query'] ?? '');
+        $defaults = array('limit' => 10, 'window' => 10 * MINUTE_IN_SECONDS);
+        $config = apply_filters('alma_affiliate_chat_rate_limit', $defaults);
+        $limit = max(1, absint($config['limit'] ?? $defaults['limit']));
+        $window = max(MINUTE_IN_SECONDS, absint($config['window'] ?? $defaults['window']));
+        $key = $this->get_affiliate_chat_rate_limit_key();
+        $bucket = get_transient($key);
+        if (!is_array($bucket)) {
+            $bucket = array('count' => 0, 'reset' => time() + $window);
+        }
+
+        if ((int) ($bucket['count'] ?? 0) >= $limit) {
+            ALMA_AI_Usage_Logger::log(array(
+                'task' => 'affiliate_chat_rate_limited',
+                'success' => false,
+                'error' => 'rate_limit_exceeded',
+                'reference_id' => 'public_chat:' . substr($key, -12),
+            ));
+            wp_send_json_error(array(
+                'code' => 'rate_limit_exceeded',
+                'message' => __('Hai raggiunto il limite temporaneo di richieste. Attendi qualche minuto e riprova.', 'affiliate-link-manager-ai'),
+                'retry_after' => max(1, (int) ($bucket['reset'] ?? (time() + $window)) - time()),
+            ), 429);
+        }
+
+        $bucket['count'] = (int) ($bucket['count'] ?? 0) + 1;
+        $bucket['reset'] = (int) ($bucket['reset'] ?? (time() + $window));
+        set_transient($key, $bucket, max(1, $bucket['reset'] - time()));
+        return true;
+    }
+
+    public function ajax_affiliate_chat() {
+        $this->ajax_require_nonce('alma_affiliate_chat');
+        $this->check_affiliate_chat_rate_limit();
+
+        $query = isset($_POST['query']) ? sanitize_text_field(wp_unslash($_POST['query'])) : '';
+        $query = function_exists('mb_substr') ? mb_substr($query, 0, 500) : substr($query, 0, 500);
         if (empty($query)) {
-            wp_send_json_error(__('Richiesta mancante', 'affiliate-link-manager-ai'));
+            wp_send_json_error(array('message' => __('Richiesta mancante', 'affiliate-link-manager-ai')), 400);
         }
 
         // Recupera contenuti pertinenti dalla cache
         $cached       = ALMA_Content_Analysis_AI::search_cache($query);
         $content_text = '';
         foreach ($cached as $item) {
-            $snippet = mb_substr($item['content'], 0, 200);
-            $content_text .= '- ' . $item['title'] . ': ' . $snippet . "\n";
+            $snippet = function_exists('mb_substr') ? mb_substr(wp_strip_all_tags((string) ($item['content'] ?? '')), 0, 200) : substr(wp_strip_all_tags((string) ($item['content'] ?? '')), 0, 200);
+            $content_text .= '- ' . sanitize_text_field($item['title'] ?? '') . ': ' . sanitize_text_field($snippet) . "\n";
         }
 
         $conversation = array();
         if (!empty($_POST['conversation'])) {
-            $decoded = json_decode(stripslashes($_POST['conversation']), true);
+            $decoded = json_decode(wp_unslash($_POST['conversation']), true);
             if (is_array($decoded)) {
-                foreach ($decoded as $msg) {
+                foreach (array_slice($decoded, -10) as $msg) {
                     if (empty($msg['content'])) {
                         continue;
                     }
                     $conversation[] = array(
-                        'role'    => $msg['role'] === 'assistant' ? 'assistant' : 'user',
-                        'content' => sanitize_textarea_field($msg['content'])
+                        'role'    => isset($msg['role']) && $msg['role'] === 'assistant' ? 'assistant' : 'user',
+                        'content' => function_exists('mb_substr') ? mb_substr(sanitize_textarea_field($msg['content']), 0, 1000) : substr(sanitize_textarea_field($msg['content']), 0, 1000)
                     );
                 }
             }
@@ -467,9 +528,9 @@ class AffiliateManagerAI {
 
         $links_text = '';
         foreach ($links as $type => $items) {
-            $links_text .= "$type:\n";
+            $links_text .= sanitize_text_field($type) . ":\n";
             foreach ($items as $item) {
-                $links_text .= '- ' . $item['title'] . ': ' . $item['url'] . "\n";
+                $links_text .= '- ' . sanitize_text_field($item['title']) . ': ' . esc_url_raw($item['url']) . "\n";
             }
         }
 
@@ -494,10 +555,10 @@ class AffiliateManagerAI {
         $result = ALMA_AI_Utils::call_openai_api($user_prompt, $system_prompt, $conversation);
 
         if (!$result['success']) {
-            wp_send_json_error($result['error']);
+            wp_send_json_error(array('message' => __('Non riesco a generare una risposta in questo momento. Riprova più tardi.', 'affiliate-link-manager-ai')), 502);
         }
 
-        wp_send_json_success(array('reply' => $result['response']));
+        wp_send_json_success(array('reply' => wp_kses_post($result['response'])));
     }
 
     /**
@@ -1572,7 +1633,7 @@ class AffiliateManagerAI {
         ?>
         <div class="wrap">
             <h1><?php _e('Impostazioni - Affiliate Link Manager AI', 'affiliate-link-manager-ai'); ?></h1>
-            <p style="font-size:14px;color:#666;">Versione <?php echo ALMA_VERSION; ?></p>
+            <p style="font-size:14px;color:#666;">Versione <?php echo esc_html(ALMA_VERSION); ?></p>
             
             <form method="post" action="">
                 <?php wp_nonce_field('alma_save_settings', 'alma_settings_nonce'); ?>
@@ -2892,13 +2953,11 @@ class AffiliateManagerAI {
      */
     
     public function ajax_search_links() {
-        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'alma_editor_search')) {
-            wp_send_json_error('Invalid nonce');
-            return;
-        }
-        
-        $search = sanitize_text_field($_POST['search'] ?? '');
-        $type_filter = isset($_POST['type_filter']) ? intval($_POST['type_filter']) : 0;
+        $this->ajax_require_nonce('alma_editor_search');
+        $this->ajax_require_capability('edit_posts');
+
+        $search = isset($_POST['search']) ? sanitize_text_field(wp_unslash($_POST['search'])) : '';
+        $type_filter = isset($_POST['type_filter']) ? absint($_POST['type_filter']) : 0;
         
         $args = array(
             'post_type' => 'affiliate_link',
@@ -2949,11 +3008,11 @@ class AffiliateManagerAI {
                 }
                 
                 $results[] = array(
-                    'id' => $post_id,
+                    'id' => (int) $post_id,
                     'title' => get_the_title(),
-                    'url' => $affiliate_url,
-                    'types' => $types,
-                    'clicks' => $click_count,
+                    'url' => esc_url_raw($affiliate_url),
+                    'types' => array_map('sanitize_text_field', $types),
+                    'clicks' => (int) $click_count,
                     'usage' => $usage_data,
                     'shortcode' => '[affiliate_link id="' . $post_id . '"]'
                 );
@@ -2965,10 +3024,8 @@ class AffiliateManagerAI {
     }
 
     public function ajax_ai_suggest_links() {
-        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'alma_editor_search')) {
-            wp_send_json_error('Invalid nonce');
-            return;
-        }
+        $this->ajax_require_nonce('alma_editor_search');
+        $this->ajax_require_capability('edit_posts');
 
         $title   = isset($_POST['title']) ? wp_strip_all_tags(wp_unslash($_POST['title'])) : '';
         $content = isset($_POST['content']) ? wp_strip_all_tags(wp_unslash($_POST['content'])) : '';
@@ -3032,11 +3089,11 @@ class AffiliateManagerAI {
             }
 
             $results[] = array(
-                'id'       => $id,
+                'id'       => (int) $id,
                 'title'    => get_the_title($id),
-                'url'      => $affiliate_url,
-                'types'    => $types,
-                'clicks'   => $click_count,
+                'url'      => esc_url_raw($affiliate_url),
+                'types'    => array_map('sanitize_text_field', $types),
+                'clicks'   => (int) $click_count,
                 'usage'    => $usage_data,
                 'shortcode'=> '[affiliate_link id="' . $id . '"]',
                 'score'    => max(0, min(100, round($score))),
@@ -3047,12 +3104,14 @@ class AffiliateManagerAI {
     }
 
     public function ajax_get_ai_suggestions() {
-        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'alma_admin_nonce')) {
-            wp_send_json_error('Invalid nonce');
-            return;
-        }
+        $this->ajax_require_nonce('alma_admin_nonce');
 
-        $link_id = intval($_POST['link_id']);
+        $link_id = isset($_POST['link_id']) ? absint($_POST['link_id']) : 0;
+        if ($link_id > 0) {
+            $this->ajax_require_capability('edit_post', array($link_id));
+        } else {
+            $this->ajax_require_capability('edit_posts');
+        }
 
         // Genera suggerimenti AI basati su OpenAI
         $suggestions = $this->generate_ai_suggestions($link_id);
@@ -3068,22 +3127,21 @@ class AffiliateManagerAI {
     }
 
     public function ajax_ai_suggest_text() {
-        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'alma_ai_suggest_text')) {
-            wp_send_json_error('Invalid nonce');
-            return;
-        }
+        $this->ajax_require_nonce('alma_ai_suggest_text');
+        $this->ajax_require_capability('edit_posts');
 
         $title       = isset($_POST['title']) ? sanitize_text_field(wp_unslash($_POST['title'])) : '';
         $description = isset($_POST['description']) ? sanitize_textarea_field(wp_unslash($_POST['description'])) : '';
 
         // Se non vengono passati titolo/descrizione, prova a recuperarli dal link_id
         if (!$title && !$description && isset($_POST['link_id'])) {
-            $link_id = intval($_POST['link_id']);
+            $link_id = absint($_POST['link_id']);
             $post    = get_post($link_id);
 
             if ($post && $post->post_type === 'affiliate_link') {
-                $title       = $post->post_title;
-                $description = $post->post_content;
+                $this->ajax_require_capability('edit_post', array($link_id));
+                $title       = sanitize_text_field($post->post_title);
+                $description = sanitize_textarea_field($post->post_content);
             } else {
                 wp_send_json_error('Invalid link');
                 return;
@@ -3112,16 +3170,10 @@ class AffiliateManagerAI {
     }
     
     public function ajax_test_openai_connection() {
-        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'alma_admin_nonce')) {
-            wp_send_json_error('Invalid nonce');
-            return;
-        }
-        
+        $this->ajax_require_nonce('alma_admin_nonce');
+        $this->ajax_require_capability('manage_options');
+
         $api_key = get_option('alma_openai_api_key');
-        if (!current_user_can('manage_options')) {
-            wp_send_json_error(__('Permessi insufficienti', 'affiliate-link-manager-ai'));
-            return;
-        }
 
         if (empty($api_key)) {
             wp_send_json_error('OpenAI API key non configurata');
@@ -3140,26 +3192,22 @@ class AffiliateManagerAI {
     }
     
     public function ajax_get_performance_predictions() {
-        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'alma_admin_nonce')) {
-            wp_send_json_error('Invalid nonce');
-            return;
+        $this->ajax_require_nonce('alma_admin_nonce');
+
+        $link_id = isset($_POST['link_id']) ? absint($_POST['link_id']) : 0;
+        if ($link_id > 0) {
+            $this->ajax_require_capability('edit_post', array($link_id));
+        } else {
+            $this->ajax_require_capability('edit_posts');
         }
-        
-        $link_id = intval($_POST['link_id']);
         $predictions = $this->get_ai_performance_predictions($link_id);
         
         wp_send_json_success($predictions);
     }
     
     public function ajax_get_dashboard_data() {
-        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'alma_admin_nonce')) {
-            wp_send_json_error(array('message' => 'Invalid nonce'), 403);
-            return;
-        }
-        if (!current_user_can('manage_options')) {
-            wp_send_json_error(array('message' => __('Permessi insufficienti.', 'affiliate-link-manager-ai')), 403);
-            return;
-        }
+        $this->ajax_require_nonce('alma_admin_nonce');
+        $this->ajax_require_capability('manage_options');
         $data = $this->dashboard_stats->get_summary(5);
         $data['top_links'] = array_map(function($item) {
             return array(
@@ -3173,14 +3221,8 @@ class AffiliateManagerAI {
     }
     
     public function ajax_get_chart_data() {
-        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'alma_admin_nonce')) {
-            wp_send_json_error(array('message' => 'Invalid nonce'), 403);
-            return;
-        }
-        if (!current_user_can('manage_options')) {
-            wp_send_json_error(array('message' => __('Permessi insufficienti.', 'affiliate-link-manager-ai')), 403);
-            return;
-        }
+        $this->ajax_require_nonce('alma_admin_nonce');
+        $this->ajax_require_capability('manage_options');
         $metric = sanitize_key($_POST['metric'] ?? 'clicks');
         $range  = sanitize_key($_POST['range'] ?? 'monthly');
         $chart = $this->dashboard_stats->get_chart_data($metric, $range);
@@ -3192,11 +3234,9 @@ class AffiliateManagerAI {
     }
     
     public function ajax_get_link_types() {
-        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'alma_editor_search')) {
-            wp_send_json_error('Invalid nonce');
-            return;
-        }
-        
+        $this->ajax_require_nonce('alma_editor_search');
+        $this->ajax_require_capability('edit_posts');
+
         $terms = get_terms(array(
             'taxonomy' => 'link_type',
             'hide_empty' => false,
@@ -3207,9 +3247,9 @@ class AffiliateManagerAI {
         if (!is_wp_error($terms) && !empty($terms)) {
             foreach ($terms as $term) {
                 $types[] = array(
-                    'id' => $term->term_id,
-                    'name' => $term->name,
-                    'count' => $term->count
+                    'id' => (int) $term->term_id,
+                    'name' => sanitize_text_field($term->name),
+                    'count' => (int) $term->count
                 );
             }
         }
@@ -3218,14 +3258,8 @@ class AffiliateManagerAI {
     }
     
     public function ajax_get_link_stats() {
-        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'alma_admin_nonce')) {
-            wp_send_json_error(array('message' => 'Invalid nonce'), 403);
-            return;
-        }
-        if (!current_user_can('manage_options')) {
-            wp_send_json_error(array('message' => __('Permessi insufficienti.', 'affiliate-link-manager-ai')), 403);
-            return;
-        }
+        $this->ajax_require_nonce('alma_admin_nonce');
+        $this->ajax_require_capability('manage_options');
         $link_id = isset($_POST['link_id']) ? absint($_POST['link_id']) : 0;
         if (!$link_id) {
             wp_send_json_error(array('message' => __('ID link non valido.', 'affiliate-link-manager-ai')), 400);
@@ -3237,16 +3271,15 @@ class AffiliateManagerAI {
     }
 
     public function ajax_import_affiliate_link() {
-        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'alma_import_links')) {
-            wp_send_json_error(array('code' => 'invalid_nonce'));
-        }
+        $this->ajax_require_nonce('alma_import_links');
+        $this->ajax_require_capability('manage_options');
 
-        $title = sanitize_text_field($_POST['title'] ?? '');
-        $url   = esc_url_raw($_POST['url'] ?? '');
-        $status = ($_POST['status'] ?? 'draft') === 'publish' ? 'publish' : 'draft';
-        $types = isset($_POST['types']) ? array_map('intval', (array) $_POST['types']) : array();
-        $link_rel = sanitize_text_field($_POST['rel'] ?? 'sponsored noopener');
-        $link_target = sanitize_text_field($_POST['target'] ?? '_blank');
+        $title = isset($_POST['title']) ? sanitize_text_field(wp_unslash($_POST['title'])) : '';
+        $url   = isset($_POST['url']) ? esc_url_raw(wp_unslash($_POST['url'])) : '';
+        $status = isset($_POST['status']) && sanitize_key(wp_unslash($_POST['status'])) === 'publish' ? 'publish' : 'draft';
+        $types = isset($_POST['types']) ? array_map('absint', (array) wp_unslash($_POST['types'])) : array();
+        $link_rel = isset($_POST['rel']) ? sanitize_text_field(wp_unslash($_POST['rel'])) : 'sponsored noopener';
+        $link_target = isset($_POST['target']) ? sanitize_text_field(wp_unslash($_POST['target'])) : '_blank';
 
         if (empty($title) || empty($url) || !filter_var($url, FILTER_VALIDATE_URL)) {
             wp_send_json_error(array('code' => 'invalid_data'));

--- a/includes/class-affiliate-source-manager.php
+++ b/includes/class-affiliate-source-manager.php
@@ -751,7 +751,7 @@ class ALMA_Affiliate_Source_Manager {
 
     public function ajax_test_source_connection(){
         if(!current_user_can('manage_options')) wp_send_json_error(array('message'=>'Non autorizzato'),403);
-        check_ajax_referer('alma_test_connection_nonce','nonce');
+        if(!check_ajax_referer('alma_test_connection_nonce','nonce',false)) wp_send_json_error(array('message'=>'Verifica di sicurezza non riuscita'),403);
         $source_id = absint($_POST['source_id'] ?? 0);
         if($source_id<=0) wp_send_json_error(array('message'=>'Source non valida'));
         global $wpdb;
@@ -765,7 +765,7 @@ class ALMA_Affiliate_Source_Manager {
         wp_send_json_success(array('message'=>'Connessione riuscita'));
     }
     private function map_error($code,$fallback){
-        $map=array('missing_credentials'=>'Credenziali/token mancanti','missing_endpoint'=>'Endpoint mancante','invalid_endpoint'=>'Endpoint non valido','provider_unsupported'=>'Provider non ancora supportato','invalid_environment'=>'Environment non valido','invalid_api_version'=>'Versione API non valida','unauthorized'=>'Credenziale non autorizzata','forbidden'=>'Accesso negato','rate_limited'=>'Rate limit raggiunto','timeout'=>'Timeout','api_error'=>'Errore API','invalid_json'=>'Risposta API non valida','missing_minimum_criteria'=>'Parametri minimi mancanti per discovery','missing_destination_id'=>'Destination ID mancante','missing_search_term'=>'Search term mancante','invalid_environment'=>'Environment non valido','invalid_api_version'=>'Versione API non valida','unauthorized'=>'Credenziale non autorizzata','forbidden'=>'Credenziale senza permessi','rate_limited'=>'Limite richieste raggiunto','empty_response'=>'Risposta vuota','invalid_json'=>'Risposta API non valida','response_too_large'=>'Risposta troppo grande','catalog_unavailable'=>'Catalogo campi documentato non disponibile','internal_error'=>'Errore interno');
+        $map=array('missing_credentials'=>'Credenziali/token mancanti','missing_endpoint'=>'Endpoint mancante','invalid_endpoint'=>'Endpoint non valido','missing_url'=>'URL mancante','invalid_url'=>'URL non valido','invalid_scheme'=>'Schema URL non consentito','missing_host'=>'Host URL mancante','blocked_localhost'=>'Endpoint localhost non consentito','blocked_private_ip'=>'Endpoint verso IP privato, loopback o link-local non consentito','provider_unsupported'=>'Provider non ancora supportato','invalid_environment'=>'Environment non valido','invalid_api_version'=>'Versione API non valida','unauthorized'=>'Credenziale non autorizzata','forbidden'=>'Accesso negato','rate_limited'=>'Rate limit raggiunto','timeout'=>'Timeout','api_error'=>'Errore API','invalid_json'=>'Risposta API non valida','missing_minimum_criteria'=>'Parametri minimi mancanti per discovery','missing_destination_id'=>'Destination ID mancante','missing_search_term'=>'Search term mancante','invalid_environment'=>'Environment non valido','invalid_api_version'=>'Versione API non valida','unauthorized'=>'Credenziale non autorizzata','forbidden'=>'Credenziale senza permessi','rate_limited'=>'Limite richieste raggiunto','empty_response'=>'Risposta vuota','invalid_json'=>'Risposta API non valida','response_too_large'=>'Risposta troppo grande','catalog_unavailable'=>'Catalogo campi documentato non disponibile','internal_error'=>'Errore interno');
         return $map[$code] ?? sanitize_text_field($fallback ?: 'Errore interno');
     }
     public function render_importable_fields_page(){

--- a/includes/class-affiliate-source-media-sideload-service.php
+++ b/includes/class-affiliate-source-media-sideload-service.php
@@ -40,8 +40,9 @@ class ALMA_Affiliate_Source_Media_Sideload_Service {
             return $result;
         }
 
-        if (!$this->is_valid_remote_url($url)) {
-            $result = $this->result('failed_validation', $post_id, $url, $hash, __('Immagine non importata: URL remoto non valido.', 'affiliate-link-manager-ai'), 'invalid_url');
+        $url_validation = ALMA_Affiliate_Source_URL_Validator::validate($url);
+        if (is_wp_error($url_validation)) {
+            $result = $this->result('failed_validation', $post_id, $url, $hash, __('Immagine non importata: URL remoto non valido.', 'affiliate-link-manager-ai'), $url_validation->get_error_code());
             $this->save_post_diagnostics($post_id, $result);
             $this->log_event('failed_validation', $result);
             return $result;
@@ -84,7 +85,15 @@ class ALMA_Affiliate_Source_Media_Sideload_Service {
         }
 
         $this->load_media_dependencies();
+        $request_args_filter = function($request_args, $request_url) use ($url) {
+            if ((string) $request_url === (string) $url) {
+                $request_args = ALMA_Affiliate_Source_URL_Validator::request_args($request_args);
+            }
+            return $request_args;
+        };
+        add_filter('http_request_args', $request_args_filter, 10, 2);
         $tmp = download_url($url);
+        remove_filter('http_request_args', $request_args_filter, 10);
         if (is_wp_error($tmp)) {
             $result = $this->result('failed_download', $post_id, $url, $hash, $tmp->get_error_message(), $tmp->get_error_code());
             $this->save_post_diagnostics($post_id, $result);
@@ -145,13 +154,6 @@ class ALMA_Affiliate_Source_Media_Sideload_Service {
         $normalized .= isset($parts['path']) ? (string)$parts['path'] : '/';
         if (!empty($parts['query'])) $normalized .= '?' . (string)$parts['query'];
         return esc_url_raw($normalized, array('http', 'https'));
-    }
-
-    private function is_valid_remote_url($url) {
-        $parts = wp_parse_url($url);
-        if (!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) return false;
-        if (!in_array(strtolower((string)$parts['scheme']), array('http', 'https'), true)) return false;
-        return (bool) wp_http_validate_url($url);
     }
 
     private function hash_url($url) { return hash('sha256', $this->normalize_url($url)); }

--- a/includes/class-affiliate-source-provider-client-custom-api.php
+++ b/includes/class-affiliate-source-provider-client-custom-api.php
@@ -14,9 +14,8 @@ class ALMA_Affiliate_Source_Provider_Client_Custom_API {
     private function build_request($source) {
         $settings = $this->source_settings($source);
         $credentials = $this->source_credentials($source);
-        $endpoint = esc_url_raw($settings['endpoint'] ?? ($settings['base_url'] ?? ''));
-        if (!$endpoint) { return new WP_Error('missing_endpoint', __('Endpoint mancante.', 'affiliate-link-manager-ai')); }
-        if (!filter_var($endpoint, FILTER_VALIDATE_URL)) { return new WP_Error('invalid_endpoint', __('Endpoint non valido.', 'affiliate-link-manager-ai')); }
+        $endpoint = ALMA_Affiliate_Source_URL_Validator::validate($settings['endpoint'] ?? ($settings['base_url'] ?? ''));
+        if (is_wp_error($endpoint)) { return $endpoint; }
         $method = strtoupper(sanitize_text_field($settings['method'] ?? 'GET'));
         $headers = array('Accept' => 'application/json');
         if (!empty($settings['user_agent'])) { $headers['User-Agent'] = sanitize_text_field($settings['user_agent']); }
@@ -26,7 +25,7 @@ class ALMA_Affiliate_Source_Provider_Client_Custom_API {
         if (empty($credentials['api_key']) && empty($credentials['access_token']) && empty($credentials['bearer_token'])) {
             return new WP_Error('missing_credentials', __('Credenziali mancanti.', 'affiliate-link-manager-ai'));
         }
-        return array('endpoint' => $endpoint, 'args' => array('method' => $method, 'timeout' => 8, 'redirection' => 1, 'headers' => $headers));
+        return array('endpoint' => $endpoint, 'args' => ALMA_Affiliate_Source_URL_Validator::request_args(array('method' => $method, 'timeout' => 8, 'headers' => $headers)));
     }
 
     public function test_connection($source) {

--- a/includes/class-affiliate-source-url-validator.php
+++ b/includes/class-affiliate-source-url-validator.php
@@ -1,0 +1,100 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_Affiliate_Source_URL_Validator {
+    public static function validate($url) {
+        $url = is_scalar($url) ? trim((string) $url) : '';
+        if ($url === '') {
+            return new WP_Error('missing_url', __('URL mancante.', 'affiliate-link-manager-ai'));
+        }
+
+        $url = esc_url_raw($url, array('http', 'https'));
+        if ($url === '') {
+            return new WP_Error('invalid_url', __('URL non valido.', 'affiliate-link-manager-ai'));
+        }
+
+        $parts = wp_parse_url($url);
+        if (!is_array($parts) || empty($parts['scheme'])) {
+            return new WP_Error('invalid_scheme', __('Schema URL non valido.', 'affiliate-link-manager-ai'));
+        }
+
+        $scheme = strtolower((string) $parts['scheme']);
+        if (!in_array($scheme, array('http', 'https'), true)) {
+            return new WP_Error('invalid_scheme', __('Sono consentiti solo URL http e https.', 'affiliate-link-manager-ai'));
+        }
+
+        if (empty($parts['host'])) {
+            return new WP_Error('missing_host', __('Host URL mancante.', 'affiliate-link-manager-ai'));
+        }
+
+        $host = strtolower(trim((string) $parts['host'], "[] \t\n\r\0\x0B."));
+        if ($host === '') {
+            return new WP_Error('missing_host', __('Host URL mancante.', 'affiliate-link-manager-ai'));
+        }
+
+        if ($host === 'localhost' || substr($host, -10) === '.localhost') {
+            return new WP_Error('blocked_localhost', __('Host localhost non consentito.', 'affiliate-link-manager-ai'));
+        }
+
+        $ip_error = self::validate_ip($host);
+        if (is_wp_error($ip_error)) {
+            return $ip_error;
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP) === false) {
+            $resolved = self::resolve_host_ips($host);
+            foreach ($resolved as $ip) {
+                $ip_error = self::validate_ip($ip);
+                if (is_wp_error($ip_error)) {
+                    return $ip_error;
+                }
+            }
+        }
+
+        return $url;
+    }
+
+    public static function request_args($args = array()) {
+        $args = is_array($args) ? $args : array();
+        $args['redirection'] = isset($args['redirection']) ? min(1, absint($args['redirection'])) : 1;
+        $args['reject_unsafe_urls'] = true;
+        return $args;
+    }
+
+    private static function validate_ip($host) {
+        $ip = filter_var($host, FILTER_VALIDATE_IP);
+        if ($ip === false) {
+            return true;
+        }
+
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+            return new WP_Error('blocked_private_ip', __('IP privati, loopback e link-local non consentiti.', 'affiliate-link-manager-ai'));
+        }
+
+        return true;
+    }
+
+    private static function resolve_host_ips($host) {
+        $ips = array();
+        if (function_exists('gethostbynamel')) {
+            $records = gethostbynamel($host);
+            if (is_array($records)) {
+                $ips = array_merge($ips, $records);
+            }
+        }
+        if (function_exists('dns_get_record')) {
+            $records = @dns_get_record($host, DNS_A + DNS_AAAA);
+            if (is_array($records)) {
+                foreach ($records as $record) {
+                    if (!empty($record['ip'])) {
+                        $ips[] = $record['ip'];
+                    }
+                    if (!empty($record['ipv6'])) {
+                        $ips[] = $record['ipv6'];
+                    }
+                }
+            }
+        }
+        return array_values(array_unique(array_filter($ips)));
+    }
+}

--- a/includes/providers/class-affiliate-source-provider-generic-api.php
+++ b/includes/providers/class-affiliate-source-provider-generic-api.php
@@ -3,6 +3,6 @@ if (!defined('ABSPATH')) { exit; }
 class ALMA_Affiliate_Source_Provider_Generic_API extends ALMA_Affiliate_Source_Provider_Manual {
 public function get_provider_id(){return 'generic_api';}
 public function get_label(){return __('Generic API','affiliate-link-manager-ai');}
-public function test_connection($settings){$endpoint=esc_url_raw($settings['endpoint']??''); if(!$endpoint){return new WP_Error('missing_endpoint',__('Endpoint mancante','affiliate-link-manager-ai'));} $res=wp_remote_request($endpoint,array('method'=>sanitize_text_field($settings['method']??'GET'),'timeout'=>15)); if(is_wp_error($res)){return $res;} return array('success'=>true,'message'=>__('Connessione riuscita','affiliate-link-manager-ai'));}
+public function test_connection($settings){$endpoint=ALMA_Affiliate_Source_URL_Validator::validate($settings['endpoint']??''); if(is_wp_error($endpoint)){return $endpoint;} $res=wp_remote_request($endpoint,ALMA_Affiliate_Source_URL_Validator::request_args(array('method'=>sanitize_text_field($settings['method']??'GET'),'timeout'=>15))); if(is_wp_error($res)){return $res;} return array('success'=>true,'message'=>__('Connessione riuscita','affiliate-link-manager-ai'));}
 public function fetch_items($source,$args=array()){return array();}
 }


### PR DESCRIPTION
### Motivation
- Rafforzare la sicurezza degli endpoint AJAX amministrativi/editoriali e del widget AI pubblico senza modificare flussi utente, shortcode, CPT/tassonomie o l’import GYG server-rendered.
- Ridurre il rischio di abuso degli endpoint AI pubblici e il rischio SSRF nelle chiamate verso provider esterni o nel download di immagini remote.

### Description
- File principali modificati: `affiliate-link-manager-ai.php`, `includes/class-affiliate-source-url-validator.php`, `includes/class-affiliate-source-provider-client-custom-api.php`, `includes/providers/class-affiliate-source-provider-generic-api.php`, `includes/class-affiliate-source-media-sideload-service.php`, `includes/class-affiliate-source-manager.php`, `README.md`, `CHANGELOG.md`. 
- Introdotti helper AJAX centralizzati `ajax_require_nonce()` e `ajax_require_capability()` e applicati controlli coerenti di nonce, capability, sanitizzazione e escaping sui principali handler admin/editoriali senza cambiare nomi action esistenti. 
- Protezione chat AI pubblica `alma_affiliate_chat` con rate limit tramite transient basato su IP normalizzato + User-Agent ridotto, filtro configurabile `alma_affiliate_chat_rate_limit`, messaggio JSON 429 leggibile, redaction logging tramite `ALMA_AI_Usage_Logger`, e limiti su lunghezza query/conversation. 
- Introdotta la classe `ALMA_Affiliate_Source_URL_Validator` e applicata a Custom/Generic API provider e al servizio di sideload immagini per accettare solo `http`/`https`, rifiutare host vuoti/`localhost`, loopback, IP privati/link-local, risolvere A/AAAA quando utile e limitare redirect/request args per mitigare SSRF. 
- Endpoint AJAX toccati (sintesi): `alma_affiliate_chat` (pubblico e privato), `alma_search_links`, `alma_ai_suggest_links`, `alma_get_ai_suggestions`, `alma_ai_suggest_text`, `alma_test_openai_connection`, `alma_get_performance_predictions`, `alma_get_dashboard_data`, `alma_get_chart_data`, `alma_get_link_types`, `alma_get_link_stats`, `alma_import_affiliate_link`, `alma_test_source_connection` (migliorata gestione nonce/errore). 

### Testing
- Eseguito lint PHP su file modificati con `php -l` e tutti i file controllati hanno restituito "No syntax errors detected". 
- Verificato aggiornamento versione e coerenza con script: header plugin `Version:` e costante `ALMA_VERSION` aggiornate a `2.36.0` e aggiornati `README.md`/`CHANGELOG.md`. 
- Controlli automatici eseguiti: `git diff --cached --check` per staging e assenza di errori di diff; commit creato con message `Hardening AJAX and external URL validation`. 
- Istruzioni per test manuale (verificare comportamento e non regressione): testare `admin/editor link search` con utente `edit_posts` e con utente senza capability per ottenere 403 JSON; testare `OpenAI connection` da admin senza esporre chiavi; testare `Affiliate Chat` pubblico inviando >10 richieste entro 10 minuti dallo stesso IP+UA per ottenere 429 con `retry_after`; testare `Custom API endpoint` valido con URL HTTPS pubblico e `alma_test_source_connection`; testare `Custom API endpoint` bloccato usando `http://localhost`, `http://127.0.0.1` o IP privato per verificare errore bloccato; verificare import GetYourGuide CSV (modal healthcheck, prepare, batch import) per assenza di regressioni nel flusso server-rendered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d4da740d08332ba19a0dd7e50c443)