### PR TITLE
Add Geo Index geocoding foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 ## Unreleased
+
+## 2.41.0 - 2026-06-06
+- Aggiunta la fondazione di geocoding admin-only per **Indice Geografico**, con tab Geocoding, impostazioni Google Maps API key mascherata, batch controllati e report in `alma_geo_geocoding_last_report`.
+- Creati `includes/class-geo-index-geocoder.php` e `includes/class-geo-index-google-geocoder.php` per separare orchestrazione, provider Google, validazione risposta e salvataggio DB.
+- Estesa `alma_geo_locations` con `formatted_address`, `address_components`, `geocoded_at` e `geocoding_error`, preservando dati esistenti via routine `dbDelta` idempotente.
+- Gestiti gli stati `pending`, `verified`, `ambiguous`, `manual_required`, `failed` e `not_required`, senza sovrascrivere località già `verified` quando l’opzione è disattivata.
+- Aggiornate tab Località e metabox Geolocalizzazione per mostrare/modificare coordinate, provider, Place ID, formatted address, stato, ultimo geocoding ed errori.
+- Nessuna chiamata frontend, nessuna esposizione pubblica della API key, nessun uso AI e nessuna modifica a Widget Contestuale, shortcode, import, matching o tracking click.
+- Versione plugin aggiornata a `2.41.0`.
 - Chiarita la distinzione tra record Geo Index attivo e stato geocoding `pending`: i record importati correttamente vengono marcati come attivi e `pending` viene mostrato come “In attesa di geocoding”.
 
 ## 2.40.1 - 2026-06-06

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+## 2.41.0 - 2026-06-06
+
+### Indice Geografico — Geocoding admin
+- Aggiunta la tab **Geocoding** nell’admin **Indice Geografico** per configurare Google Maps Geocoding API, verificare lo stato della chiave senza mostrarla completa e avviare batch controllati sulle località `pending`.
+- Introdotte le classi `ALMA_Geo_Index_Geocoder` e `ALMA_Geo_Index_Google_Geocoder`: il primo orchestra batch admin-only, validazione e salvataggio; il secondo chiama server-side l’endpoint Google Geocoding con WordPress HTTP API.
+- Estesa la tabella `alma_geo_locations` con `formatted_address`, `address_components`, `geocoded_at` e `geocoding_error`, mantenendo idempotente `dbDelta` e senza cancellare dati esistenti.
+- Il flusso conserva gli stati `pending`, `verified`, `ambiguous`, `manual_required`, `failed` e `not_required`; una località diventa `verified` solo se coordinate, Place ID e coerenza paese/tipo sono plausibili.
+- Il batch default è 20 località, massimo 50, non parte automaticamente e quindi non genera costi API senza azione esplicita dell’admin; le località già `verified` non vengono sovrascritte se l’opzione dedicata resta disattivata.
+- La tab **Località** ora mostra lat/lng, provider, Place ID, formatted address, stato, errore, data geocoding e azioni protette da nonce per geocodificare o riprovare singole località.
+- Il metabox **Geolocalizzazione contenuto** mostra i dettagli geocoding della località primaria e consente correzioni manuali di latitudine, longitudine, Place ID e stato; se lat/lng sono salvati manualmente come `verified`, il provider può essere `manual`.
+- Nessuna chiamata Google Maps viene eseguita sul frontend, nessuna API key viene esposta in JavaScript pubblico, non viene usata AI e il Widget Link Contestuale, gli shortcode, gli import e il tracking restano invariati.
+- Le fasi successive useranno eventualmente il Geo Index per Widget Contestuale, import/geocoding dei Link Affiliati e mappe Google interattive.
+- Versione plugin aggiornata a `2.41.0`.
+
 ## 2.40.0 - 2026-06-06
 
 ### Indice Geografico

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.40.1
+ * Version: 2.41.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.40.1');
+define('ALMA_VERSION', '2.41.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -95,6 +95,8 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-shortcodes.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-editor-ajax.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-dashboard-widget.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-store.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-google-geocoder.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-geocoder.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-metabox.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-importer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-admin.php';

--- a/includes/class-geo-index-admin.php
+++ b/includes/class-geo-index-admin.php
@@ -10,11 +10,13 @@ class ALMA_Geo_Index_Admin {
 
     private $store;
     private $importer;
+    private $geocoder;
     private $notice = '';
 
     public function __construct($store = null) {
         $this->store = $store ?: new ALMA_Geo_Index_Store();
         $this->importer = new ALMA_Geo_Index_Importer($this->store);
+        $this->geocoder = new ALMA_Geo_Index_Geocoder($this->store);
     }
 
     public function init() {
@@ -38,19 +40,20 @@ class ALMA_Geo_Index_Admin {
         }
 
         $tab = isset($_GET['tab']) ? sanitize_key($_GET['tab']) : 'dashboard';
-        if (!in_array($tab, array('dashboard', 'import', 'locations', 'log'), true)) {
+        if (!in_array($tab, array('dashboard', 'import', 'locations', 'geocoding', 'log'), true)) {
             $tab = 'dashboard';
         }
         $this->handle_actions($tab);
         ?>
         <div class="wrap">
             <h1><?php esc_html_e('Indice Geografico', 'affiliate-link-manager-ai'); ?></h1>
-            <p><?php esc_html_e('Modulo di fondazione per collegare articoli, pagine e Link Affiliati a località geografiche. In questa fase non usa AI e non chiama Google Maps API.', 'affiliate-link-manager-ai'); ?></p>
+            <p><?php esc_html_e('Modulo di fondazione per collegare articoli, pagine e Link Affiliati a località geografiche. Il geocoding usa Google Maps API solo da admin e solo su azione esplicita.', 'affiliate-link-manager-ai'); ?></p>
             <?php echo $this->notice; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
             <nav class="nav-tab-wrapper">
                 <?php $this->tab_link('dashboard', __('Dashboard', 'affiliate-link-manager-ai'), $tab); ?>
                 <?php $this->tab_link('import', __('Importa record articoli', 'affiliate-link-manager-ai'), $tab); ?>
                 <?php $this->tab_link('locations', __('Località', 'affiliate-link-manager-ai'), $tab); ?>
+                <?php $this->tab_link('geocoding', __('Geocoding', 'affiliate-link-manager-ai'), $tab); ?>
                 <?php $this->tab_link('log', __('Log / ultimi import', 'affiliate-link-manager-ai'), $tab); ?>
             </nav>
             <?php
@@ -58,6 +61,8 @@ class ALMA_Geo_Index_Admin {
                 $this->render_import_tab();
             } elseif ($tab === 'locations') {
                 $this->render_locations_tab();
+            } elseif ($tab === 'geocoding') {
+                $this->render_geocoding_tab();
             } elseif ($tab === 'log') {
                 $this->render_log_tab();
             } else {
@@ -69,15 +74,88 @@ class ALMA_Geo_Index_Admin {
     }
 
     private function handle_actions($tab) {
-        if ($tab !== 'import' || empty($_POST['alma_geo_index_action'])) {
+        if (empty($_POST['alma_geo_index_action'])) {
             return;
         }
-        check_admin_referer('alma_geo_index_import');
         $action = sanitize_key(wp_unslash($_POST['alma_geo_index_action']));
-        if ($action === 'preview') {
-            $this->handle_preview_upload();
-        } elseif ($action === 'import') {
-            $this->handle_import_submit();
+        if ($tab === 'import') {
+            check_admin_referer('alma_geo_index_import');
+            if ($action === 'preview') {
+                $this->handle_preview_upload();
+            } elseif ($action === 'import') {
+                $this->handle_import_submit();
+            }
+            return;
+        }
+        if (in_array($tab, array('geocoding', 'locations'), true)) {
+            check_admin_referer('alma_geo_index_geocoding');
+            $this->handle_geocoding_action($action);
+        }
+    }
+
+    private function handle_geocoding_action($action) {
+        if (!current_user_can('manage_options')) {
+            $this->notice_error(__('Permessi insufficienti.', 'affiliate-link-manager-ai'));
+            return;
+        }
+        if ($action === 'save_geocoding_settings') {
+            $api_key = isset($_POST['alma_geo_google_maps_api_key']) ? trim(sanitize_text_field(wp_unslash($_POST['alma_geo_google_maps_api_key']))) : '';
+            update_option('alma_geo_geocoding_provider', 'google', false);
+            if ($api_key !== '') {
+                update_option('alma_geo_google_maps_api_key', $api_key, false);
+            }
+            update_option('alma_geo_geocoding_batch_size', max(1, min(50, absint($_POST['alma_geo_geocoding_batch_size'] ?? 20))), false);
+            update_option('alma_geo_geocoding_timeout', max(1, min(60, absint($_POST['alma_geo_geocoding_timeout'] ?? 15))), false);
+            update_option('alma_geo_geocoding_delay_ms', max(0, min(5000, absint($_POST['alma_geo_geocoding_delay_ms'] ?? 200))), false);
+            update_option('alma_geo_geocoding_overwrite_verified', !empty($_POST['alma_geo_geocoding_overwrite_verified']) ? 'yes' : 'no', false);
+            update_option('alma_geo_geocoding_country_bias', sanitize_text_field(wp_unslash($_POST['alma_geo_geocoding_country_bias'] ?? '')), false);
+            $this->notice_success($api_key === '' && get_option('alma_geo_google_maps_api_key', '') === '' ? __('Impostazioni salvate. API key non configurata.', 'affiliate-link-manager-ai') : __('Impostazioni geocoding salvate.', 'affiliate-link-manager-ai'));
+            return;
+        }
+        if ($action === 'test_api_key') {
+            if (!$this->geocoder->is_enabled()) {
+                $this->notice_error(__('API key non configurata.', 'affiliate-link-manager-ai'));
+                return;
+            }
+            $provider = new ALMA_Geo_Index_Google_Geocoder(get_option('alma_geo_google_maps_api_key', ''), (int) get_option('alma_geo_geocoding_timeout', 15));
+            $test = $provider->geocode('Palermo, Sicilia, Italy', array('region' => get_option('alma_geo_geocoding_country_bias', '')));
+            if (!empty($test['success'])) {
+                $this->notice_success(__('Test API key completato: Google Geocoding ha risposto correttamente.', 'affiliate-link-manager-ai'));
+            } else {
+                $this->notice_error(sprintf(__('Test API key fallito: %s', 'affiliate-link-manager-ai'), sanitize_text_field($test['message'] ?? $test['status'] ?? 'errore')));
+            }
+            return;
+        }
+        if ($action === 'batch_pending' || $action === 'retry_failed') {
+            if (!$this->geocoder->is_enabled()) {
+                $this->notice_error(__('API key non configurata. Salva una chiave Google Maps prima di avviare il batch.', 'affiliate-link-manager-ai'));
+                return;
+            }
+            $settings = $this->geocoder->get_settings();
+            $report = $this->geocoder->geocode_batch($settings['batch_size'], $action === 'retry_failed' ? 'failed' : 'pending');
+            $this->notice_success(sprintf(__('Batch geocoding completato: %1$d processate, %2$d verified, %3$d ambiguous, %4$d manual_required, %5$d failed.', 'affiliate-link-manager-ai'), $report['processed'], $report['verified'], $report['ambiguous'], $report['manual_required'], $report['failed']));
+            return;
+        }
+        if ($action === 'geocode_location' || $action === 'retry_location') {
+            if (!$this->geocoder->is_enabled()) {
+                $this->notice_error(__('API key non configurata.', 'affiliate-link-manager-ai'));
+                return;
+            }
+            $location_id = absint($_POST['location_id'] ?? 0);
+            $location = $this->store->get_location($location_id);
+            $expected_status = $action === 'retry_location' ? 'failed' : 'pending';
+            if (!$location || ($location['geocoding_status'] ?? '') !== $expected_status) {
+                $this->notice_error(__('Azione non eseguita: la località non è nello stato previsto per questa operazione.', 'affiliate-link-manager-ai'));
+                return;
+            }
+            $result = $this->geocoder->geocode_location($location_id);
+            $this->notice_success(sprintf(__('Località #%1$d aggiornata con stato %2$s.', 'affiliate-link-manager-ai'), $location_id, ALMA_Geo_Index_Metabox::geocoding_status_label($result['status'] ?? 'failed')));
+            return;
+        }
+        if ($action === 'mark_manual_required') {
+            $location_id = absint($_POST['location_id'] ?? 0);
+            $this->store->update_location_geocoding($location_id, array('status' => 'manual_required', 'message' => __('Marcata manual_required da admin.', 'affiliate-link-manager-ai')));
+            $this->notice_success(__('Località marcata come richiede verifica manuale.', 'affiliate-link-manager-ai'));
         }
     }
 
@@ -223,14 +301,97 @@ class ALMA_Geo_Index_Admin {
         }
         $locations = $this->store->get_locations(100);
         echo '<h2>' . esc_html__('Località', 'affiliate-link-manager-ai') . '</h2>';
-        echo '<table class="widefat striped"><thead><tr><th>ID</th><th>' . esc_html__('Nome canonico', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Tipo', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Paese', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Regione', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Città', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Area', 'affiliate-link-manager-ai') . '</th><th>POI</th><th>' . esc_html__('Stato geocoding', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Query suggerita', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Contenuti', 'affiliate-link-manager-ai') . '</th></tr></thead><tbody>';
+        $this->render_locations_table($locations, true);
+
+    }
+
+
+    private function render_geocoding_tab() {
+        if (!$this->store->tables_exist()) {
+            echo '<div class="notice notice-warning inline"><p>' . esc_html__('Le tabelle dell’Indice Geografico non sono disponibili.', 'affiliate-link-manager-ai') . '</p></div>';
+            return;
+        }
+        $settings = $this->geocoder->get_settings();
+        $counts = $this->store->get_geocoding_status_counts();
+        $api_key = (string) get_option('alma_geo_google_maps_api_key', '');
+        $masked_key = $api_key === '' ? __('Non configurata', 'affiliate-link-manager-ai') : sprintf(__('Configurata (termina con %s)', 'affiliate-link-manager-ai'), substr($api_key, -4));
+        echo '<h2>' . esc_html__('Geocoding', 'affiliate-link-manager-ai') . '</h2>';
+        echo '<div class="postbox"><div class="inside"><h3>' . esc_html__('Stato configurazione', 'affiliate-link-manager-ai') . '</h3><table class="widefat striped"><tbody>';
+        $rows = array(
+            __('Provider attivo', 'affiliate-link-manager-ai') => 'Google Maps',
+            __('Google Maps API key', 'affiliate-link-manager-ai') => $masked_key,
+            __('Località pending', 'affiliate-link-manager-ai') => $counts['pending'],
+            __('Località verified', 'affiliate-link-manager-ai') => $counts['verified'],
+            __('Località ambiguous', 'affiliate-link-manager-ai') => $counts['ambiguous'],
+            __('Località failed', 'affiliate-link-manager-ai') => $counts['failed'],
+            __('Batch size', 'affiliate-link-manager-ai') => $settings['batch_size'],
+            __('Timeout', 'affiliate-link-manager-ai') => $settings['timeout'],
+        );
+        foreach ($rows as $label => $value) {
+            echo '<tr><th>' . esc_html($label) . '</th><td>' . esc_html((string) $value) . '</td></tr>';
+        }
+        echo '</tbody></table></div></div>';
+
+        $last_report = get_option(ALMA_Geo_Index_Geocoder::LAST_REPORT_OPTION, array());
+        if (!empty($last_report)) {
+            echo '<div class="postbox"><div class="inside"><h3>' . esc_html__('Ultimo report geocoding', 'affiliate-link-manager-ai') . '</h3><pre style="white-space:pre-wrap">' . esc_html(wp_json_encode($last_report, JSON_PRETTY_PRINT)) . '</pre></div></div>';
+        }
+        ?>
+        <form method="post" class="postbox" style="padding:12px;">
+            <?php wp_nonce_field('alma_geo_index_geocoding'); ?>
+            <input type="hidden" name="alma_geo_index_action" value="save_geocoding_settings">
+            <h3><?php esc_html_e('Impostazioni geocoding', 'affiliate-link-manager-ai'); ?></h3>
+            <table class="form-table"><tbody>
+                <tr><th><label><?php esc_html_e('Provider geocoding', 'affiliate-link-manager-ai'); ?></label></th><td><select name="alma_geo_geocoding_provider"><option value="google">Google Maps</option></select></td></tr>
+                <tr><th><label for="alma_geo_google_maps_api_key"><?php esc_html_e('API key Google Maps', 'affiliate-link-manager-ai'); ?></label></th><td><input type="password" id="alma_geo_google_maps_api_key" name="alma_geo_google_maps_api_key" value="" class="regular-text" autocomplete="off"><p class="description"><?php echo esc_html($masked_key); ?>. <?php esc_html_e('Lascia vuoto per mantenere la chiave esistente.', 'affiliate-link-manager-ai'); ?></p></td></tr>
+                <tr><th><label for="alma_geo_geocoding_batch_size"><?php esc_html_e('Batch size', 'affiliate-link-manager-ai'); ?></label></th><td><input type="number" min="1" max="50" id="alma_geo_geocoding_batch_size" name="alma_geo_geocoding_batch_size" value="<?php echo esc_attr((string) $settings['batch_size']); ?>"></td></tr>
+                <tr><th><label for="alma_geo_geocoding_timeout"><?php esc_html_e('Timeout richiesta', 'affiliate-link-manager-ai'); ?></label></th><td><input type="number" min="1" max="60" id="alma_geo_geocoding_timeout" name="alma_geo_geocoding_timeout" value="<?php echo esc_attr((string) $settings['timeout']); ?>"></td></tr>
+                <tr><th><label for="alma_geo_geocoding_delay_ms"><?php esc_html_e('Pausa tra richieste (ms)', 'affiliate-link-manager-ai'); ?></label></th><td><input type="number" min="0" max="5000" id="alma_geo_geocoding_delay_ms" name="alma_geo_geocoding_delay_ms" value="<?php echo esc_attr((string) $settings['delay_ms']); ?>"></td></tr>
+                <tr><th><label for="alma_geo_geocoding_country_bias"><?php esc_html_e('Country bias opzionale', 'affiliate-link-manager-ai'); ?></label></th><td><input type="text" id="alma_geo_geocoding_country_bias" name="alma_geo_geocoding_country_bias" value="<?php echo esc_attr($settings['country_bias']); ?>" class="small-text" maxlength="10"></td></tr>
+                <tr><th><?php esc_html_e('Sovrascrittura', 'affiliate-link-manager-ai'); ?></th><td><label><input type="checkbox" name="alma_geo_geocoding_overwrite_verified" value="1" <?php checked($settings['overwrite_verified'], 'yes'); ?>> <?php esc_html_e('Permetti sovrascrittura località già verified', 'affiliate-link-manager-ai'); ?></label></td></tr>
+            </tbody></table>
+            <?php submit_button(__('Salva impostazioni geocoding', 'affiliate-link-manager-ai'), 'primary', 'submit', false); ?>
+        </form>
+        <div style="display:flex;gap:8px;flex-wrap:wrap;margin:16px 0;">
+            <?php $this->render_geocoding_button('test_api_key', __('Test API key', 'affiliate-link-manager-ai')); ?>
+            <?php $this->render_geocoding_button('batch_pending', __('Geocodifica prossime località pending', 'affiliate-link-manager-ai')); ?>
+            <?php $this->render_geocoding_button('retry_failed', __('Riprova failed', 'affiliate-link-manager-ai')); ?>
+        </div>
+        <?php
+        echo '<h3>' . esc_html__('Località pending/recenti', 'affiliate-link-manager-ai') . '</h3>';
+        $this->render_locations_table($this->store->get_locations(50), false);
+    }
+
+    private function render_geocoding_button($action, $label, $location_id = 0) {
+        echo '<form method="post" style="display:inline-block;margin:0 4px 4px 0;">';
+        wp_nonce_field('alma_geo_index_geocoding');
+        echo '<input type="hidden" name="alma_geo_index_action" value="' . esc_attr($action) . '">';
+        if ($location_id) {
+            echo '<input type="hidden" name="location_id" value="' . esc_attr((string) absint($location_id)) . '">';
+        }
+        submit_button($label, 'secondary small', 'submit', false);
+        echo '</form>';
+    }
+
+    private function render_locations_table($locations, $include_content_count) {
+        echo '<div style="max-width:100%;overflow:auto;"><table class="widefat striped"><thead><tr><th>ID</th><th>' . esc_html__('Nome canonico', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Tipo', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Paese', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Regione', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Città', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Query', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Stato', 'affiliate-link-manager-ai') . '</th><th>Lat/Lng</th><th>Provider</th><th>Place ID</th><th>' . esc_html__('Formatted address', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Errore', 'affiliate-link-manager-ai') . '</th><th>Geocoded at</th>' . ($include_content_count ? '<th>' . esc_html__('Contenuti', 'affiliate-link-manager-ai') . '</th>' : '') . '<th>' . esc_html__('Azioni', 'affiliate-link-manager-ai') . '</th></tr></thead><tbody>';
         if (empty($locations)) {
-            echo '<tr><td colspan="11">' . esc_html__('Nessuna località salvata.', 'affiliate-link-manager-ai') . '</td></tr>';
+            $colspan = $include_content_count ? 16 : 15;
+            echo '<tr><td colspan="' . esc_attr((string) $colspan) . '">' . esc_html__('Nessuna località salvata.', 'affiliate-link-manager-ai') . '</td></tr>';
         }
         foreach ($locations as $location) {
-            echo '<tr><td>' . esc_html((string) $location['id']) . '</td><td>' . esc_html($location['canonical_name']) . '</td><td>' . esc_html($location['type']) . '</td><td>' . esc_html($location['country']) . '</td><td>' . esc_html($location['region']) . '</td><td>' . esc_html($location['city']) . '</td><td>' . esc_html($location['area']) . '</td><td>' . esc_html($location['poi']) . '</td><td>' . esc_html(ALMA_Geo_Index_Metabox::geocoding_status_label($location['geocoding_status'])) . '</td><td>' . esc_html($location['suggested_geocoding_query']) . '</td><td>' . esc_html((string) $location['content_count']) . '</td></tr>';
+            $lat_lng = ($location['lat'] !== null && $location['lng'] !== null) ? $location['lat'] . ', ' . $location['lng'] : '';
+            echo '<tr><td>' . esc_html((string) $location['id']) . '</td><td>' . esc_html($location['canonical_name']) . '</td><td>' . esc_html($location['type']) . '</td><td>' . esc_html($location['country']) . '</td><td>' . esc_html($location['region']) . '</td><td>' . esc_html($location['city']) . '</td><td>' . esc_html($location['suggested_geocoding_query']) . '</td><td>' . esc_html(ALMA_Geo_Index_Metabox::geocoding_status_label($location['geocoding_status'])) . '</td><td>' . esc_html($lat_lng) . '</td><td>' . esc_html($location['geo_provider']) . '</td><td>' . esc_html($location['geo_provider_place_id']) . '</td><td>' . esc_html(wp_trim_words((string) ($location['formatted_address'] ?? ''), 12, '…')) . '</td><td>' . esc_html(wp_trim_words((string) ($location['geocoding_error'] ?? ''), 12, '…')) . '</td><td>' . esc_html((string) ($location['geocoded_at'] ?? '')) . '</td>';
+            if ($include_content_count) {
+                echo '<td>' . esc_html((string) $location['content_count']) . '</td>';
+            }
+            echo '<td>';
+            $this->render_geocoding_button('geocode_location', __('Geocodifica', 'affiliate-link-manager-ai'), (int) $location['id']);
+            $this->render_geocoding_button('retry_location', __('Riprova', 'affiliate-link-manager-ai'), (int) $location['id']);
+            $this->render_geocoding_button('mark_manual_required', __('Segna manual_required', 'affiliate-link-manager-ai'), (int) $location['id']);
+            echo '</td></tr>';
         }
-        echo '</tbody></table>';
+        echo '</tbody></table></div>';
     }
 
     private function render_log_tab() {

--- a/includes/class-geo-index-geocoder.php
+++ b/includes/class-geo-index-geocoder.php
@@ -1,0 +1,185 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+/**
+ * Orchestrates admin-only Geo Index geocoding batches.
+ */
+class ALMA_Geo_Index_Geocoder {
+    const PROVIDER_GOOGLE = 'google';
+    const LAST_REPORT_OPTION = 'alma_geo_geocoding_last_report';
+
+    private $store;
+    private $provider;
+
+    public function __construct($store = null) {
+        $this->store = $store ?: new ALMA_Geo_Index_Store();
+    }
+
+    public function get_settings() {
+        return array(
+            'provider' => sanitize_key(get_option('alma_geo_geocoding_provider', self::PROVIDER_GOOGLE)),
+            'google_maps_api_key' => (string) get_option('alma_geo_google_maps_api_key', ''),
+            'batch_size' => max(1, min(50, absint(get_option('alma_geo_geocoding_batch_size', 20)))),
+            'timeout' => max(1, min(60, absint(get_option('alma_geo_geocoding_timeout', 15)))),
+            'delay_ms' => max(0, min(5000, absint(get_option('alma_geo_geocoding_delay_ms', 200)))),
+            'overwrite_verified' => get_option('alma_geo_geocoding_overwrite_verified', 'no') === 'yes' ? 'yes' : 'no',
+            'country_bias' => sanitize_text_field(get_option('alma_geo_geocoding_country_bias', '')),
+        );
+    }
+
+    public function is_enabled() {
+        $settings = $this->get_settings();
+        return $settings['provider'] === self::PROVIDER_GOOGLE && trim($settings['google_maps_api_key']) !== '';
+    }
+
+    public function get_pending_locations($limit = 20) {
+        return $this->store->get_locations_by_geocoding_status('pending', $limit);
+    }
+
+    public function geocode_batch($limit = 20, $status = 'pending') {
+        $limit = max(1, min(50, absint($limit)));
+        $status = sanitize_key($status);
+        $locations = $this->store->get_locations_by_geocoding_status($status === 'failed' ? 'failed' : 'pending', $limit);
+        $settings = $this->get_settings();
+        $report = array(
+            'date' => current_time('mysql'),
+            'provider' => $settings['provider'],
+            'batch_size' => $limit,
+            'processed' => 0,
+            'verified' => 0,
+            'ambiguous' => 0,
+            'manual_required' => 0,
+            'failed' => 0,
+            'skipped_verified' => 0,
+            'errors' => array(),
+        );
+
+        foreach ($locations as $location) {
+            $result = $this->geocode_location((int) $location['id']);
+            if (!empty($result['skipped_verified'])) {
+                $report['skipped_verified']++;
+            } else {
+                $report['processed']++;
+                $result_status = sanitize_key($result['status'] ?? 'failed');
+                if (isset($report[$result_status])) {
+                    $report[$result_status]++;
+                }
+                if (!empty($result['message']) && $result_status !== 'verified') {
+                    $report['errors'][] = array('location_id' => (int) $location['id'], 'status' => $result_status, 'message' => sanitize_text_field($result['message']));
+                }
+            }
+            if ($settings['delay_ms'] > 0) {
+                usleep($settings['delay_ms'] * 1000);
+            }
+        }
+
+        update_option(self::LAST_REPORT_OPTION, $report, false);
+        return $report;
+    }
+
+    public function geocode_location($location_id) {
+        $location = $this->store->get_location(absint($location_id));
+        if (!$location) {
+            return array('status' => 'failed', 'message' => __('Località non trovata.', 'affiliate-link-manager-ai'));
+        }
+        $settings = $this->get_settings();
+        if (($location['geocoding_status'] ?? '') === 'verified' && $settings['overwrite_verified'] !== 'yes') {
+            return array('status' => 'verified', 'skipped_verified' => true, 'message' => __('Località già verificata: sovrascrittura disattivata.', 'affiliate-link-manager-ai'));
+        }
+
+        $query = $this->build_location_query($location);
+        $provider = $this->get_provider();
+        $provider_result = $provider->geocode($query, array('region' => $settings['country_bias']));
+        $validated = $this->validate_result($location, $provider_result);
+        $this->store->update_location_geocoding($location['id'], $validated);
+        $this->log_result($location['id'], $query, $validated, $provider_result);
+        return $validated;
+    }
+
+    public function validate_result($location, $result) {
+        if (empty($result['success'])) {
+            return array('status' => 'failed', 'message' => sanitize_text_field($result['message'] ?? $result['status'] ?? __('Geocoding fallito.', 'affiliate-link-manager-ai')));
+        }
+        $results = is_array($result['results'] ?? null) ? $result['results'] : array();
+        if (empty($results)) {
+            return array('status' => 'failed', 'message' => __('Nessun risultato Google Geocoding.', 'affiliate-link-manager-ai'));
+        }
+        $first = $results[0];
+        if ($first['lat'] === null || $first['lng'] === null || empty($first['place_id'])) {
+            return array('status' => 'failed', 'message' => __('Risultato senza coordinate o Place ID.', 'affiliate-link-manager-ai'));
+        }
+
+        $expected_country = strtoupper(sanitize_text_field($location['country_code'] ?? ''));
+        $actual_country = strtoupper(sanitize_text_field($first['country_code'] ?? ''));
+        $types = is_array($first['types'] ?? null) ? $first['types'] : array();
+        $status = 'verified';
+        $message = '';
+
+        if ($expected_country !== '' && $actual_country !== '' && $expected_country !== $actual_country) {
+            $status = 'manual_required';
+            $message = __('Codice paese restituito diverso da quello atteso.', 'affiliate-link-manager-ai');
+        } elseif (!empty($first['partial_match'])) {
+            $status = 'manual_required';
+            $message = __('Google segnala un partial match.', 'affiliate-link-manager-ai');
+        } elseif (($location['type'] ?? '') === 'city' && empty(array_intersect($types, array('locality', 'postal_town', 'administrative_area_level_3')))) {
+            $status = count($results) > 1 ? 'ambiguous' : 'manual_required';
+            $message = __('Tipo risultato non chiaramente coerente con una città.', 'affiliate-link-manager-ai');
+        } elseif (count($results) > 1) {
+            $status = 'ambiguous';
+            $message = __('Google ha restituito più risultati: verifica consigliata.', 'affiliate-link-manager-ai');
+        }
+
+        return array(
+            'status' => $status,
+            'lat' => $first['lat'],
+            'lng' => $first['lng'],
+            'geo_provider' => 'google_maps',
+            'place_id' => $first['place_id'],
+            'formatted_address' => $first['formatted_address'],
+            'address_components' => $first['address_components'],
+            'message' => $message,
+        );
+    }
+
+    public function build_location_query($location) {
+        if (!empty($location['suggested_geocoding_query'])) {
+            return sanitize_text_field($location['suggested_geocoding_query']);
+        }
+        $parts = array($location['poi'] ?? '', $location['area'] ?? '', $location['city'] ?? '', $location['region'] ?? '', $location['country'] ?? '');
+        $parts = array_filter(array_map('trim', $parts));
+        if (empty($parts)) {
+            $parts[] = $location['canonical_name'] ?? '';
+        } else {
+            array_unshift($parts, $location['canonical_name'] ?? '');
+        }
+        return sanitize_text_field(implode(', ', array_unique(array_filter($parts))));
+    }
+
+    private function get_provider() {
+        if (!$this->provider) {
+            $settings = $this->get_settings();
+            $this->provider = new ALMA_Geo_Index_Google_Geocoder($settings['google_maps_api_key'], $settings['timeout']);
+        }
+        return $this->provider;
+    }
+
+    private function log_result($location_id, $query, $validated, $provider_result) {
+        if (!class_exists('ALMA_Logger')) {
+            return;
+        }
+        $context = array(
+            'location_id' => absint($location_id),
+            'query' => sanitize_text_field($query),
+            'status' => sanitize_key($validated['status'] ?? ''),
+            'error' => sanitize_text_field($validated['message'] ?? ''),
+            'response_code' => absint($provider_result['response_code'] ?? 0),
+            'provider' => 'google_maps',
+            'duration_ms' => absint($provider_result['duration_ms'] ?? 0),
+        );
+        if (($validated['status'] ?? '') === 'verified') {
+            ALMA_Logger::info('Geo Index geocoding completed.', $context);
+        } else {
+            ALMA_Logger::warning('Geo Index geocoding needs attention.', $context);
+        }
+    }
+}

--- a/includes/class-geo-index-google-geocoder.php
+++ b/includes/class-geo-index-google-geocoder.php
@@ -1,0 +1,109 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+/**
+ * Google Maps Geocoding API provider for Geo Index admin geocoding.
+ */
+class ALMA_Geo_Index_Google_Geocoder {
+    const ENDPOINT = 'https://maps.googleapis.com/maps/api/geocode/json';
+
+    private $api_key;
+    private $timeout;
+
+    public function __construct($api_key = '', $timeout = 15) {
+        $this->api_key = trim((string) $api_key);
+        $this->timeout = max(1, absint($timeout));
+    }
+
+    public function geocode($query, $args = array()) {
+        $query = sanitize_text_field($query);
+        if ($query === '') {
+            return array('success' => false, 'status' => 'INVALID_QUERY', 'message' => __('Query geocoding vuota.', 'affiliate-link-manager-ai'));
+        }
+        if ($this->api_key === '') {
+            return array('success' => false, 'status' => 'API_KEY_MISSING', 'message' => __('API key Google Maps non configurata.', 'affiliate-link-manager-ai'));
+        }
+
+        $url = $this->build_request_url($query, $args);
+        $started = microtime(true);
+        $response = wp_remote_get($url, array('timeout' => $this->timeout));
+        $duration_ms = (int) round((microtime(true) - $started) * 1000);
+
+        if (is_wp_error($response)) {
+            return array(
+                'success' => false,
+                'status' => 'HTTP_ERROR',
+                'message' => $response->get_error_message(),
+                'response_code' => 0,
+                'duration_ms' => $duration_ms,
+            );
+        }
+
+        $code = (int) wp_remote_retrieve_response_code($response);
+        $body = wp_remote_retrieve_body($response);
+        $normalized = $this->normalize_response($body);
+        $normalized['response_code'] = $code;
+        $normalized['duration_ms'] = $duration_ms;
+        if ($code < 200 || $code >= 300) {
+            $normalized['success'] = false;
+            $normalized['status'] = 'HTTP_' . $code;
+            $normalized['message'] = sprintf(__('Errore HTTP Google Geocoding: %d.', 'affiliate-link-manager-ai'), $code);
+        }
+        return $normalized;
+    }
+
+    public function normalize_response($response) {
+        $data = json_decode((string) $response, true);
+        if (!is_array($data)) {
+            return array('success' => false, 'status' => 'INVALID_JSON', 'message' => __('Risposta Google non valida.', 'affiliate-link-manager-ai'), 'results' => array());
+        }
+
+        $status = sanitize_text_field($data['status'] ?? 'UNKNOWN');
+        $results = is_array($data['results'] ?? null) ? $data['results'] : array();
+        $normalized_results = array();
+        foreach ($results as $result) {
+            $location = $result['geometry']['location'] ?? array();
+            $components = is_array($result['address_components'] ?? null) ? $result['address_components'] : array();
+            $normalized_results[] = array(
+                'place_id' => sanitize_text_field($result['place_id'] ?? ''),
+                'formatted_address' => sanitize_text_field($result['formatted_address'] ?? ''),
+                'lat' => isset($location['lat']) ? (float) $location['lat'] : null,
+                'lng' => isset($location['lng']) ? (float) $location['lng'] : null,
+                'types' => array_map('sanitize_key', is_array($result['types'] ?? null) ? $result['types'] : array()),
+                'country_code' => $this->extract_country_code($components),
+                'address_components' => $components,
+                'partial_match' => !empty($result['partial_match']),
+            );
+        }
+
+        return array(
+            'success' => $status === 'OK',
+            'status' => $status,
+            'message' => sanitize_text_field($data['error_message'] ?? ($status === 'OK' ? '' : sprintf(__('Google Geocoding status: %s.', 'affiliate-link-manager-ai'), $status))),
+            'results' => $normalized_results,
+            'raw_status' => $status,
+        );
+    }
+
+    public function build_request_url($query, $args = array()) {
+        $params = array(
+            'address' => sanitize_text_field($query),
+            'key' => $this->api_key,
+            'language' => 'it',
+        );
+        if (!empty($args['region'])) {
+            $params['region'] = strtolower(sanitize_text_field($args['region']));
+        }
+        return add_query_arg($params, self::ENDPOINT);
+    }
+
+    private function extract_country_code($components) {
+        foreach ($components as $component) {
+            $types = is_array($component['types'] ?? null) ? $component['types'] : array();
+            if (in_array('country', $types, true) && !empty($component['short_name'])) {
+                return strtoupper(sanitize_text_field($component['short_name']));
+            }
+        }
+        return '';
+    }
+}

--- a/includes/class-geo-index-metabox.php
+++ b/includes/class-geo-index-metabox.php
@@ -40,7 +40,7 @@ class ALMA_Geo_Index_Metabox {
         ?>
         <p><?php esc_html_e('Questi dati servono a collegare il contenuto a una località geografica e saranno usati in futuro per il Widget Link Contestuale, per il matching con Link Affiliati e per mappe interattive.', 'affiliate-link-manager-ai'); ?></p>
         <style>
-            .alma-geo-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px 18px}.alma-geo-field label{display:block;font-weight:600;margin-bottom:4px}.alma-geo-field input,.alma-geo-field select,.alma-geo-field textarea{width:100%;max-width:100%}.alma-geo-section{border-top:1px solid #dcdcde;margin-top:16px;padding-top:12px}.alma-geo-checks label{margin-right:18px}.alma-geo-status-summary{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px;margin:12px 0}.alma-geo-badge{display:inline-block;border-radius:999px;padding:3px 9px;font-weight:600;background:#f0f0f1;color:#2c3338}.alma-geo-badge-active{background:#d1e7dd;color:#0f5132}.alma-geo-badge-inactive{background:#f8d7da;color:#842029}.alma-geo-badge-pending{background:#fff3cd;color:#664d03}.alma-geo-badge-verified{background:#cfe2ff;color:#084298}.alma-geo-badge-manual{background:#fde2c2;color:#7a3e00}.alma-geo-badge-failed{background:#f8d7da;color:#842029}
+            .alma-geo-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px 18px}.alma-geo-field label{display:block;font-weight:600;margin-bottom:4px}.alma-geo-field input,.alma-geo-field select,.alma-geo-field textarea{width:100%;max-width:100%}.alma-geo-section{border-top:1px solid #dcdcde;margin-top:16px;padding-top:12px}.alma-geo-checks label{margin-right:18px}.alma-geo-status-summary{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px;margin:12px 0}.alma-geo-badge{display:inline-block;border-radius:999px;padding:3px 9px;font-weight:600;background:#f0f0f1;color:#2c3338}.alma-geo-badge-active{background:#d1e7dd;color:#0f5132}.alma-geo-badge-inactive{background:#f8d7da;color:#842029}.alma-geo-badge-pending{background:#fff3cd;color:#664d03}.alma-geo-badge-verified{background:#cfe2ff;color:#084298}.alma-geo-badge-manual{background:#fde2c2;color:#7a3e00}.alma-geo-badge-failed{background:#f8d7da;color:#842029}.alma-geo-badge-ambiguous{background:#e2d9f3;color:#3d0a69}
         </style>
         <div class="alma-geo-section">
             <h3><?php esc_html_e('Stato', 'affiliate-link-manager-ai'); ?></h3>
@@ -61,6 +61,14 @@ class ALMA_Geo_Index_Metabox {
                 <?php $this->render_input('_alma_geo_source', __('Fonte dati', 'affiliate-link-manager-ai'), $values); ?>
                 <?php $this->render_input('_alma_geo_updated_at', __('Ultimo aggiornamento', 'affiliate-link-manager-ai'), $values, 'text', 'readonly'); ?>
             </div>
+            <?php if (!empty($primary_location)) : ?>
+                <div class="alma-geo-section" style="grid-column:1/-1">
+                    <h4><?php esc_html_e('Dati geocoding salvati nella località primaria', 'affiliate-link-manager-ai'); ?></h4>
+                    <p><strong><?php esc_html_e('Provider:', 'affiliate-link-manager-ai'); ?></strong> <?php echo esc_html($primary_location['geo_provider'] ?? ''); ?> — <strong><?php esc_html_e('Place ID:', 'affiliate-link-manager-ai'); ?></strong> <?php echo esc_html($primary_location['geo_provider_place_id'] ?? ''); ?></p>
+                    <p><strong><?php esc_html_e('Formatted address:', 'affiliate-link-manager-ai'); ?></strong> <?php echo esc_html($primary_location['formatted_address'] ?? ''); ?></p>
+                    <p><strong><?php esc_html_e('Ultimo geocoding:', 'affiliate-link-manager-ai'); ?></strong> <?php echo esc_html($primary_location['geocoded_at'] ?? ''); ?> — <strong><?php esc_html_e('Errore:', 'affiliate-link-manager-ai'); ?></strong> <?php echo esc_html($primary_location['geocoding_error'] ?? ''); ?></p>
+                </div>
+            <?php endif; ?>
         </div>
         <div class="alma-geo-section">
             <h3><?php esc_html_e('Classificazione', 'affiliate-link-manager-ai'); ?></h3>
@@ -84,7 +92,8 @@ class ALMA_Geo_Index_Metabox {
                 <?php $this->render_input('_alma_geo_primary_poi', __('POI', 'affiliate-link-manager-ai'), $values); ?>
                 <?php $this->render_input('_alma_geo_primary_lat', __('Latitudine', 'affiliate-link-manager-ai'), $values, 'number', 'step="0.0000001"'); ?>
                 <?php $this->render_input('_alma_geo_primary_lng', __('Longitudine', 'affiliate-link-manager-ai'), $values, 'number', 'step="0.0000001"'); ?>
-                <?php $this->render_input('_alma_geo_primary_place_id', __('Google Place ID', 'affiliate-link-manager-ai'), $values); ?>
+                <?php $this->render_input('_alma_geo_primary_place_id', __('Place ID', 'affiliate-link-manager-ai'), $values); ?>
+                <?php $this->render_input('_alma_geo_provider', __('Provider geocoding', 'affiliate-link-manager-ai'), $values); ?>
                 <div class="alma-geo-field" style="grid-column:1/-1">
                     <label for="alma_geo_suggested_geocoding_query"><?php esc_html_e('Query geocoding suggerita', 'affiliate-link-manager-ai'); ?></label>
                     <input type="text" id="alma_geo_suggested_geocoding_query" name="alma_geo[suggested_geocoding_query]" value="<?php echo esc_attr($suggested_query); ?>">
@@ -158,6 +167,7 @@ class ALMA_Geo_Index_Metabox {
                 'poi' => $data['_alma_geo_primary_poi'],
                 'lat' => $data['_alma_geo_primary_lat'],
                 'lng' => $data['_alma_geo_primary_lng'],
+                'geo_provider' => $data['_alma_geo_provider'],
                 'geo_provider_place_id' => $data['_alma_geo_primary_place_id'],
                 'suggested_geocoding_query' => $data['suggested_geocoding_query'] ?? '',
                 'geocoding_status' => $data['_alma_geo_geocoding_status'],
@@ -197,12 +207,15 @@ class ALMA_Geo_Index_Metabox {
         $data['_alma_geo_import_status'] = $this->sanitize_allowed($raw['_alma_geo_import_status'] ?? '', self::geo_import_statuses(), 'review');
         $data['_alma_geo_geocoding_status'] = $this->sanitize_allowed($raw['_alma_geo_geocoding_status'] ?? '', self::geocoding_statuses(), 'pending');
 
-        foreach (array('_alma_geo_primary_name','_alma_geo_primary_canonical_name','_alma_geo_primary_country','_alma_geo_primary_country_code','_alma_geo_primary_region','_alma_geo_primary_city','_alma_geo_primary_area','_alma_geo_primary_poi','_alma_geo_primary_place_id','_alma_geo_source') as $key) {
+        foreach (array('_alma_geo_primary_name','_alma_geo_primary_canonical_name','_alma_geo_primary_country','_alma_geo_primary_country_code','_alma_geo_primary_region','_alma_geo_primary_city','_alma_geo_primary_area','_alma_geo_primary_poi','_alma_geo_primary_place_id','_alma_geo_provider','_alma_geo_source') as $key) {
             $data[$key] = sanitize_text_field($raw[$key] ?? '');
         }
         $data['_alma_geo_primary_country_code'] = strtoupper($data['_alma_geo_primary_country_code']);
         $data['_alma_geo_primary_lat'] = isset($raw['_alma_geo_primary_lat']) && $raw['_alma_geo_primary_lat'] !== '' ? (string) (float) $raw['_alma_geo_primary_lat'] : '';
         $data['_alma_geo_primary_lng'] = isset($raw['_alma_geo_primary_lng']) && $raw['_alma_geo_primary_lng'] !== '' ? (string) (float) $raw['_alma_geo_primary_lng'] : '';
+        if ($data['_alma_geo_primary_lat'] !== '' && $data['_alma_geo_primary_lng'] !== '' && $data['_alma_geo_geocoding_status'] === 'verified' && $data['_alma_geo_provider'] === '') {
+            $data['_alma_geo_provider'] = 'manual';
+        }
         $data['_alma_geo_confidence'] = isset($raw['_alma_geo_confidence']) && $raw['_alma_geo_confidence'] !== '' ? (string) min(1, max(0, (float) $raw['_alma_geo_confidence'])) : '';
         $data['_alma_geo_match_weight'] = isset($raw['_alma_geo_match_weight']) && $raw['_alma_geo_match_weight'] !== '' ? (string) (int) $raw['_alma_geo_match_weight'] : '';
         $data['_alma_geo_locations_json'] = $this->sanitize_json_textarea($raw['_alma_geo_locations_json'] ?? '');
@@ -216,7 +229,7 @@ class ALMA_Geo_Index_Metabox {
     public static function meta_keys() {
         return array(
             '_alma_geo_enabled','_alma_geo_scope','_alma_geo_content_type','_alma_geo_commercial_intent','_alma_geo_widget_eligible',
-            '_alma_geo_primary_name','_alma_geo_primary_canonical_name','_alma_geo_primary_type','_alma_geo_primary_country','_alma_geo_primary_country_code','_alma_geo_primary_region','_alma_geo_primary_city','_alma_geo_primary_area','_alma_geo_primary_poi','_alma_geo_primary_lat','_alma_geo_primary_lng','_alma_geo_primary_place_id',
+            '_alma_geo_primary_name','_alma_geo_primary_canonical_name','_alma_geo_primary_type','_alma_geo_primary_country','_alma_geo_primary_country_code','_alma_geo_primary_region','_alma_geo_primary_city','_alma_geo_primary_area','_alma_geo_primary_poi','_alma_geo_primary_lat','_alma_geo_primary_lng','_alma_geo_primary_place_id','_alma_geo_provider',
             '_alma_geo_confidence','_alma_geo_match_weight','_alma_geo_geocoding_status','_alma_geo_import_status','_alma_geo_locations_json','_alma_geo_quality_flags','_alma_geo_notes','_alma_geo_source','_alma_geo_updated_at'
         );
     }
@@ -226,7 +239,7 @@ class ALMA_Geo_Index_Metabox {
     public static function content_types() { return array('destination_guide','country_guide','region_guide','city_guide','area_guide','poi_guide','itinerary','itinerary_multi_location','cruise_ship','cruise_company','travel_advice','honeymoon','informational','generic_travel','non_travel','uncertain'); }
     public static function commercial_intents() { return array('high','medium','low','none'); }
     public static function geo_import_statuses() { return array('active','ready','review','discard','needs_geocoding','geocoding_failed'); }
-    public static function geocoding_statuses() { return array('pending','not_required','manual_required','verified','failed'); }
+    public static function geocoding_statuses() { return array('pending','verified','ambiguous','manual_required','failed','not_required'); }
 
 
     private function has_geo_payload($data) {
@@ -280,6 +293,7 @@ class ALMA_Geo_Index_Metabox {
         $classes = array(
             'pending' => 'alma-geo-badge-pending',
             'verified' => 'alma-geo-badge-verified',
+            'ambiguous' => 'alma-geo-badge-ambiguous',
             'manual_required' => 'alma-geo-badge-manual',
             'failed' => 'alma-geo-badge-failed',
         );
@@ -301,6 +315,7 @@ class ALMA_Geo_Index_Metabox {
         $labels = array(
             'pending' => __('In attesa di geocoding', 'affiliate-link-manager-ai'),
             'verified' => __('Geocodificato', 'affiliate-link-manager-ai'),
+            'ambiguous' => __('Ambiguo', 'affiliate-link-manager-ai'),
             'manual_required' => __('Richiede verifica manuale', 'affiliate-link-manager-ai'),
             'failed' => __('Geocoding fallito', 'affiliate-link-manager-ai'),
             'not_required' => __('Non richiesto', 'affiliate-link-manager-ai'),

--- a/includes/class-geo-index-store.php
+++ b/includes/class-geo-index-store.php
@@ -46,6 +46,10 @@ class ALMA_Geo_Index_Store {
             geo_provider_place_id VARCHAR(255) DEFAULT '',
             suggested_geocoding_query TEXT NULL,
             geocoding_status VARCHAR(50) DEFAULT 'pending',
+            formatted_address TEXT NULL,
+            address_components LONGTEXT NULL,
+            geocoded_at DATETIME NULL,
+            geocoding_error TEXT NULL,
             aliases LONGTEXT NULL,
             created_at DATETIME NOT NULL,
             updated_at DATETIME NOT NULL,
@@ -254,9 +258,9 @@ class ALMA_Geo_Index_Store {
             'affiliate_links_with_geo_meta' => (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(DISTINCT pm.post_id) FROM {$wpdb->postmeta} pm INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id WHERE pm.meta_key = '_alma_geo_enabled' AND pm.meta_value IN $enabled_values AND p.post_type = %s", self::OBJECT_TYPE_AFFILIATE_LINK)),
             'locations' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_locations()}"),
             'content_relations' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_content_index()}"),
-            'pending_geocoding' => (int) $wpdb->get_var("SELECT COUNT(DISTINCT pm.post_id) FROM {$wpdb->postmeta} pm INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id INNER JOIN {$wpdb->postmeta} enabled ON enabled.post_id = pm.post_id AND enabled.meta_key = '_alma_geo_enabled' AND enabled.meta_value IN $enabled_values WHERE pm.meta_key = '_alma_geo_geocoding_status' AND pm.meta_value = 'pending' AND p.post_type IN ('post','page')"),
-            'verified_geocoding' => (int) $wpdb->get_var("SELECT COUNT(DISTINCT post_id) FROM {$wpdb->postmeta} WHERE meta_key = '_alma_geo_geocoding_status' AND meta_value = 'verified'"),
-            'manual_review' => (int) $wpdb->get_var("SELECT COUNT(DISTINCT post_id) FROM {$wpdb->postmeta} WHERE (meta_key = '_alma_geo_geocoding_status' AND meta_value = 'manual_required') OR (meta_key = '_alma_geo_import_status' AND meta_value = 'review')"),
+            'pending_geocoding' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_locations()} WHERE geocoding_status = 'pending'"),
+            'verified_geocoding' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_locations()} WHERE geocoding_status = 'verified'"),
+            'manual_review' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_locations()} WHERE geocoding_status IN ('manual_required','ambiguous')"),
             'inactive_or_discarded' => (int) $wpdb->get_var("SELECT COUNT(DISTINCT post_id) FROM {$wpdb->postmeta} WHERE (meta_key = '_alma_geo_enabled' AND meta_value IN $inactive_values) OR (meta_key = '_alma_geo_import_status' AND meta_value IN ('discard','geocoding_failed'))"),
             'widget_eligible' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_content_index()} WHERE widget_eligible = 1"),
         );
@@ -279,6 +283,103 @@ class ALMA_Geo_Index_Store {
         );
     }
 
+    public function get_location($location_id) {
+        global $wpdb;
+        if (!$this->tables_exist()) {
+            return null;
+        }
+        return $wpdb->get_row(
+            $wpdb->prepare("SELECT * FROM {$this->table_locations()} WHERE id = %d LIMIT 1", absint($location_id)),
+            ARRAY_A
+        );
+    }
+
+    public function get_locations_by_geocoding_status($status = 'pending', $limit = 20) {
+        global $wpdb;
+        if (!$this->tables_exist()) {
+            return array();
+        }
+        $status = sanitize_key($status);
+        $limit = max(1, min(50, absint($limit)));
+        return $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT * FROM {$this->table_locations()} WHERE geocoding_status = %s ORDER BY updated_at ASC, id ASC LIMIT %d",
+                $status,
+                $limit
+            ),
+            ARRAY_A
+        );
+    }
+
+    public function get_geocoding_status_counts() {
+        global $wpdb;
+        $counts = array('pending' => 0, 'verified' => 0, 'ambiguous' => 0, 'manual_required' => 0, 'failed' => 0, 'not_required' => 0);
+        if (!$this->tables_exist()) {
+            return $counts;
+        }
+        $rows = $wpdb->get_results("SELECT geocoding_status, COUNT(*) AS total FROM {$this->table_locations()} GROUP BY geocoding_status", ARRAY_A);
+        foreach ($rows as $row) {
+            $status = sanitize_key($row['geocoding_status'] ?? '');
+            if (isset($counts[$status])) {
+                $counts[$status] = (int) $row['total'];
+            }
+        }
+        return $counts;
+    }
+
+    public function update_location_geocoding($location_id, $result) {
+        global $wpdb;
+        $location_id = absint($location_id);
+        if (!$location_id || !$this->tables_exist()) {
+            return false;
+        }
+        $status = sanitize_key($result['status'] ?? 'failed');
+        $allowed_statuses = array('pending', 'verified', 'ambiguous', 'manual_required', 'failed', 'not_required');
+        if (!in_array($status, $allowed_statuses, true)) {
+            $status = 'failed';
+        }
+
+        $row = array(
+            'geocoding_status' => $status,
+            'geocoding_error' => sanitize_textarea_field($result['message'] ?? ''),
+            'updated_at' => current_time('mysql'),
+        );
+        $formats = array('%s', '%s', '%s');
+
+        if (in_array($status, array('verified', 'ambiguous', 'manual_required'), true)) {
+            foreach (array('lat' => '%f', 'lng' => '%f') as $key => $format) {
+                if (isset($result[$key]) && $result[$key] !== null && $result[$key] !== '') {
+                    $row[$key] = (float) $result[$key];
+                    $formats[] = $format;
+                }
+            }
+            if (!empty($result['geo_provider'])) {
+                $row['geo_provider'] = sanitize_key($result['geo_provider']);
+                $formats[] = '%s';
+            }
+            if (!empty($result['place_id'])) {
+                $row['geo_provider_place_id'] = sanitize_text_field($result['place_id']);
+                $formats[] = '%s';
+            }
+            if (!empty($result['formatted_address'])) {
+                $row['formatted_address'] = sanitize_text_field($result['formatted_address']);
+                $formats[] = '%s';
+            }
+            if (!empty($result['address_components'])) {
+                $row['address_components'] = wp_json_encode($result['address_components']);
+                $formats[] = '%s';
+            }
+            $row['geocoded_at'] = current_time('mysql');
+            $formats[] = '%s';
+        }
+
+        if ($status === 'verified') {
+            $row['geocoding_error'] = '';
+        }
+
+        return false !== $wpdb->update($this->table_locations(), $row, array('id' => $location_id), $formats, array('%d'));
+    }
+
     public function sanitize_location_data($data) {
         $data = is_array($data) ? $data : array();
         return array(
@@ -296,6 +397,10 @@ class ALMA_Geo_Index_Store {
             'geo_provider_place_id' => sanitize_text_field($data['geo_provider_place_id'] ?? ''),
             'suggested_geocoding_query' => sanitize_text_field($data['suggested_geocoding_query'] ?? ''),
             'geocoding_status' => sanitize_key($data['geocoding_status'] ?? 'pending'),
+            'formatted_address' => sanitize_text_field($data['formatted_address'] ?? ''),
+            'address_components' => isset($data['address_components']) ? wp_json_encode($data['address_components']) : null,
+            'geocoded_at' => sanitize_text_field($data['geocoded_at'] ?? ''),
+            'geocoding_error' => sanitize_textarea_field($data['geocoding_error'] ?? ''),
             'aliases' => isset($data['aliases']) ? wp_json_encode($data['aliases']) : null,
         );
     }


### PR DESCRIPTION
### Motivation
- Aggiungere una funzionalità admin-only di geocoding per trasformare le località importate (`alma_geo_locations`) in coordinate, Place ID e dati indirizzo usando Google Geocoding in modo controllato e reversibile. 
- Preparare l’architettura per supportare provider futuri pur mantenendo tutte le funzionalità frontend, widget, shortcode, import e AI invariati. 

### Description
- Nuove classi: aggiunti `includes/class-geo-index-geocoder.php` (orchestratore admin-only, batch, validazione, salvataggio, report, logging) e `includes/class-geo-index-google-geocoder.php` (provider Google Maps che usa `wp_remote_get()` e normalizza la risposta). 
- Database: estesa la tabella `{$wpdb->prefix}alma_geo_locations` tramite `dbDelta` con i campi `formatted_address TEXT NULL`, `address_components LONGTEXT NULL`, `geocoded_at DATETIME NULL` e `geocoding_error TEXT NULL` mantenendo idempotenza e dati esistenti. 
- Admin UI: aggiunta la tab **Geocoding** in **Indice Geografico** con impostazioni (`alma_geo_geocoding_provider`, `alma_geo_google_maps_api_key`, `alma_geo_geocoding_batch_size`, `alma_geo_geocoding_timeout`, `alma_geo_geocoding_delay_ms`, `alma_geo_geocoding_overwrite_verified`, `alma_geo_geocoding_country_bias`), mascheramento della key, pulsanti `Test API key`, `Geocodifica prossime località pending`, `Riprova failed`, e report salvato in `alma_geo_geocoding_last_report`. 
- Flusso e regole: geocoding eseguito solo da admin su azione esplicita; batch conservativo (default 20, max 50), delay configurabile; non viene eseguito niente automaticamente sul frontend. 
- Validazione e stati: implementata validazione della risposta Google (status OK, lat/lng, `place_id`, coerenza country/tipo, partial match, risultati multipli) e mappatura in stati `pending`, `verified`, `ambiguous`, `manual_required`, `failed`, `not_required`. Località `verified` non vengono sovrascritte se `overwrite_verified` è disattivato. 
- Store & metabox: aggiunti helper nello storage (`get_location`, `get_locations_by_geocoding_status`, `get_geocoding_status_counts`, `update_location_geocoding`) e aggiornato il metabox Geolocalizzazione per mostrare dati geocoding della località primaria, consentire modifica manuale di lat/lng/place_id/provider/stato e assegnare `manual` come provider se l’admin salva coordinate verificate manualmente. 
- Logging & sicurezza: uso `ALMA_Logger` per log redatti (non includere API key né URL completi con key); tutte le azioni admin usano capability e nonce; sanitizzazione con funzioni WP (`sanitize_text_field`, `sanitize_key`, `absint`, `wp_json_encode`, ecc.). 
- Piccoli aggiornamenti: registrazione delle nuove classi nel bootstrap plugin e bump versione a `2.41.0`; aggiornamento di `README.md` e `CHANGELOG.md` con le note sul geocoding. 

### Testing
- Sintassi PHP verificata con `php -l` su tutti i file modificati/aggiunti: `affiliate-link-manager-ai.php`, `includes/class-geo-index-store.php`, `includes/class-geo-index-admin.php`, `includes/class-geo-index-metabox.php`, `includes/class-geo-index-geocoder.php`, `includes/class-geo-index-google-geocoder.php` — tutti i controlli sono passati. 
- Verificato `git diff --check` per errori di spazio/whitespace e non sono stati rilevati problemi. 
- Nota: test manuali consigliati elencati nel PR (apertura tab Geocoding, salvataggio impostazioni senza key, test key, esecuzione batch, verifica colonne Località, verifica metabox su post) e dovrebbero essere eseguiti in ambiente admin con attenzione all’uso della API key (evitare chiamate non volute in ambienti con costi attivi).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23e3ac28d08332abd8250e23a6e24b)