### PR TITLE
Fix Geo Index active import status display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Chiarita la distinzione tra record Geo Index attivo e stato geocoding `pending`: i record importati correttamente vengono marcati come attivi e `pending` viene mostrato come “In attesa di geocoding”.
 
 ## 2.40.1 - 2026-06-06
 - Corretto l’upload CSV del modulo **Indice Geografico** evitando il blocco MIME di WordPress su file `.csv` identificati come `text/plain`, `application/vnd.ms-excel`, `application/csv` o `application/octet-stream` valido.
@@ -10,7 +11,7 @@
 - Aggiunto il modulo **Indice Geografico** come fondazione interna del plugin, con menu admin `alma-geo-index`, dashboard conteggi, import CSV safe, elenco località e log ultimo import.
 - Create via `dbDelta` le nuove tabelle `alma_geo_locations` e `alma_geo_content_index`, senza rimuovere o modificare dati/tabelle esistenti.
 - Aggiunto il metabox **Geolocalizzazione contenuto** su `post`, `page` e `affiliate_link`, con nonce, capability, check autosave/revision, sanitizzazione, post meta `_alma_geo_*` e sincronizzazione verso le tabelle Geo Index.
-- Implementato l’import conservativo di `sothra_geo_article_index_safe_import.csv` per `post` e `page`: validazione header, preview primi 10 record, import solo se `safe_for_auto_import` e `safe_for_auto_geocoding` sono veri, gestione no-overwrite default e report in option.
+- Implementato l’import conservativo di `sothra_geo_article_index_safe_import.csv` per `post` e `page`: validazione header, preview primi 10 record, import solo se `safe_for_auto_import` è vero, gestione no-overwrite default e report in option.
 - Nessun uso di AI, nessuna chiamata Google Maps API e nessuna modifica alla logica frontend del Widget Link Contestuale o agli shortcode esistenti.
 - Versione plugin aggiornata a `2.40.0`.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - Introdotte le tabelle dedicate `alma_geo_locations` e `alma_geo_content_index` per salvare località uniche e relazioni contenuto/località senza modificare le tabelle esistenti.
 - Aggiunto il metabox **Geolocalizzazione contenuto** su `post`, `page` e `affiliate_link`, con salvataggio sicuro dei meta `_alma_geo_*` e sincronizzazione conservativa verso le nuove tabelle.
 - Implementato l’import del file `sothra_geo_article_index_safe_import.csv` per record sicuri di articoli/pagine: valida header, mostra preview dei primi 10 record, importa solo righe safe, rispetta il default “non sovrascrivere” e salva l’ultimo report in `alma_geo_index_last_import_report`.
+- I record importati correttamente sono marcati come attivi nell’Indice Geografico, mentre lo stato `pending` resta limitato al geocoding e viene visualizzato come “In attesa di geocoding”.
 - In questa fase non viene chiamata Google Maps API, non viene eseguito geocoding automatico, non viene usata AI e il **Widget Link Contestuale** continua a usare la logica precedente.
 - La struttura è pronta per fasi successive: import Link Affiliati, geocoding Google Maps, uso del Geo Index nel Widget Contestuale e mappe interattive.
 - Versione plugin aggiornata a `2.40.0`.

