### PR TITLE
Sync verified geocoding data to Geo Index objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Unreleased
+- Corretto allineamento tra località geocodificate e stato geocoding dei contenuti collegati.
+- Aggiunta risincronizzazione manuale dei dati geocoding nei post.
+- Semplificato il metabox Geolocalizzazione contenuto con vista sintetica e sezioni avanzate.
+
 
 ## 2.41.0 - 2026-06-06
 - Aggiunta la fondazione di geocoding admin-only per **Indice Geografico**, con tab Geocoding, impostazioni Google Maps API key mascherata, batch controllati e report in `alma_geo_geocoding_last_report`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Indice Geografico — sincronizzazione geocoding
+- Le località `verified` sincronizzano i dati geocoding sui contenuti primari collegati tramite `alma_geo_content_index`, mantenendo compatibilità con i meta `_alma_geo_*` esistenti.
+- La tab **Geocoding** include il pulsante **Risincronizza geocoding nei contenuti**, che copia solo dati già salvati nelle località senza chiamare Google Maps.
+- Il metabox **Geolocalizzazione contenuto** separa indice, import e geocoding, mostra lo stato effettivo della località primaria verificata e sposta classificazione, campi tecnici e località secondarie in sezioni richiudibili.
+
 ## 2.41.0 - 2026-06-06
 
 ### Indice Geografico — Geocoding admin

--- a/includes/class-geo-index-admin.php
+++ b/includes/class-geo-index-admin.php
@@ -133,7 +133,13 @@ class ALMA_Geo_Index_Admin {
             }
             $settings = $this->geocoder->get_settings();
             $report = $this->geocoder->geocode_batch($settings['batch_size'], $action === 'retry_failed' ? 'failed' : 'pending');
