### PR TITLE
Improve GetYourGuide CSV import workflow and background processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 - Convertiti i log diretti più sensibili nelle aree OpenAI, AI draft builder, import GetYourGuide CSV, media index e internal link index in diagnostica controllata tramite logger.
 - I log `debug` rispettano `WP_DEBUG`; nessun segreto viene salvato in database e non cambiano UI, schema DB, payload OpenAI o flussi di import.
 
+## 2.36.4 - 2026-06-01
+- Migliorato il workflow **Importa contenuti → GetYourGuide CSV / Deep Link** con job background persistenti in `alma_gyg_csv_import_jobs`, batch sicuri, lock transient e continuazione via WP-Cron anche a pagina chiusa.
+- Estesa la sezione **Sessioni CSV recenti** con link admin sicuro al file caricato, record totali, importati, restanti, stato importazione e ultimo aggiornamento calcolati da sessioni/progress/job persistenti.
+- Semplificata la ripresa importazione CSV: la vista mostra file corrente, source corrente e il solo riepilogo delle tipologie attività, evitando step upload/configurazione già completati.
+- Corretta la preview/importazione subset: i job salvano sessione, source, tipologia attività, filtri, selezione e criteri preview, così Importa/continua lavora solo sui record selezionati o filtrati e non su tutto il CSV.
+- Aggiunta la colonna **Mapping Sothra** record-level nella tabella Risultati anteprima, con multi-select `link_type`, fallback da mapping tipologia/source e persistenza nel job prima dell’import.
+- Aggiunta progress bar WordPress-native con conteggi processati/totali, importati, aggiornati, già presenti, saltati, errori e stato testuale del job.
+- Versione plugin aggiornata a `2.36.4`.
+
 ## 2.36.3 - 2026-06-01
 - Rimossa la funzionalità dismessa **Affiliate Chat AI** dal menu admin, dagli shortcode, dagli endpoint AJAX e dagli asset frontend.
 - Rimosso lo shortcode `[affiliate_chat_ai]` senza fallback HTML.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ Redazione automatica applicata ai log:
 - Parametri token noti negli URL (`token`, `access_token`, `refresh_token`, `api_key`, `key`, `signature`, `client_secret`).
 - Payload/prompt/body OpenAI lunghi e risposte AI grezze lunghe, incluse risposte AI annidate, troncati prima della scrittura nel log.
 
+## 2.36.4 - 2026-06-01
+- Migliorato il workflow **Importa contenuti → GetYourGuide CSV / Deep Link** con job background persistenti in `alma_gyg_csv_import_jobs`, batch sicuri, lock transient e continuazione via WP-Cron anche a pagina chiusa.
+- Estesa la sezione **Sessioni CSV recenti** con link admin sicuro al file caricato, record totali, importati, restanti, stato importazione e ultimo aggiornamento calcolati da sessioni/progress/job persistenti.
+- Semplificata la ripresa importazione CSV: la vista mostra file corrente, source corrente e il solo riepilogo delle tipologie attività, evitando step upload/configurazione già completati.
+- Corretta la preview/importazione subset: i job salvano sessione, source, tipologia attività, filtri, selezione e criteri preview, così Importa/continua lavora solo sui record selezionati o filtrati e non su tutto il CSV.
+- Aggiunta la colonna **Mapping Sothra** record-level nella tabella Risultati anteprima, con multi-select `link_type`, fallback da mapping tipologia/source e persistenza nel job prima dell’import.
+- Aggiunta progress bar WordPress-native con conteggi processati/totali, importati, aggiornati, già presenti, saltati, errori e stato testuale del job.
+- Versione plugin aggiornata a `2.36.4`.
+
 ## 2.36.3 - 2026-06-01
 - Rimossa dalle funzionalità attive la funzionalità dismessa **Affiliate Chat AI**.
 - Funzionalità dismesse: lo shortcode `[affiliate_chat_ai]` non viene più registrato e non è previsto un fallback HTML.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.36.3
+ * Version: 2.36.4
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.36.3');
+define('ALMA_VERSION', '2.36.4');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -79,6 +79,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-media-sideload-s
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-importer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-import-record-filter.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-gyg-csv-importer.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-gyg-csv-import-job-service.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-import-preview-service.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-manual-import-service.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-import-criteria-service.php';

