### PR TITLE
Improve AI widget layout previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 - Convertiti i log diretti più sensibili nelle aree OpenAI, AI draft builder, import GetYourGuide CSV, media index e internal link index in diagnostica controllata tramite logger.
 - I log `debug` rispettano `WP_DEBUG`; nessun segreto viene salvato in database e non cambiano UI, schema DB, payload OpenAI o flussi di import.
 
+## 2.37.0 - 2026-06-05
+- Aggiunta la sezione visuale **Scegli layout widget** nelle pagine **Crea Widget AI** e **Modifica Widget**, con sei preset selezionabili e miniature SVG locali negli asset del plugin.
+- I preset aggiornano i campi esistenti per colonne desktop/mobile e visibilità di immagine, titolo, contenuto e pulsante, mantenendo i controlli tecnici come opzioni avanzate.
+- Introdotto il campo opzionale `layout_preset` nelle istanze widget, con deduzione automatica del layout più vicino per widget legacy privi del nuovo campo.
+- La pagina **Shortcode Widget AI** mostra il layout usato tramite una nuova colonna/badge, senza modificare il rendering frontend o gli shortcode esistenti.
+- Versione plugin aggiornata a `2.37.0`.
+
 ## 2.36.6 - 2026-06-03
 - Corretto il rendering duplicato delle progress bar GetYourGuide CSV, limitando il markup alla sola colonna **Progressi** della riga tipologia attività.
 - Tradotto lo stato tecnico `not_started` in **Non importato** nel render PHP e negli aggiornamenti AJAX.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Redazione automatica applicata ai log:
 - Parametri token noti negli URL (`token`, `access_token`, `refresh_token`, `api_key`, `key`, `signature`, `client_secret`).
 - Payload/prompt/body OpenAI lunghi e risposte AI grezze lunghe, incluse risposte AI annidate, troncati prima della scrittura nel log.
 
+## 2.37.0 - 2026-06-05
+- Aggiunta la sezione visuale **Scegli layout widget** nelle pagine **Crea Widget AI** e **Modifica Widget**, con sei preset selezionabili e miniature SVG locali negli asset del plugin.
+- I preset aggiornano i campi esistenti per colonne desktop/mobile e visibilità di immagine, titolo, contenuto e pulsante, mantenendo i controlli tecnici come opzioni avanzate.
+- Introdotto il campo opzionale `layout_preset` nelle istanze widget, con deduzione automatica del layout più vicino per widget legacy privi del nuovo campo.
+- La pagina **Shortcode Widget AI** mostra il layout usato tramite una nuova colonna/badge, senza modificare il rendering frontend o gli shortcode esistenti.
+- Versione plugin aggiornata a `2.37.0`.
+
 ## 2.36.6 - 2026-06-03
 - Corretto il rendering duplicato delle progress bar GetYourGuide CSV, ora visibili solo nella colonna **Progressi** della tabella riepilogo tipologie attività.
 - Lo stato iniziale `not_started` viene mostrato come **Non importato** anche durante polling AJAX e ricarica pagina.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.36.6
+ * Version: 2.37.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.36.6');
+define('ALMA_VERSION', '2.37.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -1554,6 +1554,193 @@ class AffiliateManagerAI {
         <?php
     }
 
