### PR TITLE
Fix Geo Index location manager persistence and POI handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 ## Unreleased
+
+- Corretta la persistenza delle località associate al salvataggio bozza/post nel metabox Geo Index.
+- Migliorata la gestione dei POI nei risultati Google del Geo Index.
+- Aggiunta la rimozione dei risultati ricerca prima dell’associazione.
+- Tradotti i ruoli località nell’interfaccia admin mantenendo i valori tecnici salvati.
+- Corretto `ZERO_RESULTS` Google per mostrare “Nessun luogo trovato” invece di errore.
+- Aggiornati i campi derivati quando cambia la località principale.
+
 - Migliorata la gestione delle località nel metabox Geo Index: sostituito il JSON visibile con una lista di località associate, una località principale selezionabile e più località secondarie aggiungibili tramite ricerca Google.
 - Migliorato il metabox Geolocalizzazione contenuto con ricerca località tramite Google Maps, associazione guidata del luogo e autopopolazione dei campi geografici.
 - Corretto allineamento tra località geocodificate e stato geocoding dei contenuti collegati.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Il metabox **Geolocalizzazione contenuto** mantiene ora un JSON hidden sincronizzato dalla lista visuale, ripopola le località associate dopo il salvataggio, include POI come musei/attrazioni nei risultati Google, consente di nascondere singoli risultati ricerca e mostra ruoli località in italiano.
 - Il metabox **Geolocalizzazione contenuto** sostituisce il JSON visibile delle località con una lista visuale di località associate: ricerca Google Maps, pulsante **Associa luogo**, radio per una sola località principale, ruoli sulle secondarie e persistenza in `alma_geo_locations`, `alma_geo_content_index` e `_alma_geo_locations_json` tecnico.
 - Il metabox **Geolocalizzazione contenuto** ora apre con **Cerca e associa località**, usa Google Maps server-side via AJAX admin protetto e compila automaticamente stato, località primaria, coordinate, Place ID e campi Geo Index al salvataggio.
 

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -1360,3 +1360,8 @@ button:disabled {
 @media (max-width: 782px){
     .alma-geo-associated-table { display:block; overflow-x:auto; }
 }
+.alma-geo-result-actions { display:flex; align-items:center; gap:8px; margin-top:10px; }
+.alma-geo-hide-result { color:#646970; min-width:32px; min-height:32px; display:inline-flex; align-items:center; justify-content:center; text-decoration:none; }
+.alma-geo-hide-result:hover,
+.alma-geo-hide-result:focus { color:#d63638; }
+.alma-geo-associated-table .alma-geo-location-role { min-width: 170px; }

--- a/assets/geo-index-admin.js
+++ b/assets/geo-index-admin.js
@@ -8,6 +8,10 @@
         return (window.almaGeoIndexAdmin && window.almaGeoIndexAdmin.strings && window.almaGeoIndexAdmin.strings[key]) || key;
     }
 
+    function roleLabel(role) {
+        return (window.almaGeoIndexAdmin && window.almaGeoIndexAdmin.roleLabels && window.almaGeoIndexAdmin.roleLabels[role]) || role;
+    }
+
     function maxLocations() {
         return parseInt((window.almaGeoIndexAdmin && window.almaGeoIndexAdmin.maxLocations) || 10, 10);
     }
@@ -32,23 +36,32 @@
         field(key).val(value == null ? '' : value).trigger('change');
     }
 
-    function currentFieldValue(key) {
-        return field(key).val() || '';
-    }
-
-    function setIfEmpty(key, value) {
-        if (!currentFieldValue(key)) {
-            setField(key, value);
-        }
-    }
-
     function truthy(value) {
         return value === true || value === 1 || value === '1' || value === 'yes' || value === 'true';
     }
 
+    function derivedForType(type) {
+        var map = {
+            city: ['city', 'city_guide'],
+            country: ['country', 'country_guide'],
+            region: ['region', 'region_guide'],
+            area: ['area', 'area_guide'],
+            poi: ['poi', 'poi_guide'],
+            route: ['itinerary_multi_location', 'itinerary']
+        };
+        return map[type] || ['uncertain', 'destination_guide'];
+    }
+
+    function isVerifiedLocation(item) {
+        return item.geocoding_status === 'verified' || (item.lat !== '' && item.lng !== '' && item.geo_provider_place_id !== '');
+    }
+
     function normalizeLocation(data, isPrimary) {
+        data = data || {};
         var primary = truthy(isPrimary) || truthy(data.is_primary);
-        return {
+        var status = data.geocoding_status || (data.place_id || data.geo_provider_place_id ? 'verified' : 'pending');
+        var item = {
+            local_id: data.local_id || data.geo_provider_place_id || data.place_id || ('alma-local-' + Date.now() + '-' + Math.floor(Math.random() * 100000)),
             location_id: data.location_id || data.id || 0,
             name: data.name || data.canonical_name || '',
             canonical_name: data.canonical_name || data.name || '',
@@ -61,16 +74,20 @@
             poi: data.poi || '',
             lat: data.lat == null ? '' : data.lat,
             lng: data.lng == null ? '' : data.lng,
-            geo_provider: data.geo_provider || data.provider || 'google_maps',
+            geo_provider: data.geo_provider || data.provider || (data.place_id ? 'google_maps' : ''),
             geo_provider_place_id: data.geo_provider_place_id || data.place_id || '',
             formatted_address: data.formatted_address || '',
-            geocoding_status: data.geocoding_status || 'verified',
+            geocoding_status: status,
             role: primary ? 'main_destination' : (data.role && data.role !== 'main_destination' ? data.role : 'major_destination'),
             is_primary: primary,
             source: data.source || 'manual_google_search',
             confidence: data.confidence == null || data.confidence === '' ? 1 : data.confidence,
             match_weight: primary ? 100 : (data.match_weight || 70)
         };
+        if (isVerifiedLocation(item)) {
+            item.geocoding_status = 'verified';
+        }
+        return item;
     }
 
     function signature(item) {
@@ -103,9 +120,9 @@
     function updateBadges() {
         var primary = primaryLocation();
         if (!primary) {
-            setBadge('Indice geografico:', 'Non completo', 'alma-geo-badge-pending');
-            setBadge('Stato import:', 'Da importare', 'alma-geo-badge-pending');
-            setBadge('Stato geocoding:', 'In attesa', 'alma-geo-badge-pending');
+            setBadge('Indice geografico:', 'Non attivo', 'alma-geo-badge-inactive');
+            setBadge('Stato import:', 'Richiede revisione', 'alma-geo-badge-inactive');
+            setBadge('Stato geocoding:', 'In attesa di geocoding', 'alma-geo-badge-pending');
             return;
         }
         setBadge('Indice geografico:', 'Attivo', 'alma-geo-badge-active');
@@ -113,19 +130,33 @@
         if (primary.geocoding_status === 'verified') {
             setBadge('Stato geocoding:', 'Geocodificato', 'alma-geo-badge-verified');
         } else if (primary.geocoding_status === 'failed') {
-            setBadge('Stato geocoding:', 'Fallito', 'alma-geo-badge-failed');
+            setBadge('Stato geocoding:', 'Geocoding fallito', 'alma-geo-badge-failed');
         } else if (primary.geocoding_status === 'manual_required') {
-            setBadge('Stato geocoding:', 'Manuale', 'alma-geo-badge-manual');
+            setBadge('Stato geocoding:', 'Richiede verifica manuale', 'alma-geo-badge-manual');
         } else {
-            setBadge('Stato geocoding:', 'In attesa', 'alma-geo-badge-pending');
+            setBadge('Stato geocoding:', 'In attesa di geocoding', 'alma-geo-badge-pending');
         }
+    }
+
+    function applyDerivedGeoFieldsFromPrimary(primary) {
+        if (!primary) {
+            return;
+        }
+        var derived = derivedForType(primary.type || 'unknown');
+        setField('_alma_geo_scope', derived[0]);
+        setField('_alma_geo_content_type', derived[1]);
+        setField('_alma_geo_commercial_intent', primary.commercial_intent || 'high');
+        setField('_alma_geo_match_weight', primary.match_weight || 100);
+        setField('_alma_geo_confidence', primary.confidence == null || primary.confidence === '' ? 1 : primary.confidence);
     }
 
     function updatePrimaryFields() {
         var primary = primaryLocation();
         if (!primary) {
             ['_alma_geo_primary_name', '_alma_geo_primary_canonical_name', '_alma_geo_primary_type', '_alma_geo_primary_country', '_alma_geo_primary_country_code', '_alma_geo_primary_region', '_alma_geo_primary_city', '_alma_geo_primary_area', '_alma_geo_primary_poi', '_alma_geo_primary_lat', '_alma_geo_primary_lng', '_alma_geo_primary_place_id', '_alma_geo_provider', '_alma_geo_primary_provider', '_alma_geo_primary_formatted_address'].forEach(function (key) { setField(key, ''); });
+            $('#_alma_geo_enabled, #_alma_geo_widget_eligible').prop('checked', false);
             setField('_alma_geo_geocoding_status', 'pending');
+            setField('_alma_geo_import_status', 'review');
             $('.alma-geo-metabox').attr('data-has-primary-location', '0');
             return;
         }
@@ -145,14 +176,37 @@
         setField('_alma_geo_primary_provider', primary.geo_provider);
         setField('_alma_geo_primary_formatted_address', primary.formatted_address);
         setField('_alma_geo_geocoding_status', primary.geocoding_status || 'pending');
-        setField('_alma_geo_confidence', primary.confidence || 1);
-        setField('_alma_geo_match_weight', 100);
         setField('_alma_geo_source', primary.source || 'manual_google_search');
+        setField('_alma_geo_import_status', 'imported');
+        $('#_alma_geo_enabled, #_alma_geo_widget_eligible').prop('checked', true);
+        applyDerivedGeoFieldsFromPrimary(primary);
         $('.alma-geo-metabox').attr('data-has-primary-location', '1');
     }
 
-    function syncHidden() {
-        locations = locations.map(function (item) { return normalizeLocation(item, item.is_primary); });
+    function ensureSinglePrimary() {
+        var hasPrimary = false;
+        locations = locations.slice(0, maxLocations()).map(function (item) {
+            item = normalizeLocation(item, item.is_primary);
+            if (truthy(item.is_primary) && !hasPrimary) {
+                hasPrimary = true;
+                item.is_primary = true;
+                item.role = 'main_destination';
+                item.match_weight = 100;
+            } else {
+                item.is_primary = false;
+                item.role = item.role === 'main_destination' ? 'major_destination' : item.role;
+            }
+            return item;
+        });
+        if (!hasPrimary && locations.length) {
+            locations[0].is_primary = true;
+            locations[0].role = 'main_destination';
+            locations[0].match_weight = 100;
+        }
+    }
+
+    function syncAssociatedLocationsToHiddenField() {
+        ensureSinglePrimary();
         $('#alma_geo_associated_locations_json').val(JSON.stringify(locations));
         updatePrimaryFields();
         updateBadges();
@@ -160,6 +214,7 @@
 
     function renderLocations() {
         var $tbody = $('#alma_geo_associated_locations_table tbody').empty();
+        ensureSinglePrimary();
         $('#alma_geo_empty_locations').toggle(!locations.length);
         locations.forEach(function (item, index) {
             var $row = $('<tr></tr>');
@@ -183,12 +238,12 @@
             $('<td></td>').text(statusLabel(item.geocoding_status)).appendTo($row);
             var $select = $('<select class="alma-geo-location-role"></select>');
             roles.forEach(function (role) {
-                $('<option></option>').val(role).text(role).prop('selected', item.role === role).appendTo($select);
+                $('<option></option>').val(role).text(roleLabel(role)).prop('selected', item.role === role).appendTo($select);
             });
             $select.prop('disabled', truthy(item.is_primary)).on('change', function () {
                 locations[index].role = $(this).val();
                 locations[index].match_weight = '';
-                syncHidden();
+                syncAssociatedLocationsToHiddenField();
             });
             $('<td></td>').append($select).appendTo($row);
             $('<td></td>').append($('<button type="button" class="button button-small"></button>').text(strings('remove')).on('click', function () {
@@ -206,7 +261,7 @@
             })).appendTo($row);
             $tbody.append($row);
         });
-        syncHidden();
+        syncAssociatedLocationsToHiddenField();
     }
 
     function addLocation(data) {
@@ -225,11 +280,6 @@
             item.match_weight = 70;
         }
         locations.push(item);
-        $('#_alma_geo_enabled, #_alma_geo_widget_eligible').prop('checked', true);
-        setField('_alma_geo_import_status', 'imported');
-        setIfEmpty('_alma_geo_commercial_intent', data.commercial_intent || 'high');
-        setIfEmpty('_alma_geo_scope', data.geo_scope || 'uncertain');
-        setIfEmpty('_alma_geo_content_type', data.content_type || 'destination_guide');
         renderLocations();
         setFeedback(strings('associated'), 'success');
     }
@@ -242,12 +292,20 @@
         }
         results.forEach(function (item) {
             var $card = $('<div class="alma-geo-result-card"></div>');
+            var $actions = $('<div class="alma-geo-result-actions"></div>');
             $card.append('<strong class="alma-geo-result-title">' + esc(item.name) + '</strong>');
             $card.append('<div class="alma-geo-result-address">' + esc(item.formatted_address) + '</div>');
             $card.append('<div class="alma-geo-result-meta">' + esc(strings('type')) + ' ' + esc(item.type || 'unknown') + (item.country ? ' · ' + esc(strings('country')) + ' ' + esc(item.country) : '') + '</div>');
             $('<button type="button" class="button button-primary"></button>').text(strings('associate')).on('click', function () {
                 addLocation(item);
-            }).appendTo($card);
+            }).appendTo($actions);
+            $('<button type="button" class="button-link alma-geo-hide-result" aria-label="' + esc(strings('hideSearchResult')) + '" title="' + esc(strings('hideSearchResult')) + '"><span class="dashicons dashicons-no-alt" aria-hidden="true"></span></button>').on('click', function () {
+                $card.remove();
+                if (!$wrap.children().length) {
+                    setFeedback(strings('noResults'), 'warning');
+                }
+            }).appendTo($actions);
+            $card.append($actions);
             $wrap.append($card);
         });
         setFeedback('', 'success');
@@ -274,6 +332,9 @@
         }).done(function (response) {
             if (response && response.success) {
                 renderResults((response.data && response.data.results) || []);
+                if (response.data && response.data.message && !(response.data.results || []).length) {
+                    setFeedback(response.data.message, 'warning');
+                }
                 return;
             }
             setFeedback((response.data && response.data.message) || strings('searchError'), 'error');
@@ -291,11 +352,6 @@
             locations = [];
         }
         locations = locations.map(function (item) { return normalizeLocation(item, item.is_primary); });
-        if (locations.length && !primaryLocation()) {
-            locations[0].is_primary = true;
-            locations[0].role = 'main_destination';
-            locations[0].match_weight = 100;
-        }
         renderLocations();
     }
 