-            $this->notice_success(sprintf(__('Batch geocoding completato: %1$d processate, %2$d verified, %3$d ambiguous, %4$d manual_required, %5$d failed.', 'affiliate-link-manager-ai'), $report['processed'], $report['verified'], $report['ambiguous'], $report['manual_required'], $report['failed']));
+            $this->notice_success(sprintf(__('Batch geocoding completato: %1$d processate, %2$d verified, %3$d ambiguous, %4$d manual_required, %5$d failed. Oggetti collegati sincronizzati: %6$d, errori sync: %7$d.', 'affiliate-link-manager-ai'), $report['processed'], $report['verified'], $report['ambiguous'], $report['manual_required'], $report['failed'], $report['linked_objects_synced'], $report['linked_objects_sync_errors']));
+            return;
+        }
+        if ($action === 'sync_verified_locations') {
+            $report = $this->store->sync_all_verified_locations_to_objects();
+            update_option('alma_geo_geocoding_last_sync_report', $report, false);
+            $this->notice_success(sprintf(__('Risincronizzazione completata: %1$d località verified, %2$d oggetti trovati, %3$d aggiornati, %4$d saltati, %5$d errori.', 'affiliate-link-manager-ai'), $report['locations_found'], $report['objects_found'], $report['objects_updated'], $report['objects_skipped'], count($report['errors'])));
             return;
         }
         if ($action === 'geocode_location' || $action === 'retry_location') {
@@ -149,7 +155,7 @@ class ALMA_Geo_Index_Admin {
                 return;
             }
             $result = $this->geocoder->geocode_location($location_id);
-            $this->notice_success(sprintf(__('Località #%1$d aggiornata con stato %2$s.', 'affiliate-link-manager-ai'), $location_id, ALMA_Geo_Index_Metabox::geocoding_status_label($result['status'] ?? 'failed')));
+            $this->notice_success(sprintf(__('Località #%1$d aggiornata con stato %2$s. Oggetti collegati sincronizzati: %3$d, errori sync: %4$d.', 'affiliate-link-manager-ai'), $location_id, ALMA_Geo_Index_Metabox::geocoding_status_label($result['status'] ?? 'failed'), (int) ($result['linked_objects_synced'] ?? 0), (int) ($result['linked_objects_sync_errors'] ?? 0)));
             return;
         }
         if ($action === 'mark_manual_required') {
@@ -230,8 +236,11 @@ class ALMA_Geo_Index_Admin {
         }
         $cards = array(
             __('Contenuti geolocalizzati attivi', 'affiliate-link-manager-ai') => $counts['active_geo_content'],
-            __('In attesa di geocoding', 'affiliate-link-manager-ai') => $counts['pending_geocoding'],
-            __('Geocodificati', 'affiliate-link-manager-ai') => $counts['verified_geocoding'],
+            __('Contenuti con località verified', 'affiliate-link-manager-ai') => $counts['content_with_verified_locations'],
+            __('Contenuti ancora pending', 'affiliate-link-manager-ai') => $counts['content_pending_geocoding'],
+            __('Località verified', 'affiliate-link-manager-ai') => $counts['locations_verified'],
+            __('Località pending', 'affiliate-link-manager-ai') => $counts['locations_pending'],
+            __('Località failed', 'affiliate-link-manager-ai') => $counts['locations_failed'],
             __('Da revisione', 'affiliate-link-manager-ai') => $counts['manual_review'],
             __('Non attivi/scartati', 'affiliate-link-manager-ai') => $counts['inactive_or_discarded'],
             __('Compatibilità widget', 'affiliate-link-manager-ai') => $counts['widget_eligible'],
@@ -336,6 +345,10 @@ class ALMA_Geo_Index_Admin {
         if (!empty($last_report)) {
             echo '<div class="postbox"><div class="inside"><h3>' . esc_html__('Ultimo report geocoding', 'affiliate-link-manager-ai') . '</h3><pre style="white-space:pre-wrap">' . esc_html(wp_json_encode($last_report, JSON_PRETTY_PRINT)) . '</pre></div></div>';
         }
+        $last_sync_report = get_option('alma_geo_geocoding_last_sync_report', array());
+        if (!empty($last_sync_report)) {
+            echo '<div class="postbox"><div class="inside"><h3>' . esc_html__('Ultimo report risincronizzazione', 'affiliate-link-manager-ai') . '</h3><pre style="white-space:pre-wrap">' . esc_html(wp_json_encode($last_sync_report, JSON_PRETTY_PRINT)) . '</pre></div></div>';
+        }
         ?>
         <form method="post" class="postbox" style="padding:12px;">
             <?php wp_nonce_field('alma_geo_index_geocoding'); ?>
@@ -356,6 +369,7 @@ class ALMA_Geo_Index_Admin {
             <?php $this->render_geocoding_button('test_api_key', __('Test API key', 'affiliate-link-manager-ai')); ?>
             <?php $this->render_geocoding_button('batch_pending', __('Geocodifica prossime località pending', 'affiliate-link-manager-ai')); ?>
             <?php $this->render_geocoding_button('retry_failed', __('Riprova failed', 'affiliate-link-manager-ai')); ?>
+            <?php $this->render_geocoding_button('sync_verified_locations', __('Risincronizza geocoding nei contenuti', 'affiliate-link-manager-ai')); ?>
         </div>
         <?php
         echo '<h3>' . esc_html__('Località pending/recenti', 'affiliate-link-manager-ai') . '</h3>';

--- a/includes/class-geo-index-geocoder.php
+++ b/includes/class-geo-index-geocoder.php
@@ -51,6 +51,8 @@ class ALMA_Geo_Index_Geocoder {
             'manual_required' => 0,
             'failed' => 0,
             'skipped_verified' => 0,
+            'linked_objects_synced' => 0,
+            'linked_objects_sync_errors' => 0,
             'errors' => array(),
         );
 
@@ -67,6 +69,8 @@ class ALMA_Geo_Index_Geocoder {
                 if (!empty($result['message']) && $result_status !== 'verified') {
                     $report['errors'][] = array('location_id' => (int) $location['id'], 'status' => $result_status, 'message' => sanitize_text_field($result['message']));
                 }
+                $report['linked_objects_synced'] += (int) ($result['linked_objects_synced'] ?? 0);
+                $report['linked_objects_sync_errors'] += (int) ($result['linked_objects_sync_errors'] ?? 0);
             }
             if ($settings['delay_ms'] > 0) {
                 usleep($settings['delay_ms'] * 1000);
@@ -92,6 +96,12 @@ class ALMA_Geo_Index_Geocoder {
         $provider_result = $provider->geocode($query, array('region' => $settings['country_bias']));
         $validated = $this->validate_result($location, $provider_result);
         $this->store->update_location_geocoding($location['id'], $validated);
+        if (($validated['status'] ?? '') === 'verified') {
+            $sync_report = $this->store->sync_location_to_linked_objects((int) $location['id']);
+            $validated['linked_objects_synced'] = (int) ($sync_report['objects_updated'] ?? 0);
+            $validated['linked_objects_sync_errors'] = count($sync_report['errors'] ?? array());
+            $validated['linked_objects_sync_report'] = $sync_report;
+        }
         $this->log_result($location['id'], $query, $validated, $provider_result);
         return $validated;
     }

--- a/includes/class-geo-index-metabox.php
+++ b/includes/class-geo-index-metabox.php
@@ -36,79 +36,122 @@ class ALMA_Geo_Index_Metabox {
         wp_nonce_field(self::NONCE_ACTION, self::NONCE_NAME);
         $values = $this->get_values($post->ID);
         $primary_location = $this->store->get_primary_location_for_object($post->ID, $post->post_type);
+        $effective_geocoding_status = $this->effective_geocoding_status($values, $primary_location);
+        $meta_synced = $this->is_primary_location_synced($values, $primary_location);
         $suggested_query = $primary_location['suggested_geocoding_query'] ?? '';
+        $provider = $values['_alma_geo_primary_provider'] ?: ($values['_alma_geo_provider'] ?? '');
+        $provider = $provider ?: ($primary_location['geo_provider'] ?? '');
+        $place_id = $values['_alma_geo_primary_place_id'] ?: ($primary_location['geo_provider_place_id'] ?? '');
+        $formatted_address = $values['_alma_geo_primary_formatted_address'] ?: ($primary_location['formatted_address'] ?? '');
+        $lat = $values['_alma_geo_primary_lat'] ?: ($primary_location['lat'] ?? '');
+        $lng = $values['_alma_geo_primary_lng'] ?: ($primary_location['lng'] ?? '');
+        $display_values = array_merge($values, array(
+            '_alma_geo_primary_name' => $values['_alma_geo_primary_name'] ?: ($primary_location['canonical_name'] ?? ''),
+            '_alma_geo_primary_canonical_name' => $values['_alma_geo_primary_canonical_name'] ?: ($primary_location['canonical_name'] ?? ''),
+            '_alma_geo_primary_type' => $values['_alma_geo_primary_type'] ?: ($primary_location['type'] ?? 'unknown'),
+            '_alma_geo_primary_country' => $values['_alma_geo_primary_country'] ?: ($primary_location['country'] ?? ''),
+            '_alma_geo_primary_country_code' => $values['_alma_geo_primary_country_code'] ?: ($primary_location['country_code'] ?? ''),
+            '_alma_geo_primary_region' => $values['_alma_geo_primary_region'] ?: ($primary_location['region'] ?? ''),
+            '_alma_geo_primary_city' => $values['_alma_geo_primary_city'] ?: ($primary_location['city'] ?? ''),
+            '_alma_geo_primary_area' => $values['_alma_geo_primary_area'] ?: ($primary_location['area'] ?? ''),
+            '_alma_geo_primary_poi' => $values['_alma_geo_primary_poi'] ?: ($primary_location['poi'] ?? ''),
+        ));
         ?>
-        <p><?php esc_html_e('Questi dati servono a collegare il contenuto a una località geografica e saranno usati in futuro per il Widget Link Contestuale, per il matching con Link Affiliati e per mappe interattive.', 'affiliate-link-manager-ai'); ?></p>
+        <p><?php esc_html_e('Vista sintetica dei dati geografici del contenuto. I campi manuali restano modificabili, mentre i dettagli tecnici sono raccolti nelle sezioni avanzate.', 'affiliate-link-manager-ai'); ?></p>
         <style>
-            .alma-geo-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px 18px}.alma-geo-field label{display:block;font-weight:600;margin-bottom:4px}.alma-geo-field input,.alma-geo-field select,.alma-geo-field textarea{width:100%;max-width:100%}.alma-geo-section{border-top:1px solid #dcdcde;margin-top:16px;padding-top:12px}.alma-geo-checks label{margin-right:18px}.alma-geo-status-summary{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px;margin:12px 0}.alma-geo-badge{display:inline-block;border-radius:999px;padding:3px 9px;font-weight:600;background:#f0f0f1;color:#2c3338}.alma-geo-badge-active{background:#d1e7dd;color:#0f5132}.alma-geo-badge-inactive{background:#f8d7da;color:#842029}.alma-geo-badge-pending{background:#fff3cd;color:#664d03}.alma-geo-badge-verified{background:#cfe2ff;color:#084298}.alma-geo-badge-manual{background:#fde2c2;color:#7a3e00}.alma-geo-badge-failed{background:#f8d7da;color:#842029}.alma-geo-badge-ambiguous{background:#e2d9f3;color:#3d0a69}
+            .alma-geo-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px 18px}.alma-geo-field label{display:block;font-weight:600;margin-bottom:4px}.alma-geo-field input,.alma-geo-field select,.alma-geo-field textarea{width:100%;max-width:100%}.alma-geo-section{border-top:1px solid #dcdcde;margin-top:16px;padding-top:12px}.alma-geo-summary{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px;margin:12px 0}.alma-geo-kv{display:grid;grid-template-columns:180px 1fr;gap:6px 12px}.alma-geo-kv dt{font-weight:600}.alma-geo-badge{display:inline-block;border-radius:999px;padding:3px 9px;font-weight:600;background:#f0f0f1;color:#2c3338}.alma-geo-badge-active{background:#d1e7dd;color:#0f5132}.alma-geo-badge-inactive{background:#f8d7da;color:#842029}.alma-geo-badge-pending{background:#fff3cd;color:#664d03}.alma-geo-badge-verified{background:#cfe2ff;color:#084298}.alma-geo-badge-manual{background:#fde2c2;color:#7a3e00}.alma-geo-badge-failed{background:#f8d7da;color:#842029}.alma-geo-badge-ambiguous{background:#e2d9f3;color:#3d0a69}.alma-geo-actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:12px}.alma-geo-actions .button{margin:0}.alma-geo-details{border:1px solid #dcdcde;padding:10px 12px;margin-top:14px;background:#fff}.alma-geo-details summary{font-weight:600;cursor:pointer}
         </style>
+
         <div class="alma-geo-section">
-            <h3><?php esc_html_e('Stato', 'affiliate-link-manager-ai'); ?></h3>
-            <div class="alma-geo-status-summary">
+            <h3><?php esc_html_e('Stato sintetico', 'affiliate-link-manager-ai'); ?></h3>
+            <div class="alma-geo-summary">
                 <div><?php esc_html_e('Indice geografico:', 'affiliate-link-manager-ai'); ?> <?php echo $this->render_record_status_badge($values['_alma_geo_enabled'] ?? 'no'); ?></div>
                 <div><?php esc_html_e('Stato import:', 'affiliate-link-manager-ai'); ?> <?php echo $this->render_import_status_badge($values['_alma_geo_import_status'] ?? 'review'); ?></div>
-                <div><?php esc_html_e('Stato geocoding:', 'affiliate-link-manager-ai'); ?> <?php echo $this->render_geocoding_status_badge($values['_alma_geo_geocoding_status'] ?? 'pending'); ?></div>
+                <div><?php esc_html_e('Stato geocoding:', 'affiliate-link-manager-ai'); ?> <?php echo $this->render_geocoding_status_badge($effective_geocoding_status); ?></div>
             </div>
-            <p class="alma-geo-checks">
+            <p>
                 <label><input type="checkbox" name="alma_geo[_alma_geo_enabled]" value="yes" <?php checked($this->is_yes($values['_alma_geo_enabled'] ?? ''), true); ?>> <?php esc_html_e('Abilita geolocalizzazione', 'affiliate-link-manager-ai'); ?></label>
+                &nbsp;&nbsp;
                 <label><input type="checkbox" name="alma_geo[_alma_geo_widget_eligible]" value="yes" <?php checked($this->is_yes($values['_alma_geo_widget_eligible'] ?? ''), true); ?>> <?php esc_html_e('Widget eligible', 'affiliate-link-manager-ai'); ?></label>
             </p>
-            <div class="alma-geo-grid">
-                <?php $this->render_select('_alma_geo_import_status', __('Stato import', 'affiliate-link-manager-ai'), $values, self::geo_import_statuses()); ?>
-                <?php $this->render_select('_alma_geo_geocoding_status', __('Stato geocoding', 'affiliate-link-manager-ai'), $values, self::geocoding_statuses()); ?>
-                <?php $this->render_input('_alma_geo_confidence', __('Confidence', 'affiliate-link-manager-ai'), $values, 'number', 'step="0.001" min="0" max="1"'); ?>
-                <?php $this->render_input('_alma_geo_match_weight', __('Match weight', 'affiliate-link-manager-ai'), $values, 'number'); ?>
-                <?php $this->render_input('_alma_geo_source', __('Fonte dati', 'affiliate-link-manager-ai'), $values); ?>
-                <?php $this->render_input('_alma_geo_updated_at', __('Ultimo aggiornamento', 'affiliate-link-manager-ai'), $values, 'text', 'readonly'); ?>
-            </div>
-            <?php if (!empty($primary_location)) : ?>
-                <div class="alma-geo-section" style="grid-column:1/-1">
-                    <h4><?php esc_html_e('Dati geocoding salvati nella località primaria', 'affiliate-link-manager-ai'); ?></h4>
-                    <p><strong><?php esc_html_e('Provider:', 'affiliate-link-manager-ai'); ?></strong> <?php echo esc_html($primary_location['geo_provider'] ?? ''); ?> — <strong><?php esc_html_e('Place ID:', 'affiliate-link-manager-ai'); ?></strong> <?php echo esc_html($primary_location['geo_provider_place_id'] ?? ''); ?></p>
-                    <p><strong><?php esc_html_e('Formatted address:', 'affiliate-link-manager-ai'); ?></strong> <?php echo esc_html($primary_location['formatted_address'] ?? ''); ?></p>
-                    <p><strong><?php esc_html_e('Ultimo geocoding:', 'affiliate-link-manager-ai'); ?></strong> <?php echo esc_html($primary_location['geocoded_at'] ?? ''); ?> — <strong><?php esc_html_e('Errore:', 'affiliate-link-manager-ai'); ?></strong> <?php echo esc_html($primary_location['geocoding_error'] ?? ''); ?></p>
-                </div>
-            <?php endif; ?>
         </div>
+
         <div class="alma-geo-section">
-            <h3><?php esc_html_e('Classificazione', 'affiliate-link-manager-ai'); ?></h3>
+            <h3><?php esc_html_e('Località primaria', 'affiliate-link-manager-ai'); ?></h3>
+            <div class="alma-geo-grid">
+                <?php $this->render_input('_alma_geo_primary_name', __('Nome località', 'affiliate-link-manager-ai'), $display_values); ?>
+                <?php $this->render_select('_alma_geo_primary_type', __('Tipo', 'affiliate-link-manager-ai'), $display_values, self::primary_types()); ?>
+                <?php $this->render_input('_alma_geo_primary_country', __('Paese', 'affiliate-link-manager-ai'), $display_values); ?>
+                <?php $this->render_input('_alma_geo_primary_region', __('Regione', 'affiliate-link-manager-ai'), $display_values); ?>
+                <?php $this->render_input('_alma_geo_primary_city', __('Città', 'affiliate-link-manager-ai'), $display_values); ?>
+                <?php $this->render_input('_alma_geo_primary_area', __('Area', 'affiliate-link-manager-ai'), $display_values); ?>
+                <?php $this->render_input('_alma_geo_primary_poi', __('POI', 'affiliate-link-manager-ai'), $display_values); ?>
+            </div>
+        </div>
+
+        <div class="alma-geo-section">
+            <h3><?php esc_html_e('Dati geocoding', 'affiliate-link-manager-ai'); ?></h3>
+            <dl class="alma-geo-kv">
+                <dt><?php esc_html_e('Provider', 'affiliate-link-manager-ai'); ?></dt><dd><?php echo esc_html($provider); ?></dd>
+                <dt><?php esc_html_e('Place ID', 'affiliate-link-manager-ai'); ?></dt><dd><?php echo esc_html($place_id); ?></dd>
+                <dt><?php esc_html_e('Formatted address', 'affiliate-link-manager-ai'); ?></dt><dd><?php echo esc_html($formatted_address); ?></dd>
+                <dt><?php esc_html_e('Latitudine', 'affiliate-link-manager-ai'); ?></dt><dd><?php echo esc_html((string) $lat); ?></dd>
+                <dt><?php esc_html_e('Longitudine', 'affiliate-link-manager-ai'); ?></dt><dd><?php echo esc_html((string) $lng); ?></dd>
+                <dt><?php esc_html_e('Ultimo geocoding', 'affiliate-link-manager-ai'); ?></dt><dd><?php echo esc_html($primary_location['geocoded_at'] ?? ''); ?></dd>
+                <dt><?php esc_html_e('Errore', 'affiliate-link-manager-ai'); ?></dt><dd><?php echo esc_html($primary_location['geocoding_error'] ?? ''); ?></dd>
+            </dl>
+            <div class="alma-geo-grid">
+                <?php $this->render_input('_alma_geo_primary_lat', __('Latitudine manuale', 'affiliate-link-manager-ai'), array_merge($values, array('_alma_geo_primary_lat' => $lat)), 'number', 'step="0.0000001"'); ?>
+                <?php $this->render_input('_alma_geo_primary_lng', __('Longitudine manuale', 'affiliate-link-manager-ai'), array_merge($values, array('_alma_geo_primary_lng' => $lng)), 'number', 'step="0.0000001"'); ?>
+                <?php $this->render_input('_alma_geo_primary_place_id', __('Place ID', 'affiliate-link-manager-ai'), array_merge($values, array('_alma_geo_primary_place_id' => $place_id))); ?>
+                <?php $this->render_input('_alma_geo_provider', __('Provider geocoding', 'affiliate-link-manager-ai'), array_merge($values, array('_alma_geo_provider' => $provider))); ?>
+                <?php $this->render_input('_alma_geo_primary_formatted_address', __('Formatted address', 'affiliate-link-manager-ai'), array_merge($values, array('_alma_geo_primary_formatted_address' => $formatted_address))); ?>
+                <input type="hidden" name="alma_geo[_alma_geo_primary_provider]" value="<?php echo esc_attr($provider); ?>">
+            </div>
+            <div class="alma-geo-actions">
+                <a class="button" href="#alma_geo_suggested_geocoding_query"><?php esc_html_e('Cerca località', 'affiliate-link-manager-ai'); ?></a>
+                <?php if ($effective_geocoding_status === 'pending') : ?>
+                    <span class="button disabled" aria-disabled="true"><?php esc_html_e('Geocodifica questa località dalla tab Geocoding', 'affiliate-link-manager-ai'); ?></span>
+                <?php endif; ?>
+                <?php if (!empty($primary_location['id']) && ($primary_location['geocoding_status'] ?? '') === 'verified' && !$meta_synced) : ?>
+                    <button type="submit" class="button" name="alma_geo_resync_post" value="1"><?php esc_html_e('Risincronizza dati località', 'affiliate-link-manager-ai'); ?></button>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <details class="alma-geo-details">
+            <summary><?php esc_html_e('Classificazione', 'affiliate-link-manager-ai'); ?></summary>
             <div class="alma-geo-grid">
                 <?php $this->render_select('_alma_geo_content_type', __('Content type', 'affiliate-link-manager-ai'), $values, self::content_types()); ?>
                 <?php $this->render_select('_alma_geo_commercial_intent', __('Commercial intent', 'affiliate-link-manager-ai'), $values, self::commercial_intents()); ?>
                 <?php $this->render_select('_alma_geo_scope', __('Geo scope', 'affiliate-link-manager-ai'), $values, self::geo_scopes()); ?>
+                <?php $this->render_input('_alma_geo_confidence', __('Confidence', 'affiliate-link-manager-ai'), $values, 'number', 'step="0.001" min="0" max="1"'); ?>
+                <?php $this->render_input('_alma_geo_match_weight', __('Match weight', 'affiliate-link-manager-ai'), $values, 'number'); ?>
             </div>
-        </div>
-        <div class="alma-geo-section">
-            <h3><?php esc_html_e('Località primaria', 'affiliate-link-manager-ai'); ?></h3>
+        </details>
+
+        <details class="alma-geo-details">
+            <summary><?php esc_html_e('Campi tecnici', 'affiliate-link-manager-ai'); ?></summary>
             <div class="alma-geo-grid">
-                <?php $this->render_input('_alma_geo_primary_name', __('Nome località', 'affiliate-link-manager-ai'), $values); ?>
-                <?php $this->render_input('_alma_geo_primary_canonical_name', __('Nome canonico', 'affiliate-link-manager-ai'), $values); ?>
-                <?php $this->render_select('_alma_geo_primary_type', __('Tipo località', 'affiliate-link-manager-ai'), $values, self::primary_types()); ?>
-                <?php $this->render_input('_alma_geo_primary_country', __('Paese', 'affiliate-link-manager-ai'), $values); ?>
-                <?php $this->render_input('_alma_geo_primary_country_code', __('Codice paese', 'affiliate-link-manager-ai'), $values); ?>
-                <?php $this->render_input('_alma_geo_primary_region', __('Regione', 'affiliate-link-manager-ai'), $values); ?>
-                <?php $this->render_input('_alma_geo_primary_city', __('Città', 'affiliate-link-manager-ai'), $values); ?>
-                <?php $this->render_input('_alma_geo_primary_area', __('Area', 'affiliate-link-manager-ai'), $values); ?>
-                <?php $this->render_input('_alma_geo_primary_poi', __('POI', 'affiliate-link-manager-ai'), $values); ?>
-                <?php $this->render_input('_alma_geo_primary_lat', __('Latitudine', 'affiliate-link-manager-ai'), $values, 'number', 'step="0.0000001"'); ?>
-                <?php $this->render_input('_alma_geo_primary_lng', __('Longitudine', 'affiliate-link-manager-ai'), $values, 'number', 'step="0.0000001"'); ?>
-                <?php $this->render_input('_alma_geo_primary_place_id', __('Place ID', 'affiliate-link-manager-ai'), $values); ?>
-                <?php $this->render_input('_alma_geo_provider', __('Provider geocoding', 'affiliate-link-manager-ai'), $values); ?>
+                <?php $this->render_input('_alma_geo_primary_canonical_name', __('Nome canonico', 'affiliate-link-manager-ai'), $display_values); ?>
+                <?php $this->render_input('_alma_geo_primary_country_code', __('Codice paese', 'affiliate-link-manager-ai'), $display_values); ?>
+                <?php $this->render_select('_alma_geo_import_status', __('Geo import status', 'affiliate-link-manager-ai'), $values, self::geo_import_statuses()); ?>
+                <?php $this->render_select('_alma_geo_geocoding_status', __('Stato geocoding meta', 'affiliate-link-manager-ai'), array_merge($values, array('_alma_geo_geocoding_status' => $effective_geocoding_status)), self::geocoding_statuses()); ?>
+                <?php $this->render_input('_alma_geo_source', __('Fonte dati', 'affiliate-link-manager-ai'), $values); ?>
+                <?php $this->render_input('_alma_geo_updated_at', __('Ultimo aggiornamento', 'affiliate-link-manager-ai'), $values, 'text', 'readonly'); ?>
                 <div class="alma-geo-field" style="grid-column:1/-1">
                     <label for="alma_geo_suggested_geocoding_query"><?php esc_html_e('Query geocoding suggerita', 'affiliate-link-manager-ai'); ?></label>
                     <input type="text" id="alma_geo_suggested_geocoding_query" name="alma_geo[suggested_geocoding_query]" value="<?php echo esc_attr($suggested_query); ?>">
                 </div>
             </div>
-        </div>
-        <div class="alma-geo-section">
-            <h3><?php esc_html_e('Località secondarie', 'affiliate-link-manager-ai'); ?></h3>
-            <?php $this->render_textarea('_alma_geo_locations_json', __('Località secondarie JSON', 'affiliate-link-manager-ai'), $values, 5); ?>
-        </div>
-        <div class="alma-geo-section">
-            <h3><?php esc_html_e('Qualità e note', 'affiliate-link-manager-ai'); ?></h3>
             <?php $this->render_textarea('_alma_geo_quality_flags', __('Quality flags', 'affiliate-link-manager-ai'), $values, 3); ?>
             <?php $this->render_textarea('_alma_geo_notes', __('Note interne', 'affiliate-link-manager-ai'), $values, 4); ?>
-        </div>
+        </details>
+
+        <details class="alma-geo-details">
+            <summary><?php esc_html_e('Località secondarie', 'affiliate-link-manager-ai'); ?></summary>
+            <?php $this->render_textarea('_alma_geo_locations_json', __('Località secondarie JSON', 'affiliate-link-manager-ai'), $values, 5); ?>
+        </details>
         <?php
     }
 
@@ -133,6 +176,14 @@ class ALMA_Geo_Index_Metabox {
             return;
         }
         if (!isset($_POST['alma_geo']) || !is_array($_POST['alma_geo'])) {
+            return;
+        }
+
+        if (!empty($_POST['alma_geo_resync_post'])) {
+            $primary_location = $this->store->get_primary_location_for_object($post_id, $post->post_type);
+            if (!empty($primary_location['id']) && ($primary_location['geocoding_status'] ?? '') === 'verified') {
+                $this->store->sync_location_to_linked_objects((int) $primary_location['id']);
+            }
             return;
         }
 
@@ -207,7 +258,7 @@ class ALMA_Geo_Index_Metabox {
         $data['_alma_geo_import_status'] = $this->sanitize_allowed($raw['_alma_geo_import_status'] ?? '', self::geo_import_statuses(), 'review');
         $data['_alma_geo_geocoding_status'] = $this->sanitize_allowed($raw['_alma_geo_geocoding_status'] ?? '', self::geocoding_statuses(), 'pending');
 
-        foreach (array('_alma_geo_primary_name','_alma_geo_primary_canonical_name','_alma_geo_primary_country','_alma_geo_primary_country_code','_alma_geo_primary_region','_alma_geo_primary_city','_alma_geo_primary_area','_alma_geo_primary_poi','_alma_geo_primary_place_id','_alma_geo_provider','_alma_geo_source') as $key) {
+        foreach (array('_alma_geo_primary_name','_alma_geo_primary_canonical_name','_alma_geo_primary_country','_alma_geo_primary_country_code','_alma_geo_primary_region','_alma_geo_primary_city','_alma_geo_primary_area','_alma_geo_primary_poi','_alma_geo_primary_place_id','_alma_geo_provider','_alma_geo_primary_provider','_alma_geo_primary_formatted_address','_alma_geo_source') as $key) {
             $data[$key] = sanitize_text_field($raw[$key] ?? '');
         }
         $data['_alma_geo_primary_country_code'] = strtoupper($data['_alma_geo_primary_country_code']);
@@ -229,7 +280,7 @@ class ALMA_Geo_Index_Metabox {
     public static function meta_keys() {
         return array(
             '_alma_geo_enabled','_alma_geo_scope','_alma_geo_content_type','_alma_geo_commercial_intent','_alma_geo_widget_eligible',
-            '_alma_geo_primary_name','_alma_geo_primary_canonical_name','_alma_geo_primary_type','_alma_geo_primary_country','_alma_geo_primary_country_code','_alma_geo_primary_region','_alma_geo_primary_city','_alma_geo_primary_area','_alma_geo_primary_poi','_alma_geo_primary_lat','_alma_geo_primary_lng','_alma_geo_primary_place_id','_alma_geo_provider',
+            '_alma_geo_primary_name','_alma_geo_primary_canonical_name','_alma_geo_primary_type','_alma_geo_primary_country','_alma_geo_primary_country_code','_alma_geo_primary_region','_alma_geo_primary_city','_alma_geo_primary_area','_alma_geo_primary_poi','_alma_geo_primary_lat','_alma_geo_primary_lng','_alma_geo_primary_place_id','_alma_geo_provider','_alma_geo_primary_provider','_alma_geo_primary_formatted_address',
             '_alma_geo_confidence','_alma_geo_match_weight','_alma_geo_geocoding_status','_alma_geo_import_status','_alma_geo_locations_json','_alma_geo_quality_flags','_alma_geo_notes','_alma_geo_source','_alma_geo_updated_at'
         );
     }
@@ -327,12 +378,30 @@ class ALMA_Geo_Index_Metabox {
         $labels = array(
             'active' => __('Importato', 'affiliate-link-manager-ai'),
             'ready' => __('Importato', 'affiliate-link-manager-ai'),
-            'needs_geocoding' => __('Importato — in attesa di geocoding', 'affiliate-link-manager-ai'),
+            'needs_geocoding' => __('Importato', 'affiliate-link-manager-ai'),
             'review' => __('Richiede revisione', 'affiliate-link-manager-ai'),
             'discard' => __('Scartato', 'affiliate-link-manager-ai'),
             'geocoding_failed' => __('Geocoding fallito', 'affiliate-link-manager-ai'),
         );
         return $labels[sanitize_key($status)] ?? $status;
+    }
+
+    private function effective_geocoding_status($values, $primary_location) {
+        if (!empty($primary_location) && ($primary_location['geocoding_status'] ?? '') === 'verified') {
+            return 'verified';
+        }
+        return sanitize_key($values['_alma_geo_geocoding_status'] ?? 'pending');
+    }
+
+    private function is_primary_location_synced($values, $primary_location) {
+        if (empty($primary_location) || ($primary_location['geocoding_status'] ?? '') !== 'verified') {
+            return true;
+        }
+        return ($values['_alma_geo_geocoding_status'] ?? '') === 'verified'
+            && (string) ($values['_alma_geo_primary_place_id'] ?? '') === (string) ($primary_location['geo_provider_place_id'] ?? '')
+            && (string) ($values['_alma_geo_provider'] ?? '') === (string) ($primary_location['geo_provider'] ?? '')
+            && (string) ($values['_alma_geo_primary_lat'] ?? '') !== ''
+            && (string) ($values['_alma_geo_primary_lng'] ?? '') !== '';
     }
 
     private function is_yes($value) {

--- a/includes/class-geo-index-store.php
+++ b/includes/class-geo-index-store.php
@@ -260,6 +260,11 @@ class ALMA_Geo_Index_Store {
             'content_relations' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_content_index()}"),
             'pending_geocoding' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_locations()} WHERE geocoding_status = 'pending'"),
             'verified_geocoding' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_locations()} WHERE geocoding_status = 'verified'"),
+            'content_with_verified_locations' => (int) $wpdb->get_var("SELECT COUNT(DISTINCT ci.object_id) FROM {$this->table_content_index()} ci INNER JOIN {$this->table_locations()} l ON l.id = ci.location_id WHERE ci.is_primary = 1 AND l.geocoding_status = 'verified'"),
+            'content_pending_geocoding' => (int) $wpdb->get_var("SELECT COUNT(DISTINCT ci.object_id) FROM {$this->table_content_index()} ci INNER JOIN {$this->table_locations()} l ON l.id = ci.location_id WHERE ci.is_primary = 1 AND l.geocoding_status = 'pending'"),
+            'locations_verified' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_locations()} WHERE geocoding_status = 'verified'"),
+            'locations_pending' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_locations()} WHERE geocoding_status = 'pending'"),
+            'locations_failed' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_locations()} WHERE geocoding_status = 'failed'"),
             'manual_review' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_locations()} WHERE geocoding_status IN ('manual_required','ambiguous')"),
             'inactive_or_discarded' => (int) $wpdb->get_var("SELECT COUNT(DISTINCT post_id) FROM {$wpdb->postmeta} WHERE (meta_key = '_alma_geo_enabled' AND meta_value IN $inactive_values) OR (meta_key = '_alma_geo_import_status' AND meta_value IN ('discard','geocoding_failed'))"),
             'widget_eligible' => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->table_content_index()} WHERE widget_eligible = 1"),
@@ -300,7 +305,7 @@ class ALMA_Geo_Index_Store {
             return array();
         }
         $status = sanitize_key($status);
-        $limit = max(1, min(50, absint($limit)));
+        $limit = max(1, min(5000, absint($limit)));
         return $wpdb->get_results(
             $wpdb->prepare(
                 "SELECT * FROM {$this->table_locations()} WHERE geocoding_status = %s ORDER BY updated_at ASC, id ASC LIMIT %d",
@@ -309,6 +314,94 @@ class ALMA_Geo_Index_Store {
             ),
             ARRAY_A
         );
+    }
+
+    public function sync_location_to_linked_objects($location_id) {
+        global $wpdb;
+        $report = array(
+            'location_id' => absint($location_id),
+            'objects_found' => 0,
+            'objects_updated' => 0,
+            'objects_skipped' => 0,
+            'errors' => array(),
+        );
+
+        $location = $this->get_location($location_id);
+        if (!$location) {
+            $report['errors'][] = __('Località non trovata.', 'affiliate-link-manager-ai');
+            return $report;
+        }
+        if (($location['geocoding_status'] ?? '') !== 'verified') {
+            $report['errors'][] = __('Località non verified: sincronizzazione saltata.', 'affiliate-link-manager-ai');
+            return $report;
+        }
+
+        $allowed_types = array(self::OBJECT_TYPE_POST, self::OBJECT_TYPE_PAGE, self::OBJECT_TYPE_AFFILIATE_LINK);
+        $relations = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT * FROM {$this->table_content_index()} WHERE location_id = %d AND is_primary = 1",
+                absint($location_id)
+            ),
+            ARRAY_A
+        );
+        $report['objects_found'] = count($relations);
+
+        foreach ($relations as $relation) {
+            $object_id = absint($relation['object_id'] ?? 0);
+            $object_type = sanitize_key($relation['object_type'] ?? '');
+            if (!$object_id || !in_array($object_type, $allowed_types, true)) {
+                $report['objects_skipped']++;
+                continue;
+            }
+
+            $post = get_post($object_id);
+            if (!$post || $post->post_type !== $object_type) {
+                $report['objects_skipped']++;
+                $report['errors'][] = sprintf(__('Oggetto #%1$d non trovato o tipo non coerente.', 'affiliate-link-manager-ai'), $object_id);
+                continue;
+            }
+
+            $current_primary = $this->get_primary_location_for_object($object_id, $object_type);
+            if (!empty($current_primary['id']) && (int) $current_primary['id'] !== (int) $location['id']) {
+                $report['objects_skipped']++;
+                continue;
+            }
+
+            update_post_meta($object_id, '_alma_geo_geocoding_status', 'verified');
+            update_post_meta($object_id, '_alma_geo_primary_lat', $location['lat'] !== null ? (string) $location['lat'] : '');
+            update_post_meta($object_id, '_alma_geo_primary_lng', $location['lng'] !== null ? (string) $location['lng'] : '');
+            update_post_meta($object_id, '_alma_geo_primary_place_id', (string) ($location['geo_provider_place_id'] ?? ''));
+            update_post_meta($object_id, '_alma_geo_provider', (string) ($location['geo_provider'] ?? ''));
+            update_post_meta($object_id, '_alma_geo_primary_provider', (string) ($location['geo_provider'] ?? ''));
+            update_post_meta($object_id, '_alma_geo_primary_formatted_address', (string) ($location['formatted_address'] ?? ''));
+            update_post_meta($object_id, '_alma_geo_updated_at', current_time('mysql'));
+            $report['objects_updated']++;
+        }
+
+        return $report;
+    }
+
+    public function sync_all_verified_locations_to_objects() {
+        $locations = $this->get_locations_by_geocoding_status('verified', 5000);
+        $report = array(
+            'locations_found' => count($locations),
+            'locations_processed' => 0,
+            'objects_found' => 0,
+            'objects_updated' => 0,
+            'objects_skipped' => 0,
+            'errors' => array(),
+        );
+        foreach ($locations as $location) {
+            $sync = $this->sync_location_to_linked_objects((int) $location['id']);
+            $report['locations_processed']++;
+            $report['objects_found'] += (int) ($sync['objects_found'] ?? 0);
+            $report['objects_updated'] += (int) ($sync['objects_updated'] ?? 0);
+            $report['objects_skipped'] += (int) ($sync['objects_skipped'] ?? 0);
+            foreach (($sync['errors'] ?? array()) as $error) {
+                $report['errors'][] = array('location_id' => (int) $location['id'], 'message' => $error);
+            }
+        }
+        return $report;
     }
 
     public function get_geocoding_status_counts() {


### PR DESCRIPTION
### Motivation
- Fix situations where a location in `alma_geo_locations` becomes `verified` but linked content meta remains `pending`, causing inconsistent metabox state and admin confusion.
- Provide an admin-safe way to copy already-saved geocoding data from locations to their primary linked objects without calling external providers.
- Simplify the `Geolocalizzazione contenuto` metabox so the UI reflects the effective geocoding state and surfaces a manual resync action.

### Description
- Added `sync_location_to_linked_objects($location_id)` and `sync_all_verified_locations_to_objects()` to `ALMA_Geo_Index_Store` to find primary relations and update content meta (`_alma_geo_geocoding_status`, `_alma_geo_primary_lat`, `_alma_geo_primary_lng`, `_alma_geo_primary_place_id`, `_alma_geo_provider`, `_alma_geo_primary_formatted_address`, `_alma_geo_updated_at`) while returning a report of found/updated/skipped/errors and preserving compatibility with existing meta keys. 
- Triggered synchronization after a successful geocode in `ALMA_Geo_Index_Geocoder::geocode_location()` and aggregated per-batch counts (`linked_objects_synced`, `linked_objects_sync_errors`) in `geocode_batch()`, and included sync counts/errors in single-location results. 
- Added an admin button `Risincronizza geocoding nei contenuti` in the Geo Index → Geocoding tab that runs `sync_all_verified_locations_to_objects()` (protected by nonce/capability) and stores/prints a final sync report without contacting Google Maps. 
- Reworked the post metabox `Geolocalizzazione contenuto` to show an effective geocoding state derived from the linked primary location, display concise primary/location/provider/place-id/lat/lng/formatted address/last geocoding, offer a `Risincronizza dati località` action when verified location data differs from post meta, and move classification/technical/secondary-location fields into collapsible `<details>` sections while preserving meta keys and manual edits. 
- Updated dashboard counts to surface content/locality counts broken down by verified/pending/failed, and updated `CHANGELOG.md` and `README.md` with the new sync/resync and metabox changes.

### Testing
- Ran `php -l affiliate-link-manager-ai.php` and it reported no syntax errors. 
- Ran `php -l includes/class-geo-index-store.php`, `php -l includes/class-geo-index-admin.php`, `php -l includes/class-geo-index-metabox.php`, `php -l includes/class-geo-index-geocoder.php` and `php -l includes/class-geo-index-google-geocoder.php` and all returned no syntax errors. 
- Ran `git diff --check` and fixed/verified diffs; changes were committed with message `Sync verified geocoding data to Geo Index objects`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23fe9950a4833295b894d2ec8b4f5a)