+
+    /**
+     * Restituisce i preset visuali disponibili per i widget AI.
+     */
+    private function get_widget_layout_presets() {
+        return array(
+            'vertical_single' => array(
+                'label'          => __('Card verticale singola', 'affiliate-link-manager-ai'),
+                'description'    => __('Una card ampia per dare risalto a un link alla volta.', 'affiliate-link-manager-ai'),
+                'image'          => 'layout-card-vertical-single.svg',
+                'desktop'        => 1,
+                'mobile'         => 1,
+                'show_image'     => 1,
+                'show_title'     => 1,
+                'show_content'   => 1,
+                'show_button'    => 0,
+            ),
+            'grid_two' => array(
+                'label'          => __('Griglia 2 colonne', 'affiliate-link-manager-ai'),
+                'description'    => __('Mostra due card affiancate su desktop, ideale per confronti semplici.', 'affiliate-link-manager-ai'),
+                'image'          => 'layout-grid-2-columns.svg',
+                'desktop'        => 2,
+                'mobile'         => 1,
+                'show_image'     => 1,
+                'show_title'     => 1,
+                'show_content'   => 1,
+                'show_button'    => 0,
+            ),
+            'grid_three' => array(
+                'label'          => __('Griglia 3 colonne', 'affiliate-link-manager-ai'),
+                'description'    => __('Compatta più suggerimenti nella stessa riga su schermi grandi.', 'affiliate-link-manager-ai'),
+                'image'          => 'layout-grid-3-columns.svg',
+                'desktop'        => 3,
+                'mobile'         => 1,
+                'show_image'     => 1,
+                'show_title'     => 1,
+                'show_content'   => 1,
+                'show_button'    => 0,
+            ),
+            'compact_list' => array(
+                'label'          => __('Lista compatta', 'affiliate-link-manager-ai'),
+                'description'    => __('Elenco essenziale e veloce da leggere, senza immagini o testo lungo.', 'affiliate-link-manager-ai'),
+                'image'          => 'layout-compact-list.svg',
+                'desktop'        => 1,
+                'mobile'         => 1,
+                'show_image'     => 0,
+                'show_title'     => 1,
+                'show_content'   => 0,
+                'show_button'    => 0,
+            ),
+            'cta_button' => array(
+                'label'          => __('Card CTA con pulsante', 'affiliate-link-manager-ai'),
+                'description'    => __('Card completa con pulsante ben visibile per aumentare i clic.', 'affiliate-link-manager-ai'),
+                'image'          => 'layout-card-cta-button.svg',
+                'desktop'        => 1,
+                'mobile'         => 1,
+                'show_image'     => 1,
+                'show_title'     => 1,
+                'show_content'   => 1,
+                'show_button'    => 1,
+            ),
+            'mobile_first' => array(
+                'label'          => __('Mobile first', 'affiliate-link-manager-ai'),
+                'description'    => __('Layout pensato per smartphone, con due elementi per riga quando lo spazio lo consente.', 'affiliate-link-manager-ai'),
+                'image'          => 'layout-mobile-first.svg',
+                'desktop'        => 2,
+                'mobile'         => 2,
+                'show_image'     => 1,
+                'show_title'     => 1,
+                'show_content'   => 0,
+                'show_button'    => 1,
+            ),
+        );
+    }
+
+    /**
+     * Sanitizza il preset layout opzionale salvato nell'istanza widget.
+     */
+    private function sanitize_widget_layout_preset($layout_preset) {
+        $layout_preset = sanitize_key($layout_preset);
+        $presets = $this->get_widget_layout_presets();
+
+        return isset($presets[$layout_preset]) ? $layout_preset : '';
+    }
+
+    /**
+     * Deduce il preset più vicino per widget legacy privi di layout_preset.
+     */
+    private function infer_widget_layout_preset($instance) {
+        $desktop     = isset($instance['template_desktop_columns']) ? (int) $instance['template_desktop_columns'] : 1;
+        $mobile      = isset($instance['template_mobile_columns']) ? (int) $instance['template_mobile_columns'] : 1;
+        $show_image  = !empty($instance['show_image']);
+        $show_content = !empty($instance['show_content']);
+        $show_button = !empty($instance['show_button']);
+
+        if ($mobile >= 2) {
+            return 'mobile_first';
+        }
+
+        if (!$show_image && !$show_content) {
+            return 'compact_list';
+        }
+
+        if ($show_button && $desktop <= 1) {
+            return 'cta_button';
+        }
+
+        if ($desktop >= 3) {
+            return 'grid_three';
+        }
+
+        if ($desktop === 2) {
+            return 'grid_two';
+        }
+
+        return 'vertical_single';
+    }
+
+    /**
+     * Restituisce il preset salvato o, per i widget legacy, quello dedotto dai campi esistenti.
+     */
+    private function get_widget_layout_preset_for_instance($instance) {
+        $saved = $this->sanitize_widget_layout_preset($instance['layout_preset'] ?? '');
+
+        return $saved ? $saved : $this->infer_widget_layout_preset($instance);
+    }
+
+    /**
+     * Nome leggibile del layout widget per le tabelle admin.
+     */
+    private function get_widget_layout_label($layout_preset) {
+        $presets = $this->get_widget_layout_presets();
+        $layout_preset = $this->sanitize_widget_layout_preset($layout_preset);
+
+        return $layout_preset && isset($presets[$layout_preset]) ? $presets[$layout_preset]['label'] : __('Layout automatico', 'affiliate-link-manager-ai');
+    }
+
+    /**
+     * Renderizza la selezione visuale dei layout widget.
+     */
+    private function render_widget_layout_preset_field($selected_layout) {
+        $presets = $this->get_widget_layout_presets();
+        $selected_layout = $this->sanitize_widget_layout_preset($selected_layout);
+        if (!$selected_layout) {
+            $selected_layout = 'vertical_single';
+        }
+        ?>
+        <tr>
+            <th scope="row"><?php _e('Scegli layout widget', 'affiliate-link-manager-ai'); ?></th>
+            <td>
+                <fieldset class="alma-layout-picker" aria-describedby="alma-layout-picker-description">
+                    <legend class="screen-reader-text"><span><?php _e('Scegli layout widget', 'affiliate-link-manager-ai'); ?></span></legend>
+                    <p id="alma-layout-picker-description" class="description alma-layout-picker__intro">
+                        <?php _e('Seleziona l’aspetto più adatto: i campi avanzati sotto verranno aggiornati automaticamente e potrai comunque modificarli.', 'affiliate-link-manager-ai'); ?>
+                    </p>
+                    <div class="alma-layout-grid">
+                        <?php foreach ($presets as $slug => $preset) :
+                            $input_id = 'alma_layout_preset_' . $slug;
+                            ?>
+                            <label class="alma-layout-card" for="<?php echo esc_attr($input_id); ?>">
+                                <input
+                                    type="radio"
+                                    id="<?php echo esc_attr($input_id); ?>"
+                                    name="layout_preset"
+                                    value="<?php echo esc_attr($slug); ?>"
+                                    data-desktop-columns="<?php echo esc_attr($preset['desktop']); ?>"
+                                    data-mobile-columns="<?php echo esc_attr($preset['mobile']); ?>"
+                                    data-show-image="<?php echo esc_attr($preset['show_image']); ?>"
+                                    data-show-title="<?php echo esc_attr($preset['show_title']); ?>"
+                                    data-show-content="<?php echo esc_attr($preset['show_content']); ?>"
+                                    data-show-button="<?php echo esc_attr($preset['show_button']); ?>"
+                                    <?php checked($selected_layout, $slug); ?>
+                                >
+                                <span class="alma-layout-card__visual">
+                                    <img src="<?php echo esc_url(ALMA_PLUGIN_URL . 'assets/' . $preset['image']); ?>" alt="<?php echo esc_attr(sprintf(__('Anteprima layout: %s', 'affiliate-link-manager-ai'), $preset['label'])); ?>" loading="lazy">
+                                </span>
+                                <span class="alma-layout-card__name"><?php echo esc_html($preset['label']); ?></span>
+                                <span class="alma-layout-card__description"><?php echo esc_html($preset['description']); ?></span>
+                            </label>
+                        <?php endforeach; ?>
+                    </div>
+                </fieldset>
+            </td>
+        </tr>
+        <?php
+    }
+
     /**
      * Pagina creazione widget
      */