@@ -307,6 +363,9 @@
                 event.preventDefault();
                 searchLocation();
             }
+        });
+        $('#post').on('submit', function () {
+            syncAssociatedLocationsToHiddenField();
         });
     });
 }(jQuery));

--- a/includes/class-geo-index-google-geocoder.php
+++ b/includes/class-geo-index-google-geocoder.php
@@ -58,7 +58,7 @@ class ALMA_Geo_Index_Google_Geocoder {
             return $result;
         }
         $results = array();
-        foreach (array_slice($result['results'] ?? array(), 0, 5) as $item) {
+        foreach (array_slice($result['results'] ?? array(), 0, 10) as $item) {
             $results[] = $this->normalize_location_result($item);
         }
         $result['results'] = $results;
@@ -128,9 +128,9 @@ class ALMA_Geo_Index_Google_Geocoder {
         }
 
         return array(
-            'success' => $status === 'OK',
+            'success' => in_array($status, array('OK', 'ZERO_RESULTS'), true),
             'status' => $status,
-            'message' => sanitize_text_field($data['error_message'] ?? ($status === 'OK' ? '' : sprintf(__('Google Geocoding status: %s.', 'affiliate-link-manager-ai'), $status))),
+            'message' => sanitize_text_field($data['error_message'] ?? ($status === 'ZERO_RESULTS' ? __('Nessun luogo trovato.', 'affiliate-link-manager-ai') : ($status === 'OK' ? '' : sprintf(__('Google Geocoding status: %s.', 'affiliate-link-manager-ai'), $status)))),
             'results' => $normalized_results,
             'raw_status' => $status,
         );
@@ -162,19 +162,25 @@ class ALMA_Geo_Index_Google_Geocoder {
         if (in_array('airport', $types, true)) {
             return 'airport';
         }
+        if (in_array('port', $types, true) || in_array('transit_station', $types, true)) {
+            return 'port';
+        }
         if (in_array('route', $types, true)) {
             return 'route';
         }
-        if (in_array('natural_feature', $types, true) || in_array('neighborhood', $types, true) || in_array('sublocality', $types, true)) {
-            return 'area';
-        }
-        if (in_array('tourist_attraction', $types, true) || in_array('point_of_interest', $types, true) || in_array('establishment', $types, true)) {
+        if (array_intersect($types, array('tourist_attraction', 'point_of_interest', 'establishment', 'museum', 'church', 'stadium'))) {
             return 'poi';
+        }
+        if (in_array('park', $types, true) || in_array('natural_feature', $types, true) || in_array('neighborhood', $types, true) || in_array('sublocality', $types, true)) {
+            return 'area';
         }
         return 'unknown';
     }
 
     private function default_geo_scope_for_type($type) {
+        if ($type === 'route') {
+            return 'itinerary_multi_location';
+        }
         return in_array($type, array('country', 'region', 'city', 'area', 'poi'), true) ? $type : 'uncertain';
     }
 
@@ -185,6 +191,7 @@ class ALMA_Geo_Index_Google_Geocoder {
             'city' => 'city_guide',
             'area' => 'area_guide',
             'poi' => 'poi_guide',
+            'route' => 'itinerary',
         );
         return $map[$type] ?? 'destination_guide';
     }
@@ -192,7 +199,7 @@ class ALMA_Geo_Index_Google_Geocoder {
     private function extract_name($components, $fallback) {
         foreach ($components as $component) {
             $types = is_array($component['types'] ?? null) ? $component['types'] : array();
-            if (in_array('point_of_interest', $types, true) || in_array('establishment', $types, true) || in_array('tourist_attraction', $types, true)) {
+            if (array_intersect($types, array('point_of_interest', 'establishment', 'tourist_attraction', 'museum', 'church', 'stadium'))) {
                 return sanitize_text_field($component['long_name'] ?? $fallback);
             }
         }

--- a/includes/class-geo-index-metabox.php
+++ b/includes/class-geo-index-metabox.php
@@ -56,7 +56,9 @@ class ALMA_Geo_Index_Metabox {
                     'emptyLocations' => __('Nessuna località associata.', 'affiliate-link-manager-ai'),
                     'remove' => __('Rimuovi', 'affiliate-link-manager-ai'),
                     'main' => __('Principale', 'affiliate-link-manager-ai'),
+                    'hideSearchResult' => __('Nascondi questo risultato di ricerca', 'affiliate-link-manager-ai'),
                 ),
+                'roleLabels' => ALMA_Geo_Index_Store::get_location_role_labels(),
                 'maxLocations' => self::MAX_ASSOCIATED_LOCATIONS,
             ));
         }
@@ -90,7 +92,7 @@ class ALMA_Geo_Index_Metabox {
         if (empty($result['success'])) {
             wp_send_json_error(array('message' => sanitize_text_field($result['message'] ?? __('Errore durante la ricerca località.', 'affiliate-link-manager-ai'))), 500);
         }
-        $results = array_slice(is_array($result['results'] ?? null) ? $result['results'] : array(), 0, 5);
+        $results = array_slice(is_array($result['results'] ?? null) ? $result['results'] : array(), 0, self::MAX_ASSOCIATED_LOCATIONS);
         if (empty($results)) {
             wp_send_json_success(array('results' => array(), 'message' => __('Nessun luogo trovato.', 'affiliate-link-manager-ai')));
         }
@@ -230,7 +232,7 @@ class ALMA_Geo_Index_Metabox {
                 </div>
                 <?php $this->render_textarea('_alma_geo_quality_flags', __('Quality flags', 'affiliate-link-manager-ai'), $values, 3); ?>
                 <?php $this->render_textarea('_alma_geo_notes', __('Note interne', 'affiliate-link-manager-ai'), $values, 4); ?>
-                <?php $this->render_textarea('_alma_geo_locations_json', __('JSON tecnico località', 'affiliate-link-manager-ai'), $values, 5); ?>
+                <?php $this->render_textarea('_alma_geo_locations_json', __('JSON tecnico località', 'affiliate-link-manager-ai'), $values, 5, 'readonly'); ?>
             </details>
         </div>
         <?php
@@ -282,6 +284,7 @@ class ALMA_Geo_Index_Metabox {
                 'content_type' => $data['_alma_geo_content_type'],
                 'commercial_intent' => $data['_alma_geo_commercial_intent'],
                 'widget_eligible' => $data['_alma_geo_widget_eligible'],
+                'derive_from_primary' => true,
             ), 'manual_google_search');
             foreach (self::meta_keys() as $key) {
                 if (!array_key_exists($key, $result['meta'] ?? array())) {
@@ -441,8 +444,23 @@ class ALMA_Geo_Index_Metabox {
     private function get_associated_locations($post_id, $post_type, $display_values) {
         $locations = $this->store->get_associated_locations_for_object($post_id, $post_type);
         if (!empty($locations)) {
-            return $locations;
+            return $this->store->normalize_associated_locations(array_slice($locations, 0, self::MAX_ASSOCIATED_LOCATIONS), 'manual_google_search');
         }
+
+        $decoded = json_decode((string) ($display_values['_alma_geo_locations_json'] ?? ''), true);
+        if (is_array($decoded) && !empty($decoded)) {
+            $json_locations = array();
+            foreach (array_slice($decoded, 0, self::MAX_ASSOCIATED_LOCATIONS) as $location) {
+                if (is_array($location)) {
+                    $json_locations[] = $this->store->format_location_for_json($location);
+                }
+            }
+            $json_locations = $this->store->normalize_associated_locations($json_locations, 'manual_google_search');
+            if (!empty($json_locations)) {
+                return $json_locations;
+            }
+        }
+
         $locations = array();
         if (!empty($display_values['_alma_geo_primary_name']) || !empty($display_values['_alma_geo_primary_place_id'])) {
             $locations[] = array(
@@ -469,17 +487,7 @@ class ALMA_Geo_Index_Metabox {
                 'match_weight' => 100,
             );
         }
-        $decoded = json_decode((string) ($display_values['_alma_geo_locations_json'] ?? ''), true);
-        if (is_array($decoded)) {
-            foreach ($decoded as $secondary) {
-                if (is_array($secondary)) {
-                    $secondary['is_primary'] = false;
-                    $secondary['role'] = sanitize_key($secondary['role'] ?? 'major_destination');
-                    $locations[] = $this->store->format_location_for_json($secondary);
-                }
-            }
-        }
-        return $this->store->normalize_associated_locations($locations, 'manual');
+        return $this->store->normalize_associated_locations($locations, 'manual_google_search');
     }
 
     private function sanitize_associated_locations($json) {
@@ -492,7 +500,7 @@ class ALMA_Geo_Index_Metabox {
             return array();
         }
         $locations = array();
-        foreach ($decoded as $location) {
+        foreach (array_slice($decoded, 0, self::MAX_ASSOCIATED_LOCATIONS) as $location) {
             if (is_array($location)) {
                 $locations[] = $this->store->format_location_for_json($location);
             }
@@ -609,8 +617,8 @@ class ALMA_Geo_Index_Metabox {
         printf('<div class="alma-geo-field"><label for="%1$s">%2$s</label><input type="%3$s" id="%1$s" name="alma_geo[%1$s]" value="%4$s" %5$s></div>', esc_attr($key), esc_html($label), esc_attr($type), esc_attr($values[$key] ?? ''), $attrs);
     }
 
-    private function render_textarea($key, $label, $values, $rows = 4) {
-        printf('<div class="alma-geo-field"><label for="%1$s">%2$s</label><textarea id="%1$s" name="alma_geo[%1$s]" rows="%3$d">%4$s</textarea></div>', esc_attr($key), esc_html($label), absint($rows), esc_textarea($values[$key] ?? ''));
+    private function render_textarea($key, $label, $values, $rows = 4, $attrs = '') {
+        printf('<div class="alma-geo-field"><label for="%1$s">%2$s</label><textarea id="%1$s" name="alma_geo[%1$s]" rows="%3$d" %5$s>%4$s</textarea></div>', esc_attr($key), esc_html($label), absint($rows), esc_textarea($values[$key] ?? ''), $attrs);
     }
 
     private function render_select($key, $label, $values, $options) {

--- a/includes/class-geo-index-store.php
+++ b/includes/class-geo-index-store.php
@@ -325,8 +325,9 @@ class ALMA_Geo_Index_Store {
             }
         }
 
-        $geo_scope = sanitize_key($geo_data['geo_scope'] ?? ($primary ? $this->default_geo_scope_for_type($primary['type']) : 'uncertain'));
-        $content_type = sanitize_key($geo_data['content_type'] ?? ($primary ? $this->default_content_type_for_type($primary['type']) : 'uncertain'));
+        $derive_from_primary = !empty($geo_data['derive_from_primary']);
+        $geo_scope = $derive_from_primary && $primary ? $this->default_geo_scope_for_type($primary['type']) : sanitize_key($geo_data['geo_scope'] ?? ($primary ? $this->default_geo_scope_for_type($primary['type']) : 'uncertain'));
+        $content_type = $derive_from_primary && $primary ? $this->default_content_type_for_type($primary['type']) : sanitize_key($geo_data['content_type'] ?? ($primary ? $this->default_content_type_for_type($primary['type']) : 'uncertain'));
         $commercial_intent = sanitize_key($geo_data['commercial_intent'] ?? 'none');
         $widget_eligible = !empty($geo_data['widget_eligible']) && !in_array((string) $geo_data['widget_eligible'], array('no', '0', 'false', 'off'), true);
         $now = current_time('mysql');
@@ -452,6 +453,7 @@ class ALMA_Geo_Index_Store {
         $place_id = sanitize_text_field($location['geo_provider_place_id'] ?? ($location['place_id'] ?? ''));
         $is_primary = !empty($location['is_primary']) && !in_array((string) $location['is_primary'], array('0', 'no', 'false', 'off'), true);
         return array(
+            'local_id' => sanitize_text_field($location['local_id'] ?? ''),
             'location_id' => absint($location['location_id'] ?? ($location['id'] ?? 0)),
             'name' => sanitize_text_field($location['name'] ?? ($location['canonical_name'] ?? '')),
             'canonical_name' => sanitize_text_field($location['canonical_name'] ?? ($location['name'] ?? '')),
@@ -476,6 +478,18 @@ class ALMA_Geo_Index_Store {
         );
     }
 
+    public static function get_location_role_labels() {
+        return array(
+            'main_destination' => __('Località principale', 'affiliate-link-manager-ai'),
+            'major_destination' => __('Località importante', 'affiliate-link-manager-ai'),
+            'mentioned_destination' => __('Località citata', 'affiliate-link-manager-ai'),
+            'excursion' => __('Escursione', 'affiliate-link-manager-ai'),
+            'nearby_place' => __('Luogo vicino', 'affiliate-link-manager-ai'),
+            'route_stop' => __('Tappa itinerario', 'affiliate-link-manager-ai'),
+            'context_only' => __('Solo contesto', 'affiliate-link-manager-ai'),
+        );
+    }
+
     private function default_match_weight_for_role($role) {
         $weights = array(
             'main_destination' => 100,
@@ -491,11 +505,14 @@ class ALMA_Geo_Index_Store {
     }
 
     private function default_geo_scope_for_type($type) {
+        if ($type === 'route') {
+            return 'itinerary_multi_location';
+        }
         return in_array($type, array('country', 'region', 'city', 'area', 'poi'), true) ? $type : 'uncertain';
     }
 
     private function default_content_type_for_type($type) {
-        $map = array('country' => 'country_guide', 'region' => 'region_guide', 'city' => 'city_guide', 'area' => 'area_guide', 'poi' => 'poi_guide');
+        $map = array('country' => 'country_guide', 'region' => 'region_guide', 'city' => 'city_guide', 'area' => 'area_guide', 'poi' => 'poi_guide', 'route' => 'itinerary');
         return $map[$type] ?? 'destination_guide';
     }
 


### PR DESCRIPTION
### Motivation

- Risolvere la perdita delle località associate al salvataggio di bozze/post e rendere il metabox `Geolocalizzazione contenuto` stabile per workflow di ricerca/associazione. 
- Non scartare i POI nei risultati Google, permettere di nascondere singoli risultati prima dell’associazione e migliorare l’esperienza editoriale (ruoli in italiano, aggiornamento campi derivati dalla primaria).

### Description

- JS: introdotto array centrale `locations`, rendering dalla lista, funzione `syncAssociatedLocationsToHiddenField()` chiamata prima del submit, garanzia di una sola `is_primary`, aggiornamento immediato di badge e campi primaria, supporto per `roleLabels` localizzate e bottone `hide` (Dashicon) per rimuovere un risultato ricerca senza chiamare il server; i campi derivati non usano più `setIfEmpty()` ma `applyDerivedGeoFieldsFromPrimary()` quando cambia la primaria (file: `assets/geo-index-admin.js`).
- PHP metabox: aggiunto hidden JSON `alma_geo[associated_locations_json]`, lettura e sanitizzazione su save tramite `sanitize_associated_locations()`, limite a `self::MAX_ASSOCIATED_LOCATIONS` e fallback per ricostruire la lista da `alma_geo_content_index`, `_alma_geo_locations_json` o meta primario quando si apre il post (file: `includes/class-geo-index-metabox.php`).
- Store/database: `ALMA_Geo_Index_Store::save_geo_meta_for_object()` ora supporta `derive_from_primary` per scegliere `geo_scope`/`content_type` dalla primaria, mantiene il `local_id` nel payload JSON serializzato e normalizza/salva relazioni su `alma_geo_locations` / `alma_geo_content_index` (file: `includes/class-geo-index-store.php`).
- Google provider: `ALMA_Geo_Index_Google_Geocoder` tratta `ZERO_RESULTS` come ricerca valida (risposta `success`) con messaggio "Nessun luogo trovato", estende la normalizzazione dei tipi per includere `poi` (museum/church/stadium/tourist_attraction/establishment/point_of_interest), `port`/`transit_station`, mappa `route`→`itinerary` e aumenta i risultati normalizzati usati in admin (file: `includes/class-geo-index-google-geocoder.php`).
- UI/CSS: aggiunte classi e regole in `assets/admin.css` per le azioni sui risultati (`.alma-geo-result-actions`, `.alma-geo-hide-result`) e adattamenti della tabella località; traduzioni/label italiane localizzate via `wp_localize_script` (`roleLabels`).
- Documentazione: aggiornati `CHANGELOG.md` e `README.md` con le correzioni e le note di comportamento.

### Testing

- Sintassi PHP controllata con `php -l` su `affiliate-link-manager-ai.php`, `includes/class-geo-index-metabox.php`, `includes/class-geo-index-store.php`, `includes/class-geo-index-admin.php`, `includes/class-geo-index-geocoder.php`, e `includes/class-geo-index-google-geocoder.php` — tutti passati con esito positivo.
- Controllo sintassi JS con `node -c assets/geo-index-admin.js` — esito positivo.
- `git diff --check` eseguito e senza nuovi warning rilevanti.

Tutti i test automatici elencati sono stati eseguiti con successo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24212f96f88332a8a191dd7f75d1b2)