--- a/includes/class-geo-index-admin.php
+++ b/includes/class-geo-index-admin.php
@@ -151,12 +151,15 @@ class ALMA_Geo_Index_Admin {
             return;
         }
         $cards = array(
-            __('Articoli/pagine con geo meta', 'affiliate-link-manager-ai') => $counts['posts_with_geo_meta'],
+            __('Contenuti geolocalizzati attivi', 'affiliate-link-manager-ai') => $counts['active_geo_content'],
+            __('In attesa di geocoding', 'affiliate-link-manager-ai') => $counts['pending_geocoding'],
+            __('Geocodificati', 'affiliate-link-manager-ai') => $counts['verified_geocoding'],
+            __('Da revisione', 'affiliate-link-manager-ai') => $counts['manual_review'],
+            __('Non attivi/scartati', 'affiliate-link-manager-ai') => $counts['inactive_or_discarded'],
+            __('Compatibilità widget', 'affiliate-link-manager-ai') => $counts['widget_eligible'],
             __('Link Affiliati con geo meta', 'affiliate-link-manager-ai') => $counts['affiliate_links_with_geo_meta'],
             __('Località salvate', 'affiliate-link-manager-ai') => $counts['locations'],
             __('Relazioni contenuto/località', 'affiliate-link-manager-ai') => $counts['content_relations'],
-            __('Record pending geocoding', 'affiliate-link-manager-ai') => $counts['pending_geocoding'],
-            __('Record widget eligible', 'affiliate-link-manager-ai') => $counts['widget_eligible'],
         );
         echo '<div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:16px;margin-top:16px;">';
         foreach ($cards as $label => $value) {
@@ -225,7 +228,7 @@ class ALMA_Geo_Index_Admin {
             echo '<tr><td colspan="11">' . esc_html__('Nessuna località salvata.', 'affiliate-link-manager-ai') . '</td></tr>';
         }
         foreach ($locations as $location) {
-            echo '<tr><td>' . esc_html((string) $location['id']) . '</td><td>' . esc_html($location['canonical_name']) . '</td><td>' . esc_html($location['type']) . '</td><td>' . esc_html($location['country']) . '</td><td>' . esc_html($location['region']) . '</td><td>' . esc_html($location['city']) . '</td><td>' . esc_html($location['area']) . '</td><td>' . esc_html($location['poi']) . '</td><td>' . esc_html($location['geocoding_status']) . '</td><td>' . esc_html($location['suggested_geocoding_query']) . '</td><td>' . esc_html((string) $location['content_count']) . '</td></tr>';
+            echo '<tr><td>' . esc_html((string) $location['id']) . '</td><td>' . esc_html($location['canonical_name']) . '</td><td>' . esc_html($location['type']) . '</td><td>' . esc_html($location['country']) . '</td><td>' . esc_html($location['region']) . '</td><td>' . esc_html($location['city']) . '</td><td>' . esc_html($location['area']) . '</td><td>' . esc_html($location['poi']) . '</td><td>' . esc_html(ALMA_Geo_Index_Metabox::geocoding_status_label($location['geocoding_status'])) . '</td><td>' . esc_html($location['suggested_geocoding_query']) . '</td><td>' . esc_html((string) $location['content_count']) . '</td></tr>';
         }
         echo '</tbody></table>';
     }