@@ -1584,6 +1771,7 @@ class AffiliateManagerAI {
             'button_text'  => '',
             'template_desktop_columns' => 1,
             'template_mobile_columns'  => 1,
+            'layout_preset' => 'vertical_single',
             'links'        => array(),
             'manual_ids'   => array(),
         );
@@ -1598,6 +1786,12 @@ class AffiliateManagerAI {
             $instance['show_content'] = !empty($_POST['show_content']) ? 1 : 0;
             $instance['show_button']  = !empty($_POST['show_button']) ? 1 : 0;
             $instance['button_text']  = sanitize_text_field($_POST['button_text'] ?? '');
+            $layout_preset = $this->sanitize_widget_layout_preset($_POST['layout_preset'] ?? '');
+            if ($layout_preset) {
+                $instance['layout_preset'] = $layout_preset;
+            } else {
+                unset($instance['layout_preset']);
+            }
             $desktop_columns = isset($_POST['template_desktop_columns']) ? intval($_POST['template_desktop_columns']) : 1;
             if ($desktop_columns < 1 || $desktop_columns > 6) {
                 $desktop_columns = 1;
@@ -1744,6 +1938,7 @@ class AffiliateManagerAI {
                             <th scope="row"><label for="alma_widget_content"><?php _e('Contenuto', 'affiliate-link-manager-ai'); ?></label></th>
                             <td><textarea name="custom_content" id="alma_widget_content" rows="4" class="large-text code"><?php echo esc_textarea($instance['custom_content']); ?></textarea></td>
                         </tr>
+                        <?php $this->render_widget_layout_preset_field($this->get_widget_layout_preset_for_instance($instance)); ?>
                         <tr>
                             <th scope="row"><?php _e('Opzioni', 'affiliate-link-manager-ai'); ?></th>
                             <td>
@@ -1758,10 +1953,10 @@ class AffiliateManagerAI {
                             <td><input name="button_text" type="text" id="alma_widget_button_text" value="<?php echo esc_attr($instance['button_text']); ?>" class="regular-text"></td>
                         </tr>
                         <tr>
-                            <th scope="row" class="alma-required"><label for="alma_widget_template_desktop"><?php _e('Template Widget', 'affiliate-link-manager-ai'); ?></label></th>
+                            <th scope="row" class="alma-required"><label for="alma_widget_template_desktop"><?php _e('Controlli avanzati layout', 'affiliate-link-manager-ai'); ?></label></th>
                             <td>
                                 <fieldset>
-                                    <legend class="screen-reader-text"><span><?php _e('Template Widget', 'affiliate-link-manager-ai'); ?></span></legend>
+                                    <legend class="screen-reader-text"><span><?php _e('Controlli avanzati layout', 'affiliate-link-manager-ai'); ?></span></legend>
                                     <label for="alma_widget_template_desktop"><?php _e('Link per riga (Desktop)', 'affiliate-link-manager-ai'); ?></label>
                                     <select name="template_desktop_columns" id="alma_widget_template_desktop" class="alma-required-field" required>
                                         <?php for ($i = 1; $i <= 6; $i++) : ?>
@@ -1775,7 +1970,7 @@ class AffiliateManagerAI {
                                             <option value="<?php echo esc_attr($i); ?>" <?php selected((int) $instance['template_mobile_columns'], $i); ?>><?php echo esc_html($i); ?></option>
                                         <?php endfor; ?>
                                     </select>
-                                    <p class="description"><?php _e('Imposta il numero di link da mostrare per riga su desktop e smartphone.', 'affiliate-link-manager-ai'); ?></p>
+                                    <p class="description"><?php _e('Controlli opzionali per utenti esperti: modificano quante card vengono mostrate per riga su desktop e smartphone.', 'affiliate-link-manager-ai'); ?></p>
                                 </fieldset>
                             </td>
                         </tr>
@@ -1871,6 +2066,7 @@ class AffiliateManagerAI {
             'button_text'    => '',
             'template_desktop_columns' => 1,
             'template_mobile_columns'  => 1,
+            'layout_preset' => '',
         );
         if (!array_key_exists('template_desktop_columns', $instances[$widget_id])) {
             if (!empty($instance['format']) && $instance['format'] === 'small') {
@@ -1901,6 +2097,12 @@ class AffiliateManagerAI {
             $instance['show_content'] = !empty($_POST['show_content']) ? 1 : 0;
             $instance['show_button']  = !empty($_POST['show_button']) ? 1 : 0;
             $instance['button_text']  = sanitize_text_field($_POST['button_text'] ?? '');
+            $layout_preset = $this->sanitize_widget_layout_preset($_POST['layout_preset'] ?? '');
+            if ($layout_preset) {
+                $instance['layout_preset'] = $layout_preset;
+            } else {
+                unset($instance['layout_preset']);
+            }
             $desktop_columns = isset($_POST['template_desktop_columns']) ? intval($_POST['template_desktop_columns']) : (int) ($instance['template_desktop_columns'] ?? 1);
             if ($desktop_columns < 1 || $desktop_columns > 6) {
                 $desktop_columns = 1;
@@ -1988,6 +2190,7 @@ class AffiliateManagerAI {
                             <th scope="row"><label for="alma_widget_content"><?php _e('Contenuto', 'affiliate-link-manager-ai'); ?></label></th>
                             <td><textarea name="custom_content" id="alma_widget_content" rows="4" class="large-text code"><?php echo esc_textarea($instance['custom_content']); ?></textarea></td>
                         </tr>
+                        <?php $this->render_widget_layout_preset_field($this->get_widget_layout_preset_for_instance($instance)); ?>
                         <tr>
                             <th scope="row"><?php _e('Opzioni', 'affiliate-link-manager-ai'); ?></th>
                             <td>
@@ -2002,10 +2205,10 @@ class AffiliateManagerAI {
                             <td><input name="button_text" type="text" id="alma_widget_button_text" value="<?php echo esc_attr($instance['button_text']); ?>" class="regular-text"></td>
                         </tr>
                         <tr>
-                            <th scope="row"><label for="alma_widget_template_desktop"><?php _e('Template Widget', 'affiliate-link-manager-ai'); ?></label></th>
+                            <th scope="row"><label for="alma_widget_template_desktop"><?php _e('Controlli avanzati layout', 'affiliate-link-manager-ai'); ?></label></th>
                             <td>
                                 <fieldset>
-                                    <legend class="screen-reader-text"><span><?php _e('Template Widget', 'affiliate-link-manager-ai'); ?></span></legend>
+                                    <legend class="screen-reader-text"><span><?php _e('Controlli avanzati layout', 'affiliate-link-manager-ai'); ?></span></legend>
                                     <label for="alma_widget_template_desktop"><?php _e('Link per riga (Desktop)', 'affiliate-link-manager-ai'); ?></label>
                                     <select name="template_desktop_columns" id="alma_widget_template_desktop">
                                         <?php for ($i = 1; $i <= 6; $i++) : ?>
@@ -2019,7 +2222,7 @@ class AffiliateManagerAI {
                                             <option value="<?php echo esc_attr($i); ?>" <?php selected((int) $instance['template_mobile_columns'], $i); ?>><?php echo esc_html($i); ?></option>
                                         <?php endfor; ?>
                                     </select>
-                                    <p class="description"><?php _e('Imposta il numero di link da mostrare per riga su desktop e smartphone.', 'affiliate-link-manager-ai'); ?></p>
+                                    <p class="description"><?php _e('Controlli opzionali per utenti esperti: modificano quante card vengono mostrate per riga su desktop e smartphone.', 'affiliate-link-manager-ai'); ?></p>
                                 </fieldset>
                             </td>
                         </tr>
@@ -2110,6 +2313,7 @@ class AffiliateManagerAI {
                             <th><?php _e('ID Widget', 'affiliate-link-manager-ai'); ?></th>
                             <th><?php _e('Titolo', 'affiliate-link-manager-ai'); ?></th>
                             <th><?php _e('Creato il', 'affiliate-link-manager-ai'); ?></th>
+                            <th><?php _e('Layout', 'affiliate-link-manager-ai'); ?></th>
                             <th><?php _e('Shortcode', 'affiliate-link-manager-ai'); ?></th>
                             <th><?php _e('Azioni', 'affiliate-link-manager-ai'); ?></th>
                         </tr>
@@ -2123,11 +2327,13 @@ class AffiliateManagerAI {
                             $shortcode    = '[affiliate_links_widget id="' . $id . '"]';
                             $created_at   = $instance['created_at'] ?? '';
                             $created_disp = $created_at ? mysql2date(get_option('date_format'), $created_at) : '-';
+                            $layout_label = $this->get_widget_layout_label($this->get_widget_layout_preset_for_instance($instance));
                         ?>
                         <tr>
                             <td><?php echo esc_html($id); ?></td>
                             <td><?php echo esc_html($title); ?></td>
                             <td><?php echo esc_html($created_disp); ?></td>
+                            <td><span class="alma-layout-badge"><?php echo esc_html($layout_label); ?></span></td>
                             <td><code><?php echo esc_html($shortcode); ?></code></td>
                             <td>
                                 <a href="<?php echo esc_url(admin_url('admin.php?page=alma-edit-widget&widget_id=' . $id)); ?>"><?php _e('Modifica', 'affiliate-link-manager-ai'); ?></a> |

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -1129,3 +1129,97 @@ button:disabled {
         width: 100%;
     }
 }
+
+/* ===== AI Widget layout picker ===== */
+.alma-layout-picker__intro {
+    margin: 0 0 12px;
+    max-width: 760px;
+}
+
+.alma-layout-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+    gap: 14px;
+    max-width: 1100px;
+}
+
+.alma-layout-card {
+    position: relative;
+    display: block;
+    margin: 0;
+    padding: 12px;
+    border: 1px solid #c3c4c7;
+    border-radius: 4px;
+    background: #fff;
+    color: #1d2327;
+    cursor: pointer;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.alma-layout-card:hover,
+.alma-layout-card:focus-within {
+    border-color: #2271b1;
+    box-shadow: 0 0 0 1px #2271b1;
+}
+
+.alma-layout-card:focus-within {
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
+}
+
+.alma-layout-card input[type="radio"] {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    z-index: 1;
+    margin: 0;
+}
+
+.alma-layout-card:has(input[type="radio"]:checked) {
+    border-color: #2271b1;
+    box-shadow: 0 0 0 2px #2271b1;
+    background: #f0f6fc;
+}
+
+.alma-layout-card__visual {
+    display: block;
+    margin-bottom: 10px;
+    padding: 8px;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    background: #f6f7f7;
+}
+
+.alma-layout-card__visual img {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.alma-layout-card__name,
+.alma-layout-card__description {
+    display: block;
+    padding-left: 26px;
+}
+
+.alma-layout-card__name {
+    margin-bottom: 4px;
+    font-weight: 600;
+}
+
+.alma-layout-card__description {
+    color: #646970;
+    font-size: 13px;
+    line-height: 1.4;
+}
+
+.alma-layout-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border: 1px solid #c3c4c7;
+    border-radius: 999px;
+    background: #f6f7f7;
+    color: #1d2327;
+    font-size: 12px;
+    line-height: 1.6;
+}

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -24,4 +24,94 @@
     promptTextarea.addEventListener('input', syncPrompt);
     promptTextarea.addEventListener('change', syncPrompt);
   }
+
+  var layoutPickers = document.querySelectorAll('.alma-layout-picker');
+
+  if (!layoutPickers.length) {
+    return;
+  }
+
+  var setCheckboxValue = function (form, name, value) {
+    var field = form.querySelector('input[name="' + name + '"]');
+
+    if (field) {
+      field.checked = value === '1';
+    }
+  };
+
+  var setSelectValue = function (form, name, value) {
+    var field = form.querySelector('select[name="' + name + '"]');
+
+    if (field) {
+      field.value = value;
+    }
+  };
+
+  var getFieldCheckedValue = function (form, name) {
+    var field = form.querySelector('input[name="' + name + '"]');
+
+    return field && field.checked ? '1' : '0';
+  };
+
+  var syncLayoutPreset = function (input) {
+    var form = input.form;
+
+    if (!form) {
+      return;
+    }
+
+    setSelectValue(form, 'template_desktop_columns', input.dataset.desktopColumns || '1');
+    setSelectValue(form, 'template_mobile_columns', input.dataset.mobileColumns || '1');
+    setCheckboxValue(form, 'show_image', input.dataset.showImage || '0');
+    setCheckboxValue(form, 'show_title', input.dataset.showTitle || '0');
+    setCheckboxValue(form, 'show_content', input.dataset.showContent || '0');
+    setCheckboxValue(form, 'show_button', input.dataset.showButton || '0');
+  };
+
+  var syncPresetFromAdvancedFields = function (form) {
+    var selectedPreset = null;
+    var presets = form.querySelectorAll('input[name="layout_preset"]');
+    var desktopColumns = form.querySelector('select[name="template_desktop_columns"]');
+    var mobileColumns = form.querySelector('select[name="template_mobile_columns"]');
+
+    presets.forEach(function (preset) {
+      var matches = desktopColumns && mobileColumns &&
+        preset.dataset.desktopColumns === desktopColumns.value &&
+        preset.dataset.mobileColumns === mobileColumns.value &&
+        preset.dataset.showImage === getFieldCheckedValue(form, 'show_image') &&
+        preset.dataset.showTitle === getFieldCheckedValue(form, 'show_title') &&
+        preset.dataset.showContent === getFieldCheckedValue(form, 'show_content') &&
+        preset.dataset.showButton === getFieldCheckedValue(form, 'show_button');
+
+      if (matches) {
+        selectedPreset = preset;
+      }
+    });
+
+    presets.forEach(function (preset) {
+      preset.checked = preset === selectedPreset;
+    });
+  };
+
+  layoutPickers.forEach(function (picker) {
+    var form = picker.closest('form');
+    var advancedFields;
+
+    picker.addEventListener('change', function (event) {
+      if (event.target && event.target.matches('input[name="layout_preset"]')) {
+        syncLayoutPreset(event.target);
+      }
+    });
+
+    if (!form) {
+      return;
+    }
+
+    advancedFields = form.querySelectorAll('select[name="template_desktop_columns"], select[name="template_mobile_columns"], input[name="show_image"], input[name="show_title"], input[name="show_content"], input[name="show_button"]');
+    advancedFields.forEach(function (field) {
+      field.addEventListener('change', function () {
+        syncPresetFromAdvancedFields(form);
+      });
+    });
+  });
 })();

--- a/assets/layout-card-cta-button.svg
+++ b/assets/layout-card-cta-button.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">Card CTA con pulsante</title>
+  <desc id="desc">Card completa con pulsante di invito all'azione.</desc>
+  <rect width="320" height="180" fill="#f0f6fc"/>
+  <rect x="70" y="18" width="180" height="144" rx="10" fill="#fff" stroke="#2271b1" stroke-width="3"/>
+  <rect x="90" y="34" width="140" height="42" rx="6" fill="#cfe5f7"/>
+  <rect x="90" y="90" width="112" height="10" rx="5" fill="#1d2327"/>
+  <rect x="90" y="110" width="130" height="7" rx="3.5" fill="#8c8f94"/>
+  <rect x="90" y="132" width="96" height="20" rx="10" fill="#2271b1"/>
+  <rect x="108" y="139" width="60" height="6" rx="3" fill="#fff"/>
+</svg>

--- a/assets/layout-card-vertical-single.svg
+++ b/assets/layout-card-vertical-single.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">Card verticale singola</title>
+  <desc id="desc">Una card con immagine, titolo e testo su una colonna.</desc>
+  <rect width="320" height="180" fill="#f0f6fc"/>
+  <rect x="82" y="18" width="156" height="144" rx="10" fill="#fff" stroke="#2271b1" stroke-width="3"/>
+  <rect x="100" y="36" width="120" height="48" rx="6" fill="#cfe5f7"/>
+  <rect x="100" y="98" width="102" height="10" rx="5" fill="#1d2327"/>
+  <rect x="100" y="118" width="120" height="7" rx="3.5" fill="#8c8f94"/>
+  <rect x="100" y="132" width="90" height="7" rx="3.5" fill="#8c8f94"/>
+</svg>

--- a/assets/layout-compact-list.svg
+++ b/assets/layout-compact-list.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">Lista compatta</title>
+  <desc id="desc">Lista di righe compatte senza immagini.</desc>
+  <rect width="320" height="180" fill="#f6f7f7"/>
+  <rect x="46" y="28" width="228" height="124" rx="10" fill="#fff" stroke="#2271b1" stroke-width="3"/>
+  <g fill="#1d2327"><rect x="72" y="54" width="142" height="10" rx="5"/><rect x="72" y="86" width="126" height="10" rx="5"/><rect x="72" y="118" width="150" height="10" rx="5"/></g>
+  <g fill="#8c8f94"><circle cx="56" cy="59" r="5"/><circle cx="56" cy="91" r="5"/><circle cx="56" cy="123" r="5"/></g>
+</svg>

--- a/assets/layout-grid-2-columns.svg
+++ b/assets/layout-grid-2-columns.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">Griglia 2 colonne</title>
+  <desc id="desc">Due card affiancate con immagini e testo.</desc>
+  <rect width="320" height="180" fill="#f6f7f7"/>
+  <g fill="#fff" stroke="#2271b1" stroke-width="3">
+    <rect x="28" y="24" width="124" height="132" rx="9"/>
+    <rect x="168" y="24" width="124" height="132" rx="9"/>
+  </g>
+  <g fill="#cfe5f7"><rect x="44" y="42" width="92" height="42" rx="5"/><rect x="184" y="42" width="92" height="42" rx="5"/></g>
+  <g fill="#1d2327"><rect x="44" y="98" width="78" height="9" rx="4.5"/><rect x="184" y="98" width="78" height="9" rx="4.5"/></g>
+  <g fill="#8c8f94"><rect x="44" y="118" width="92" height="7" rx="3.5"/><rect x="44" y="132" width="70" height="7" rx="3.5"/><rect x="184" y="118" width="92" height="7" rx="3.5"/><rect x="184" y="132" width="70" height="7" rx="3.5"/></g>
+</svg>

--- a/assets/layout-grid-3-columns.svg
+++ b/assets/layout-grid-3-columns.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">Griglia 3 colonne</title>
+  <desc id="desc">Tre card compatte affiancate.</desc>
+  <rect width="320" height="180" fill="#f6f7f7"/>
+  <g fill="#fff" stroke="#2271b1" stroke-width="3">
+    <rect x="22" y="30" width="82" height="120" rx="8"/>
+    <rect x="119" y="30" width="82" height="120" rx="8"/>
+    <rect x="216" y="30" width="82" height="120" rx="8"/>
+  </g>
+  <g fill="#cfe5f7"><rect x="34" y="46" width="58" height="34" rx="5"/><rect x="131" y="46" width="58" height="34" rx="5"/><rect x="228" y="46" width="58" height="34" rx="5"/></g>
+  <g fill="#1d2327"><rect x="34" y="94" width="50" height="8" rx="4"/><rect x="131" y="94" width="50" height="8" rx="4"/><rect x="228" y="94" width="50" height="8" rx="4"/></g>
+  <g fill="#8c8f94"><rect x="34" y="114" width="58" height="6" rx="3"/><rect x="34" y="128" width="44" height="6" rx="3"/><rect x="131" y="114" width="58" height="6" rx="3"/><rect x="131" y="128" width="44" height="6" rx="3"/><rect x="228" y="114" width="58" height="6" rx="3"/><rect x="228" y="128" width="44" height="6" rx="3"/></g>
+</svg>

--- a/assets/layout-mobile-first.svg
+++ b/assets/layout-mobile-first.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">Mobile first</title>
+  <desc id="desc">Anteprima smartphone con due card per riga.</desc>
+  <rect width="320" height="180" fill="#f6f7f7"/>
+  <rect x="110" y="14" width="100" height="152" rx="16" fill="#fff" stroke="#2271b1" stroke-width="3"/>
+  <rect x="122" y="32" width="34" height="46" rx="6" fill="#cfe5f7"/>
+  <rect x="164" y="32" width="34" height="46" rx="6" fill="#cfe5f7"/>
+  <rect x="122" y="98" width="34" height="46" rx="6" fill="#cfe5f7"/>
+  <rect x="164" y="98" width="34" height="46" rx="6" fill="#cfe5f7"/>
+  <g fill="#1d2327"><rect x="126" y="84" width="26" height="5" rx="2.5"/><rect x="168" y="84" width="26" height="5" rx="2.5"/><rect x="126" y="150" width="26" height="5" rx="2.5"/><rect x="168" y="150" width="26" height="5" rx="2.5"/></g>
+  <circle cx="160" cy="24" r="3" fill="#8c8f94"/>
+</svg>

--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -92,7 +92,7 @@ class ALMA_Assets {
                     ),
                 ));
             }
-            if ($hook === 'affiliate_link_page_alma-ai-content-agent' && file_exists(ALMA_PLUGIN_DIR . 'assets/admin.js')) {
+            if (in_array($hook, array('affiliate_link_page_alma-ai-content-agent', 'affiliate_link_page_alma-create-widget', 'affiliate_link_page_alma-edit-widget'), true) && file_exists(ALMA_PLUGIN_DIR . 'assets/admin.js')) {
                 wp_enqueue_script(
                     'alma-admin-script',
                     ALMA_PLUGIN_URL . 'assets/admin.js',


### PR DESCRIPTION
### Motivation
- Provide non-technical users a visual way to choose widget layout presets on the AI widget create/edit pages while preserving existing advanced controls and backward compatibility. 
- Enable saving an optional `layout_preset` per widget and infer a sensible preset for legacy widgets that do not have the new field. 
- Surface the resolved layout in the Shortcode Widget AI list to help admins identify widgets' appearance without changing frontend rendering or existing shortcodes.

### Description
- Added visual layout presets and mapping logic in `affiliate-link-manager-ai.php`, including `get_widget_layout_presets()`, `sanitize_widget_layout_preset()`, `infer_widget_layout_preset()`, `get_widget_layout_preset_for_instance()`, `get_widget_layout_label()` and `render_widget_layout_preset_field()` and a non-mandatory `layout_preset` saved on widget instances. 
- Injected the layout picker UI into both create and edit pages and added a Layout column/badge to the Shortcode Widget AI list, keeping all existing widget fields and behavior intact. 
- Implemented admin JS sync logic in `assets/admin.js` to keep the visual card selection and the advanced technical controls (`template_desktop_columns`, `template_mobile_columns`, `show_image`, `show_title`, `show_content`, `show_button`) synchronized without frameworks, and enqueued this script also for `alma-create-widget` and `alma-edit-widget` in `includes/class-assets.php`. 
- Added lightweight SVG thumbnails in `assets/` and styling in `assets/admin.css`, and updated plugin version/README/CHANGELOG to `2.37.0`.

Files modified: `affiliate-link-manager-ai.php`, `includes/class-assets.php`, `assets/admin.js`, `assets/admin.css`, `README.md`, `CHANGELOG.md`.
Files added: `assets/layout-card-vertical-single.svg`, `assets/layout-grid-2-columns.svg`, `assets/layout-grid-3-columns.svg`, `assets/layout-compact-list.svg`, `assets/layout-card-cta-button.svg`, `assets/layout-mobile-first.svg`.

### Testing
- `node --check assets/admin.js` was run and returned no syntax errors. 
- PHP lint (`php -l` across PHP files) was run and reported "No syntax errors detected" for the checked files. 
- `git diff --check` was run with no problems reported.
- Manual test plan performed/recommended: create widgets with each preset, edit legacy widgets to verify preset inference, verify shortcodes render unchanged on the frontend, and verify advanced controls still function and sync with the visual picker.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22a2e1b7e08332b2da29d400e87334)