### PR TITLE
Add AI rewrite flow for affiliate link widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 ## Unreleased
+
+## 2.39.0 - 2026-06-05
+- Aggiunta la tab **Prompt Widget** in **Impostazioni - Affiliate Link Manager AI** con prompt configurabile, max output tokens, timeout richiesta, stato OpenAI e ultimi log `widget_link_rewrite`.
+- Introdotta la riscrittura AI obbligatoria dei testi in **Crea Widget Link**: prima del salvataggio OpenAI riscrive titolo e descrizione dei Link Affiliati selezionati usando Contesto AI, istruzioni Source e Prompt Widget.
+- Aggiunta `ALMA_Affiliate_Widget_AI_Rewriter`, che prepara payload compatti, usa `ALMA_OpenAI_Service::request()`, valida JSON Schema, registra log sintetici/diagnostici e blocca il salvataggio in caso di errore.
+- Le riscritture vengono salvate solo nell'istanza widget nel nuovo campo `rewritten_links`, con `context_hash`, data e modello, senza modificare `post_title`, `post_content` o `_alma_ai_context` dei Link Affiliati.
+- In modifica widget vengono inviati a OpenAI solo i nuovi Link Affiliati aggiunti, vengono mantenute le riscritture esistenti e vengono rimosse quelle relative ai link eliminati.
+- Aggiornato il rendering frontend dei widget per usare titolo/descrizione riscritti quando presenti, mantenendo URL affiliato, immagine full/originale, CTA, link neri, click tracking e fallback legacy.
+- Versione plugin aggiornata a `2.39.0`.
+
 - Corretto il rendering immagini dei Widget Link: il builder passa sempre `img_size="full"` allo shortcode `[affiliate_link]`, usando l'immagine originale/full del Link Affiliato in tutti i preset.
 - Corretto il blocco del browser che impediva ricerca, paginazione e selezione dei Link Affiliati prima dell'inserimento del titolo widget; il titolo viene validato solo su creazione/salvataggio finale.
 - Introdotto `ALMA_Logger`, logger centralizzato con livelli `debug`, `info`, `warning` ed `error`, redazione automatica di API key, bearer token, header Authorization, URL con token e contenuti AI troppo lunghi. Il troncamento copre anche risposte AI annidate.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ Redazione automatica applicata ai log:
 - Parametri token noti negli URL (`token`, `access_token`, `refresh_token`, `api_key`, `key`, `signature`, `client_secret`).
 - Payload/prompt/body OpenAI lunghi e risposte AI grezze lunghe, incluse risposte AI annidate, troncati prima della scrittura nel log.
 
+## 2.39.0 - 2026-06-05
+- Aggiunta la tab **Prompt Widget** in **Impostazioni - Affiliate Link Manager AI** per configurare il prompt di riscrittura widget, il limite `alma_widget_ai_rewrite_max_output_tokens`, il timeout `alma_widget_ai_rewrite_timeout`, vedere lo stato OpenAI e consultare gli ultimi log `widget_link_rewrite`.
+- **Crea Widget Link** ora richiede una riscrittura AI obbligatoria prima della creazione: per ogni Link Affiliato selezionato legge titolo, descrizione/contenuto, `_alma_ai_context`, source collegata e istruzioni `ai_source_instructions`, quindi salva il widget solo dopo una risposta OpenAI JSON valida.
+- Le riscritture sono salvate esclusivamente nell'istanza widget nel campo `rewritten_links` (`title`, `description`, `context_hash`, `rewritten_at`, `model`), senza sovrascrivere dati del post `affiliate_link` o il Contesto AI interno.
+- **Modifica Widget** riscrive solo i nuovi Link Affiliati aggiunti, conserva le riscritture già salvate e rimuove da `rewritten_links` gli ID non più presenti nel widget.
+- Il frontend di `[affiliate_links_widget]` mostra titolo e descrizione riscritti quando disponibili, mantenendo URL affiliato originale, immagine full/originale, CTA cliccabile, tracking click e fallback per widget legacy senza `rewritten_links`.
+- Gli errori OpenAI bloccano creazione/salvataggio con messaggi chiari e selezione/form preservati; log sintetici e diagnostici sono redatti e non includono API key, prompt completi lunghi o risposte complete.
+- Versione plugin aggiornata a `2.39.0`.
+
 ## 2.38.0 - 2026-06-05
 - Riprogettato il workflow **Crea Widget Link** e **Modifica Widget**: titolo, contenuto introduttivo, preset layout, testo CTA, ricerca link affiliati, ID manuali validati e riepilogo link selezionati.
 - Rimossi dalla UI builder i toggle manuali di visibilità, i controlli avanzati desktop/mobile e il pulsante **Genera suggerimenti AI**; i nuovi widget salvano sempre immagine, titolo, contenuto e pulsante attivi.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.38.0