--- a/includes/class-geo-index-importer.php
+++ b/includes/class-geo-index-importer.php
@@ -239,8 +239,7 @@ class ALMA_Geo_Index_Importer {
     public function is_safe_row($row) {
         $import_status = sanitize_key($row['geo_import_status'] ?? '');
         return $this->to_bool($row['safe_for_auto_import'] ?? false)
-            && $this->to_bool($row['safe_for_auto_geocoding'] ?? false)
-            && in_array($import_status, array('needs_geocoding', 'ready'), true);
+            && in_array($import_status, array('', 'active', 'needs_geocoding', 'ready'), true);
     }
 
     public function row_to_meta($row) {
@@ -248,15 +247,14 @@ class ALMA_Geo_Index_Importer {
         $commercial_intent = $this->allowed_or_default($row['commercial_intent'] ?? '', ALMA_Geo_Index_Metabox::commercial_intents(), 'none');
         $geo_scope = $this->allowed_or_default($row['geo_scope'] ?? '', ALMA_Geo_Index_Metabox::geo_scopes(), 'uncertain');
         $primary_type = $this->allowed_or_default($row['primary_type'] ?? '', ALMA_Geo_Index_Metabox::primary_types(), 'unknown');
-        $import_status = $this->allowed_or_default($row['geo_import_status'] ?? '', ALMA_Geo_Index_Metabox::geo_import_statuses(), 'review');
-        $geocoding_status = $this->allowed_or_default($row['geocoding_status'] ?? '', ALMA_Geo_Index_Metabox::geocoding_statuses(), 'pending');
+        $widget_eligible = $this->to_bool($row['widget_eligible'] ?? false) || $this->to_bool($row['safe_for_auto_import'] ?? false);
 
         return array(
-            '_alma_geo_enabled' => '1',
+            '_alma_geo_enabled' => 'yes',
             '_alma_geo_scope' => $geo_scope,
             '_alma_geo_content_type' => $content_type,
             '_alma_geo_commercial_intent' => $commercial_intent,
-            '_alma_geo_widget_eligible' => $commercial_intent === 'high' || $commercial_intent === 'medium' ? '1' : '0',
+            '_alma_geo_widget_eligible' => $widget_eligible ? 'yes' : 'no',
             '_alma_geo_primary_name' => sanitize_text_field($row['primary_name'] ?? ''),
             '_alma_geo_primary_canonical_name' => sanitize_text_field($row['primary_canonical_name'] ?? ($row['primary_name'] ?? '')),
             '_alma_geo_primary_type' => $primary_type,
@@ -271,12 +269,12 @@ class ALMA_Geo_Index_Importer {
             '_alma_geo_primary_place_id' => '',
             '_alma_geo_confidence' => isset($row['confidence']) && $row['confidence'] !== '' ? (string) min(1, max(0, (float) $row['confidence'])) : '',
             '_alma_geo_match_weight' => isset($row['match_weight']) && $row['match_weight'] !== '' ? (string) (int) $row['match_weight'] : '',
-            '_alma_geo_geocoding_status' => $geocoding_status,
-            '_alma_geo_import_status' => $import_status,
+            '_alma_geo_geocoding_status' => 'pending',
+            '_alma_geo_import_status' => 'active',
             '_alma_geo_locations_json' => '',
             '_alma_geo_quality_flags' => sanitize_textarea_field($row['geo_quality_flags'] ?? ''),
             '_alma_geo_notes' => '',
-            '_alma_geo_source' => sanitize_text_field($row['primary_source'] ?? 'safe_csv'),
+            '_alma_geo_source' => sanitize_text_field(!empty($row['primary_source']) ? $row['primary_source'] : 'safe_import_csv'),
             '_alma_geo_updated_at' => current_time('mysql'),
         );
     }

--- a/includes/class-geo-index-metabox.php
+++ b/includes/class-geo-index-metabox.php
@@ -40,13 +40,18 @@ class ALMA_Geo_Index_Metabox {
         ?>
         <p><?php esc_html_e('Questi dati servono a collegare il contenuto a una località geografica e saranno usati in futuro per il Widget Link Contestuale, per il matching con Link Affiliati e per mappe interattive.', 'affiliate-link-manager-ai'); ?></p>
         <style>
-            .alma-geo-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px 18px}.alma-geo-field label{display:block;font-weight:600;margin-bottom:4px}.alma-geo-field input,.alma-geo-field select,.alma-geo-field textarea{width:100%;max-width:100%}.alma-geo-section{border-top:1px solid #dcdcde;margin-top:16px;padding-top:12px}.alma-geo-checks label{margin-right:18px}
+            .alma-geo-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px 18px}.alma-geo-field label{display:block;font-weight:600;margin-bottom:4px}.alma-geo-field input,.alma-geo-field select,.alma-geo-field textarea{width:100%;max-width:100%}.alma-geo-section{border-top:1px solid #dcdcde;margin-top:16px;padding-top:12px}.alma-geo-checks label{margin-right:18px}.alma-geo-status-summary{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px;margin:12px 0}.alma-geo-badge{display:inline-block;border-radius:999px;padding:3px 9px;font-weight:600;background:#f0f0f1;color:#2c3338}.alma-geo-badge-active{background:#d1e7dd;color:#0f5132}.alma-geo-badge-inactive{background:#f8d7da;color:#842029}.alma-geo-badge-pending{background:#fff3cd;color:#664d03}.alma-geo-badge-verified{background:#cfe2ff;color:#084298}.alma-geo-badge-manual{background:#fde2c2;color:#7a3e00}.alma-geo-badge-failed{background:#f8d7da;color:#842029}
         </style>
         <div class="alma-geo-section">
             <h3><?php esc_html_e('Stato', 'affiliate-link-manager-ai'); ?></h3>
+            <div class="alma-geo-status-summary">
+                <div><?php esc_html_e('Indice geografico:', 'affiliate-link-manager-ai'); ?> <?php echo $this->render_record_status_badge($values['_alma_geo_enabled'] ?? 'no'); ?></div>
+                <div><?php esc_html_e('Stato import:', 'affiliate-link-manager-ai'); ?> <?php echo $this->render_import_status_badge($values['_alma_geo_import_status'] ?? 'review'); ?></div>
+                <div><?php esc_html_e('Stato geocoding:', 'affiliate-link-manager-ai'); ?> <?php echo $this->render_geocoding_status_badge($values['_alma_geo_geocoding_status'] ?? 'pending'); ?></div>
+            </div>
             <p class="alma-geo-checks">
-                <label><input type="checkbox" name="alma_geo[_alma_geo_enabled]" value="1" <?php checked($values['_alma_geo_enabled'], '1'); ?>> <?php esc_html_e('Abilita geolocalizzazione', 'affiliate-link-manager-ai'); ?></label>
-                <label><input type="checkbox" name="alma_geo[_alma_geo_widget_eligible]" value="1" <?php checked($values['_alma_geo_widget_eligible'], '1'); ?>> <?php esc_html_e('Widget eligible', 'affiliate-link-manager-ai'); ?></label>
+                <label><input type="checkbox" name="alma_geo[_alma_geo_enabled]" value="yes" <?php checked($this->is_yes($values['_alma_geo_enabled'] ?? ''), true); ?>> <?php esc_html_e('Abilita geolocalizzazione', 'affiliate-link-manager-ai'); ?></label>
+                <label><input type="checkbox" name="alma_geo[_alma_geo_widget_eligible]" value="yes" <?php checked($this->is_yes($values['_alma_geo_widget_eligible'] ?? ''), true); ?>> <?php esc_html_e('Widget eligible', 'affiliate-link-manager-ai'); ?></label>
             </p>
             <div class="alma-geo-grid">
                 <?php $this->render_select('_alma_geo_import_status', __('Stato import', 'affiliate-link-manager-ai'), $values, self::geo_import_statuses()); ?>
@@ -165,7 +170,7 @@ class ALMA_Geo_Index_Metabox {
             'geo_scope' => $data['_alma_geo_scope'],
             'content_type' => $data['_alma_geo_content_type'],
             'commercial_intent' => $data['_alma_geo_commercial_intent'],
-            'widget_eligible' => $data['_alma_geo_widget_eligible'] === '1',
+            'widget_eligible' => $this->is_yes($data['_alma_geo_widget_eligible']),
             'confidence' => $data['_alma_geo_confidence'],
             'match_weight' => $data['_alma_geo_match_weight'],
             'source' => $data['_alma_geo_source'],
@@ -183,8 +188,8 @@ class ALMA_Geo_Index_Metabox {
         foreach (self::meta_keys() as $key) {
             $data[$key] = '';
         }
-        $data['_alma_geo_enabled'] = !empty($raw['_alma_geo_enabled']) ? '1' : '0';
-        $data['_alma_geo_widget_eligible'] = !empty($raw['_alma_geo_widget_eligible']) ? '1' : '0';
+        $data['_alma_geo_enabled'] = !empty($raw['_alma_geo_enabled']) ? 'yes' : 'no';
+        $data['_alma_geo_widget_eligible'] = !empty($raw['_alma_geo_widget_eligible']) ? 'yes' : 'no';
         $data['_alma_geo_scope'] = $this->sanitize_allowed($raw['_alma_geo_scope'] ?? '', self::geo_scopes(), 'uncertain');
         $data['_alma_geo_content_type'] = $this->sanitize_allowed($raw['_alma_geo_content_type'] ?? '', self::content_types(), 'uncertain');
         $data['_alma_geo_commercial_intent'] = $this->sanitize_allowed($raw['_alma_geo_commercial_intent'] ?? '', self::commercial_intents(), 'none');
@@ -220,12 +225,12 @@ class ALMA_Geo_Index_Metabox {
     public static function primary_types() { return array('continent','country','region','city','area','island','poi','airport','port','route','unknown'); }
     public static function content_types() { return array('destination_guide','country_guide','region_guide','city_guide','area_guide','poi_guide','itinerary','itinerary_multi_location','cruise_ship','cruise_company','travel_advice','honeymoon','informational','generic_travel','non_travel','uncertain'); }
     public static function commercial_intents() { return array('high','medium','low','none'); }
-    public static function geo_import_statuses() { return array('ready','review','discard','needs_geocoding','geocoding_failed'); }
+    public static function geo_import_statuses() { return array('active','ready','review','discard','needs_geocoding','geocoding_failed'); }
     public static function geocoding_statuses() { return array('pending','not_required','manual_required','verified','failed'); }
 
 
     private function has_geo_payload($data) {
-        if (($data['_alma_geo_enabled'] ?? '0') === '1' || ($data['_alma_geo_widget_eligible'] ?? '0') === '1') {
+        if ($this->is_yes($data['_alma_geo_enabled'] ?? 'no') || $this->is_yes($data['_alma_geo_widget_eligible'] ?? 'no')) {
             return true;
         }
         if (($data['_alma_geo_scope'] ?? 'uncertain') !== 'uncertain' || ($data['_alma_geo_content_type'] ?? 'uncertain') !== 'uncertain' || ($data['_alma_geo_commercial_intent'] ?? 'none') !== 'none' || ($data['_alma_geo_import_status'] ?? 'review') !== 'review' || ($data['_alma_geo_geocoding_status'] ?? 'pending') !== 'pending' || ($data['_alma_geo_primary_type'] ?? 'unknown') !== 'unknown') {
@@ -256,6 +261,69 @@ class ALMA_Geo_Index_Metabox {
         return $values;
     }
 
+
+    private function render_record_status_badge($value) {
+        $active = $this->is_yes($value);
+        $label = $active ? __('Attivo', 'affiliate-link-manager-ai') : __('Non attivo', 'affiliate-link-manager-ai');
+        $class = $active ? 'alma-geo-badge-active' : 'alma-geo-badge-inactive';
+        return '<span class="alma-geo-badge ' . esc_attr($class) . '">' . esc_html($label) . '</span>';
+    }
+
+    private function render_import_status_badge($status) {
+        $status = sanitize_key($status);
+        $class = in_array($status, array('active', 'ready', 'needs_geocoding'), true) ? 'alma-geo-badge-active' : 'alma-geo-badge-inactive';
+        return '<span class="alma-geo-badge ' . esc_attr($class) . '">' . esc_html(self::import_status_label($status)) . '</span>';
+    }
+
+    private function render_geocoding_status_badge($status) {
+        $status = sanitize_key($status);
+        $classes = array(
+            'pending' => 'alma-geo-badge-pending',
+            'verified' => 'alma-geo-badge-verified',
+            'manual_required' => 'alma-geo-badge-manual',
+            'failed' => 'alma-geo-badge-failed',
+        );
+        $class = $classes[$status] ?? 'alma-geo-badge';
+        return '<span class="alma-geo-badge ' . esc_attr($class) . '">' . esc_html(self::geocoding_status_label($status)) . '</span>';
+    }
+
+    private function status_label($key, $status) {
+        if ($key === '_alma_geo_geocoding_status') {
+            return self::geocoding_status_label($status);
+        }
+        if ($key === '_alma_geo_import_status') {
+            return self::import_status_label($status);
+        }
+        return $status;
+    }
+
+    public static function geocoding_status_label($status) {
+        $labels = array(
+            'pending' => __('In attesa di geocoding', 'affiliate-link-manager-ai'),
+            'verified' => __('Geocodificato', 'affiliate-link-manager-ai'),
+            'manual_required' => __('Richiede verifica manuale', 'affiliate-link-manager-ai'),
+            'failed' => __('Geocoding fallito', 'affiliate-link-manager-ai'),
+            'not_required' => __('Non richiesto', 'affiliate-link-manager-ai'),
+        );
+        return $labels[sanitize_key($status)] ?? $status;
+    }
+
+    public static function import_status_label($status) {
+        $labels = array(
+            'active' => __('Importato', 'affiliate-link-manager-ai'),
+            'ready' => __('Importato', 'affiliate-link-manager-ai'),
+            'needs_geocoding' => __('Importato — in attesa di geocoding', 'affiliate-link-manager-ai'),
+            'review' => __('Richiede revisione', 'affiliate-link-manager-ai'),
+            'discard' => __('Scartato', 'affiliate-link-manager-ai'),
+            'geocoding_failed' => __('Geocoding fallito', 'affiliate-link-manager-ai'),
+        );
+        return $labels[sanitize_key($status)] ?? $status;
+    }
+
+    private function is_yes($value) {
+        return in_array((string) $value, array('1', 'yes', 'true', 'on'), true);
+    }
+
     private function render_input($key, $label, $values, $type = 'text', $attrs = '') {
         printf('<div class="alma-geo-field"><label for="%1$s">%2$s</label><input type="%3$s" id="%1$s" name="alma_geo[%1$s]" value="%4$s" %5$s></div>', esc_attr($key), esc_html($label), esc_attr($type), esc_attr($values[$key] ?? ''), $attrs);
     }
@@ -268,7 +336,7 @@ class ALMA_Geo_Index_Metabox {
         echo '<div class="alma-geo-field"><label for="' . esc_attr($key) . '">' . esc_html($label) . '</label><select id="' . esc_attr($key) . '" name="alma_geo[' . esc_attr($key) . ']">';
         echo '<option value="">' . esc_html__('— Seleziona —', 'affiliate-link-manager-ai') . '</option>';
         foreach ($options as $option) {
-            echo '<option value="' . esc_attr($option) . '" ' . selected($values[$key] ?? '', $option, false) . '>' . esc_html($option) . '</option>';
+            echo '<option value="' . esc_attr($option) . '" ' . selected($values[$key] ?? '', $option, false) . '>' . esc_html($this->status_label($key, $option)) . '</option>';
         }
         echo '</select></div>';
     }

--- a/includes/class-geo-index-store.php
+++ b/includes/class-geo-index-store.php
@@ -244,13 +244,20 @@ class ALMA_Geo_Index_Store {
             return array('tables_exist' => false);
         }
 
+        $enabled_values = "('1','yes','true','on')";
+        $inactive_values = "('0','no','false','off')";
+
         return array(
             'tables_exist' => true,
-            'posts_with_geo_meta' => (int) $wpdb->get_var("SELECT COUNT(DISTINCT pm.post_id) FROM {$wpdb->postmeta} pm INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id WHERE pm.meta_key = '_alma_geo_enabled' AND pm.meta_value = '1' AND p.post_type IN ('post','page')"),
-            'affiliate_links_with_geo_meta' => (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(DISTINCT pm.post_id) FROM {$wpdb->postmeta} pm INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id WHERE pm.meta_key = '_alma_geo_enabled' AND pm.meta_value = '1' AND p.post_type = %s", self::OBJECT_TYPE_AFFILIATE_LINK)),
+            'active_geo_content' => (int) $wpdb->get_var("SELECT COUNT(DISTINCT pm.post_id) FROM {$wpdb->postmeta} pm INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id WHERE pm.meta_key = '_alma_geo_enabled' AND pm.meta_value IN $enabled_values AND p.post_type IN ('post','page')"),
+            'posts_with_geo_meta' => (int) $wpdb->get_var("SELECT COUNT(DISTINCT pm.post_id) FROM {$wpdb->postmeta} pm INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id WHERE pm.meta_key = '_alma_geo_enabled' AND pm.meta_value IN $enabled_values AND p.post_type IN ('post','page')"),
+            'affiliate_links_with_geo_meta' => (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(DISTINCT pm.post_id) FROM {$wpdb->postmeta} pm INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id WHERE pm.meta_key = '_alma_geo_enabled' AND pm.meta_value IN $enabled_values AND p.post_type = %s", self::OBJECT_TYPE_AFFILIATE_LINK)),
             'locations' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_locations()}"),
             'content_relations' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_content_index()}"),
-            'pending_geocoding' => (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$this->table_locations()} WHERE geocoding_status = %s", 'pending')),
+            'pending_geocoding' => (int) $wpdb->get_var("SELECT COUNT(DISTINCT pm.post_id) FROM {$wpdb->postmeta} pm INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id INNER JOIN {$wpdb->postmeta} enabled ON enabled.post_id = pm.post_id AND enabled.meta_key = '_alma_geo_enabled' AND enabled.meta_value IN $enabled_values WHERE pm.meta_key = '_alma_geo_geocoding_status' AND pm.meta_value = 'pending' AND p.post_type IN ('post','page')"),
+            'verified_geocoding' => (int) $wpdb->get_var("SELECT COUNT(DISTINCT post_id) FROM {$wpdb->postmeta} WHERE meta_key = '_alma_geo_geocoding_status' AND meta_value = 'verified'"),
+            'manual_review' => (int) $wpdb->get_var("SELECT COUNT(DISTINCT post_id) FROM {$wpdb->postmeta} WHERE (meta_key = '_alma_geo_geocoding_status' AND meta_value = 'manual_required') OR (meta_key = '_alma_geo_import_status' AND meta_value = 'review')"),
+            'inactive_or_discarded' => (int) $wpdb->get_var("SELECT COUNT(DISTINCT post_id) FROM {$wpdb->postmeta} WHERE (meta_key = '_alma_geo_enabled' AND meta_value IN $inactive_values) OR (meta_key = '_alma_geo_import_status' AND meta_value IN ('discard','geocoding_failed'))"),
             'widget_eligible' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_content_index()} WHERE widget_eligible = 1"),
         );
     }


### PR DESCRIPTION
### Motivation
- Ensure records imported from the safe CSV are treated as active entries in the Geo Index even when geocoding is still `pending` so admin UI clearly distinguishes record activation from geocoding state. 
- Accept `geo_import_status = needs_geocoding` as importable (not an error) and avoid requiring auto-geocoding flags for safe imports. 
- Provide clearer, localized badges/labels in metabox and dashboard so `pending` is shown as “In attesa di geocoding” rather than implying the record is inactive.

### Description
- Updated the CSV importer (`includes/class-geo-index-importer.php`) to treat safe rows with `geo_import_status` in `('', 'active', 'needs_geocoding', 'ready')` as importable and to write canonical post meta per requirements: `_alma_geo_enabled = 'yes'`, `_alma_geo_widget_eligible = 'yes'|'no'` (from CSV/safe import), `_alma_geo_import_status = 'active'`, and `_alma_geo_geocoding_status = 'pending'`; also set `_alma_geo_source` default to `safe_import_csv` when missing. 
- Enhanced the metabox (`includes/class-geo-index-metabox.php`) to render three separate status badges: record status (Attivo / Non attivo), import status (Importato / Richiede revisione / etc.), and geocoding status with localized labels (`In attesa di geocoding`, `Geocodificato`, `Richiede verifica manuale`, `Geocoding fallito`, `Non richiesto`), and to accept legacy and new boolean/meta encodings (`1`/`yes`). 
- Adjusted dashboard and store (`includes/class-geo-index-admin.php`, `includes/class-geo-index-store.php`) to expose distinct counts (active geo content, pending geocoding, verified geocoding, manual review, inactive/discarded, widget compatibility) and to show readable geocoding labels in the locations table. 
- Updated `README.md` and `CHANGELOG.md` to document the distinction between record activation and geocoding `pending`. 
- Preserved behavior constraints: no Google Maps API calls, no frontend/widget behavior changes, and import does not alter contextual widget logic.

### Testing
- Ran PHP syntax checks: `php -l affiliate-link-manager-ai.php`, `php -l includes/class-geo-index-admin.php`, `php -l includes/class-geo-index-importer.php`, `php -l includes/class-geo-index-metabox.php`, and `php -l includes/class-geo-index-store.php`, all returned "No syntax errors detected.". 
- Ran `git diff --check` and static checks; no whitespace/merge errors reported. 
- Note: manual import/admin verification (importing `sothra_geo_article_index_safe_import.csv` and inspecting posts/meta/UI) was not executed in CI and should be performed in a WordPress test instance following the PR description checklist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23e178eb848332ab58092df8d87c20)