### PR TITLE
Fix Widget Link: always use full image and relax title required validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+- Corretto il rendering immagini dei Widget Link: il builder passa sempre `img_size="full"` allo shortcode `[affiliate_link]`, usando l'immagine originale/full del Link Affiliato in tutti i preset.
+- Corretto il blocco del browser che impediva ricerca, paginazione e selezione dei Link Affiliati prima dell'inserimento del titolo widget; il titolo viene validato solo su creazione/salvataggio finale.
 - Introdotto `ALMA_Logger`, logger centralizzato con livelli `debug`, `info`, `warning` ed `error`, redazione automatica di API key, bearer token, header Authorization, URL con token e contenuti AI troppo lunghi. Il troncamento copre anche risposte AI annidate.
 - Convertiti i log diretti più sensibili nelle aree OpenAI, AI draft builder, import GetYourGuide CSV, media index e internal link index in diagnostica controllata tramite logger.
 - I log `debug` rispettano `WP_DEBUG`; nessun segreto viene salvato in database e non cambiano UI, schema DB, payload OpenAI o flussi di import.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Redazione automatica applicata ai log:
 - Corrette le review P2: `assets/admin.js` viene caricato anche nella pagina nascosta `admin_page_alma-edit-widget` e la rimozione link elimina gli ID sia da `links` sia da `manual_ids`.
 - Rifinita la UX di **Crea Widget Link**: descrizione introduttiva, titolo obbligatorio, ricerca senza risultati iniziali, pulsante **Aggiungi selezionati al widget**, rimozione con Dashicon accessibile e shortcode subito visibile dopo la creazione.
 - Il rendering frontend di `[affiliate_links_widget]` e del widget WordPress stampa il titolo in H3, poi il contenuto introduttivo solo se presente, quindi la griglia link affiliati.