+ * Version: 2.39.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.38.0');
+define('ALMA_VERSION', '2.39.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -27,6 +27,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-content-analysis-ai.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-dashboard-stats.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-openai-service.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-usage-logger.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-widget-ai-rewriter.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-admin.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-store.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-media-index.php';
@@ -1093,6 +1094,13 @@ class AffiliateManagerAI {
             update_option('alma_openai_max_output_tokens', absint($_POST['openai_max_output_tokens'] ?? 600));
             update_option('alma_openai_timeout', absint($_POST['openai_timeout'] ?? 30));
             update_option('alma_openai_temperature', floatval($_POST['openai_temperature'] ?? 0.7));
+
+            // Prompt Widget AI rewrite settings
+            update_option('alma_widget_ai_rewrite_prompt', sanitize_textarea_field(wp_unslash($_POST['alma_widget_ai_rewrite_prompt'] ?? '')));
+            $widget_tokens = absint($_POST['alma_widget_ai_rewrite_max_output_tokens'] ?? ALMA_Affiliate_Widget_AI_Rewriter::DEFAULT_MAX_OUTPUT_TOKENS);
+            update_option('alma_widget_ai_rewrite_max_output_tokens', $widget_tokens > 0 ? $widget_tokens : ALMA_Affiliate_Widget_AI_Rewriter::DEFAULT_MAX_OUTPUT_TOKENS);
+            $widget_timeout = absint($_POST['alma_widget_ai_rewrite_timeout'] ?? ALMA_Affiliate_Widget_AI_Rewriter::DEFAULT_TIMEOUT);
+            update_option('alma_widget_ai_rewrite_timeout', $widget_timeout > 0 ? $widget_timeout : ALMA_Affiliate_Widget_AI_Rewriter::DEFAULT_TIMEOUT);
             
             echo '<div class="notice notice-success"><p>' . __('Impostazioni salvate!', 'affiliate-link-manager-ai') . '</p></div>';
         }
@@ -1103,6 +1111,10 @@ class AffiliateManagerAI {
         $openai_api_key = get_option('alma_openai_api_key', '');
         $openai_model = get_option('alma_openai_model', 'gpt-5.4-mini');
         $openai_temperature = get_option('alma_openai_temperature', 0.7);
+        $widget_rewrite_prompt = get_option('alma_widget_ai_rewrite_prompt', '');
+        $widget_rewrite_max_output_tokens = ALMA_Affiliate_Widget_AI_Rewriter::get_max_output_tokens();
+        $widget_rewrite_timeout = ALMA_Affiliate_Widget_AI_Rewriter::get_timeout();
+        $widget_rewrite_logs = $this->get_widget_ai_rewrite_logs(10);
         $allowed_post_types = get_option('alma_link_post_types', array('post', 'page'));
 
         ?>
@@ -1121,6 +1133,7 @@ class AffiliateManagerAI {
                     <a href="#ai" class="nav-tab">AI Settings</a>
                     <a href="#openai" class="nav-tab">OpenAI API</a>
                     <a href="#content-analysis" class="nav-tab">Content Analysis AI</a>
+                    <a href="#prompt-widget" class="nav-tab">Prompt Widget</a>
                     <a href="#editor" class="nav-tab">Editor</a>
                     <a href="#cleanup" class="nav-tab">Pulizia</a>
                 </h2>
@@ -1263,6 +1276,63 @@ class AffiliateManagerAI {
                                 ?>
                                 <p class="description"><?php _e('Seleziona i contenuti da analizzare e memorizzare in cache.', 'affiliate-link-manager-ai'); ?></p>
                                 <?php submit_button(__('Analizza e aggiorna cache', 'affiliate-link-manager-ai'), 'secondary', 'alma_refresh_content_cache', false); ?>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+
+                <!-- Prompt Widget Settings -->
+                <div id="prompt-widget" class="alma-settings-section" style="display:none;">
+                    <h2><?php _e('Prompt Widget', 'affiliate-link-manager-ai'); ?></h2>
+                    <p><?php _e('Configura il prompt usato per riscrivere obbligatoriamente titolo e descrizione dei Link Affiliati selezionati prima della creazione o salvataggio di un Widget Link.', 'affiliate-link-manager-ai'); ?></p>
+                    <table class="form-table">
+                        <tr>
+                            <th scope="row"><label for="alma_widget_ai_rewrite_prompt"><?php _e('Prompt Widget', 'affiliate-link-manager-ai'); ?></label></th>
+                            <td>
+                                <textarea name="alma_widget_ai_rewrite_prompt" id="alma_widget_ai_rewrite_prompt" rows="8" class="large-text"><?php echo esc_textarea($widget_rewrite_prompt); ?></textarea>
+                                <p class="description"><?php _e('Se lasciato vuoto viene usato il prompt default qui sotto. Il prompt viene combinato con Contesto AI del link e istruzioni della Source.', 'affiliate-link-manager-ai'); ?></p>
+                                <p><strong><?php _e('Prompt default:', 'affiliate-link-manager-ai'); ?></strong></p>
+                                <pre style="white-space:pre-wrap;background:#fff;border:1px solid #ccd0d4;padding:12px;max-width:900px;"><?php echo esc_html(ALMA_Affiliate_Widget_AI_Rewriter::default_prompt()); ?></pre>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><label for="alma_widget_ai_rewrite_max_output_tokens"><?php _e('Max output tokens Widget', 'affiliate-link-manager-ai'); ?></label></th>
+                            <td><input type="number" min="1" name="alma_widget_ai_rewrite_max_output_tokens" id="alma_widget_ai_rewrite_max_output_tokens" value="<?php echo esc_attr($widget_rewrite_max_output_tokens); ?>" class="small-text"><p class="description"><?php _e('Default consigliato: 3000.', 'affiliate-link-manager-ai'); ?></p></td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><label for="alma_widget_ai_rewrite_timeout"><?php _e('Timeout richiesta Widget', 'affiliate-link-manager-ai'); ?></label></th>
+                            <td><input type="number" min="1" name="alma_widget_ai_rewrite_timeout" id="alma_widget_ai_rewrite_timeout" value="<?php echo esc_attr($widget_rewrite_timeout); ?>" class="small-text"> <?php esc_html_e('secondi', 'affiliate-link-manager-ai'); ?><p class="description"><?php _e('Default consigliato: 60 secondi.', 'affiliate-link-manager-ai'); ?></p></td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php _e('Stato OpenAI', 'affiliate-link-manager-ai'); ?></th>
+                            <td>
+                                <?php if (ALMA_Affiliate_Widget_AI_Rewriter::is_openai_configured()) : ?>
+                                    <span style="color:#008a20;font-weight:600;"><?php _e('Configurato', 'affiliate-link-manager-ai'); ?></span>
+                                <?php else : ?>
+                                    <span style="color:#b32d2e;font-weight:600;"><?php _e('Non configurato', 'affiliate-link-manager-ai'); ?></span>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php _e('Ultimi log riscrittura widget', 'affiliate-link-manager-ai'); ?></th>
+                            <td>
+                                <?php if (empty($widget_rewrite_logs)) : ?>
+                                    <p class="description"><?php _e('Nessun log disponibile per widget_link_rewrite.', 'affiliate-link-manager-ai'); ?></p>
+                                <?php else : ?>
+                                    <table class="widefat striped" style="max-width:1000px;"><thead><tr><th><?php _e('Data', 'affiliate-link-manager-ai'); ?></th><th><?php _e('Esito', 'affiliate-link-manager-ai'); ?></th><th><?php _e('Modello', 'affiliate-link-manager-ai'); ?></th><th><?php _e('Tempo', 'affiliate-link-manager-ai'); ?></th><th><?php _e('Token', 'affiliate-link-manager-ai'); ?></th><th><?php _e('Riferimento', 'affiliate-link-manager-ai'); ?></th><th><?php _e('Errore', 'affiliate-link-manager-ai'); ?></th></tr></thead><tbody>
+                                    <?php foreach ($widget_rewrite_logs as $log) : ?>
+                                        <tr>
+                                            <td><?php echo esc_html($log['created_at'] ?? ''); ?></td>
+                                            <td><?php echo !empty($log['success']) ? esc_html__('Successo', 'affiliate-link-manager-ai') : esc_html__('Fallimento', 'affiliate-link-manager-ai'); ?></td>
+                                            <td><?php echo esc_html($log['model'] ?? ''); ?></td>
+                                            <td><?php echo esc_html(isset($log['response_time']) ? absint($log['response_time']) . ' ms' : ''); ?></td>
+                                            <td><?php echo esc_html(absint($log['input_tokens'] ?? 0) . ' / ' . absint($log['output_tokens'] ?? 0)); ?></td>
+                                            <td><?php echo esc_html($log['reference_id'] ?? ''); ?></td>
+                                            <td><?php echo esc_html($log['error_message'] ?? ''); ?></td>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                    </tbody></table>
+                                <?php endif; ?>
                             </td>
                         </tr>
                     </table>
@@ -1796,6 +1866,12 @@ class AffiliateManagerAI {
 
         $instance['links'] = array_values(array_diff(array_map('absint', (array) ($instance['links'] ?? array())), array($remove_id)));
         $instance['manual_ids'] = array_values(array_diff(array_map('absint', (array) ($instance['manual_ids'] ?? array())), array($remove_id)));
+        if (isset($instance['rewritten_links'][(string) $remove_id])) {
+            unset($instance['rewritten_links'][(string) $remove_id]);
+        }
+        if (isset($instance['rewritten_links'][$remove_id])) {
+            unset($instance['rewritten_links'][$remove_id]);
+        }
 
         return $instance;
     }
@@ -2040,6 +2116,17 @@ class AffiliateManagerAI {
         <?php
     }
 
+    private function get_widget_ai_rewrite_logs($limit = 10) {
+        global $wpdb;
+        $table = ALMA_AI_Usage_Logger::table_name();
+        $exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table));
+        if ($exists !== $table) {
+            return array();
+        }
+        $rows = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$table} WHERE task = %s ORDER BY created_at DESC LIMIT %d", ALMA_Affiliate_Widget_AI_Rewriter::TASK, absint($limit)), ARRAY_A);
+        return is_array($rows) ? $rows : array();
+    }
+
     /**
      * Pagina creazione widget
      */
@@ -2056,6 +2143,7 @@ class AffiliateManagerAI {
         $no_links_selected = false;
         $no_result_links_selected = false;
         $title_required = false;
+        $ai_rewrite_error = '';
         $instance = array(
             'title' => '',
             'custom_content' => '',
@@ -2093,13 +2181,19 @@ class AffiliateManagerAI {
                     while (isset($instances[$id])) {
                         $id++;
                     }
-                    update_option('alma_widget_next_id', $id + 1);
-                    $instance['created_at'] = current_time('mysql');
-                    $instances[$id] = $instance;
-                    update_option('widget_affiliate_links_widget', $instances);
-                    $created = true;
-                    $shortcode = '[affiliate_links_widget id="' . $id . '"]';
-                    $php_code = "<?php echo do_shortcode('" . $shortcode . "'); ?>";
+                    $rewrite = ALMA_Affiliate_Widget_AI_Rewriter::rewrite_links($instance['links'], array('widget_id' => $id));
+                    if (empty($rewrite['success'])) {
+                        $ai_rewrite_error = sanitize_text_field($rewrite['error'] ?? __('Riscrittura AI non riuscita: il widget non è stato creato.', 'affiliate-link-manager-ai'));
+                    } else {
+                        update_option('alma_widget_next_id', $id + 1);
+                        $instance['created_at'] = current_time('mysql');
+                        $instance['rewritten_links'] = ALMA_Affiliate_Widget_AI_Rewriter::sanitize_rewritten_links($rewrite['items'] ?? array(), $instance['links']);
+                        $instances[$id] = $instance;
+                        update_option('widget_affiliate_links_widget', $instances);
+                        $created = true;
+                        $shortcode = '[affiliate_links_widget id="' . $id . '"]';
+                        $php_code = "<?php echo do_shortcode('" . $shortcode . "'); ?>";
+                    }
                 }
             }
         }
@@ -2114,8 +2208,9 @@ class AffiliateManagerAI {
             <?php if ($title_required) : ?><div class="notice notice-error"><p><?php _e('Il titolo widget è obbligatorio per creare il widget.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
             <?php if ($no_links_selected) : ?><div class="notice notice-error"><p><?php _e('Seleziona almeno un link prima di creare il widget.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
             <?php if ($no_result_links_selected) : ?><div class="notice notice-warning"><p><?php _e('Seleziona almeno un risultato di ricerca prima di aggiungerlo al widget.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
+            <?php if ($ai_rewrite_error !== '') : ?><div class="notice notice-error"><p><?php echo esc_html($ai_rewrite_error); ?></p></div><?php endif; ?>
             <?php if ($created) : ?>
-                <div class="notice notice-success"><p><?php _e('Widget creato con successo!', 'affiliate-link-manager-ai'); ?></p></div>
+                <div class="notice notice-success"><p><?php _e('Widget Link creato. I testi dei link selezionati sono stati riscritti dall’AI.', 'affiliate-link-manager-ai'); ?></p></div>
                 <div class="alma-widget-created-box">
                     <p><strong><?php _e('Shortcode:', 'affiliate-link-manager-ai'); ?></strong> <code id="alma-created-shortcode"><?php echo esc_html($shortcode); ?></code> <button type="button" class="button alma-copy-button" data-copy-target="#alma-created-shortcode"><?php esc_html_e('Copia shortcode', 'affiliate-link-manager-ai'); ?></button></p>
                     <p><strong><?php _e('Codice PHP:', 'affiliate-link-manager-ai'); ?></strong> <code id="alma-created-php"><?php echo esc_html($php_code); ?></code> <button type="button" class="button alma-copy-button" data-copy-target="#alma-created-php"><?php esc_html_e('Copia codice PHP', 'affiliate-link-manager-ai'); ?></button></p>
@@ -2158,6 +2253,7 @@ class AffiliateManagerAI {
         $no_links_selected = false;
         $no_result_links_selected = false;
         $title_required = false;
+        $ai_rewrite_error = '';
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             check_admin_referer('alma_edit_widget');
@@ -2174,12 +2270,26 @@ class AffiliateManagerAI {
                 } elseif (empty($instance['links'])) {
                     $no_links_selected = true;
                 } else {
-                    if (empty($instance['created_at'])) {
-                        $instance['created_at'] = current_time('mysql');
+                    $existing_rewrites = ALMA_Affiliate_Widget_AI_Rewriter::sanitize_rewritten_links($instances[$widget_id]['rewritten_links'] ?? array(), $instance['links']);
+                    $new_link_ids = array_values(array_diff(array_map('absint', (array) $instance['links']), array_map('absint', array_keys($existing_rewrites))));
+                    $new_rewrites = array();
+                    if (!empty($new_link_ids)) {
+                        $rewrite = ALMA_Affiliate_Widget_AI_Rewriter::rewrite_links($new_link_ids, array('widget_id' => $widget_id));
+                        if (empty($rewrite['success'])) {
+                            $ai_rewrite_error = sanitize_text_field($rewrite['error'] ?? __('Riscrittura AI non riuscita: il widget non è stato salvato.', 'affiliate-link-manager-ai'));
+                        } else {
+                            $new_rewrites = ALMA_Affiliate_Widget_AI_Rewriter::sanitize_rewritten_links($rewrite['items'] ?? array(), $new_link_ids);
+                        }
                     }
-                    $instances[$widget_id] = $instance;
-                    update_option('widget_affiliate_links_widget', $instances);
-                    $saved = true;
+                    if ($ai_rewrite_error === '') {
+                        if (empty($instance['created_at'])) {
+                            $instance['created_at'] = current_time('mysql');
+                        }
+                        $instance['rewritten_links'] = ALMA_Affiliate_Widget_AI_Rewriter::sanitize_rewritten_links(array_replace($existing_rewrites, $new_rewrites), $instance['links']);
+                        $instances[$widget_id] = $instance;
+                        update_option('widget_affiliate_links_widget', $instances);
+                        $saved = true;
+                    }
                 }
             }
         }
@@ -2188,12 +2298,13 @@ class AffiliateManagerAI {
         ?>
         <div class="wrap alma-widget-builder">
             <h1><?php printf(esc_html__('Modifica Widget #%d', 'affiliate-link-manager-ai'), absint($widget_id)); ?></h1>
-            <?php if ($saved) : ?><div class="notice notice-success"><p><?php _e('Widget aggiornato.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
+            <?php if ($saved) : ?><div class="notice notice-success"><p><?php _e('Widget Link aggiornato. I nuovi link aggiunti sono stati riscritti dall’AI.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
             <?php if ($link_limit_exceeded) : ?><div class="notice notice-warning"><p><?php _e('Hai selezionato più di 20 link: verranno utilizzati solo i primi 20.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
             <?php if (!empty($invalid_manual_ids)) : ?><div class="notice notice-warning"><p><?php printf(esc_html__('Gli ID %s non sono validi e sono stati ignorati.', 'affiliate-link-manager-ai'), esc_html(implode(', ', $invalid_manual_ids))); ?></p></div><?php endif; ?>
             <?php if ($title_required) : ?><div class="notice notice-error"><p><?php _e('Il titolo widget è obbligatorio per salvare il widget.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
             <?php if ($no_links_selected) : ?><div class="notice notice-error"><p><?php _e('Seleziona almeno un link prima di salvare il widget.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
             <?php if ($no_result_links_selected) : ?><div class="notice notice-warning"><p><?php _e('Seleziona almeno un risultato di ricerca prima di aggiungerlo al widget.', 'affiliate-link-manager-ai'); ?></p></div><?php endif; ?>
+            <?php if ($ai_rewrite_error !== '') : ?><div class="notice notice-error"><p><?php echo esc_html($ai_rewrite_error); ?></p></div><?php endif; ?>
             <form method="post">
                 <?php wp_nonce_field('alma_edit_widget'); ?>
                 <table class="form-table" role="presentation"><tbody>
@@ -2231,6 +2342,7 @@ class AffiliateManagerAI {
             'template_mobile_columns'  => absint($preset['mobile']),
             'links'                    => $links,
             'manual_ids'               => $manual_ids,
+            'rewritten_links'          => class_exists('ALMA_Affiliate_Widget_AI_Rewriter') ? ALMA_Affiliate_Widget_AI_Rewriter::sanitize_rewritten_links($instance['rewritten_links'] ?? array(), $links) : (array) ($instance['rewritten_links'] ?? array()),
         ));
     }
 

--- a/includes/class-affiliate-links-widget.php
+++ b/includes/class-affiliate-links-widget.php
@@ -40,6 +40,7 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
         if ($button_text === '') {
             $button_text = __('Scopri di più', 'affiliate-link-manager-ai');
         }
+        $rewritten_links = self::normalize_rewritten_links($instance['rewritten_links'] ?? array());
 
         if ($desktop_columns < 1) {
             if (!empty($instance['format']) && $instance['format'] === 'small') {
@@ -111,11 +112,22 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
             $q->the_post();
             $id = get_the_ID();
 
-            $fields_attr = !empty($fields) ? ' fields="' . implode(',', $fields) . '"' : '';
-            $button_attr = $show_button ? ' button="yes"' : ' button="no"';
-            $text_attr = ($show_button && $button_text !== '') ? ' button_text="' . esc_attr($button_text) . '"' : '';
-            $shortcode = '[affiliate_link id="' . $id . '" img="' . $img . '" img_size="' . $img_size . '"' . $fields_attr . $button_attr . $text_attr . ' source="widget"]';
-            $link_html = do_shortcode($shortcode);
+            if (isset($rewritten_links[(string) $id])) {
+                $link_html = self::render_rewritten_link($id, $rewritten_links[(string) $id], array(
+                    'show_image' => $show_image,
+                    'show_title' => $show_title,
+                    'show_content' => $show_content,
+                    'show_button' => $show_button,
+                    'button_text' => $button_text,
+                    'img_size' => $img_size,
+                ));
+            } else {
+                $fields_attr = !empty($fields) ? ' fields="' . implode(',', $fields) . '"' : '';
+                $button_attr = $show_button ? ' button="yes"' : ' button="no"';
+                $text_attr = ($show_button && $button_text !== '') ? ' button_text="' . esc_attr($button_text) . '"' : '';
+                $shortcode = '[affiliate_link id="' . $id . '" img="' . $img . '" img_size="' . $img_size . '"' . $fields_attr . $button_attr . $text_attr . ' source="widget"]';
+                $link_html = do_shortcode($shortcode);
+            }
 
             $output .= '<div class="alma-affiliate-item">' . $link_html . '</div>';
         }
@@ -124,6 +136,72 @@ class ALMA_Affiliate_Links_Widget extends WP_Widget {
         $output .= '</div>';
 
         return $output;
+    }
+
+    private static function normalize_rewritten_links($rewritten_links) {
+        $items = array();
+        foreach ((array) $rewritten_links as $link_id => $item) {
+            $key = (string) absint($link_id);
+            if ($key === '0' || !is_array($item)) {
+                continue;
+            }
+            $title = sanitize_text_field((string) ($item['title'] ?? ''));
+            $description = sanitize_textarea_field((string) ($item['description'] ?? ''));
+            if ($title === '' || $description === '') {
+                continue;
+            }
+            $items[$key] = array('title' => $title, 'description' => $description);
+        }
+        return $items;
+    }
+
+    private static function render_rewritten_link($id, $rewrite, $args) {
+        $affiliate_url = get_post_meta($id, '_affiliate_url', true);
+        if (!$affiliate_url) {
+            return '<span style="color:red;">' . esc_html__('[Affiliate Link: URL non configurato]', 'affiliate-link-manager-ai') . '</span>';
+        }
+
+        $link_rel = get_post_meta($id, '_link_rel', true);
+        if ($link_rel === '') {
+            // Link interno: nessun attributo rel.
+        } elseif (!$link_rel) {
+            $link_rel = 'sponsored noopener';
+        }
+        $link_target = get_post_meta($id, '_link_target', true) ?: '_blank';
+        $link_title = get_post_meta($id, '_link_title', true);
+        if (empty($link_title)) {
+            $link_title = $rewrite['title'];
+        }
+
+        $image_html = '';
+        if (!empty($args['show_image'])) {
+            $image_html = get_the_post_thumbnail($id, $args['img_size'] ?? 'full', array('class' => 'alma-affiliate-img', 'alt' => esc_attr($rewrite['title'])));
+        }
+
+        $title_html = '';
+        if (!empty($args['show_title'])) {
+            $title_html = '<h4 class="alma-link-title">' . esc_html($rewrite['title']) . '</h4>';
+        }
+
+        $base_attrs = ' href="' . esc_url($affiliate_url) . '" data-link-id="' . esc_attr($id) . '" data-track="1" data-source="widget"';
+        if ($link_rel !== '') {
+            $base_attrs .= ' rel="' . esc_attr($link_rel) . '"';
+        }
+        $base_attrs .= ' target="' . esc_attr($link_target) . '" title="' . esc_attr($link_title) . '"';
+
+        $html = '<a' . $base_attrs . ' class="affiliate-link-btn alma-affiliate-link">' . $image_html . $title_html . '</a>';
+        if (!empty($args['show_content'])) {
+            $html .= '<div class="alma-link-content">' . wpautop(esc_html($rewrite['description'])) . '</div>';
+        }
+        if (!empty($args['show_button'])) {
+            $button_text = sanitize_text_field($args['button_text'] ?? '');
+            if ($button_text === '') {
+                $button_text = __('Scopri di più', 'affiliate-link-manager-ai');
+            }
+            $html .= '<div class="alma-button-wrapper" style="text-align:left;"><a' . $base_attrs . ' class="alma-affiliate-button alma-btn-medium alma-affiliate-link">' . esc_html($button_text) . '</a></div>';
+        }
+
+        return $html;
     }
 
     public function widget($args, $instance) {

--- a/includes/class-affiliate-widget-ai-rewriter.php
+++ b/includes/class-affiliate-widget-ai-rewriter.php
@@ -1,0 +1,320 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALMA_Affiliate_Widget_AI_Rewriter {
+    const TASK = 'widget_link_rewrite';
+    const DEFAULT_MAX_OUTPUT_TOKENS = 3000;
+    const DEFAULT_TIMEOUT = 60;
+    const MAX_LINKS = 20;
+
+    public static function default_prompt() {
+        return 'Riscrivi il titolo e la descrizione dei Link Affiliati per un widget editoriale SEO oriented. Usa parole diverse rispetto al testo del provider. Mantieni accuratezza, destinazione, tipo esperienza e benefici principali. Non inventare prezzi, disponibilità, sconti, recensioni o condizioni non presenti nel contesto. Scrivi in italiano naturale, chiaro e utile per viaggiatori. Titolo massimo 80 caratteri. Descrizione massimo 320 caratteri. Evita keyword stuffing. Mantieni tono editoriale autorevole e accessibile.';
+    }
+
+    public static function is_openai_configured() {
+        return trim((string) get_option('alma_openai_api_key', '')) !== '';
+    }
+
+    public static function get_prompt() {
+        $prompt = trim((string) get_option('alma_widget_ai_rewrite_prompt', ''));
+        return $prompt !== '' ? $prompt : self::default_prompt();
+    }
+
+    public static function get_max_output_tokens() {
+        $tokens = absint(get_option('alma_widget_ai_rewrite_max_output_tokens', self::DEFAULT_MAX_OUTPUT_TOKENS));
+        return $tokens > 0 ? $tokens : self::DEFAULT_MAX_OUTPUT_TOKENS;
+    }
+
+    public static function get_timeout() {
+        $timeout = absint(get_option('alma_widget_ai_rewrite_timeout', self::DEFAULT_TIMEOUT));
+        return $timeout > 0 ? $timeout : self::DEFAULT_TIMEOUT;
+    }
+
+    public static function rewrite_links($link_ids, $args = array()) {
+        $link_ids = array_slice(array_values(array_unique(array_filter(array_map('absint', (array) $link_ids)))), 0, self::MAX_LINKS);
+        $widget_id = isset($args['widget_id']) ? absint($args['widget_id']) : 0;
+
+        if (empty($link_ids)) {
+            return array('success' => true, 'items' => array(), 'model' => '');
+        }
+
+        if (!self::is_openai_configured()) {
+            $message = __('OpenAI non è configurato. Configura la chiave API nelle impostazioni prima di creare Widget Link con riscrittura AI.', 'affiliate-link-manager-ai');
+            self::log_result(false, '', 0, null, $widget_id, $link_ids, $message);
+            return array('success' => false, 'error' => $message);
+        }
+
+        $prompt = self::get_prompt();
+        $prepared = self::prepare_links($link_ids, $prompt);
+        if (is_wp_error($prepared)) {
+            $message = $prepared->get_error_message();
+            self::log_result(false, '', 0, null, $widget_id, $link_ids, $message);
+            return array('success' => false, 'error' => $message);
+        }
+
+        $system_prompt = implode("\n", array(
+            'Sei un editor SEO per widget di Link Affiliati.',
+            'Non copiare testo del provider.',
+            'Non inventare prezzi, disponibilità, recensioni, rating, sconti o condizioni.',
+            'Usa solo i dati disponibili nel Contesto AI e nei dati del link.',
+            'Restituisci solo JSON valido, senza Markdown e senza testo extra.',
+            'Mantieni un item per ogni link richiesto.',
+            'Rispetta la lingua italiana salvo future configurazioni.',
+            'Usa uno stile SEO naturale, senza keyword stuffing.',
+        ));
+
+        $user_prompt = "Prompt Widget configurato:\n" . $prompt . "\n\n";
+        $user_prompt .= "Dati link in JSON compatto. Se ai_context è vuoto o segnala contesto non disponibile, usa solo titolo e descrizione originali senza inventare dettagli.\n";
+        $user_prompt .= wp_json_encode(array('items' => $prepared['payload']), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        $request = array(
+            'system_prompt' => $system_prompt,
+            'user_prompt' => $user_prompt,
+            'max_output_tokens' => self::get_max_output_tokens(),
+            'timeout' => self::get_timeout(),
+            'temperature' => 0.2,
+            'response_format' => self::response_schema(),
+        );
+
+        $response = ALMA_OpenAI_Service::request($request);
+        $model = sanitize_text_field($response['model'] ?? get_option('alma_openai_model', ''));
+        $response_time = isset($response['response_time']) ? (int) $response['response_time'] : 0;
+        $usage = is_array($response['usage'] ?? null) ? $response['usage'] : null;
+
+        if (empty($response['success'])) {
+            $message = sanitize_text_field($response['error'] ?? __('Riscrittura AI widget non riuscita.', 'affiliate-link-manager-ai'));
+            self::log_result(false, $model, $response_time, $usage, $widget_id, $link_ids, $message);
+            return array('success' => false, 'error' => $message, 'model' => $model);
+        }
+
+        $validated = self::validate_response((string) ($response['response'] ?? ''), $link_ids, $prepared['hashes'], $model);
+        if (is_wp_error($validated)) {
+            $message = $validated->get_error_message();
+            self::log_result(false, $model, $response_time, $usage, $widget_id, $link_ids, $message);
+            return array('success' => false, 'error' => $message, 'model' => $model);
+        }
+
+        self::log_result(true, $model, $response_time, $usage, $widget_id, $link_ids, 'ok');
+
+        return array('success' => true, 'items' => $validated, 'model' => $model);
+    }
+
+    private static function prepare_links($link_ids, $prompt) {
+        $payload = array();
+        $hashes = array();
+        foreach ($link_ids as $link_id) {
+            $post = get_post($link_id);
+            if (!$post || $post->post_type !== 'affiliate_link' || $post->post_status !== 'publish') {
+                return new WP_Error('invalid_link', sprintf(__('Link Affiliato non valido: %d', 'affiliate-link-manager-ai'), $link_id));
+            }
+
+            $source = self::get_source_data($link_id);
+            $original_title = get_the_title($link_id);
+            $original_description = wp_strip_all_tags($post->post_excerpt ?: $post->post_content);
+            $ai_context = (string) get_post_meta($link_id, '_alma_ai_context', true);
+            $source_instructions = (string) ($source['instructions'] ?? '');
+
+            $payload[] = array(
+                'link_id' => $link_id,
+                'original_title' => self::limit_text($original_title, 200),
+                'original_description' => self::limit_text($original_description, 600),
+                'ai_context' => self::limit_text($ai_context !== '' ? $ai_context : 'Contesto AI non disponibile.', 1200),
+                'source_instructions' => self::limit_text($source_instructions, 800),
+                'source_name' => self::limit_text((string) ($source['name'] ?? ''), 160),
+            );
+            $hashes[(string) $link_id] = self::context_hash($ai_context, $original_title, $original_description, $prompt, $source_instructions);
+        }
+
+        return array('payload' => $payload, 'hashes' => $hashes);
+    }
+
+    private static function get_source_data($link_id) {
+        global $wpdb;
+        $source_id = absint(get_post_meta($link_id, '_alma_source_id', true));
+        $data = array('id' => $source_id, 'name' => '', 'instructions' => '');
+
+        if ($source_id > 0) {
+            $table = $wpdb->prefix . 'alma_affiliate_sources';
+            $exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table));
+            if ($exists === $table) {
+                $source = $wpdb->get_row($wpdb->prepare("SELECT name, provider_label, provider, settings FROM {$table} WHERE id = %d", $source_id), ARRAY_A);
+                if (is_array($source)) {
+                    $provider = (string) (($source['provider_label'] ?? '') ?: ($source['provider'] ?? ''));
+                    $data['name'] = trim((string) ($source['name'] ?? '') . ($provider !== '' ? ' · ' . $provider : ''));
+                    $settings = json_decode((string) ($source['settings'] ?? ''), true);
+                    if (is_array($settings)) {
+                        $data['instructions'] = sanitize_textarea_field((string) ($settings['ai_source_instructions'] ?? ''));
+                    }
+                    return $data;
+                }
+            }
+        }
+
+        $snapshot = (string) get_post_meta($link_id, '_alma_source_name', true);
+        $provider = (string) get_post_meta($link_id, '_alma_source_provider_label', true);
+        if ($provider === '') {
+            $provider = (string) get_post_meta($link_id, '_alma_source_provider', true);
+        }
+        $data['name'] = trim($snapshot . ($provider !== '' ? ' · ' . $provider : ''));
+        return $data;
+    }
+
+    private static function response_schema() {
+        return array(
+            'type' => 'json_schema',
+            'name' => 'widget_link_rewrite',
+            'strict' => true,
+            'schema' => array(
+                'type' => 'object',
+                'additionalProperties' => false,
+                'required' => array('items'),
+                'properties' => array(
+                    'items' => array(
+                        'type' => 'array',
+                        'items' => array(
+                            'type' => 'object',
+                            'additionalProperties' => false,
+                            'required' => array('link_id', 'title', 'description'),
+                            'properties' => array(
+                                'link_id' => array('type' => 'integer'),
+                                'title' => array('type' => 'string'),
+                                'description' => array('type' => 'string'),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        );
+    }
+
+    private static function validate_response($raw, $requested_ids, $hashes, $model) {
+        $raw = trim($raw);
+        $raw = preg_replace('/^```(?:json)?\s*/i', '', $raw);
+        $raw = preg_replace('/\s*```$/', '', $raw);
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded) || !isset($decoded['items']) || !is_array($decoded['items'])) {
+            return new WP_Error('invalid_json', __('Risposta AI non valida: JSON o items mancanti.', 'affiliate-link-manager-ai'));
+        }
+
+        $requested = array_fill_keys(array_map('strval', array_map('absint', $requested_ids)), true);
+        $seen = array();
+        $items = array();
+        foreach ($decoded['items'] as $item) {
+            if (!is_array($item) || !isset($item['link_id'], $item['title'], $item['description'])) {
+                return new WP_Error('invalid_item', __('Risposta AI non valida: item incompleto.', 'affiliate-link-manager-ai'));
+            }
+            $link_id = absint($item['link_id']);
+            $key = (string) $link_id;
+            if (!$link_id || !isset($requested[$key])) {
+                return new WP_Error('extra_item', __('Risposta AI non valida: contiene link_id non richiesti.', 'affiliate-link-manager-ai'));
+            }
+            if (isset($seen[$key])) {
+                return new WP_Error('duplicate_item', __('Risposta AI non valida: link_id duplicato.', 'affiliate-link-manager-ai'));
+            }
+            $title = sanitize_text_field((string) $item['title']);
+            $description = sanitize_textarea_field((string) $item['description']);
+            if ($title === '' || $description === '') {
+                return new WP_Error('empty_item', __('Risposta AI non valida: titolo o descrizione vuoti.', 'affiliate-link-manager-ai'));
+            }
+            if (self::text_length($title) > 120 || self::text_length($description) > 600) {
+                return new WP_Error('too_long', __('Risposta AI non valida: titolo o descrizione troppo lunghi.', 'affiliate-link-manager-ai'));
+            }
+            $seen[$key] = true;
+            $items[$key] = array(
+                'title' => $title,
+                'description' => $description,
+                'context_hash' => sanitize_text_field($hashes[$key] ?? ''),
+                'rewritten_at' => current_time('mysql'),
+                'model' => sanitize_text_field($model),
+            );
+        }
+
+        foreach ($requested as $key => $_) {
+            if (!isset($seen[$key])) {
+                return new WP_Error('missing_item', __('Risposta AI non valida: mancano uno o più link richiesti.', 'affiliate-link-manager-ai'));
+            }
+        }
+
+        return $items;
+    }
+
+    public static function sanitize_rewritten_links($rewritten, $allowed_ids = array()) {
+        $allowed = array_fill_keys(array_map('strval', array_map('absint', (array) $allowed_ids)), true);
+        $out = array();
+        foreach ((array) $rewritten as $link_id => $item) {
+            $key = (string) absint($link_id);
+            if ($key === '0' || (!empty($allowed) && !isset($allowed[$key])) || !is_array($item)) {
+                continue;
+            }
+            $title = sanitize_text_field((string) ($item['title'] ?? ''));
+            $description = sanitize_textarea_field((string) ($item['description'] ?? ''));
+            if ($title === '' || $description === '') {
+                continue;
+            }
+            $out[$key] = array(
+                'title' => self::text_substr($title, 0, 120),
+                'description' => self::text_substr($description, 0, 600),
+                'context_hash' => sanitize_text_field((string) ($item['context_hash'] ?? '')),
+                'rewritten_at' => sanitize_text_field((string) ($item['rewritten_at'] ?? '')),
+                'model' => sanitize_text_field((string) ($item['model'] ?? '')),
+            );
+        }
+        return $out;
+    }
+
+    private static function context_hash($ai_context, $title, $description, $prompt, $source_instructions) {
+        return hash('sha256', implode("\n---\n", array((string) $ai_context, (string) $title, (string) $description, (string) $prompt, (string) $source_instructions)));
+    }
+
+    private static function limit_text($text, $limit) {
+        $text = trim(preg_replace('/\s+/', ' ', wp_strip_all_tags((string) $text)));
+        if (self::text_length($text) > $limit) {
+            $text = self::text_substr($text, 0, $limit) . '…';
+        }
+        return $text;
+    }
+
+    private static function text_length($text) {
+        return function_exists('mb_strlen') ? mb_strlen($text) : strlen($text);
+    }
+
+    private static function text_substr($text, $start, $length) {
+        return function_exists('mb_substr') ? mb_substr($text, $start, $length) : substr($text, $start, $length);
+    }
+
+    private static function log_result($success, $model, $response_time, $usage, $widget_id, $link_ids, $message) {
+        $input_tokens = self::usage_value($usage, array('input_tokens', 'prompt_tokens'));
+        $output_tokens = self::usage_value($usage, array('output_tokens', 'completion_tokens'));
+        $reference = 'widget:' . absint($widget_id) . ';links:' . implode(',', array_map('absint', (array) $link_ids));
+        ALMA_AI_Usage_Logger::log(array(
+            'task' => self::TASK,
+            'model' => $model,
+            'input_tokens' => $input_tokens,
+            'output_tokens' => $output_tokens,
+            'response_time' => (int) $response_time,
+            'success' => $success,
+            'error' => $success ? '' : sanitize_text_field($message),
+            'reference_id' => $reference,
+        ));
+        $context = array('task' => self::TASK, 'model' => $model, 'response_time' => (int) $response_time, 'widget_id' => absint($widget_id), 'link_ids' => array_map('absint', (array) $link_ids), 'message' => sanitize_text_field($message));
+        if ($success) {
+            ALMA_Logger::info('Widget link AI rewrite completed', $context);
+        } else {
+            ALMA_Logger::warning('Widget link AI rewrite failed', $context);
+        }
+    }
+
+    private static function usage_value($usage, $keys) {
+        if (!is_array($usage)) {
+            return null;
+        }
+        foreach ($keys as $key) {
+            if (isset($usage[$key])) {
+                return (int) $usage[$key];
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
### Motivation
- Enforce an AI-driven rewrite of titles and descriptions for Affiliate Links selected in the widget builder to ensure editorial/SEO-safe copy before widget creation or update.
- Reuse the existing OpenAI integration and each Link's `_alma_ai_context` plus Source `ai_source_instructions` to produce context-aware rewrites under a configurable prompt.
- Provide admin control (prompt, tokens, timeout) and safe logging so widget creation is blocked on invalid or failed AI responses.

### Description
- Added a new class `ALMA_Affiliate_Widget_AI_Rewriter` in `includes/class-affiliate-widget-ai-rewriter.php` that prepares compact per-link payloads, reads `_alma_ai_context` and Source instructions, builds system/user prompts, calls `ALMA_OpenAI_Service::request()`, validates JSON-schema responses and returns sanitized rewritten texts while logging usage/diagnostics via `ALMA_AI_Usage_Logger` and `ALMA_Logger`.
- Added the Prompt Widget settings tab to `Impostazioni - Affiliate Link Manager AI` and stored options `alma_widget_ai_rewrite_prompt`, `alma_widget_ai_rewrite_max_output_tokens`, `alma_widget_ai_rewrite_timeout`, and exposed a recent `widget_link_rewrite` log view; bootstrapped the new class in the plugin main file (`affiliate-link-manager-ai.php`).
- Updated the Crea Widget flow to call the rewriter synchronously before saving: widget creation is blocked until OpenAI returns a valid JSON response; on success the widget instance is saved with a new `rewritten_links` field; on failure the widget is not created and a clear admin error is shown while preserving form selection.
- Updated the Modifica Widget flow to detect already-saved `rewritten_links`, compute newly added link IDs, send only new IDs to OpenAI, merge new rewrites with existing ones, and remove rewritten entries for links removed from the widget; saving is blocked if new rewrites fail.
- Persisted rewrites only in the widget instance under `rewritten_links` keyed by link ID with structure `title`, `description`, `context_hash`, `rewritten_at`, `model`, where `context_hash` is deterministic over `_alma_ai_context`, original title, original description, the widget prompt and source instructions (no automatic regeneration when prompt changes in this phase).
- Updated frontend widget rendering in `includes/class-affiliate-links-widget.php` to use `rewritten_links[ID].title` and `.description` when present while keeping affiliate URL, original/full image, CTA, and click tracking unchanged and preserving the shortcode/fallback behavior for legacy widgets.

### Testing
- Ran PHP lint on changed files: `php -l affiliate-link-manager-ai.php` (no syntax errors), `php -l includes/class-affiliate-links-widget.php` (no syntax errors), `php -l includes/class-affiliate-widget-ai-rewriter.php` (no syntax errors), and `php -l includes/class-openai-service.php` (no syntax errors). All succeeded.
- Ran `git diff --check` to ensure no whitespace/conflict markers remain; check passed.
- Note: interactive/manual tests that require a running WordPress admin and a configured OpenAI API key (creating widgets via the admin UI, verifying live OpenAI calls and frontend rendering with real rewrites, click tracking validations) were not executed in this CLI-only environment and should be performed during QA on a staging site with OpenAI configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22f5e1097083329dfd1b1e46fbded0)