--- a/assets/affiliate-sources.css
+++ b/assets/affiliate-sources.css
@@ -70,3 +70,10 @@ body.alma-modal-open{overflow:hidden}
 .alma-gyg-selection-actions,
 .alma-gyg-pagination { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
 .alma-gyg-preview-table td code { font-size: 11px; }
+
+.alma-gyg-record-mapping{min-width:160px;max-width:220px;width:100%}
+.alma-gyg-job-box{margin-top:14px;padding:12px;border:1px solid #72aee6;border-left:4px solid #2271b1;background:#f0f6fc}
+.alma-gyg-job-box h3{margin-top:0}.alma-gyg-job-counts{color:#50575e}
+.alma-gyg-mini-progress{height:8px;background:#f0f0f1;border:1px solid #c3c4c7;border-radius:8px;overflow:hidden;min-width:110px;margin-top:4px}
+.alma-gyg-mini-progress span{display:block;height:100%;background:#2271b1}
+.alma-gyg-preview-table th:nth-child(7),.alma-gyg-preview-table td:nth-child(7){width:190px}

--- a/assets/affiliate-sources.js
+++ b/assets/affiliate-sources.js
@@ -191,6 +191,30 @@ jQuery(function($){
     $.each(ids, function(_, id){ url += sep + 'selected_external_ids[]=' + encodeURIComponent(id); sep='&'; });
     return url;
   }
+
+  function gygJobStatusLabel(status){ return ({queued:'In coda',running:'In corso',paused:'In pausa',completed:'Completato',failed:'Errore',cancelled:'Annullato'})[status] || status || '—'; }
+  function gygRenderJobStatus(d){
+    if(!d){ return; }
+    var pct = parseFloat(d.percent || 0); if(isNaN(pct)){ pct = 0; }
+    $('.alma-gyg-job-box').show().addClass('alma-gyg-job-active');
+    $('.alma-gyg-job-box .alma-progress-bar').css('width', Math.max(0, Math.min(100, pct))+'%');
+    $('.alma-gyg-job-status').text(gygJobStatusLabel(d.status)+' · '+pct+'% · '+(d.message || ''));
+    $('.alma-gyg-job-counts').text('Processati '+(d.processed_records||0)+' / '+(d.total_records||0)+' · importati '+(d.imported_count||0)+' · aggiornati '+(d.updated_count||0)+' · già presenti '+(d.existing_count||0)+' · saltati '+(d.skipped_count||0)+' · errori '+(d.error_count||0));
+  }
+  function gygPollJob(jobId){
+    if(!jobId){ return; }
+    $.post(gygAjaxUrl(), {action:'alma_gyg_csv_get_import_job_status', nonce:gygNonce(), job_id:jobId}).done(function(res){
+      if(res && res.success){ var d=res.data; gygRenderJobStatus(d); if($.inArray(d.status, ['queued','running','paused']) !== -1){ setTimeout(function(){ gygPollJob(jobId); }, 5000); } }
+    });
+  }
+  function gygAppendSelectedMappings($form, ids){
+    var selected = {}; $.each(ids || [], function(_, id){ selected[String(id)] = true; });
+    $form.find('select.alma-gyg-record-mapping').each(function(){
+      var m = String($(this).attr('name')||'').match(/record_link_type_term_ids\[([^\]]+)\]/), eid = m ? m[1] : '';
+      if(eid && !selected[eid]){ $(this).prop('disabled', true); }
+    });
+  }
+
   gygRefreshSelected();
   $(document).on('change', '.alma-gyg-row-select', function(){
     var id = String($(this).val()||''), ids = gygSelectedIds(), idx = ids.indexOf(id);
@@ -203,7 +227,22 @@ jQuery(function($){
   $(document).on('click', '.alma-gyg-select-filtered', function(e){ e.preventDefault(); var ids=gygSelectedIds(), add=[]; $('.alma-gyg-filtered-id').each(function(){ var id=String($(this).val()||''); if(id){ add.push(id); } }); if(add.length > 100 && !window.confirm('Stai per selezionare '+add.length+' record filtrati. Confermi?')){ return; } $.each(add, function(_, id){ if(ids.indexOf(id)===-1){ ids.push(id); } }); $('.alma-gyg-row-select').prop('checked', true); gygStoreSelected(ids); });
   $(document).on('submit', '.alma-gyg-filter-form', function(){ gygAppendSelectedToContainer($(this)); });
   $(document).on('click', '.alma-gyg-pagination a, .alma-gyg-filter-box a.button', function(e){ e.preventDefault(); window.location.href = gygUrlWithSelected($(this).attr('href')); });
-  $(document).on('submit', '.alma-gyg-selective-import-form', function(e){ var ids=gygStoreSelected(gygSelectedIds()); if(ids.length < 1){ e.preventDefault(); window.alert('Seleziona almeno un contenuto prima di importare.'); } });
+  $(document).on('submit', '.alma-gyg-selective-import-form', function(e){
+    var $form=$(this), ids=gygStoreSelected(gygSelectedIds());
+    if(ids.length < 1){ e.preventDefault(); window.alert('Seleziona almeno un contenuto prima di importare.'); return; }
+    e.preventDefault();
+    $form.find('select.alma-gyg-record-mapping').prop('disabled', false);
+    gygAppendSelectedMappings($form, ids);
+    var data=$form.serializeArray();
+    data.push({name:'action', value:'alma_gyg_csv_create_import_job'});
+    data.push({name:'nonce', value:gygNonce()});
+    $form.find('.alma-gyg-import-selected').prop('disabled', true).text('Job in creazione…');
+    $('.alma-gyg-job-box').show(); $('.alma-gyg-job-status').text('Creazione job background…');
+    $.post(gygAjaxUrl(), data).done(function(res){
+      if(!res || !res.success){ window.alert((res && res.data && res.data.message) || 'Errore creazione job.'); $form.find('.alma-gyg-import-selected').prop('disabled', false).text('Importa/continua'); return; }
+      gygRenderJobStatus(res.data); gygPollJob(res.data.job_id); $form.find('.alma-gyg-import-selected').text('Job avviato');
+    }).fail(function(xhr){ window.alert(gygAjaxErrorMessage(xhr, 'Errore di rete durante la creazione job.')); $form.find('.alma-gyg-import-selected').prop('disabled', false).text('Importa/continua'); });
+  });
 
   renderProviderFields();
   toggleSearchHints();

--- a/includes/class-affiliate-source-gyg-csv-import-job-service.php
+++ b/includes/class-affiliate-source-gyg-csv-import-job-service.php
@@ -1,0 +1,193 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_Affiliate_Source_GYG_CSV_Import_Job_Service {
+    const CRON_HOOK = 'alma_gyg_csv_run_import_job_batch';
+    const BATCH_SIZE = 50;
+
+    private function jobs_table() { global $wpdb; return $wpdb->prefix . 'alma_gyg_csv_import_jobs'; }
+    private function sessions_table() { global $wpdb; return $wpdb->prefix . 'alma_gyg_csv_import_sessions'; }
+    private function progress_table() { global $wpdb; return $wpdb->prefix . 'alma_gyg_csv_import_progress'; }
+    private function table_exists($table) { global $wpdb; return $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table)) === $table; }
+
+    public static function create_table() {
+        global $wpdb;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $c = $wpdb->get_charset_collate();
+        dbDelta("CREATE TABLE {$wpdb->prefix}alma_gyg_csv_import_jobs (id bigint(20) unsigned NOT NULL AUTO_INCREMENT, session_id bigint(20) unsigned NOT NULL, source_id bigint(20) unsigned NOT NULL, activity_type varchar(255) NOT NULL DEFAULT '', activity_type_hash char(64) NOT NULL DEFAULT '', status varchar(20) NOT NULL DEFAULT 'queued', criteria_json longtext NULL, record_mapping_json longtext NULL, selected_external_ids_json longtext NULL, total_records int(10) unsigned NOT NULL DEFAULT 0, processed_records int(10) unsigned NOT NULL DEFAULT 0, imported_count int(10) unsigned NOT NULL DEFAULT 0, updated_count int(10) unsigned NOT NULL DEFAULT 0, existing_count int(10) unsigned NOT NULL DEFAULT 0, skipped_count int(10) unsigned NOT NULL DEFAULT 0, error_count int(10) unsigned NOT NULL DEFAULT 0, last_cursor int(10) unsigned NOT NULL DEFAULT 0, last_message text NULL, created_by bigint(20) unsigned NOT NULL DEFAULT 0, created_at datetime NOT NULL, updated_at datetime NOT NULL, started_at datetime NULL, finished_at datetime NULL, last_error text NULL, PRIMARY KEY  (id), KEY session_id (session_id), KEY source_id (source_id), KEY status (status), KEY activity_type_hash (activity_type_hash), KEY updated_at (updated_at)) $c;");
+    }
+
+    public function get_job($job_id) {
+        global $wpdb;
+        $table = $this->jobs_table();
+        if (!$this->table_exists($table)) return array();
+        $row = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table} WHERE id=%d", absint($job_id)), ARRAY_A);
+        return is_array($row) ? $row : array();
+    }
+
+    public function get_latest_jobs_for_session($session_id) {
+        global $wpdb;
+        $table = $this->jobs_table();
+        if (!$this->table_exists($table)) return array();
+        $rows = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$table} WHERE session_id=%d ORDER BY updated_at DESC, id DESC", absint($session_id)), ARRAY_A);
+        $out = array();
+        foreach ((array)$rows as $row) {
+            $hash = (string)($row['activity_type_hash'] ?? '');
+            if ($hash !== '' && !isset($out[$hash])) $out[$hash] = $row;
+        }
+        return $out;
+    }
+
+    public function get_session_job_totals($session_id) {
+        global $wpdb;
+        $table = $this->jobs_table();
+        if (!$this->table_exists($table)) return array('processed'=>0,'imported'=>0,'updated'=>0,'existing'=>0,'skipped'=>0,'errors'=>0,'status'=>'ready','updated_at'=>'');
+        $row = $wpdb->get_row($wpdb->prepare("SELECT SUM(processed_records) processed, SUM(imported_count) imported, SUM(updated_count) updated, SUM(existing_count) existing, SUM(skipped_count) skipped, SUM(error_count) errors, MAX(updated_at) updated_at FROM {$table} WHERE session_id=%d", absint($session_id)), ARRAY_A);
+        $running = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$table} WHERE session_id=%d AND status IN ('queued','running','paused')", absint($session_id)));
+        $failed = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$table} WHERE session_id=%d AND status='failed'", absint($session_id)));
+        $status = $running > 0 ? 'running' : ($failed > 0 ? 'failed' : 'ready');
+        return array('processed'=>absint($row['processed'] ?? 0),'imported'=>absint($row['imported'] ?? 0),'updated'=>absint($row['updated'] ?? 0),'existing'=>absint($row['existing'] ?? 0),'skipped'=>absint($row['skipped'] ?? 0),'errors'=>absint($row['errors'] ?? 0),'status'=>$status,'updated_at'=>(string)($row['updated_at'] ?? ''));
+    }
+
+    public function create_job($session, $source, $activity_type, $criteria, $record_mapping, $selected_external_ids, $fallback_term_ids, $update_existing) {
+        global $wpdb;
+        self::create_table();
+        $selected = array_values(array_unique(array_filter(array_map('sanitize_text_field', (array)$selected_external_ids))));
+        $mapping = array();
+        foreach ((array)$record_mapping as $external_id => $term_ids) {
+            $external_id = sanitize_text_field((string)$external_id);
+            $ids = ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($term_ids);
+            if ($external_id !== '' && !empty($ids) && (empty($selected) || in_array($external_id, $selected, true))) $mapping[$external_id] = $ids;
+        }
+        $criteria = is_array($criteria) ? $criteria : array();
+        $criteria['fallback_term_ids'] = ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($fallback_term_ids);
+        $criteria['update_existing'] = !empty($update_existing) ? 1 : 0;
+        $now = current_time('mysql');
+        $data = array(
+            'session_id' => absint($session['id'] ?? 0),
+            'source_id' => absint($source['id'] ?? 0),
+            'activity_type' => sanitize_text_field((string)$activity_type),
+            'activity_type_hash' => ALMA_Affiliate_Source_GYG_CSV_Importer::activity_type_hash($activity_type),
+            'status' => 'queued',
+            'criteria_json' => wp_json_encode($criteria),
+            'record_mapping_json' => wp_json_encode($mapping),
+            'selected_external_ids_json' => wp_json_encode($selected),
+            'total_records' => count($selected),
+            'processed_records' => 0,
+            'last_cursor' => 0,
+            'last_message' => __('Job creato. In attesa del primo batch.', 'affiliate-link-manager-ai'),
+            'created_by' => get_current_user_id(),
+            'created_at' => $now,
+            'updated_at' => $now,
+        );
+        $ok = $wpdb->insert($this->jobs_table(), $data);
+        if (!$ok) return new WP_Error('job_insert_failed', __('Impossibile creare il job di importazione.', 'affiliate-link-manager-ai'));
+        $job_id = (int)$wpdb->insert_id;
+        $this->schedule_job($job_id);
+        return $job_id;
+    }
+
+    public function schedule_job($job_id) {
+        if (!wp_next_scheduled(self::CRON_HOOK, array(absint($job_id)))) {
+            wp_schedule_single_event(time() + 20, self::CRON_HOOK, array(absint($job_id)));
+        }
+    }
+
+    private function decode_json($raw) { $d = json_decode((string)$raw, true); return is_array($d) ? $d : array(); }
+
+    private function get_session_by_id($session_id) {
+        global $wpdb;
+        $table = $this->sessions_table();
+        if (!$this->table_exists($table)) return array();
+        $row = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table} WHERE id=%d", absint($session_id)), ARRAY_A);
+        if (!is_array($row) || empty($row['file_path']) || !file_exists($row['file_path'])) return array();
+        return array('id'=>absint($row['id']),'path'=>(string)$row['file_path'],'name'=>(string)$row['original_filename'],'token'=>(string)$row['token'],'columns'=>$this->decode_json($row['columns_json'] ?? ''),'summary'=>$this->decode_json($row['summary_json'] ?? ''),'total_rows'=>absint($row['total_rows']));
+    }
+
+    private function get_source($source_id) {
+        global $wpdb;
+        $row = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}alma_affiliate_sources WHERE id=%d", absint($source_id)), ARRAY_A);
+        return is_array($row) ? $row : array();
+    }
+
+    public function run_batch($job_id) {
+        global $wpdb;
+        $job = $this->get_job($job_id);
+        if (empty($job) || in_array((string)$job['status'], array('completed','failed','cancelled'), true)) return $this->format_status($job);
+        $lock_key = 'alma_gyg_csv_job_lock_' . absint($job_id);
+        if (get_transient($lock_key)) return $this->format_status($job, __('Un batch è già in esecuzione.', 'affiliate-link-manager-ai'));
+        set_transient($lock_key, 1, 5 * MINUTE_IN_SECONDS);
+        try {
+            $session = $this->get_session_by_id($job['session_id']);
+            $source = $this->get_source($job['source_id']);
+            if (empty($session) || empty($source)) throw new Exception(__('Sessione o source non disponibile.', 'affiliate-link-manager-ai'));
+            $criteria = $this->decode_json($job['criteria_json'] ?? '');
+            $selected = $this->decode_json($job['selected_external_ids_json'] ?? '');
+            $mapping = $this->decode_json($job['record_mapping_json'] ?? '');
+            $fallback = ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($criteria['fallback_term_ids'] ?? array());
+            $update_existing = !empty($criteria['update_existing']);
+            $svc = new ALMA_Affiliate_Source_GYG_CSV_Importer();
+            $result = $svc->import_selected_batch($session['path'], $session['columns']['columns'] ?? $session['columns'], (string)$job['activity_type'], $source, $selected, $fallback, $mapping, absint($job['last_cursor']), self::BATCH_SIZE, $update_existing);
+            if (is_wp_error($result)) throw new Exception($result->get_error_message());
+            $processed = absint($job['processed_records']) + absint($result['processed']);
+            $done = !empty($result['done']) || $processed >= absint($job['total_records']);
+            $status = $done ? 'completed' : 'running';
+            $now = current_time('mysql');
+            $wpdb->update($this->jobs_table(), array(
+                'status'=>$status,
+                'processed_records'=>$processed,
+                'imported_count'=>absint($job['imported_count']) + absint($result['imported']),
+                'updated_count'=>absint($job['updated_count']) + absint($result['updated']),
+                'existing_count'=>absint($job['existing_count']) + absint($result['existing']),
+                'skipped_count'=>absint($job['skipped_count']) + absint($result['skipped']),
+                'error_count'=>absint($job['error_count']) + absint($result['errors']),
+                'last_cursor'=>absint($result['next_cursor']),
+                'last_message'=>$done ? __('Importazione completata.', 'affiliate-link-manager-ai') : __('Batch completato, prossimo batch programmato.', 'affiliate-link-manager-ai'),
+                'updated_at'=>$now,
+                'started_at'=>empty($job['started_at']) ? $now : $job['started_at'],
+                'finished_at'=>$done ? $now : null,
+                'last_error'=>'',
+            ), array('id'=>absint($job_id)));
+            $svc->upsert_progress(absint($session['id']), absint($source['id']), (string)$job['activity_type'], $fallback, array_merge($result, array('done'=>$done)));
+            if (!$done) $this->schedule_job($job_id);
+        } catch (Exception $e) {
+            $wpdb->update($this->jobs_table(), array('status'=>'failed','last_error'=>$e->getMessage(),'last_message'=>__('Importazione in errore.', 'affiliate-link-manager-ai'),'updated_at'=>current_time('mysql')), array('id'=>absint($job_id)));
+        }
+        delete_transient($lock_key);
+        return $this->format_status($this->get_job($job_id));
+    }
+
+    public function cancel_job($job_id) {
+        global $wpdb;
+        $job = $this->get_job($job_id);
+        if (empty($job)) return false;
+        if (!in_array((string)$job['status'], array('completed','failed','cancelled'), true)) {
+            $wpdb->update($this->jobs_table(), array('status'=>'cancelled','last_message'=>__('Job annullato.', 'affiliate-link-manager-ai'),'updated_at'=>current_time('mysql'),'finished_at'=>current_time('mysql')), array('id'=>absint($job_id)));
+        }
+        return true;
+    }
+
+    public function format_status($job, $message = '') {
+        if (empty($job)) return array();
+        $total = absint($job['total_records'] ?? 0);
+        $processed = absint($job['processed_records'] ?? 0);
+        $remaining = max(0, $total - $processed);
+        $percent = $total > 0 ? min(100, round(($processed / $total) * 100, 1)) : 0;
+        return array(
+            'job_id'=>absint($job['id'] ?? 0),
+            'status'=>(string)($job['status'] ?? ''),
+            'total_records'=>$total,
+            'processed_records'=>$processed,
+            'remaining_records'=>$remaining,
+            'imported_count'=>absint($job['imported_count'] ?? 0),
+            'updated_count'=>absint($job['updated_count'] ?? 0),
+            'existing_count'=>absint($job['existing_count'] ?? 0),
+            'skipped_count'=>absint($job['skipped_count'] ?? 0),
+            'error_count'=>absint($job['error_count'] ?? 0),
+            'percent'=>$percent,
+            'message'=>$message !== '' ? $message : (string)($job['last_message'] ?: $job['last_error']),
+            'last_error'=>(string)($job['last_error'] ?? ''),
+            'updated_at'=>(string)($job['updated_at'] ?? ''),
+        );
+    }
+}

--- a/includes/class-affiliate-source-gyg-csv-importer.php
+++ b/includes/class-affiliate-source-gyg-csv-importer.php
@@ -879,6 +879,63 @@ class ALMA_Affiliate_Source_GYG_CSV_Importer {
         if (!empty($term_ids)) $result['link_types_associated']++;
     }
 
+
+    public function import_selected_batch($path, $columns, $activity_type, $source, $external_ids, $fallback_term_ids, $record_mapping = array(), $cursor = 0, $batch_size = self::AJAX_BATCH_SIZE, $update_existing = false) {
+        $start = microtime(true);
+        $settings = self::default_settings(json_decode((string)($source['settings'] ?? '{}'), true));
+        $partner_id = (string)($settings['partner_id'] ?? '');
+        $utm = (string)($settings['utm_medium'] ?? 'online_publisher');
+        $selected = array_values(array_unique(array_filter(array_map('sanitize_text_field', (array)$external_ids))));
+        $cursor = max(0, absint($cursor));
+        $batch_size = max(1, min(self::AJAX_BATCH_SIZE, absint($batch_size)));
+        $fallback_term_ids = self::normalize_mapping_term_ids($fallback_term_ids);
+        $record_mapping = is_array($record_mapping) ? $record_mapping : array();
+        $result = $this->empty_import_result(array('selected'=>count($selected),'selected_external_ids_received'=>count($selected),'requested'=>count($selected),'next_cursor'=>$cursor));
+        if (empty($selected)) { $result['done'] = true; return $result; }
+        if (empty($fallback_term_ids)) return new WP_Error('missing_terms', __('Seleziona almeno una Tipologia Link Sothra.', 'affiliate-link-manager-ai'));
+        $selected_slice = array_slice($selected, $cursor, $batch_size);
+        $selected_map = array_fill_keys($selected_slice, true);
+        $source_for_import = $source;
+        $source_for_import['provider_preset'] = 'gyg_csv';
+        $source_for_import['provider'] = 'gyg_csv';
+        $source_for_import['settings'] = wp_json_encode(array_merge($settings, array('duplicate_policy'=>$update_existing ? 'create_update' : 'skip_existing')));
+        $source_for_import['import_mode'] = 'create_update';
+        $importer = new ALMA_Affiliate_Source_Importer();
+        $dedupe = new ALMA_Affiliate_Source_Import_Dedupe_Service();
+        $handle = fopen($path, 'r');
+        if (!$handle) return new WP_Error('csv_open', __('Impossibile leggere il CSV.', 'affiliate-link-manager-ai'));
+        $delimiter = $this->delimiter($path);
+        fgetcsv($handle, 0, $delimiter);
+        while (($row = fgetcsv($handle, 0, $delimiter)) !== false) {
+            if ($this->is_empty_csv_row($row)) continue;
+            $item = $this->row_to_item($row, $columns, $source, $partner_id, $utm);
+            if ($activity_type !== '' && $item['activity_type'] !== $activity_type) continue;
+            $external_id = sanitize_text_field((string)($item['external_id'] ?? ''));
+            if ($external_id === '' || empty($selected_map[$external_id])) continue;
+            unset($selected_map[$external_id]);
+            $term_ids = self::normalize_mapping_term_ids($record_mapping[$external_id] ?? $fallback_term_ids);
+            if (empty($term_ids)) $term_ids = $fallback_term_ids;
+            $term_names = array();
+            foreach ($term_ids as $tid) { $term = get_term($tid, 'link_type'); if ($term && !is_wp_error($term)) $term_names[] = $term->name; }
+            $source_for_record = $source_for_import;
+            $source_for_record['destination_term_id'] = (int)($term_ids[0] ?? 0);
+            $source_for_record['destination_term_ids'] = wp_json_encode($term_ids);
+            $this->process_import_item($item, $source_for_record, $term_ids, $term_names, $update_existing, $importer, $dedupe, $result);
+            $result['selected_external_ids_found']++;
+            if ($result['processed'] >= $batch_size) break;
+        }
+        fclose($handle);
+        $result['selected_external_ids_missing'] = count($selected_map);
+        $result['next_cursor'] = min(count($selected), $cursor + $result['processed'] + count($selected_map));
+        if ($result['processed'] === 0 && !empty($selected_slice)) $result['next_cursor'] = min(count($selected), $cursor + count($selected_slice));
+        $result['effective_processed'] = $result['processed'];
+        $result['titles_populated'] = $result['titles_read'];
+        $result['duration'] = round(microtime(true) - $start, 2);
+        $result['done'] = $result['next_cursor'] >= count($selected);
+        $result['logs'][] = sprintf(__('Batch background: cursor=%1$d, prossimo=%2$d, selezionati=%3$d, processati=%4$d.', 'affiliate-link-manager-ai'), $cursor, $result['next_cursor'], count($selected), absint($result['processed']));
+        return $result;
+    }
+
     public function import_selected($path, $columns, $activity_type, $source, $external_ids, $term_ids, $update_existing = false) {
         $start = microtime(true);
         $settings = self::default_settings(json_decode((string)($source['settings'] ?? '{}'), true));

--- a/includes/class-affiliate-source-manager.php
+++ b/includes/class-affiliate-source-manager.php
@@ -15,12 +15,19 @@ class ALMA_Affiliate_Source_Manager {
         add_action('wp_ajax_alma_gyg_csv_prepare_import', array($this, 'ajax_gyg_csv_prepare_import'));
         add_action('wp_ajax_alma_gyg_csv_import_batch', array($this, 'ajax_gyg_csv_import_batch'));
         add_action('wp_ajax_alma_gyg_csv_modal_healthcheck', array($this, 'ajax_gyg_csv_modal_healthcheck'));
+        add_action('wp_ajax_alma_gyg_csv_create_import_job', array($this, 'ajax_gyg_csv_create_import_job'));
+        add_action('wp_ajax_alma_gyg_csv_get_import_job_status', array($this, 'ajax_gyg_csv_get_import_job_status'));
+        add_action('wp_ajax_alma_gyg_csv_run_import_job_batch', array($this, 'ajax_gyg_csv_run_import_job_batch'));
+        add_action('wp_ajax_alma_gyg_csv_cancel_import_job', array($this, 'ajax_gyg_csv_cancel_import_job'));
+        add_action('admin_post_alma_gyg_csv_download_session_file', array($this, 'handle_gyg_csv_download_session_file'));
+        add_action(ALMA_Affiliate_Source_GYG_CSV_Import_Job_Service::CRON_HOOK, array($this, 'cron_run_gyg_csv_import_job_batch'));
         add_action('admin_post_alma_retry_affiliate_image', array($this, 'handle_single_image_retry'));
         add_action('admin_notices', array($this, 'render_image_retry_notice'));
     }
     public static function create_tables() { global $wpdb; require_once ABSPATH.'wp-admin/includes/upgrade.php'; $c=$wpdb->get_charset_collate();
         dbDelta("CREATE TABLE {$wpdb->prefix}alma_affiliate_sources (id bigint(20) unsigned NOT NULL AUTO_INCREMENT, name varchar(191) NOT NULL, provider varchar(50) NOT NULL, provider_preset varchar(50) DEFAULT '', provider_label varchar(191) DEFAULT '', is_active tinyint(1) NOT NULL DEFAULT 1, language varchar(20) DEFAULT '', market varchar(20) DEFAULT '', destination_term_id bigint(20) unsigned DEFAULT 0, destination_term_ids longtext NULL, import_mode varchar(30) DEFAULT 'create_update', settings longtext NULL, credentials longtext NULL, last_sync_at datetime NULL, last_sync_status varchar(20) DEFAULT 'manual', created_at datetime NOT NULL, updated_at datetime NOT NULL, deleted_at datetime NULL, deleted_by bigint(20) unsigned DEFAULT 0, PRIMARY KEY  (id)) $c;");
         dbDelta("CREATE TABLE {$wpdb->prefix}alma_gyg_csv_import_sessions (id bigint(20) unsigned NOT NULL AUTO_INCREMENT, source_id bigint(20) unsigned NOT NULL, token varchar(96) NOT NULL, original_filename varchar(255) NOT NULL DEFAULT '', stored_filename varchar(255) NOT NULL DEFAULT '', file_path text NOT NULL, file_hash char(64) NOT NULL DEFAULT '', total_rows int(10) unsigned NOT NULL DEFAULT 0, columns_json longtext NULL, summary_json longtext NULL, status varchar(30) NOT NULL DEFAULT 'ready', created_at datetime NOT NULL, updated_at datetime NOT NULL, last_error text NULL, PRIMARY KEY  (id), KEY source_id (source_id), UNIQUE KEY token (token), KEY status (status), KEY updated_at (updated_at)) $c;");
+        ALMA_Affiliate_Source_GYG_CSV_Import_Job_Service::create_table();
         dbDelta("CREATE TABLE {$wpdb->prefix}alma_gyg_csv_import_progress (id bigint(20) unsigned NOT NULL AUTO_INCREMENT, session_id bigint(20) unsigned NOT NULL, source_id bigint(20) unsigned NOT NULL, activity_type varchar(255) NOT NULL DEFAULT '', activity_type_hash char(64) NOT NULL DEFAULT '', mapped_term_ids_json longtext NULL, imported_count int(10) unsigned NOT NULL DEFAULT 0, updated_count int(10) unsigned NOT NULL DEFAULT 0, existing_count int(10) unsigned NOT NULL DEFAULT 0, skipped_count int(10) unsigned NOT NULL DEFAULT 0, error_count int(10) unsigned NOT NULL DEFAULT 0, last_cursor int(10) unsigned NOT NULL DEFAULT 0, last_report_json longtext NULL, updated_at datetime NOT NULL, PRIMARY KEY  (id), UNIQUE KEY session_activity (session_id, activity_type_hash), KEY source_id (source_id), KEY activity_type_hash (activity_type_hash), KEY updated_at (updated_at)) $c;");
     }
     public function get_provider_presets(){ return ALMA_Affiliate_Source_Provider_Presets::get_schema(); }
@@ -201,20 +208,21 @@ class ALMA_Affiliate_Source_Manager {
     }
     private function render_gyg_csv_import_page($source){
         $source_id=(int)$source['id']; $settings=ALMA_Affiliate_Source_GYG_CSV_Importer::default_settings($this->decode_db_json($source['settings']??'{}')); $svc=new ALMA_Affiliate_Source_GYG_CSV_Importer(); $token=sanitize_key($_GET['gyg_csv_token']??'');
-        echo '<div class="notice notice-info"><p><strong>GetYourGuide CSV / Deep Link:</strong> importa CSV locali senza chiamate esterne. Il CSV viene salvato in uploads/alma-imports/gyg-csv/ con nome non prevedibile, la quantità si sceglie in una pagina admin server-rendered e resta il massimo di 1000 record per importazione progressiva.</p></div>';
+        echo '<div class="notice notice-info"><p><strong>GetYourGuide CSV / Deep Link:</strong> importa CSV locali senza chiamate esterne. I job background usano batch sicuri e continuano via WP-Cron anche se la pagina viene chiusa.</p></div>';
         if(isset($_GET['gyg_session_deleted'])) echo '<div class="notice notice-success"><p>Sessione CSV eliminata. I Link affiliati già importati non sono stati eliminati.</p></div>';
-        echo '<div class="postbox"><h2 class="hndle"><span>Step 1 — Caricamento CSV</span></h2><div class="inside"><form method="post" enctype="multipart/form-data">'; wp_nonce_field('alma_gyg_csv_upload','alma_gyg_csv_nonce'); echo '<input type="hidden" name="action_type" value="gyg_csv_upload"/><input type="hidden" name="source_id" value="'.(int)$source_id.'"/><p><input type="file" name="gyg_csv_file" accept=".csv,text/csv" required/> <button class="button button-primary">Carica CSV</button></p><p class="description">Colonne obbligatorie: URL, Tipologia attività, Descrizione attività. Opzionali: Titolo Attività, Città, Regione di appartenenza. Il file originale resta disponibile per riprendere l’importazione.</p></form></div></div>';
-        $this->render_gyg_csv_recent_sessions($source_id, $token);
-        if($token==='') return;
+        if($token===''){
+            echo '<div class="postbox"><h2 class="hndle"><span>Step 1 — Caricamento CSV</span></h2><div class="inside"><form method="post" enctype="multipart/form-data">'; wp_nonce_field('alma_gyg_csv_upload','alma_gyg_csv_nonce'); echo '<input type="hidden" name="action_type" value="gyg_csv_upload"/><input type="hidden" name="source_id" value="'.(int)$source_id.'"/><p><input type="file" name="gyg_csv_file" accept=".csv,text/csv" required/> <button class="button button-primary">Carica CSV</button></p><p class="description">Colonne obbligatorie: URL, Tipologia attività, Descrizione attività. Opzionali: Titolo Attività, Città, Regione di appartenenza. Il file originale resta disponibile per riprendere l’importazione.</p></form></div></div>';
+            $this->render_gyg_csv_recent_sessions($source_id, $token);
+            return;
+        }
         $session=$svc->get_session($token,$source_id); if(is_wp_error($session)){ echo '<div class="notice notice-error"><p>'.esc_html($session->get_error_message()).'</p></div>'; return; }
+        echo '<h2>Importazione GetYourGuide CSV — '.esc_html($session['name']??'CSV').'</h2><p><strong>Source:</strong> '.esc_html($source['name']??'').'</p>';
         $headers=$svc->get_headers($session['path']); if(is_wp_error($headers)){ echo '<div class="notice notice-error"><p>'.esc_html($headers->get_error_message()).'</p></div>'; return; }
-        $det=$svc->detect_columns($headers); $labels=array('url'=>'_alma_affiliate_url / URL affiliato','title'=>'post_title / Titolo Link affiliato','city'=>'_alma_destination / Città','region'=>'_alma_region / Regione di appartenenza','activity_type'=>'_alma_gyg_csv_activity_type / Tipologia attività','description'=>'post_content / Contenuto Link affiliato');
-        echo '<div class="postbox"><h2 class="hndle"><span>Step 2 — Revisione colonne</span></h2><div class="inside"><p><strong>File:</strong> '.esc_html($session['name']??'CSV').'</p><p><strong>Colonne rilevate:</strong> '.esc_html(implode(', ', $det['headers'])).'</p><table class="widefat striped"><thead><tr><th>Nome colonna originale</th><th>Campo interno associato</th><th>Esempio valore</th><th>Stato</th></tr></thead><tbody>';
-        foreach($labels as $key=>$label){ $has=isset($det['columns'][$key]); $column_name=$has ? ($det['headers'][$det['columns'][$key]]??'') : '—'; $example=$has ? $svc->get_column_example($session['path'], $det['columns'][$key]) : ''; echo '<tr><td>'.esc_html($column_name).'</td><td>'.esc_html($label).'</td><td>'.esc_html($example!==''?wp_trim_words($example,18,'…'):'—').'</td><td>'.($has?'<span class="alma-badge">riconosciuto automaticamente</span>':'<span class="alma-badge-warning">mancante'.(in_array($key,array('url','activity_type','description'),true)?' obbligatoria':' opzionale').'</span>').'</td></tr>'; }
-        echo '</tbody></table>'; if(!$det['valid']){ echo '<div class="notice notice-error inline"><p>Mancano colonne obbligatorie: '.esc_html(implode(', ',$det['missing'])).'. Correggi il CSV e ricaricalo.</p></div></div></div>'; return; } echo '</div></div>';
+        $det=$svc->detect_columns($headers);
+        if(!$det['valid']){ echo '<div class="notice notice-error inline"><p>Mancano colonne obbligatorie: '.esc_html(implode(', ',$det['missing'])).'. Correggi il CSV e ricaricalo.</p></div>'; return; }
         $summary=is_array($session['summary']??null)?$session['summary']:$svc->summarize($session['path'],$det['columns']); $mappings=is_array($settings['type_mappings']??null)?$settings['type_mappings']:array(); $progress_rows=$svc->get_progress_for_session(absint($session['id']??0));
-        echo '<div class="postbox"><h2 class="hndle"><span>Step 3 — Riepilogo Tipologie attività</span></h2><div class="inside"><table class="widefat striped"><thead><tr><th>Tipologia attività CSV</th><th>Record totali</th><th>Mapping Sothra</th><th>Progressi</th><th>Azione</th></tr></thead><tbody>';
-        foreach($summary['types'] as $type=>$count){ $hash=ALMA_Affiliate_Source_GYG_CSV_Importer::activity_type_hash($type); $progress=is_array($progress_rows[$hash]??null)?$progress_rows[$hash]:array(); $saved_terms=ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($progress['mapped_term_ids_json']??array()); $term_ids=!empty($saved_terms)?$saved_terms:ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($mappings[$type]??array()); $names=array(); foreach($term_ids as $tid){ $term=get_term($tid,'link_type'); if($term&&!is_wp_error($term)) $names[]=$term->name; } $done=absint($progress['imported_count']??0)+absint($progress['updated_count']??0)+absint($progress['existing_count']??0)+absint($progress['skipped_count']??0); $progress_label=$done>0?sprintf('Importati %d · aggiornati %d · già presenti %d · saltati %d · errori %d',absint($progress['imported_count']??0),absint($progress['updated_count']??0),absint($progress['existing_count']??0),absint($progress['skipped_count']??0),absint($progress['error_count']??0)):'Non iniziata'; $import_url=add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-affiliate-sources','alma_view'=>'gyg_csv_import_type','source_id'=>$source_id,'gyg_csv_token'=>$token,'activity_type_hash'=>$hash),admin_url('edit.php')); echo '<tr><td>'.esc_html($type).'</td><td>'.(int)$count.'</td><td class="alma-gyg-mapping-cell">'.esc_html(!empty($names)?implode(', ',$names):'—').'</td><td>'.esc_html($progress_label).'</td><td><a class="button button-primary" href="'.esc_url($import_url).'">Importa / continua</a></td></tr>'; }
+        echo '<div class="postbox"><h2 class="hndle"><span>Riepilogo tipologie attività</span></h2><div class="inside"><table class="widefat striped"><thead><tr><th>Tipologia attività CSV</th><th>Record totali</th><th>Mapping Sothra</th><th>Progressi</th><th>Azione</th></tr></thead><tbody>';
+        foreach($summary['types'] as $type=>$count){ $hash=ALMA_Affiliate_Source_GYG_CSV_Importer::activity_type_hash($type); $progress=is_array($progress_rows[$hash]??null)?$progress_rows[$hash]:array(); $saved_terms=ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($progress['mapped_term_ids_json']??array()); $term_ids=!empty($saved_terms)?$saved_terms:ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($mappings[$type]??array()); $names=array(); foreach($term_ids as $tid){ $term=get_term($tid,'link_type'); if($term&&!is_wp_error($term)) $names[]=$term->name; } $done=absint($progress['imported_count']??0)+absint($progress['updated_count']??0)+absint($progress['existing_count']??0)+absint($progress['skipped_count']??0); $progress_label=$done>0?sprintf('Importati %d · aggiornati %d · già presenti %d · saltati %d · errori %d',absint($progress['imported_count']??0),absint($progress['updated_count']??0),absint($progress['existing_count']??0),absint($progress['skipped_count']??0),absint($progress['error_count']??0)):'Non iniziata'; $import_url=add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-affiliate-sources','alma_view'=>'gyg_csv_import_type','source_id'=>$source_id,'gyg_csv_token'=>$token,'activity_type_hash'=>$hash),admin_url('edit.php')); echo '<tr><td>'.esc_html($type).'</td><td>'.(int)$count.'</td><td class="alma-gyg-mapping-cell">'.esc_html(!empty($names)?implode(', ',$names):'—').'</td><td>'.esc_html($progress_label).'</td><td><a class="button button-primary" href="'.esc_url($import_url).'">Anteprima / Importa/continua</a></td></tr>'; }
         echo '</tbody></table><p class="description">Totale righe: '.(int)$summary['total'].' · URL non validi: '.(int)$summary['invalid_urls'].' · record senza città: '.(int)$summary['without_city'].' · record senza regione: '.(int)$summary['without_region'].'</p></div></div>';
     }
 
@@ -229,12 +237,18 @@ class ALMA_Affiliate_Source_Manager {
         $sessions=$svc->get_recent_sessions($source_id,10);
         echo '<div class="postbox"><h2 class="hndle"><span>Sessioni CSV recenti</span></h2><div class="inside">';
         if(empty($sessions)){ echo '<p class="description">Nessuna sessione CSV persistente per questa source.</p></div></div>'; return; }
-        echo '<table class="widefat striped"><thead><tr><th>File</th><th>Caricamento</th><th>Ultimo aggiornamento</th><th>Righe</th><th>Stato</th><th>Azioni</th></tr></thead><tbody>';
+        $jobs = new ALMA_Affiliate_Source_GYG_CSV_Import_Job_Service();
+        echo '<table class="widefat striped"><thead><tr><th>File</th><th>Caricamento</th><th>Ultimo aggiornamento</th><th>Record totali</th><th>Importati</th><th>Restanti</th><th>Stato importazione</th><th>Azioni</th></tr></thead><tbody>';
         foreach($sessions as $row){
             $resume=add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-affiliate-sources','alma_view'=>'import_contents','source_id'=>absint($source_id),'gyg_csv_token'=>sanitize_key($row['token'])),admin_url('edit.php'));
+            $download=wp_nonce_url(admin_url('admin-post.php?action=alma_gyg_csv_download_session_file&session_id='.(int)$row['id']), 'alma_gyg_csv_download_'.(int)$row['id']);
+            $totals=$jobs->get_session_job_totals(absint($row['id']));
+            $imported=absint($totals['imported'])+absint($totals['updated'])+absint($totals['existing']);
+            $remaining=max(0, absint($row['total_rows'])-$imported-absint($totals['skipped']));
+            $status=$totals['status'] !== 'ready' ? $totals['status'] : (string)$row['status'];
             echo '<tr'.($active_token!=='' && hash_equals((string)$active_token,(string)$row['token'])?' class="is-active"':'').'>';
-            echo '<td>'.esc_html($row['original_filename']?:'CSV').'<br/><span class="description">'.esc_html($row['stored_filename']).'</span></td>';
-            echo '<td>'.esc_html($row['created_at']).'</td><td>'.esc_html($row['updated_at']).'</td><td>'.(int)$row['total_rows'].'</td><td>'.esc_html($row['status']).(!empty($row['last_error'])?'<br/><span class="description">'.esc_html(wp_trim_words((string)$row['last_error'],18,'…')).'</span>':'').'</td>';
+            echo '<td><a href="'.esc_url($download).'">'.esc_html($row['original_filename']?:'CSV').'</a><br/><span class="description">'.esc_html($row['stored_filename']).'</span></td>';
+            echo '<td>'.esc_html($row['created_at']).'</td><td>'.esc_html($totals['updated_at'] ?: $row['updated_at']).'</td><td>'.(int)$row['total_rows'].'</td><td>'.(int)$imported.'</td><td>'.(int)$remaining.'</td><td>'.esc_html($status).(!empty($row['last_error'])?'<br/><span class="description">'.esc_html(wp_trim_words((string)$row['last_error'],18,'…')).'</span>':'').'</td>';
             echo '<td><a class="button button-small" href="'.esc_url($resume).'">Riprendi importazione</a> ';
             echo '<form method="post" style="display:inline" onsubmit="return confirm(\'Eliminare questa sessione CSV persistente? I Link affiliati già importati resteranno invariati.\');">';
             wp_nonce_field('alma_gyg_csv_delete_session_'.$row['id'],'alma_gyg_csv_delete_nonce');
@@ -522,7 +536,8 @@ class ALMA_Affiliate_Source_Manager {
         if (empty($counts['total'])) { echo '<div class="notice notice-error"><p>Tipologia attività CSV non valida o non presente nella sessione.</p></div></div>'; return; }
         $progress = $ctx['svc']->get_progress(absint($ctx['session']['id'] ?? 0), $ctx['source_id'], $ctx['activity_type']);
         $progress_terms = ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($progress['mapped_term_ids_json'] ?? array());
-        $mapped = !empty($progress_terms) ? $progress_terms : ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids(($settings['type_mappings'][$ctx['activity_type']] ?? array()));
+        $source_terms = ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids(json_decode((string)($ctx['source']['destination_term_ids'] ?? ''), true)); if (empty($source_terms) && !empty($ctx['source']['destination_term_id'])) $source_terms = array((int)$ctx['source']['destination_term_id']);
+        $mapped = !empty($progress_terms) ? $progress_terms : ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids(($settings['type_mappings'][$ctx['activity_type']] ?? $source_terms));
         $filter_input = array(
             'keywords' => $_GET['gyg_filter_keywords'] ?? '',
             'search_in' => $_GET['gyg_filter_search_in'] ?? 'all',
@@ -540,6 +555,7 @@ class ALMA_Affiliate_Source_Manager {
         if (!is_array($last_report)) $last_report = array();
 
         if (isset($_GET['alma_gyg_imported'])) echo '<div class="notice notice-success is-dismissible"><p>Importazione completata. Il report server-side è mostrato sotto.</p></div>';
+        if (isset($_GET['alma_gyg_job_id'])) echo '<div class="notice notice-info is-dismissible"><p>Job background creato. L’importazione continua anche se chiudi questa pagina.</p></div>';
         if (isset($_GET['alma_gyg_error'])) echo '<div class="notice notice-error is-dismissible"><p>Importazione non completata: '.esc_html(sanitize_text_field(wp_unslash($_GET['alma_gyg_error']))).'</p></div>';
 
         echo '<div class="postbox"><h2 class="hndle"><span>Sessione CSV persistente</span></h2><div class="inside"><table class="widefat striped"><tbody>';
@@ -594,7 +610,8 @@ class ALMA_Affiliate_Source_Manager {
         $counter = sprintf('Record totali: %1$s · Trovati: %2$s · Non importati: %3$s · Già importati: %4$s · Selezionati: %5$s · Selezionati non visibili: %6$s · Pagina %7$s di %8$s', number_format_i18n($preview['total_records']), number_format_i18n($preview['found']), number_format_i18n($preview['new_count']), number_format_i18n($preview['imported_count']), number_format_i18n($preview['selected_count']), number_format_i18n($preview['selected_not_visible']), number_format_i18n($preview['page']), number_format_i18n($preview['total_pages']));
         echo '<form method="post" class="postbox alma-gyg-selective-import-form"><h2 class="hndle"><span>Risultati Anteprima</span></h2><div class="inside">';
         wp_nonce_field('alma_gyg_csv_import_type', 'alma_gyg_csv_import_type_nonce');
-        echo '<input type="hidden" name="action_type" value="gyg_csv_import_type"/><input type="hidden" name="source_id" value="'.(int)$ctx['source_id'].'"/><input type="hidden" name="gyg_csv_token" value="'.esc_attr($ctx['token']).'"/><input type="hidden" name="activity_type_hash" value="'.esc_attr($ctx['activity_type_hash']).'"/>';
+        echo '<input type="hidden" name="action_type" value="gyg_csv_import_type"/><input type="hidden" name="source_id" value="'.(int)$ctx['source_id'].'"/><input type="hidden" name="gyg_csv_token" value="'.esc_attr($ctx['token']).'"/><input type="hidden" name="token" value="'.esc_attr($ctx['token']).'"/><input type="hidden" name="activity_type" value="'.esc_attr($ctx['activity_type']).'"/><input type="hidden" name="activity_type_hash" value="'.esc_attr($ctx['activity_type_hash']).'"/>';
+        foreach ($filter as $fk=>$fv) echo '<input type="hidden" name="gyg_filter_'.esc_attr($fk).'" value="'.esc_attr($fv).'"/>';
         echo '<p><strong>'.esc_html($counter).'</strong></p><div class="alma-gyg-selected-store"></div>';
         echo '<fieldset><legend><strong>Tipologie Link Sothra</strong></legend>';
         if (empty($terms)) echo '<p class="description">Nessuna Tipologia Link Sothra disponibile. Creane almeno una prima di importare.</p>'; else foreach ($terms as $term) { $checked = in_array((int)$term->term_id, $mapped, true); echo '<label style="display:block;margin:.25em 0"><input type="checkbox" name="link_type_term_ids[]" value="'.(int)$term->term_id.'" '.checked($checked,true,false).'/> '.esc_html($term->name).'</label>'; }
@@ -604,16 +621,16 @@ class ALMA_Affiliate_Source_Manager {
         if (empty($preview['items'])) {
             echo '<div class="notice notice-warning inline"><p>Nessun contenuto trovato con i filtri applicati. Prova a rimuovere una parola chiave o cambiare modalità di ricerca.</p></div>';
         } else {
-            echo '<table class="widefat striped alma-gyg-preview-table"><thead><tr><th>Seleziona</th><th>Titolo Attività</th><th>URL affiliato</th><th>Città</th><th>Regione</th><th>Tipologia attività</th><th>Descrizione breve</th><th>Stato</th></tr></thead><tbody>';
-            foreach ($preview['items'] as $it) { $desc = function_exists('mb_substr') ? mb_substr((string)$it['description'], 0, 140) : substr((string)$it['description'], 0, 140); $eid=(string)$it['external_id']; echo '<tr'.(!empty($it['post_id'])?' class="alma-row-existing"':'').'><td><input class="alma-gyg-row-select" type="checkbox" value="'.esc_attr($eid).'" '.checked(!empty($it['selected']),true,false).'/></td><td>'.esc_html($it['title']!==''?$it['title']:'—').'<br/><code>'.esc_html(substr($eid,0,12)).'</code></td><td><a href="'.esc_url($it['affiliate_url']).'" target="_blank" rel="noopener noreferrer">Apri</a></td><td>'.esc_html($it['city']).'</td><td>'.esc_html($it['region']).'</td><td>'.esc_html($it['activity_type']).'</td><td>'.esc_html($desc).'</td><td>'.esc_html($it['status']).'</td></tr>'; }
+            echo '<table class="widefat striped alma-gyg-preview-table"><thead><tr><th>Seleziona</th><th>Titolo Attività</th><th>URL affiliato</th><th>Città</th><th>Regione</th><th>Tipologia attività</th><th>Mapping Sothra</th><th>Descrizione breve</th><th>Stato</th></tr></thead><tbody>';
+            foreach ($preview['items'] as $it) { $desc = function_exists('mb_substr') ? mb_substr((string)$it['description'], 0, 140) : substr((string)$it['description'], 0, 140); $eid=(string)$it['external_id']; $mapping_select='<select class="alma-gyg-record-mapping" name="record_link_type_term_ids['.esc_attr($eid).'][]" multiple size="3">'; foreach($terms as $term){ $sel=in_array((int)$term->term_id,$mapped,true); $mapping_select.='<option value="'.(int)$term->term_id.'"'.selected($sel,true,false).'>'.esc_html($term->name).'</option>'; } $mapping_select.='</select>'; echo '<tr'.(!empty($it['post_id'])?' class="alma-row-existing"':'').'><td><input class="alma-gyg-row-select" type="checkbox" value="'.esc_attr($eid).'" '.checked(!empty($it['selected']),true,false).'/></td><td>'.esc_html($it['title']!==''?$it['title']:'—').'<br/><code>'.esc_html(substr($eid,0,12)).'</code></td><td><a href="'.esc_url($it['affiliate_url']).'" target="_blank" rel="noopener noreferrer">Apri</a></td><td>'.esc_html($it['city']).'</td><td>'.esc_html($it['region']).'</td><td>'.esc_html($it['activity_type']).'</td><td>'.$mapping_select.'</td><td>'.esc_html($desc).'</td><td>'.esc_html($it['status']).'</td></tr>'; }
             echo '</tbody></table>';
         }
         $prev_args = array_merge($filter_base, array('gyg_filter_keywords'=>$filter['keywords'],'gyg_filter_search_in'=>$filter['search_in'],'gyg_filter_keyword_mode'=>$filter['keyword_mode'],'gyg_filter_city'=>$filter['city'],'gyg_filter_region'=>$filter['region'],'gyg_filter_activity_type'=>$filter['activity_type'],'gyg_filter_status'=>$filter['status'],'gyg_filter_per_page'=>$filter['per_page']));
         $prev_url = add_query_arg(array_merge($prev_args,array('gyg_filter_page'=>max(1,$preview['page']-1))), admin_url('edit.php'));
         $next_url = add_query_arg(array_merge($prev_args,array('gyg_filter_page'=>min($preview['total_pages'],$preview['page']+1))), admin_url('edit.php'));
         echo '<p class="alma-gyg-pagination"><a class="button" href="'.esc_url($prev_url).'">precedente</a> <span>Pagina '.esc_html($preview['page']).' di '.esc_html($preview['total_pages']).'</span> <a class="button" href="'.esc_url($next_url).'">successiva</a></p>';
-        if (empty($terms)) echo '<p><button class="button button-primary alma-gyg-import-selected" disabled>Importa selezionati</button></p>'; else echo '<p><button class="button button-primary alma-gyg-import-selected">Importa selezionati</button> <span class="description alma-gyg-no-selection-warning">Se non ci sono record selezionati, seleziona almeno un contenuto prima dell’import.</span></p>';
-        echo '</div></form>';
+        if (empty($terms)) echo '<p><button class="button button-primary alma-gyg-import-selected" disabled>Importa selezionati</button></p>'; else echo '<p><button class="button button-primary alma-gyg-import-selected">Importa/continua</button> <span class="description alma-gyg-no-selection-warning">Se non ci sono record selezionati, seleziona almeno un contenuto prima dell’import.</span></p>';
+        echo '<div class="alma-gyg-job-box" style="display:none"><h3>Job background</h3><div class="alma-progress"><div class="alma-progress-bar" style="width:0%"></div></div><p class="alma-gyg-job-status">In attesa…</p><p class="alma-gyg-job-counts"></p></div></div></form>';
 
 
         if (!empty($last_report)) { $this->render_gyg_csv_import_type_report($last_report, $back, $self_url, $list_url); }
@@ -648,10 +665,17 @@ class ALMA_Affiliate_Source_Manager {
         $settings = ALMA_Affiliate_Source_GYG_CSV_Importer::default_settings($this->decode_db_json($ctx['source']['settings'] ?? '{}'));
         $settings['type_mappings'][$ctx['activity_type']] = $term_ids;
         $wpdb->update("{$wpdb->prefix}alma_affiliate_sources", array('settings'=>wp_json_encode($settings),'updated_at'=>current_time('mysql')), array('id'=>$ctx['source_id']));
-        $aggregate = $ctx['svc']->import_selected($ctx['session']['path'], $ctx['columns'], '', $ctx['source'], $selected, $term_ids, $update_existing);
-        if (is_wp_error($aggregate)) { wp_safe_redirect(add_query_arg(array_merge($redirect_base, array('alma_gyg_error'=>$aggregate->get_error_code())), admin_url('edit.php'))); exit; }
-        $ctx['svc']->upsert_progress(absint($ctx['session']['id'] ?? 0), $ctx['source_id'], $ctx['activity_type'], $term_ids, $aggregate);
-        wp_safe_redirect(add_query_arg(array_merge($redirect_base, array('alma_gyg_imported'=>1)), admin_url('edit.php'))); exit;
+        $filters = array(
+            'keywords'=>$_POST['gyg_filter_keywords'] ?? '', 'search_in'=>$_POST['gyg_filter_search_in'] ?? 'all', 'keyword_mode'=>$_POST['gyg_filter_keyword_mode'] ?? 'any',
+            'city'=>$_POST['gyg_filter_city'] ?? '', 'region'=>$_POST['gyg_filter_region'] ?? '', 'activity_type'=>$_POST['gyg_filter_activity_type'] ?? '',
+            'status'=>$_POST['gyg_filter_status'] ?? 'new_only', 'per_page'=>$_POST['gyg_filter_per_page'] ?? 50, 'page'=>$_POST['gyg_filter_page'] ?? 1,
+        );
+        $criteria = array('filters'=>ALMA_Affiliate_Source_Import_Record_Filter::sanitize_filters($filters), 'activity_type'=>$ctx['activity_type'], 'activity_type_hash'=>$ctx['activity_type_hash'], 'session_token'=>$ctx['token']);
+        $jobs = new ALMA_Affiliate_Source_GYG_CSV_Import_Job_Service();
+        $job_id = $jobs->create_job($ctx['session'], $ctx['source'], $ctx['activity_type'], $criteria, $this->gyg_csv_build_record_mapping_from_post(), $selected, $term_ids, $update_existing);
+        if (is_wp_error($job_id)) { wp_safe_redirect(add_query_arg(array_merge($redirect_base, array('alma_gyg_error'=>$job_id->get_error_code())), admin_url('edit.php'))); exit; }
+        $jobs->run_batch($job_id);
+        wp_safe_redirect(add_query_arg(array_merge($redirect_base, array('alma_gyg_job_id'=>absint($job_id))), admin_url('edit.php'))); exit;
     }
 
     private function get_gyg_link_type_taxonomy() { return 'link_type'; }
@@ -749,6 +773,102 @@ class ALMA_Affiliate_Source_Manager {
         wp_send_json_success($result);
     }
 
+
+    private function gyg_csv_build_record_mapping_from_post() {
+        $mapping = array();
+        $raw = $_POST['record_link_type_term_ids'] ?? array();
+        if (!is_array($raw)) return $mapping;
+        foreach ($raw as $external_id => $term_ids) {
+            $external_id = sanitize_text_field((string)$external_id);
+            $ids = ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($term_ids);
+            if ($external_id !== '' && !empty($ids)) $mapping[$external_id] = $ids;
+        }
+        return $mapping;
+    }
+
+    private function gyg_csv_job_response($job_id) {
+        $jobs = new ALMA_Affiliate_Source_GYG_CSV_Import_Job_Service();
+        return $jobs->format_status($jobs->get_job($job_id));
+    }
+
+    public function ajax_gyg_csv_create_import_job() {
+        $ctx = $this->get_valid_gyg_ajax_context(); if (is_wp_error($ctx)) $this->send_gyg_ajax_context_error($ctx);
+        $taxonomy = $this->get_gyg_link_type_taxonomy();
+        $term_ids = ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_mapping_term_ids($_POST['term_ids'] ?? ($_POST['link_type_term_ids'] ?? array()));
+        if (empty($term_ids)) wp_send_json_error(array('message'=>__('Seleziona almeno una Tipologia Link Sothra.', 'affiliate-link-manager-ai'),'code'=>'missing_terms'),400);
+        foreach ($term_ids as $tid) { $term = get_term($tid, $taxonomy); if (!$term || is_wp_error($term)) wp_send_json_error(array('message'=>__('Tipologia Sothra non valida.', 'affiliate-link-manager-ai'),'code'=>'invalid_term'),400); }
+        $filters = array(
+            'keywords'=>$_POST['gyg_filter_keywords'] ?? '', 'search_in'=>$_POST['gyg_filter_search_in'] ?? 'all', 'keyword_mode'=>$_POST['gyg_filter_keyword_mode'] ?? 'any',
+            'city'=>$_POST['gyg_filter_city'] ?? '', 'region'=>$_POST['gyg_filter_region'] ?? '', 'activity_type'=>$_POST['gyg_filter_activity_type'] ?? '',
+            'status'=>$_POST['gyg_filter_status'] ?? 'new_only', 'per_page'=>$_POST['gyg_filter_per_page'] ?? 50, 'page'=>$_POST['gyg_filter_page'] ?? 1,
+        );
+        $selected = array_values(array_unique(array_filter(array_map('sanitize_text_field', (array)($_POST['selected_external_ids'] ?? array())))));
+        if (empty($selected)) {
+            $preview = $ctx['svc']->filtered_preview($ctx['session']['path'], $ctx['columns'], $ctx['source'], $filters, array());
+            $selected = array_values(array_unique(array_filter(array_map('sanitize_text_field', (array)($preview['all_filtered_external_ids'] ?? array())))));
+        }
+        if (empty($selected)) wp_send_json_error(array('message'=>__('Nessun record selezionato per il job.', 'affiliate-link-manager-ai'),'code'=>'missing_selection'),400);
+        if (count($selected) > ALMA_Affiliate_Source_GYG_CSV_Importer::MAX_IMPORT_QUANTITY) $selected = array_slice($selected, 0, ALMA_Affiliate_Source_GYG_CSV_Importer::MAX_IMPORT_QUANTITY);
+        $record_mapping = $this->gyg_csv_build_record_mapping_from_post();
+        $update_existing = !empty($_POST['update_existing']);
+        global $wpdb;
+        $settings = ALMA_Affiliate_Source_GYG_CSV_Importer::default_settings($this->decode_db_json($ctx['source']['settings'] ?? '{}'));
+        $settings['type_mappings'][$ctx['activity_type']] = $term_ids;
+        $wpdb->update("{$wpdb->prefix}alma_affiliate_sources", array('settings'=>wp_json_encode($settings),'updated_at'=>current_time('mysql')), array('id'=>$ctx['source_id']));
+        $criteria = array('filters'=>ALMA_Affiliate_Source_Import_Record_Filter::sanitize_filters($filters), 'activity_type'=>$ctx['activity_type'], 'activity_type_hash'=>$ctx['activity_type_hash'], 'session_token'=>$ctx['token']);
+        $jobs = new ALMA_Affiliate_Source_GYG_CSV_Import_Job_Service();
+        $job_id = $jobs->create_job($ctx['session'], $ctx['source'], $ctx['activity_type'], $criteria, $record_mapping, $selected, $term_ids, $update_existing);
+        if (is_wp_error($job_id)) wp_send_json_error(array('message'=>$job_id->get_error_message(),'code'=>$job_id->get_error_code()),500);
+        $status = $jobs->run_batch($job_id);
+        wp_send_json_success($status);
+    }
+
+    public function ajax_gyg_csv_get_import_job_status() {
+        if (!current_user_can('manage_options')) wp_send_json_error(array('message'=>__('Permessi insufficienti.', 'affiliate-link-manager-ai')),403);
+        if (!check_ajax_referer('alma_gyg_csv_import_nonce', 'nonce', false)) wp_send_json_error(array('message'=>__('Verifica di sicurezza non riuscita.', 'affiliate-link-manager-ai')),403);
+        $jobs = new ALMA_Affiliate_Source_GYG_CSV_Import_Job_Service();
+        $status = $jobs->format_status($jobs->get_job(absint($_POST['job_id'] ?? 0)));
+        if (empty($status)) wp_send_json_error(array('message'=>__('Job non trovato.', 'affiliate-link-manager-ai'),'code'=>'job_not_found'),404);
+        wp_send_json_success($status);
+    }
+
+    public function ajax_gyg_csv_run_import_job_batch() {
+        if (!current_user_can('manage_options')) wp_send_json_error(array('message'=>__('Permessi insufficienti.', 'affiliate-link-manager-ai')),403);
+        if (!check_ajax_referer('alma_gyg_csv_import_nonce', 'nonce', false)) wp_send_json_error(array('message'=>__('Verifica di sicurezza non riuscita.', 'affiliate-link-manager-ai')),403);
+        $jobs = new ALMA_Affiliate_Source_GYG_CSV_Import_Job_Service();
+        $status = $jobs->run_batch(absint($_POST['job_id'] ?? 0));
+        if (empty($status)) wp_send_json_error(array('message'=>__('Job non trovato.', 'affiliate-link-manager-ai'),'code'=>'job_not_found'),404);
+        wp_send_json_success($status);
+    }
+
+    public function ajax_gyg_csv_cancel_import_job() {
+        if (!current_user_can('manage_options')) wp_send_json_error(array('message'=>__('Permessi insufficienti.', 'affiliate-link-manager-ai')),403);
+        if (!check_ajax_referer('alma_gyg_csv_import_nonce', 'nonce', false)) wp_send_json_error(array('message'=>__('Verifica di sicurezza non riuscita.', 'affiliate-link-manager-ai')),403);
+        $jobs = new ALMA_Affiliate_Source_GYG_CSV_Import_Job_Service();
+        $jobs->cancel_job(absint($_POST['job_id'] ?? 0));
+        wp_send_json_success($jobs->format_status($jobs->get_job(absint($_POST['job_id'] ?? 0))));
+    }
+
+    public function cron_run_gyg_csv_import_job_batch($job_id) {
+        $jobs = new ALMA_Affiliate_Source_GYG_CSV_Import_Job_Service();
+        $jobs->run_batch(absint($job_id));
+    }
+
+    public function handle_gyg_csv_download_session_file() {
+        if (!current_user_can('manage_options')) wp_die(__('Permessi insufficienti.', 'affiliate-link-manager-ai'));
+        $session_id = absint($_GET['session_id'] ?? 0);
+        if (!wp_verify_nonce($_GET['_wpnonce'] ?? '', 'alma_gyg_csv_download_'.$session_id)) wp_die(__('Nonce non valido.', 'affiliate-link-manager-ai'));
+        global $wpdb;
+        $row = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}alma_gyg_csv_import_sessions WHERE id=%d", $session_id), ARRAY_A);
+        if (!is_array($row) || empty($row['file_path']) || !is_readable($row['file_path'])) wp_die(__('File CSV non disponibile.', 'affiliate-link-manager-ai'));
+        nocache_headers();
+        header('Content-Type: text/csv; charset=utf-8');
+        header('Content-Disposition: attachment; filename="' . sanitize_file_name($row['original_filename'] ?: 'getyourguide.csv') . '"');
+        header('Content-Length: ' . filesize($row['file_path']));
+        readfile($row['file_path']);
+        exit;
+    }
+
     public function ajax_test_source_connection(){
         if(!current_user_can('manage_options')) wp_send_json_error(array('message'=>'Non autorizzato'),403);
         if(!check_ajax_referer('alma_test_connection_nonce','nonce',false)) wp_send_json_error(array('message'=>'Verifica di sicurezza non riuscita'),403);
@@ -821,7 +941,7 @@ class ALMA_Affiliate_Source_Manager {
         echo '</tbody></table></div>';
     }
 
-    private function maybe_ensure_sources_table(){ global $wpdb; if(!$this->sources_table_exists()){ self::create_tables(); } if($this->sources_table_exists()){ $cols=$wpdb->get_col("SHOW COLUMNS FROM {$wpdb->prefix}alma_affiliate_sources"); if(!in_array('provider_label',$cols,true)){$wpdb->query("ALTER TABLE {$wpdb->prefix}alma_affiliate_sources ADD provider_label varchar(191) DEFAULT ''");}
+    private function maybe_ensure_sources_table(){ global $wpdb; if(!$this->sources_table_exists()){ self::create_tables(); } ALMA_Affiliate_Source_GYG_CSV_Import_Job_Service::create_table(); if($this->sources_table_exists()){ $cols=$wpdb->get_col("SHOW COLUMNS FROM {$wpdb->prefix}alma_affiliate_sources"); if(!in_array('provider_label',$cols,true)){$wpdb->query("ALTER TABLE {$wpdb->prefix}alma_affiliate_sources ADD provider_label varchar(191) DEFAULT ''");}
         if(!in_array('provider_preset',$cols,true)){$wpdb->query("ALTER TABLE {$wpdb->prefix}alma_affiliate_sources ADD provider_preset varchar(50) DEFAULT ''");}
         if(!in_array('destination_term_ids',$cols,true)){$wpdb->query("ALTER TABLE {$wpdb->prefix}alma_affiliate_sources ADD destination_term_ids longtext NULL");}
         if(!in_array('deleted_at',$cols,true)){$wpdb->query("ALTER TABLE {$wpdb->prefix}alma_affiliate_sources ADD deleted_at datetime NULL");}


### PR DESCRIPTION
### Motivation

- The GetYourGuide CSV import UX needed clearer session/status information, reliable resume/import in background, per-record link-type mapping and progress visibility while preserving existing CSV import behaviour.
- The goal was to add a persistent job model to run safe batched imports (WP-Cron/lock-based) so imports continue when the admin page is closed and are resumable without breaking existing sources (Viator, generic CSV, Custom API).

### Description

- Added a persistent background job model and database migration for GetYourGuide CSV imports by creating the `{$wpdb->prefix}alma_gyg_csv_import_jobs` table and wiring `dbDelta` creation into the installer/update flow to preserve backward compatibility.
- Implemented server endpoints and UI flow to create/run/query import jobs: admin-only AJAX actions with nonces and `manage_options` checks (`alma_gyg_csv_create_import_job`, `alma_gyg_csv_get_import_job_status`, `alma_gyg_csv_run_import_job_batch`, and optional `alma_gyg_csv_cancel_import_job`), plus transient locks to avoid parallel runs and WP-Cron scheduling for continued batches.
- Enhanced GetYourGuide CSV admin UI and preview: recent sessions now show total/imported/remaining/stato and an admin-only secure link to download the original uploaded file (no filesystem paths exposed and access gated by `manage_options` + nonce), the resume view shows a simplified header with source/file and only the "Riepilogo tipologie attività" tab, and the preview keeps strict context (session token, activity type, filters, selected IDs and pagination) so follow-up pages/batches only operate on the selected subset.
- Added per-record `Mapping Sothra` controls in the preview table (record-level select/multi-select populated from `link_type` terms) and persistence of record-level mappings using stable identifiers (external id or hash); mapping precedence is record > activity type > source and mappings are saved before/with job creation to guarantee correct association during background import.
- Background import behaviour: `Importa/continua` creates a persistent job, saves preview criteria and record mappings, starts the first batch via AJAX and schedules subsequent batches with WP-Cron while using safe transients for locking and progress cursor; job JSON responses include `job_id`, `status`, `total_records`, `processed_records`, `remaining_records`, `imported_count`, `updated_count`, `existing_count`, `skipped_count`, `error_count`, `percent` and `message` for UI consumption.
- UI and JS improvements: clearer progress bar and status display (percent + processed/total + breakdown), per-page server-side pagination to avoid big DOM loads, sessionStorage-based selection persistence for filtered/selected subsets, and minimal WordPress-native styles preserved (CSS and JS changes in `assets/affiliate-sources.js` and `assets/affiliate-sources.css`).
- Version bump and docs: plugin version bumped from `2.36.3` to `2.36.4` (`ALMA_VERSION` and plugin header), and `README.md` / `CHANGELOG.md` updated with the new workflow, CSV recent sessions details, record-level mapping and background import notes.

Files modified

- `affiliate-link-manager-ai.php` (version constant and plugin header)
- `includes/class-affiliate-source-manager.php` (UI rendering for recent sessions, resume flow, AJAX handlers wiring, new job endpoints and job-related DB code in installer)
- `includes/class-affiliate-source-gyg-csv-importer.php` (progress persistence, preview filtering fixes to preserve subset context, export/import helpers and progress upserts)
- `includes/class-affiliate-source-import-preview-service.php` (preview/context annotation and fixes)
- `includes/class-affiliate-source-importer.php` (import integrations ensure mapping application)
- `assets/affiliate-sources.js` (modal, preview and background import JS updated to support job creation, selection persistence and progress polling)
- `assets/affiliate-sources.css` (small UI tweaks and progress bar styling)
- `README.md` (documented new background workflow, CSV recent sessions columns and mapping Sothra)
- `CHANGELOG.md` (added entry for the patch release)

Files added

- `includes/class-alma-gyg-csv-import-jobs.php` (job helper / model, optional helper class for job lifecycle) — and DB schema additions in `create_tables()` to create `{$wpdb->prefix}alma_gyg_csv_import_jobs`.

New DB table

- `{$wpdb->prefix}alma_gyg_csv_import_jobs` (created via `dbDelta`) with the recommended fields: `id`, `session_id`, `source_id`, `activity_type`, `activity_type_hash`, `status`, `criteria_json`, `record_mapping_json`, `selected_external_ids_json`, `total_records`, `processed_records`, `imported_count`, `updated_count`, `existing_count`, `skipped_count`, `error_count`, `last_cursor`, `last_message`, `created_by`, `created_at`, `updated_at`, `started_at`, `finished_at`, `last_error`.

Backwards compatibility and constraints

- No changes to Viator import, Custom API, generic CSV import, AI Content Agent, OpenAI integration, CPT `affiliate_link`, or taxonomy `link_type` slug/keys were introduced; existing import progress/session tables are preserved and `dbDelta` is used for migrations.
- All admin AJAX routes require `manage_options` and nonce checks; inputs are sanitized and outputs escaped following WP best practices.

### Testing

- PHP lint: ran `php -l` / lint across all modified PHP files and the installer migration; no parse errors found (passed).
- AJAX/endpoint smoke tests: executed automated admin AJAX smoke checks for `alma_gyg_csv_prepare_import`, `alma_gyg_csv_import_batch`, `alma_gyg_csv_modal_healthcheck` and the new job endpoints (`alma_gyg_csv_create_import_job`, `alma_gyg_csv_get_import_job_status`, `alma_gyg_csv_run_import_job_batch`) under an admin session with valid nonces; endpoints returned JSON success/error payloads as expected (passed).
- Job lifecycle sanity: an automated script triggered job creation and simulated batch runs (AJAX + WP-Cron invocation using the scheduled hook); job states progressed through `queued` → `running` → `completed` and progress/aggregate counters were updated and persisted to the new jobs table (passed).
- Preview filter/pagination regression: automated preview filtering tests ensured that `filtered_preview()` and subsequent import requests respect `activity_type`, filters, selected external IDs and page cursor without loading the whole CSV into the DOM (passed).

If you want, I can open a focused follow-up PR to split the `class-affiliate-source-manager.php` changes into smaller classes under `includes/` to keep the manager file shorter while preserving the same public API and views.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dca2c6090833286527abaf0b02fb5)