+- Le card generate da **Crea Widget Link** usano l'immagine originale/full associata al singolo Link Affiliato, anche nei preset a 3, 4, 5 e 6 colonne.
 - Versione plugin aggiornata a `2.38.0`.
 
 ## 2.37.0 - 2026-06-05

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -2055,6 +2055,7 @@ class AffiliateManagerAI {
         $link_limit_exceeded = false;
         $no_links_selected = false;
         $no_result_links_selected = false;
+        $title_required = false;
         $instance = array(
             'title' => '',
             'custom_content' => '',
@@ -2082,7 +2083,9 @@ class AffiliateManagerAI {
             }
 
             if (isset($_POST['alma_create_widget'])) {
-                if (empty($instance['links'])) {
+                if (trim((string) ($instance['title'] ?? '')) === '') {
+                    $title_required = true;
+                } elseif (empty($instance['links'])) {
                     $no_links_selected = true;
                 } else {
                     $instances = get_option('widget_affiliate_links_widget', array());
@@ -2108,6 +2111,7 @@ class AffiliateManagerAI {
             <p class="description alma-widget-builder-description"><?php esc_html_e('Crea un widget responsive di Link Affiliati scegliendo un layout preimpostato, cercando i link da inserire e copiando lo shortcode finale nei tuoi contenuti.', 'affiliate-link-manager-ai'); ?></p>
             <?php if ($link_limit_exceeded) : ?><div class="notice notice-warning"><p><?php _e('Hai selezionato più di 20 link: verranno utilizzati solo i primi 20.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
             <?php if (!empty($invalid_manual_ids)) : ?><div class="notice notice-warning"><p><?php printf(esc_html__('Gli ID %s non sono validi e sono stati ignorati.', 'affiliate-link-manager-ai'), esc_html(implode(', ', $invalid_manual_ids))); ?></p></div><?php endif; ?>
+            <?php if ($title_required) : ?><div class="notice notice-error"><p><?php _e('Il titolo widget è obbligatorio per creare il widget.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
             <?php if ($no_links_selected) : ?><div class="notice notice-error"><p><?php _e('Seleziona almeno un link prima di creare il widget.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
             <?php if ($no_result_links_selected) : ?><div class="notice notice-warning"><p><?php _e('Seleziona almeno un risultato di ricerca prima di aggiungerlo al widget.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
             <?php if ($created) : ?>
@@ -2121,7 +2125,7 @@ class AffiliateManagerAI {
             <form method="post">
                 <?php wp_nonce_field('alma_create_widget'); ?>
                 <table class="form-table" role="presentation"><tbody>
-                    <tr><th scope="row"><label for="alma_widget_title"><?php _e('Titolo widget', 'affiliate-link-manager-ai'); ?></label></th><td><input name="title" id="alma_widget_title" type="text" value="<?php echo esc_attr($instance['title']); ?>" class="regular-text" required></td></tr>
+                    <tr><th scope="row"><label for="alma_widget_title"><?php _e('Titolo widget', 'affiliate-link-manager-ai'); ?></label></th><td><input name="title" id="alma_widget_title" type="text" value="<?php echo esc_attr($instance['title']); ?>" class="regular-text"></td></tr>
                     <tr><th scope="row"><label for="alma_widget_content"><?php _e('Contenuto introduttivo', 'affiliate-link-manager-ai'); ?></label></th><td><textarea name="custom_content" id="alma_widget_content" rows="5" class="large-text"><?php echo esc_textarea($instance['custom_content']); ?></textarea></td></tr>
                     <?php $this->render_widget_layout_preset_field($this->get_widget_layout_preset_for_instance($instance)); ?>
                     <tr><th scope="row"><label for="alma_widget_button_text"><?php _e('Testo pulsante', 'affiliate-link-manager-ai'); ?></label></th><td><input name="button_text" type="text" id="alma_widget_button_text" value="<?php echo esc_attr($instance['button_text']); ?>" class="regular-text"><p class="description"><?php _e('Default: Scopri di più. Se vuoto, verrà salvato il default.', 'affiliate-link-manager-ai'); ?></p></td></tr>
@@ -2153,6 +2157,7 @@ class AffiliateManagerAI {
         $link_limit_exceeded = false;
         $no_links_selected = false;
         $no_result_links_selected = false;
+        $title_required = false;
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             check_admin_referer('alma_edit_widget');
@@ -2164,7 +2169,9 @@ class AffiliateManagerAI {
                 $instance = $this->remove_widget_link_from_instance($instance, $_POST['remove_link']);
             }
             if (isset($_POST['alma_save_widget'])) {
-                if (empty($instance['links'])) {
+                if (trim((string) ($instance['title'] ?? '')) === '') {
+                    $title_required = true;
+                } elseif (empty($instance['links'])) {
                     $no_links_selected = true;
                 } else {
                     if (empty($instance['created_at'])) {
@@ -2184,12 +2191,13 @@ class AffiliateManagerAI {
             <?php if ($saved) : ?><div class="notice notice-success"><p><?php _e('Widget aggiornato.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
             <?php if ($link_limit_exceeded) : ?><div class="notice notice-warning"><p><?php _e('Hai selezionato più di 20 link: verranno utilizzati solo i primi 20.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
             <?php if (!empty($invalid_manual_ids)) : ?><div class="notice notice-warning"><p><?php printf(esc_html__('Gli ID %s non sono validi e sono stati ignorati.', 'affiliate-link-manager-ai'), esc_html(implode(', ', $invalid_manual_ids))); ?></p></div><?php endif; ?>
+            <?php if ($title_required) : ?><div class="notice notice-error"><p><?php _e('Il titolo widget è obbligatorio per salvare il widget.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
             <?php if ($no_links_selected) : ?><div class="notice notice-error"><p><?php _e('Seleziona almeno un link prima di salvare il widget.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
             <?php if ($no_result_links_selected) : ?><div class="notice notice-warning"><p><?php _e('Seleziona almeno un risultato di ricerca prima di aggiungerlo al widget.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
             <form method="post">
                 <?php wp_nonce_field('alma_edit_widget'); ?>
                 <table class="form-table" role="presentation"><tbody>
-                    <tr><th scope="row"><label for="alma_widget_title"><?php _e('Titolo widget', 'affiliate-link-manager-ai'); ?></label></th><td><input name="title" id="alma_widget_title" type="text" value="<?php echo esc_attr($instance['title'] ?? ''); ?>" class="regular-text" required></td></tr>
+                    <tr><th scope="row"><label for="alma_widget_title"><?php _e('Titolo widget', 'affiliate-link-manager-ai'); ?></label></th><td><input name="title" id="alma_widget_title" type="text" value="<?php echo esc_attr($instance['title'] ?? ''); ?>" class="regular-text"></td></tr>
                     <tr><th scope="row"><label for="alma_widget_content"><?php _e('Contenuto introduttivo', 'affiliate-link-manager-ai'); ?></label></th><td><textarea name="custom_content" id="alma_widget_content" rows="5" class="large-text"><?php echo esc_textarea($instance['custom_content'] ?? ''); ?></textarea></td></tr>
                     <?php $this->render_widget_layout_preset_field($this->get_widget_layout_preset_for_instance($instance)); ?>
                     <tr><th scope="row"><label for="alma_widget_button_text"><?php _e('Testo pulsante', 'affiliate-link-manager-ai'); ?></label></th><td><input name="button_text" type="text" id="alma_widget_button_text" value="<?php echo esc_attr($instance['button_text'] ?? __('Scopri di più', 'affiliate-link-manager-ai')); ?>" class="regular-text"><p class="description"><?php _e('Default: Scopri di più. Se vuoto, verrà salvato il default.', 'affiliate-link-manager-ai'); ?></p></td></tr>

--- a/includes/class-affiliate-links-widget.php
+++ b/includes/class-affiliate-links-widget.php
@@ -83,7 +83,8 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
         }
 
         $img = $show_image ? 'yes' : 'no';
-        $img_size = $desktop_columns > 2 ? 'thumbnail' : 'full';
+        // I widget usano sempre l'immagine originale/full del singolo Link Affiliato.
+        $img_size = 'full';
 
         $container_classes = 'alma-affiliate-widget alma-affiliate-widget--black-links template-desktop-' . $desktop_columns . ' template-mobile-' . $mobile_columns;
         if ($layout_preset) {


### PR DESCRIPTION
### Motivation
- Il widget deve mostrare sempre l’immagine originale/full associata al singolo `affiliate_link` indipendentemente dal preset di colonne. 
- Il campo "Titolo widget" non deve bloccare le azioni intermedie (ricerca, paginazione, aggiungi selezionati, rimozione) ma rimane obbligatorio al submit finale di creazione/salvataggio.

### Description
- Impostata la dimensione immagine fissa a `full` durante il render del widget e aggiunto un breve commento esplicativo; modificato `includes/class-affiliate-links-widget.php` per forzare `img_size = 'full'` e far passare sempre `img_size="full"` allo shortcode `[affiliate_link]`. 
- Rimosso l’attributo HTML `required` dal campo titolo nelle pagine di `Crea Widget Link` e `Modifica Widget` e spostata la validazione server-side: su `alma_create_widget` viene mostrata la notice `Il titolo widget è obbligatorio per creare il widget.` senza creare il widget se il titolo è vuoto, e su `alma_save_widget` viene mostrata la notice `Il titolo widget è obbligatorio per salvare il widget.` senza salvare; queste modifiche sono in `affiliate-link-manager-ai.php`. 
- La normalizzazione dell’istanza mantiene layout selezionato, link selezionati, ID manuali, testo pulsante e contenuto dopo l’errore di validazione del titolo, senza cambiare data-attribute, tracking click, shortcodes manuali né struttura dati dei widget salvati. 
- Aggiornati `CHANGELOG.md` e `README.md` con le note: uso immagine full nei widget e rimozione del blocco browser per la ricerca/selezione prima dell’inserimento del titolo.

### Testing
- Eseguito `php -l affiliate-link-manager-ai.php` e il controllo di sintassi ha riportato `No syntax errors detected` (successo). 
- Eseguito `php -l includes/class-affiliate-links-widget.php` e il controllo di sintassi ha riportato `No syntax errors detected` (successo). 
- Eseguito `git diff --check` per individuare problemi di spazio/whitespace ed è risultato pulito (successo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22ec4eba4c8332a28befd0f71d98db)