### PR TITLE
Add Widget Link Contestuale MVP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Unreleased
 
+## 2.39.1 - 2026-06-05
+- Aggiunto il **Widget Link Contestuale** come widget WordPress opzionale per sidebar, attivo solo su singole `post`/`page` supportate e senza modifiche al contenuto degli articoli.
+- Introdotta la pagina **Widget Contestuale** sotto il menu `affiliate_link`, con impostazioni globali WordPress-native, nonce, sanitizzazione, messaggio di salvataggio e pulsante **Svuota cache Widget Contestuale**.
+- Creato il matcher locale senza AI che estrae segnali da titolo, slug, categorie, tag, contenuto, excerpt e heading H2/H3, valuta i CPT `affiliate_link` pubblicati con URL affiliato e ordina i risultati per score, click e titolo.
+- Implementata cache per post con hash impostazioni, TTL configurabile e invalidazione tramite versione cache al salvataggio di articoli supportati, Link Affiliati, impostazioni e flush manuale.
+- Il frontend mostra card minimali con immagine full/originale, titolo, descrizione e CTA, mantenendo URL/rel/target originali e click tracking con source `contextual_widget`.
+- Documentati limiti MVP: candidati limitati a 200 Link Affiliati, fallback attivo `hide` e possibili evoluzioni con indice dedicato o fallback popular/manual/same_type.
+- Versione plugin aggiornata a `2.39.1`.
+
 ## 2.39.0 - 2026-06-05
 - Aggiunta la tab **Prompt Widget** in **Impostazioni - Affiliate Link Manager AI** con prompt configurabile, max output tokens, timeout richiesta, stato OpenAI e ultimi log `widget_link_rewrite`.
 - Introdotta la riscrittura AI obbligatoria dei testi in **Crea Widget Link**: prima del salvataggio OpenAI riscrive titolo e descrizione dei Link Affiliati selezionati usando Contesto AI, istruzioni Source e Prompt Widget.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+## 2.39.1 - 2026-06-05
+
+### Widget Link Contestuale
+- Aggiunto il nuovo widget WordPress **Widget Link Contestuale**, inseribile nelle sidebar e completamente opzionale: intercetta solo pagine singole supportate (`post` e, se abilitato, `page`) e non modifica mai il contenuto degli articoli.
+- La configurazione è disponibile in **Affiliate AI → Widget Contestuale** (`alma-contextual-widget`) con opzioni globali per abilitazione, post type, massimo link, soglia minima, titolo box, testo CTA, immagine, descrizione, esclusione link già presenti, TTL cache e fallback.
+- Il matching è locale e deterministico, senza OpenAI: analizza titolo, slug, contenuto pulito, excerpt, categorie, tag e heading H2/H3, confrontandoli con titolo/contenuto/tipologie/meta dei CPT `affiliate_link`.
+- Lo scoring MVP assegna punti per match nel titolo, keyword negli heading/contenuto, sovrapposizione `link_type` con categorie/tag, contesto `_alma_ai_context` e click storici, normalizzando a 100 e ordinando per score, click e titolo.
+- La cache per post salva ID link, score, timestamp e hash impostazioni con TTL `1h`, `6h`, `24h` o `7d`; una versione cache invalida i risultati quando si salvano articoli supportati, Link Affiliati o impostazioni, oppure dal pulsante **Svuota cache Widget Contestuale**.
+- Il fallback MVP supportato è `hide`: se non ci sono link sopra soglia il widget non renderizza nulla; la struttura prepara future modalità `popular`, `manual` e `same_type`.
+- Il rendering usa immagine originale/full del Link Affiliato, titolo, descrizione breve e CTA, mantenendo URL affiliato originale, `rel`/`target` del singolo link e click tracking con `data-source="contextual_widget"`.
+
 ## Logging centralizzato sicuro
 
 Il plugin usa `ALMA_Logger` per la diagnostica controllata nelle aree OpenAI, AI draft builder, import GetYourGuide CSV e indici AI. Il logger scrive solo sul canale di log PHP/WordPress e non salva segreti nel database.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.39.0
+ * Version: 2.39.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.39.0');
+define('ALMA_VERSION', '2.39.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -88,6 +88,8 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-link-ai-context-builder
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-manager.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-links-source-filter.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-widget-layout-registry.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-contextual-affiliate-matcher.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-contextual-affiliate-widget.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-assets.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-shortcodes.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-editor-ajax.php';
@@ -119,6 +121,7 @@ class AffiliateManagerAI {
         $this->editor_ajax = new ALMA_Editor_Ajax($this->dashboard_stats);
         $this->ai_content_agent_dashboard_widget = new ALMA_AI_Content_Agent_Dashboard_Widget();
         add_action('init', array($this, 'init'));
+        add_action('widgets_init', array('ALMA_Contextual_Affiliate_Widget', 'register_widget'));
         register_activation_hook(__FILE__, array($this, 'activate'));
         register_deactivation_hook(__FILE__, array($this, 'deactivate'));
         add_action('plugins_loaded', array($this, 'maybe_run_update_tasks'));
@@ -164,6 +167,7 @@ class AffiliateManagerAI {
         // Shortcodes and editor AJAX are now routed through dedicated classes.
         $this->shortcodes->init();
         $this->editor_ajax->init();
+        add_action('save_post', array('ALMA_Contextual_Affiliate_Widget', 'maybe_invalidate_on_save'), 20, 3);
         
         // Hook AJAX per tracking click (modificato per tracking asincrono)
         add_action('wp_ajax_alma_track_click', array($this, 'ajax_track_click'));
@@ -865,6 +869,16 @@ class AffiliateManagerAI {
             array($this, 'render_widget_shortcode_page')
         );
 
+        // Widget contestuale
+        add_submenu_page(
+            'edit.php?post_type=affiliate_link',
+            __('Widget Link Contestuale', 'affiliate-link-manager-ai'),
+            __('Widget Contestuale', 'affiliate-link-manager-ai'),
+            'manage_options',
+            ALMA_Contextual_Affiliate_Widget::MENU_SLUG,
+            array($this, 'render_contextual_widget_page')
+        );
+
         // BotAffiliate Post settings
         add_submenu_page(
             'edit.php?post_type=affiliate_link',
@@ -925,6 +939,7 @@ class AffiliateManagerAI {
             'edit-tags.php?taxonomy=link_type&post_type=affiliate_link',
             'alma-create-widget',
             'affiliate-link-widgets',
+            ALMA_Contextual_Affiliate_Widget::MENU_SLUG,
             'alma-bot-affiliate-settings',
             'alma-affiliate-sources',
             self::AI_CONTENT_AGENT_MENU_SLUG,
@@ -955,6 +970,9 @@ class AffiliateManagerAI {
                         case 'affiliate-link-widgets':
                             $item[0] = __('Elenco Widget Link', 'affiliate-link-manager-ai');
                             break;
+                        case ALMA_Contextual_Affiliate_Widget::MENU_SLUG:
+                            $item[0] = __('Widget Contestuale', 'affiliate-link-manager-ai');
+                            break;
                         case 'alma-bot-affiliate-settings':
                             $item[0] = __('BotAffiliate Post', 'affiliate-link-manager-ai');
                             break;
@@ -983,6 +1001,14 @@ class AffiliateManagerAI {
         }
 
         $submenu[$parent] = $new;
+    }
+    
+
+    /**
+     * Render Contextual Widget settings page.
+     */
+    public function render_contextual_widget_page() {
+        ALMA_Contextual_Affiliate_Widget::render_settings_page();
     }
     
     /**
@@ -3275,6 +3301,7 @@ class AffiliateManagerAI {
         $this->create_analytics_table();
         ALMA_AI_Usage_Logger::create_table();
         ALMA_Affiliate_Source_Manager::create_tables();
+        ALMA_Contextual_Affiliate_Widget::maybe_set_default_options();
         $this->create_default_categories();
         update_option('alma_db_schema_version', '4');
         update_option('alma_plugin_version', ALMA_VERSION);
@@ -3321,6 +3348,7 @@ class AffiliateManagerAI {
             $this->create_analytics_table();
             ALMA_AI_Usage_Logger::create_table();
             ALMA_Affiliate_Source_Manager::create_tables();
+            ALMA_Contextual_Affiliate_Widget::maybe_set_default_options();
             update_option('alma_db_schema_version', '4');
             update_option('alma_plugin_version', ALMA_VERSION);
         }

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -1332,3 +1332,18 @@ button:disabled {
         justify-content: flex-start;
     }
 }
+
+/* Widget Link Contestuale settings */
+.alma-contextual-widget-admin .card {
+    max-width: 900px;
+}
+
+.alma-contextual-widget-admin .alma-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: #f0f6fc;
+    color: #0969da;
+    font-size: 12px;
+    font-weight: 600;
+}

--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -22,3 +22,65 @@
 .alma-widget-content {
     margin-bottom: 10px;
 }
+
+/* Widget Link Contestuale */
+.alma-contextual-widget {
+    display: block;
+}
+
+.alma-contextual-widget__list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.alma-contextual-widget__item {
+    border: 1px solid #e2e4e7;
+    border-radius: 10px;
+    overflow: hidden;
+    background: #fff;
+}
+
+.alma-contextual-widget__image {
+    display: block;
+    line-height: 0;
+}
+
+.alma-contextual-widget__image img {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.alma-contextual-widget__content {
+    padding: 14px;
+}
+
+.alma-contextual-widget__link-title {
+    display: inline-block;
+    font-weight: 700;
+    color: #111827;
+    text-decoration: none;
+}
+
+.alma-contextual-widget__description {
+    margin: 8px 0 12px;
+    color: #4b5563;
+    font-size: 0.95em;
+}
+
+.alma-contextual-widget__button {
+    display: inline-block;
+    padding: 8px 12px;
+    border-radius: 6px;
+    background: #111827;
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.alma-contextual-widget__button:hover,
+.alma-contextual-widget__button:focus {
+    color: #fff;
+    opacity: 0.9;
+}

--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -66,6 +66,7 @@ class ALMA_Assets {
             $hook === 'affiliate_link_page_alma-edit-widget' ||
             $hook === 'admin_page_alma-edit-widget' ||
             $hook === 'affiliate_link_page_affiliate-link-widgets' ||
+            $hook === 'affiliate_link_page_alma-contextual-widget' ||
             $hook === 'index.php')) {
 
             if (file_exists(ALMA_PLUGIN_DIR . 'assets/admin.css')) {

--- a/includes/class-contextual-affiliate-matcher.php
+++ b/includes/class-contextual-affiliate-matcher.php
@@ -1,0 +1,328 @@
+<?php
+/**
+ * Deterministic contextual affiliate link matcher for the sidebar widget.
+ */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALMA_Contextual_Affiliate_Matcher {
+    const DEFAULT_CANDIDATE_LIMIT = 200;
+
+    private $settings;
+
+    public function __construct($settings = array()) {
+        $this->settings = wp_parse_args($settings, array(
+            'max_links' => 4,
+            'min_score' => 40,
+            'exclude_existing_links' => 'yes',
+            'candidate_limit' => self::DEFAULT_CANDIDATE_LIMIT,
+        ));
+    }
+
+    public function match($post, $settings = array()) {
+        if (!$post instanceof WP_Post) {
+            $post = get_post($post);
+        }
+
+        if (!$post || !in_array($post->post_status, array('publish', 'private'), true)) {
+            return array();
+        }
+
+        $settings = wp_parse_args($settings, $this->settings);
+        $signals = $this->extract_post_signals($post);
+        $candidates = $this->get_candidates(absint($settings['candidate_limit']));
+        $results = array();
+        $min_score = max(0, min(100, absint($settings['min_score'])));
+
+        foreach ($candidates as $candidate) {
+            $scored = $this->score_candidate($candidate, $signals, $settings);
+            if (!$scored || $scored['score'] < $min_score) {
+                continue;
+            }
+            $results[] = $scored;
+        }
+
+        usort($results, array($this, 'sort_results'));
+
+        return array_slice($results, 0, max(1, absint($settings['max_links'])));
+    }
+
+    public function extract_post_signals($post) {
+        if (!$post instanceof WP_Post) {
+            $post = get_post($post);
+        }
+
+        $raw_content = (string) $post->post_content;
+        $plain_content = $this->normalize_text(wp_strip_all_tags(strip_shortcodes($raw_content)));
+        $title = $this->normalize_text(get_the_title($post));
+        $slug = $this->normalize_text((string) $post->post_name);
+        $excerpt = $this->normalize_text(wp_strip_all_tags(get_the_excerpt($post)));
+        $headings = $this->extract_headings($raw_content);
+        $taxonomy_terms = $this->get_post_taxonomy_terms($post->ID);
+        $combined = trim($title . ' ' . $slug . ' ' . $excerpt . ' ' . implode(' ', $headings) . ' ' . implode(' ', $taxonomy_terms) . ' ' . $plain_content);
+
+        return array(
+            'id' => (int) $post->ID,
+            'post_type' => (string) $post->post_type,
+            'title' => $title,
+            'slug' => $slug,
+            'content' => $plain_content,
+            'raw_content' => $raw_content,
+            'excerpt' => $excerpt,
+            'headings' => $headings,
+            'taxonomy_terms' => array_values(array_unique($taxonomy_terms)),
+            'keywords' => $this->extract_keywords($combined, 60),
+            'combined' => $combined,
+        );
+    }
+
+    private function get_candidates($limit) {
+        $limit = max(1, min(self::DEFAULT_CANDIDATE_LIMIT, $limit));
+        return get_posts(array(
+            'post_type' => 'affiliate_link',
+            'post_status' => 'publish',
+            'posts_per_page' => $limit,
+            'orderby' => 'date',
+            'order' => 'DESC',
+            'no_found_rows' => true,
+            'update_post_meta_cache' => true,
+            'update_post_term_cache' => true,
+        ));
+    }
+
+    private function score_candidate($candidate, $signals, $settings) {
+        if (!$candidate instanceof WP_Post || $candidate->post_type !== 'affiliate_link' || $candidate->post_status !== 'publish') {
+            return null;
+        }
+
+        $affiliate_url = trim((string) get_post_meta($candidate->ID, '_affiliate_url', true));
+        if ($affiliate_url === '') {
+            return null;
+        }
+
+        $already_present = $this->is_link_already_present($candidate->ID, $affiliate_url, $signals['raw_content']);
+        if ($already_present && ($settings['exclude_existing_links'] ?? 'yes') === 'yes') {
+            return null;
+        }
+
+        $link_title = $this->normalize_text(get_the_title($candidate));
+        $link_content = $this->normalize_text(wp_strip_all_tags(strip_shortcodes((string) $candidate->post_content)));
+        $ai_context = $this->normalize_text((string) get_post_meta($candidate->ID, '_alma_ai_context', true));
+        $source_text = $this->normalize_text($this->get_candidate_source_text($candidate->ID));
+        $link_types = $this->get_link_type_terms($candidate->ID);
+        $candidate_keywords = $this->extract_keywords(trim($link_title . ' ' . $link_content . ' ' . $ai_context . ' ' . $source_text . ' ' . implode(' ', $link_types)), 30);
+        $score = 0;
+
+        if ($link_title !== '' && $this->contains_phrase($signals['title'], $link_title)) {
+            $score += 35;
+        }
+
+        if ($this->has_keyword_overlap($candidate_keywords, array($signals['title']))) {
+            $score += 25;
+        }
+
+        if (($link_title !== '' && $this->contains_phrase(implode(' ', $signals['headings']), $link_title)) || $this->has_keyword_overlap($candidate_keywords, $signals['headings'])) {
+            $score += 25;
+        }
+
+        if ($this->has_term_overlap($link_types, $signals['taxonomy_terms'])) {
+            $score += 25;
+        }
+
+        if ($this->has_keyword_overlap($candidate_keywords, array($signals['content']))) {
+            $score += 15;
+        }
+
+        if ($ai_context !== '' && $this->context_matches($ai_context, $signals)) {
+            $score += 20;
+        }
+
+        $click_count = absint(get_post_meta($candidate->ID, '_click_count', true));
+        if ($click_count > 0) {
+            $score += min(5, (int) floor(log($click_count + 1, 2)));
+        }
+
+        if ($already_present) {
+            $score -= 100;
+        }
+
+        $score = max(0, min(100, $score));
+
+        return array(
+            'id' => (int) $candidate->ID,
+            'score' => $score,
+            'click_count' => $click_count,
+            'title' => get_the_title($candidate),
+            'affiliate_url' => $affiliate_url,
+            'has_image' => has_post_thumbnail($candidate->ID),
+        );
+    }
+
+    private function sort_results($a, $b) {
+        if ($a['score'] !== $b['score']) {
+            return $b['score'] <=> $a['score'];
+        }
+        if ($a['click_count'] !== $b['click_count']) {
+            return $b['click_count'] <=> $a['click_count'];
+        }
+        return strcasecmp((string) $a['title'], (string) $b['title']);
+    }
+
+    private function is_link_already_present($link_id, $affiliate_url, $raw_content) {
+        $raw_content = (string) $raw_content;
+        if ($raw_content === '') {
+            return false;
+        }
+
+        if (preg_match('/\[affiliate_link\b[^\]]*\bid=["\']?' . preg_quote((string) absint($link_id), '/') . '\b/i', $raw_content)) {
+            return true;
+        }
+
+        return $affiliate_url !== '' && strpos($raw_content, $affiliate_url) !== false;
+    }
+
+    private function extract_headings($content) {
+        $headings = array();
+        if (preg_match_all('/<h[23][^>]*>(.*?)<\/h[23]>/is', (string) $content, $matches)) {
+            foreach ($matches[1] as $heading) {
+                $normalized = $this->normalize_text(wp_strip_all_tags($heading));
+                if ($normalized !== '') {
+                    $headings[] = $normalized;
+                }
+            }
+        }
+        return $headings;
+    }
+
+    private function get_post_taxonomy_terms($post_id) {
+        $terms = array();
+        foreach (array('category', 'post_tag') as $taxonomy) {
+            $objects = get_the_terms($post_id, $taxonomy);
+            if (is_wp_error($objects) || empty($objects)) {
+                continue;
+            }
+            foreach ($objects as $term) {
+                $terms[] = $this->normalize_text($term->name);
+                $terms[] = $this->normalize_text($term->slug);
+            }
+        }
+        return array_filter($terms);
+    }
+
+    private function get_link_type_terms($post_id) {
+        $terms = get_the_terms($post_id, 'link_type');
+        if (is_wp_error($terms) || empty($terms)) {
+            return array();
+        }
+
+        $names = array();
+        foreach ($terms as $term) {
+            $names[] = $this->normalize_text($term->name);
+            $names[] = $this->normalize_text($term->slug);
+        }
+        return array_values(array_unique(array_filter($names)));
+    }
+
+    private function get_candidate_source_text($post_id) {
+        $pieces = array();
+        foreach (array('_alma_source_name', '_alma_provider', '_alma_source_provider', '_alma_source_type', '_alma_source_id') as $meta_key) {
+            $value = get_post_meta($post_id, $meta_key, true);
+            if (is_scalar($value) && (string) $value !== '') {
+                $pieces[] = (string) $value;
+            }
+        }
+        return implode(' ', $pieces);
+    }
+
+    private function context_matches($context, $signals) {
+        if ($this->contains_phrase($signals['title'], $context) || $this->contains_phrase($signals['content'], $context)) {
+            return true;
+        }
+
+        $context_keywords = $this->extract_keywords($context, 20);
+        return $this->has_keyword_overlap($context_keywords, array($signals['title'], $signals['content']));
+    }
+
+    private function has_term_overlap($left, $right) {
+        $left = array_filter(array_map(array($this, 'normalize_text'), (array) $left));
+        $right = array_filter(array_map(array($this, 'normalize_text'), (array) $right));
+        foreach ($left as $term) {
+            if (in_array($term, $right, true)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function has_keyword_overlap($keywords, $haystacks) {
+        foreach ((array) $keywords as $keyword) {
+            $keyword = $this->normalize_text($keyword);
+            if ($keyword === '' || strlen($keyword) < 4) {
+                continue;
+            }
+            foreach ((array) $haystacks as $haystack) {
+                if ($this->contains_phrase($haystack, $keyword)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private function contains_phrase($haystack, $needle) {
+        $haystack = $this->normalize_text($haystack);
+        $needle = $this->normalize_text($needle);
+        if ($haystack === '' || $needle === '') {
+            return false;
+        }
+
+        if (strlen($needle) > 70) {
+            return false;
+        }
+
+        return strpos(' ' . $haystack . ' ', ' ' . $needle . ' ') !== false || strpos($haystack, $needle) !== false;
+    }
+
+    private function extract_keywords($text, $limit = 30) {
+        $text = $this->normalize_text($text);
+        if ($text === '') {
+            return array();
+        }
+
+        preg_match_all('/[a-z0-9àèéìòùáíóúäëïöüñç]{4,}/iu', $text, $matches);
+        $stopwords = $this->get_stopwords();
+        $counts = array();
+        foreach ($matches[0] as $word) {
+            $word = $this->normalize_text($word);
+            if ($word === '' || isset($stopwords[$word])) {
+                continue;
+            }
+            if (!isset($counts[$word])) {
+                $counts[$word] = 0;
+            }
+            $counts[$word]++;
+        }
+
+        arsort($counts);
+        return array_slice(array_keys($counts), 0, max(1, absint($limit)));
+    }
+
+    private function normalize_text($text) {
+        $text = strtolower(remove_accents(wp_strip_all_tags((string) $text)));
+        $text = preg_replace('/[^a-z0-9\s]/u', ' ', $text);
+        $text = preg_replace('/\s+/', ' ', $text);
+        return trim((string) $text);
+    }
+
+    private function get_stopwords() {
+        static $stopwords = null;
+        if ($stopwords !== null) {
+            return $stopwords;
+        }
+
+        $words = array('alla','allo','agli','alle','anche','avere','come','con','dai','dal','dalla','delle','degli','dei','del','dell','dello','dove','dopo','esta','fare','gli','hai','che','chi','cosa','come','dalla','delle','dentro','essere','il','la','lo','le','li','un','una','uno','per','piu','nel','nella','nelle','negli','non','sono','sul','sulla','sulle','tra','fra','the','and','for','with','from','this','that','your','you','are','was','were','have','has','will','not');
+        $stopwords = array_fill_keys($words, true);
+        return $stopwords;
+    }
+}

--- a/includes/class-contextual-affiliate-widget.php
+++ b/includes/class-contextual-affiliate-widget.php
@@ -1,0 +1,487 @@
+<?php
+/**
+ * Contextual affiliate links sidebar widget and admin configuration page.
+ */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALMA_Contextual_Affiliate_Widget extends WP_Widget {
+    const MENU_SLUG = 'alma-contextual-widget';
+    const CACHE_VERSION_OPTION = 'alma_contextual_widget_cache_version';
+
+    public function __construct() {
+        parent::__construct(
+            'alma_contextual_affiliate_widget',
+            __('Widget Link Contestuale', 'affiliate-link-manager-ai'),
+            array(
+                'classname' => 'alma_contextual_affiliate_widget',
+                'description' => __('Mostra automaticamente Link Affiliati coerenti con l’articolo visualizzato.', 'affiliate-link-manager-ai'),
+            )
+        );
+    }
+
+    public static function register_widget() {
+        register_widget(__CLASS__);
+    }
+
+    public static function get_defaults() {
+        return array(
+            'enabled' => 'yes',
+            'post_types' => array('post'),
+            'max_links' => 4,
+            'min_score' => 40,
+            'title' => __('Esperienze consigliate', 'affiliate-link-manager-ai'),
+            'button_text' => __('Scopri di più', 'affiliate-link-manager-ai'),
+            'show_image' => 'yes',
+            'show_description' => 'yes',
+            'exclude_existing_links' => 'yes',
+            'cache_ttl' => '24h',
+            'fallback_mode' => 'hide',
+            'candidate_limit' => 200,
+        );
+    }
+
+    public static function get_global_settings() {
+        $defaults = self::get_defaults();
+        $post_types = get_option('alma_contextual_widget_post_types', $defaults['post_types']);
+        if (!is_array($post_types)) {
+            $post_types = array($post_types);
+        }
+
+        return array(
+            'enabled' => get_option('alma_contextual_widget_enabled', $defaults['enabled']) === 'yes' ? 'yes' : 'no',
+            'post_types' => self::sanitize_post_types($post_types),
+            'max_links' => max(1, min(20, absint(get_option('alma_contextual_widget_max_links', $defaults['max_links'])))),
+            'min_score' => max(0, min(100, absint(get_option('alma_contextual_widget_min_score', $defaults['min_score'])))),
+            'title' => sanitize_text_field(get_option('alma_contextual_widget_title', $defaults['title'])),
+            'button_text' => sanitize_text_field(get_option('alma_contextual_widget_button_text', $defaults['button_text'])),
+            'show_image' => get_option('alma_contextual_widget_show_image', $defaults['show_image']) === 'yes' ? 'yes' : 'no',
+            'show_description' => get_option('alma_contextual_widget_show_description', $defaults['show_description']) === 'yes' ? 'yes' : 'no',
+            'exclude_existing_links' => get_option('alma_contextual_widget_exclude_existing_links', $defaults['exclude_existing_links']) === 'yes' ? 'yes' : 'no',
+            'cache_ttl' => self::sanitize_cache_ttl(get_option('alma_contextual_widget_cache_ttl', $defaults['cache_ttl'])),
+            'fallback_mode' => self::sanitize_fallback_mode(get_option('alma_contextual_widget_fallback_mode', $defaults['fallback_mode'])),
+            'candidate_limit' => $defaults['candidate_limit'],
+        );
+    }
+
+    public static function maybe_set_default_options() {
+        $defaults = self::get_defaults();
+        $map = array(
+            'alma_contextual_widget_enabled' => $defaults['enabled'],
+            'alma_contextual_widget_post_types' => $defaults['post_types'],
+            'alma_contextual_widget_max_links' => $defaults['max_links'],
+            'alma_contextual_widget_min_score' => $defaults['min_score'],
+            'alma_contextual_widget_title' => $defaults['title'],
+            'alma_contextual_widget_button_text' => $defaults['button_text'],
+            'alma_contextual_widget_show_image' => $defaults['show_image'],
+            'alma_contextual_widget_show_description' => $defaults['show_description'],
+            'alma_contextual_widget_exclude_existing_links' => $defaults['exclude_existing_links'],
+            'alma_contextual_widget_cache_ttl' => $defaults['cache_ttl'],
+            'alma_contextual_widget_fallback_mode' => $defaults['fallback_mode'],
+            self::CACHE_VERSION_OPTION => 1,
+        );
+        foreach ($map as $option => $value) {
+            if (get_option($option, null) === null) {
+                add_option($option, $value);
+            }
+        }
+    }
+
+    public function widget($args, $instance) {
+        if (!is_singular()) {
+            return;
+        }
+
+        $settings = $this->resolve_settings($instance);
+        if ($settings['enabled'] !== 'yes') {
+            return;
+        }
+
+        $post = get_queried_object();
+        if (!$post instanceof WP_Post) {
+            global $post;
+        }
+        if (!$post instanceof WP_Post || !in_array($post->post_type, $settings['post_types'], true)) {
+            return;
+        }
+
+        $links = $this->get_cached_matches($post, $settings);
+        if (empty($links) && $settings['fallback_mode'] === 'hide') {
+            return;
+        }
+        if (empty($links)) {
+            return;
+        }
+
+        echo $args['before_widget'];
+        echo '<div class="alma-contextual-widget">';
+        if ($settings['title'] !== '') {
+            echo $args['before_title'] . '<span class="alma-contextual-widget__title">' . esc_html($settings['title']) . '</span>' . $args['after_title'];
+        }
+        echo '<div class="alma-contextual-widget__list">';
+        foreach ($links as $link) {
+            $this->render_link_item($link, $settings);
+        }
+        echo '</div>';
+        echo '</div>';
+        echo $args['after_widget'];
+    }
+
+    public function form($instance) {
+        $instance = wp_parse_args((array) $instance, array(
+            'title' => '',
+            'max_links' => '',
+            'min_score' => '',
+            'show_image' => '',
+            'show_description' => '',
+            'button_text' => '',
+        ));
+        ?>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('title')); ?>"><?php esc_html_e('Titolo box', 'affiliate-link-manager-ai'); ?></label>
+            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('title')); ?>" name="<?php echo esc_attr($this->get_field_name('title')); ?>" type="text" value="<?php echo esc_attr($instance['title']); ?>" placeholder="<?php echo esc_attr(self::get_defaults()['title']); ?>" />
+        </p>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('max_links')); ?>"><?php esc_html_e('Numero massimo link', 'affiliate-link-manager-ai'); ?></label>
+            <input class="tiny-text" id="<?php echo esc_attr($this->get_field_id('max_links')); ?>" name="<?php echo esc_attr($this->get_field_name('max_links')); ?>" type="number" min="1" max="20" value="<?php echo esc_attr($instance['max_links']); ?>" placeholder="4" />
+        </p>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('min_score')); ?>"><?php esc_html_e('Soglia minima', 'affiliate-link-manager-ai'); ?></label>
+            <input class="tiny-text" id="<?php echo esc_attr($this->get_field_id('min_score')); ?>" name="<?php echo esc_attr($this->get_field_name('min_score')); ?>" type="number" min="0" max="100" value="<?php echo esc_attr($instance['min_score']); ?>" placeholder="40" />
+        </p>
+        <?php $this->render_widget_select('show_image', __('Mostra immagine', 'affiliate-link-manager-ai'), $instance['show_image']); ?>
+        <?php $this->render_widget_select('show_description', __('Mostra descrizione', 'affiliate-link-manager-ai'), $instance['show_description']); ?>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('button_text')); ?>"><?php esc_html_e('Testo pulsante', 'affiliate-link-manager-ai'); ?></label>
+            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('button_text')); ?>" name="<?php echo esc_attr($this->get_field_name('button_text')); ?>" type="text" value="<?php echo esc_attr($instance['button_text']); ?>" placeholder="<?php echo esc_attr(self::get_defaults()['button_text']); ?>" />
+        </p>
+        <p class="description"><?php esc_html_e('Lascia vuoto un campo per usare le impostazioni globali del Widget Contestuale.', 'affiliate-link-manager-ai'); ?></p>
+        <?php
+    }
+
+    public function update($new_instance, $old_instance) {
+        $instance = array();
+        $instance['title'] = sanitize_text_field($new_instance['title'] ?? '');
+        $instance['max_links'] = isset($new_instance['max_links']) && $new_instance['max_links'] !== '' ? (string) max(1, min(20, absint($new_instance['max_links']))) : '';
+        $instance['min_score'] = isset($new_instance['min_score']) && $new_instance['min_score'] !== '' ? (string) max(0, min(100, absint($new_instance['min_score']))) : '';
+        $instance['show_image'] = self::sanitize_yes_no_or_empty($new_instance['show_image'] ?? '');
+        $instance['show_description'] = self::sanitize_yes_no_or_empty($new_instance['show_description'] ?? '');
+        $instance['button_text'] = sanitize_text_field($new_instance['button_text'] ?? '');
+        self::bump_cache_version();
+        return $instance;
+    }
+
+    private function render_widget_select($key, $label, $selected) {
+        ?>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id($key)); ?>"><?php echo esc_html($label); ?></label>
+            <select class="widefat" id="<?php echo esc_attr($this->get_field_id($key)); ?>" name="<?php echo esc_attr($this->get_field_name($key)); ?>">
+                <option value="" <?php selected($selected, ''); ?>><?php esc_html_e('Usa impostazione globale', 'affiliate-link-manager-ai'); ?></option>
+                <option value="yes" <?php selected($selected, 'yes'); ?>><?php esc_html_e('Sì', 'affiliate-link-manager-ai'); ?></option>
+                <option value="no" <?php selected($selected, 'no'); ?>><?php esc_html_e('No', 'affiliate-link-manager-ai'); ?></option>
+            </select>
+        </p>
+        <?php
+    }
+
+    private function resolve_settings($instance) {
+        $settings = self::get_global_settings();
+        $instance = (array) $instance;
+        foreach (array('title', 'button_text') as $key) {
+            if (isset($instance[$key]) && trim((string) $instance[$key]) !== '') {
+                $settings[$key] = sanitize_text_field($instance[$key]);
+            }
+        }
+        foreach (array('max_links', 'min_score') as $key) {
+            if (isset($instance[$key]) && $instance[$key] !== '') {
+                $settings[$key] = $key === 'max_links' ? max(1, min(20, absint($instance[$key]))) : max(0, min(100, absint($instance[$key])));
+            }
+        }
+        foreach (array('show_image', 'show_description') as $key) {
+            $value = self::sanitize_yes_no_or_empty($instance[$key] ?? '');
+            if ($value !== '') {
+                $settings[$key] = $value;
+            }
+        }
+        return $settings;
+    }
+
+    private function get_cached_matches($post, $settings) {
+        $hash_settings = $settings;
+        unset($hash_settings['title'], $hash_settings['button_text']);
+        $hash_settings['cache_version'] = absint(get_option(self::CACHE_VERSION_OPTION, 1));
+        $hash = md5(wp_json_encode($hash_settings));
+        $cache_key = 'alma_contextual_widget_' . absint($post->ID) . '_' . $hash;
+        $cached = get_transient($cache_key);
+        if (is_array($cached) && isset($cached['link_ids'], $cached['settings_hash']) && $cached['settings_hash'] === $hash) {
+            return $this->hydrate_cached_links($cached);
+        }
+
+        $matcher = new ALMA_Contextual_Affiliate_Matcher($settings);
+        $links = $matcher->match($post, $settings);
+        set_transient($cache_key, array(
+            'link_ids' => wp_list_pluck($links, 'id'),
+            'scores' => wp_list_pluck($links, 'score', 'id'),
+            'timestamp' => time(),
+            'settings_hash' => $hash,
+        ), self::get_ttl_seconds($settings['cache_ttl']));
+
+        return $links;
+    }
+
+    private function hydrate_cached_links($cached) {
+        $links = array();
+        $scores = is_array($cached['scores'] ?? null) ? $cached['scores'] : array();
+        foreach ((array) $cached['link_ids'] as $id) {
+            $id = absint($id);
+            $post = get_post($id);
+            $affiliate_url = trim((string) get_post_meta($id, '_affiliate_url', true));
+            if (!$post || $post->post_type !== 'affiliate_link' || $post->post_status !== 'publish' || $affiliate_url === '') {
+                continue;
+            }
+            $links[] = array(
+                'id' => $id,
+                'score' => absint($scores[$id] ?? 0),
+                'click_count' => absint(get_post_meta($id, '_click_count', true)),
+                'title' => get_the_title($id),
+                'affiliate_url' => $affiliate_url,
+                'has_image' => has_post_thumbnail($id),
+            );
+        }
+        return $links;
+    }
+
+    private function render_link_item($link, $settings) {
+        $link_id = absint($link['id']);
+        $affiliate_url = get_post_meta($link_id, '_affiliate_url', true);
+        if ($affiliate_url === '') {
+            return;
+        }
+        $rel = get_post_meta($link_id, '_link_rel', true);
+        if ($rel === '' && metadata_exists('post', $link_id, '_link_rel')) {
+            $rel_attr = '';
+        } elseif (!$rel) {
+            $rel_attr = 'sponsored noopener';
+        } else {
+            $rel_attr = $rel;
+        }
+        $target = get_post_meta($link_id, '_link_target', true) ?: '_blank';
+        $link_title = get_post_meta($link_id, '_link_title', true) ?: get_the_title($link_id);
+        $description = wp_trim_words(wp_strip_all_tags(strip_shortcodes(get_post_field('post_excerpt', $link_id) ?: get_post_field('post_content', $link_id))), 18, '…');
+        ?>
+        <article class="alma-contextual-widget__item">
+            <?php if ($settings['show_image'] === 'yes' && has_post_thumbnail($link_id)) : ?>
+                <a class="alma-contextual-widget__image alma-affiliate-link" href="<?php echo esc_url($affiliate_url); ?>" data-track="1" data-link-id="<?php echo esc_attr($link_id); ?>" data-source="contextual_widget" <?php echo $rel_attr !== '' ? 'rel="' . esc_attr($rel_attr) . '"' : ''; ?> target="<?php echo esc_attr($target); ?>" title="<?php echo esc_attr($link_title); ?>">
+                    <?php echo get_the_post_thumbnail($link_id, 'full'); ?>
+                </a>
+            <?php endif; ?>
+            <div class="alma-contextual-widget__content">
+                <a class="alma-contextual-widget__link-title alma-affiliate-link" href="<?php echo esc_url($affiliate_url); ?>" data-track="1" data-link-id="<?php echo esc_attr($link_id); ?>" data-source="contextual_widget" <?php echo $rel_attr !== '' ? 'rel="' . esc_attr($rel_attr) . '"' : ''; ?> target="<?php echo esc_attr($target); ?>" title="<?php echo esc_attr($link_title); ?>"><?php echo esc_html(get_the_title($link_id)); ?></a>
+                <?php if ($settings['show_description'] === 'yes' && $description !== '') : ?>
+                    <p class="alma-contextual-widget__description"><?php echo esc_html($description); ?></p>
+                <?php endif; ?>
+                <a class="alma-contextual-widget__button alma-affiliate-link" href="<?php echo esc_url($affiliate_url); ?>" data-track="1" data-link-id="<?php echo esc_attr($link_id); ?>" data-source="contextual_widget" <?php echo $rel_attr !== '' ? 'rel="' . esc_attr($rel_attr) . '"' : ''; ?> target="<?php echo esc_attr($target); ?>" title="<?php echo esc_attr($link_title); ?>"><?php echo esc_html($settings['button_text']); ?></a>
+            </div>
+        </article>
+        <?php
+    }
+
+    public static function render_settings_page() {
+        if (!current_user_can('manage_options')) {
+            wp_die(esc_html__('Non hai i permessi per accedere a questa pagina.', 'affiliate-link-manager-ai'));
+        }
+
+        self::maybe_set_default_options();
+        $message = '';
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            check_admin_referer('alma_contextual_widget_settings', 'alma_contextual_widget_nonce');
+            $action = sanitize_key($_POST['alma_contextual_widget_action'] ?? 'save');
+            if ($action === 'flush') {
+                self::bump_cache_version();
+                $message = __('Cache Widget Contestuale svuotata.', 'affiliate-link-manager-ai');
+            } else {
+                self::save_settings_from_post();
+                self::bump_cache_version();
+                $message = __('Impostazioni Widget Contestuale salvate.', 'affiliate-link-manager-ai');
+            }
+        }
+
+        $settings = self::get_global_settings();
+        $public_post_types = self::get_supported_post_type_choices();
+        ?>
+        <div class="wrap alma-contextual-widget-admin">
+            <h1><?php esc_html_e('Widget Link Contestuale', 'affiliate-link-manager-ai'); ?></h1>
+            <?php if ($message !== '') : ?>
+                <div class="notice notice-success is-dismissible"><p><?php echo esc_html($message); ?></p></div>
+            <?php endif; ?>
+            <div class="card">
+                <h2><?php esc_html_e('Matching locale senza AI', 'affiliate-link-manager-ai'); ?></h2>
+                <p><?php esc_html_e('Il widget legge titolo, slug, categorie, tag, contenuto e heading H2/H3 dell’articolo corrente, assegna uno score ai Link Affiliati pubblicati e mostra solo quelli sopra soglia. Non modifica gli articoli e non usa OpenAI.', 'affiliate-link-manager-ai'); ?></p>
+                <p><span class="alma-badge"><?php esc_html_e('Cache per post', 'affiliate-link-manager-ai'); ?></span> <?php esc_html_e('La cache usa una versione interna invalidata al salvataggio di articoli supportati, Link Affiliati e impostazioni.', 'affiliate-link-manager-ai'); ?></p>
+            </div>
+            <form method="post" action="">
+                <?php wp_nonce_field('alma_contextual_widget_settings', 'alma_contextual_widget_nonce'); ?>
+                <input type="hidden" name="alma_contextual_widget_action" value="save" />
+                <table class="form-table" role="presentation">
+                    <tr>
+                        <th scope="row"><?php esc_html_e('Abilita widget', 'affiliate-link-manager-ai'); ?></th>
+                        <td><label><input type="checkbox" name="alma_contextual_widget_enabled" value="yes" <?php checked($settings['enabled'], 'yes'); ?> /> <?php esc_html_e('Abilitato', 'affiliate-link-manager-ai'); ?></label></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php esc_html_e('Post type supportati', 'affiliate-link-manager-ai'); ?></th>
+                        <td>
+                            <?php foreach ($public_post_types as $type => $label) : ?>
+                                <label><input type="checkbox" name="alma_contextual_widget_post_types[]" value="<?php echo esc_attr($type); ?>" <?php checked(in_array($type, $settings['post_types'], true)); ?> /> <?php echo esc_html($label); ?></label><br />
+                            <?php endforeach; ?>
+                            <p class="description"><?php esc_html_e('MVP: il widget è pensato per pagine singole post e page.', 'affiliate-link-manager-ai'); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="alma_contextual_widget_max_links"><?php esc_html_e('Numero massimo link', 'affiliate-link-manager-ai'); ?></label></th>
+                        <td><input type="number" id="alma_contextual_widget_max_links" name="alma_contextual_widget_max_links" min="1" max="20" value="<?php echo esc_attr($settings['max_links']); ?>" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="alma_contextual_widget_min_score"><?php esc_html_e('Soglia minima score', 'affiliate-link-manager-ai'); ?></label></th>
+                        <td><input type="number" id="alma_contextual_widget_min_score" name="alma_contextual_widget_min_score" min="0" max="100" value="<?php echo esc_attr($settings['min_score']); ?>" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="alma_contextual_widget_title"><?php esc_html_e('Titolo box', 'affiliate-link-manager-ai'); ?></label></th>
+                        <td><input type="text" class="regular-text" id="alma_contextual_widget_title" name="alma_contextual_widget_title" value="<?php echo esc_attr($settings['title']); ?>" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="alma_contextual_widget_button_text"><?php esc_html_e('Testo pulsante', 'affiliate-link-manager-ai'); ?></label></th>
+                        <td><input type="text" class="regular-text" id="alma_contextual_widget_button_text" name="alma_contextual_widget_button_text" value="<?php echo esc_attr($settings['button_text']); ?>" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php esc_html_e('Mostra immagine', 'affiliate-link-manager-ai'); ?></th>
+                        <td><label><input type="checkbox" name="alma_contextual_widget_show_image" value="yes" <?php checked($settings['show_image'], 'yes'); ?> /> <?php esc_html_e('Usa immagine originale/full del Link Affiliato', 'affiliate-link-manager-ai'); ?></label></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php esc_html_e('Mostra descrizione', 'affiliate-link-manager-ai'); ?></th>
+                        <td><label><input type="checkbox" name="alma_contextual_widget_show_description" value="yes" <?php checked($settings['show_description'], 'yes'); ?> /> <?php esc_html_e('Mostra descrizione breve', 'affiliate-link-manager-ai'); ?></label></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php esc_html_e('Escludi link già presenti', 'affiliate-link-manager-ai'); ?></th>
+                        <td><label><input type="checkbox" name="alma_contextual_widget_exclude_existing_links" value="yes" <?php checked($settings['exclude_existing_links'], 'yes'); ?> /> <?php esc_html_e('Non mostrare link già inseriti nel contenuto articolo', 'affiliate-link-manager-ai'); ?></label></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="alma_contextual_widget_cache_ttl"><?php esc_html_e('Durata cache', 'affiliate-link-manager-ai'); ?></label></th>
+                        <td><?php self::render_cache_ttl_select($settings['cache_ttl']); ?></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="alma_contextual_widget_fallback_mode"><?php esc_html_e('Fallback', 'affiliate-link-manager-ai'); ?></label></th>
+                        <td><?php self::render_fallback_select($settings['fallback_mode']); ?><p class="description"><?php esc_html_e('Per questo MVP è attivo hide: se non ci sono link coerenti, il widget non mostra nulla.', 'affiliate-link-manager-ai'); ?></p></td>
+                    </tr>
+                </table>
+                <?php submit_button(__('Salva impostazioni', 'affiliate-link-manager-ai')); ?>
+            </form>
+            <form method="post" action="">
+                <?php wp_nonce_field('alma_contextual_widget_settings', 'alma_contextual_widget_nonce'); ?>
+                <input type="hidden" name="alma_contextual_widget_action" value="flush" />
+                <?php submit_button(__('Svuota cache Widget Contestuale', 'affiliate-link-manager-ai'), 'secondary'); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    private static function save_settings_from_post() {
+        update_option('alma_contextual_widget_enabled', isset($_POST['alma_contextual_widget_enabled']) ? 'yes' : 'no');
+        update_option('alma_contextual_widget_post_types', self::sanitize_post_types($_POST['alma_contextual_widget_post_types'] ?? array()));
+        update_option('alma_contextual_widget_max_links', max(1, min(20, absint($_POST['alma_contextual_widget_max_links'] ?? 4))));
+        update_option('alma_contextual_widget_min_score', max(0, min(100, absint($_POST['alma_contextual_widget_min_score'] ?? 40))));
+        update_option('alma_contextual_widget_title', sanitize_text_field($_POST['alma_contextual_widget_title'] ?? self::get_defaults()['title']));
+        update_option('alma_contextual_widget_button_text', sanitize_text_field($_POST['alma_contextual_widget_button_text'] ?? self::get_defaults()['button_text']));
+        update_option('alma_contextual_widget_show_image', isset($_POST['alma_contextual_widget_show_image']) ? 'yes' : 'no');
+        update_option('alma_contextual_widget_show_description', isset($_POST['alma_contextual_widget_show_description']) ? 'yes' : 'no');
+        update_option('alma_contextual_widget_exclude_existing_links', isset($_POST['alma_contextual_widget_exclude_existing_links']) ? 'yes' : 'no');
+        update_option('alma_contextual_widget_cache_ttl', self::sanitize_cache_ttl($_POST['alma_contextual_widget_cache_ttl'] ?? '24h'));
+        update_option('alma_contextual_widget_fallback_mode', self::sanitize_fallback_mode($_POST['alma_contextual_widget_fallback_mode'] ?? 'hide'));
+    }
+
+    public static function maybe_invalidate_on_save($post_id, $post, $update) {
+        if (wp_is_post_autosave($post_id) || wp_is_post_revision($post_id) || !$post instanceof WP_Post) {
+            return;
+        }
+        $settings = self::get_global_settings();
+        if ($post->post_type === 'affiliate_link' || in_array($post->post_type, $settings['post_types'], true)) {
+            self::bump_cache_version();
+        }
+    }
+
+    public static function bump_cache_version() {
+        $version = absint(get_option(self::CACHE_VERSION_OPTION, 1));
+        update_option(self::CACHE_VERSION_OPTION, $version + 1, false);
+    }
+
+    private static function sanitize_post_types($post_types) {
+        $allowed = array_keys(self::get_supported_post_type_choices());
+        $clean = array();
+        foreach ((array) $post_types as $post_type) {
+            $post_type = sanitize_key($post_type);
+            if (in_array($post_type, $allowed, true)) {
+                $clean[] = $post_type;
+            }
+        }
+        $clean = array_values(array_unique($clean));
+        return empty($clean) ? array('post') : $clean;
+    }
+
+    private static function get_supported_post_type_choices() {
+        return array(
+            'post' => __('Articoli', 'affiliate-link-manager-ai'),
+            'page' => __('Pagine', 'affiliate-link-manager-ai'),
+        );
+    }
+
+    private static function sanitize_yes_no_or_empty($value) {
+        $value = sanitize_key($value);
+        return in_array($value, array('yes', 'no'), true) ? $value : '';
+    }
+
+    private static function sanitize_cache_ttl($value) {
+        $value = sanitize_key($value);
+        return array_key_exists($value, self::get_cache_ttl_choices()) ? $value : '24h';
+    }
+
+    private static function sanitize_fallback_mode($value) {
+        $value = sanitize_key($value);
+        return in_array($value, array('hide', 'popular', 'manual', 'same_type'), true) ? $value : 'hide';
+    }
+
+    private static function get_ttl_seconds($value) {
+        $choices = self::get_cache_ttl_choices();
+        return $choices[self::sanitize_cache_ttl($value)]['seconds'];
+    }
+
+    private static function get_cache_ttl_choices() {
+        return array(
+            '1h' => array('label' => __('1 ora', 'affiliate-link-manager-ai'), 'seconds' => HOUR_IN_SECONDS),
+            '6h' => array('label' => __('6 ore', 'affiliate-link-manager-ai'), 'seconds' => 6 * HOUR_IN_SECONDS),
+            '24h' => array('label' => __('24 ore', 'affiliate-link-manager-ai'), 'seconds' => DAY_IN_SECONDS),
+            '7d' => array('label' => __('7 giorni', 'affiliate-link-manager-ai'), 'seconds' => WEEK_IN_SECONDS),
+        );
+    }
+
+    private static function render_cache_ttl_select($selected) {
+        echo '<select id="alma_contextual_widget_cache_ttl" name="alma_contextual_widget_cache_ttl">';
+        foreach (self::get_cache_ttl_choices() as $value => $data) {
+            echo '<option value="' . esc_attr($value) . '" ' . selected($selected, $value, false) . '>' . esc_html($data['label']) . '</option>';
+        }
+        echo '</select>';
+    }
+
+    private static function render_fallback_select($selected) {
+        $choices = array(
+            'hide' => __('Hide - non mostrare nulla', 'affiliate-link-manager-ai'),
+            'popular' => __('Popular - futuro', 'affiliate-link-manager-ai'),
+            'manual' => __('Manual - futuro', 'affiliate-link-manager-ai'),
+            'same_type' => __('Same type - futuro', 'affiliate-link-manager-ai'),
+        );
+        echo '<select id="alma_contextual_widget_fallback_mode" name="alma_contextual_widget_fallback_mode">';
+        foreach ($choices as $value => $label) {
+            echo '<option value="' . esc_attr($value) . '" ' . selected($selected, $value, false) . ($value !== 'hide' ? ' disabled' : '') . '>' . esc_html($label) . '</option>';
+        }
+        echo '</select>';
+    }
+}


### PR DESCRIPTION
### Motivation
- Fornire un MVP opzionale per mostrare in sidebar Link Affiliati coerenti con l’articolo corrente tramite matching locale deterministico senza usare OpenAI. 
- Offrire una soluzione estendibile, sicura e non intrusiva che mantenga il tracciamento click e non modifichi mai il contenuto degli articoli. 
- Ridurre il carico di query con cache per post e preparare la strada a un indice dedicato in futuri rilasci.

### Description
- Aggiunti i file `includes/class-contextual-affiliate-widget.php` e `includes/class-contextual-affiliate-matcher.php` che implementano rispettivamente il widget `ALMA_Contextual_Affiliate_Widget` (WP_Widget) e il matcher deterministico; il matcher recupera fino a 200 candidati `affiliate_link` e applica lo scoring specificato (titolo/headings/keyword/link_type/ai_context/clicks/exclude existing). 
- Bootstrap aggiornato in `affiliate-link-manager-ai.php` per includere i nuovi file, registrare il widget su `widgets_init`, aggiungere la voce admin `Widget Contestuale` (`alma-contextual-widget`) sotto il menu `affiliate_link`, chiamare l’inizializzazione delle option di default su activate/update e agganciare l’invalidazione cache su `save_post`. 
- Implementate impostazioni globali persistenti (option) e form admin WordPress-native con nonce, sanitizzazione, messaggio di successo e pulsante “Svuota cache Widget Contestuale”; opzioni per abilitazione, post types, `max_links`, `min_score`, titolo, testo pulsante, show image/description, exclude existing, `cache_ttl` (1h/6h/24h/7d) e `fallback_mode` (MVP: `hide`). 
- Cache per post via transient con chiave `alma_contextual_widget_{post_id}_{settings_hash}` e versione cache `alma_contextual_widget_cache_version` per invalidazione su salvataggi e flush; il widget rende card con immagine `full`, titolo, descrizione e CTA mantenendo `rel`/`target` originali e attributi di tracking `data-track=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23012c68588332943131f9b54b0c3d)