### PR TITLE
Fix Geo Index POI names and location persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- Corretto il nome specifico dei POI nei risultati Google e nelle località associate, preservando città, regione, paese e indirizzo formattato.
+- Corretta la deduplica delle località Geo Index usando prima il Google Place ID e solo in assenza una firma testuale completa.
+- Corretto il bug di sovrascrittura delle località associate durante aggiunte multiple e salvataggi bozza/post.
+- Preservate le modifiche manuali ai campi avanzati Geo Index senza ricalcolo forzato dalla località primaria.
+- Preservato lo stato salvato della checkbox Widget eligible al caricamento del metabox.
+- Migliorata la persistenza di tutte le località associate dopo salvataggio bozza/post.
 - Corretta la persistenza delle località associate al salvataggio bozza/post nel metabox Geo Index.
 - Migliorata la gestione dei POI nei risultati Google del Geo Index.
 - Aggiunta la rimozione dei risultati ricerca prima dell’associazione.

--- a/assets/geo-index-admin.js
+++ b/assets/geo-index-admin.js
@@ -2,6 +2,8 @@
     'use strict';
 
     var locations = [];
+    var isInitialRender = true;
+    var primaryChanged = false;
     var roles = ['main_destination', 'major_destination', 'mentioned_destination', 'excursion', 'nearby_place', 'route_stop', 'context_only'];
 
     function strings(key) {
@@ -61,7 +63,7 @@
         var primary = truthy(isPrimary) || truthy(data.is_primary);
         var status = data.geocoding_status || (data.place_id || data.geo_provider_place_id ? 'verified' : 'pending');
         var item = {
-            local_id: data.local_id || data.geo_provider_place_id || data.place_id || ('alma-local-' + Date.now() + '-' + Math.floor(Math.random() * 100000)),
+            local_id: data.local_id || data.geo_provider_place_id || data.place_id || data.location_id || data.id || ('alma-local-' + Date.now() + '-' + Math.floor(Math.random() * 100000)),
             location_id: data.location_id || data.id || 0,
             name: data.name || data.canonical_name || '',
             canonical_name: data.canonical_name || data.name || '',
@@ -91,7 +93,16 @@
     }
 
     function signature(item) {
-        return (item.geo_provider_place_id || '') || [item.canonical_name || item.name, item.type, item.country_code, item.region, item.city, item.area, item.poi].join('|').toLowerCase();
+        item = item || {};
+        if (item.geo_provider_place_id) {
+            return 'place:' + item.geo_provider_place_id;
+        }
+        return 'text:' + [item.canonical_name || item.name, item.type, item.country_code, item.region, item.city, item.area, item.poi, item.formatted_address].join('|').toLowerCase();
+    }
+
+    function markPrimaryChanged() {
+        primaryChanged = true;
+        $('#alma_geo_primary_changed').val('1');
     }
 
     function statusLabel(status) {
@@ -154,9 +165,13 @@
         var primary = primaryLocation();
         if (!primary) {
             ['_alma_geo_primary_name', '_alma_geo_primary_canonical_name', '_alma_geo_primary_type', '_alma_geo_primary_country', '_alma_geo_primary_country_code', '_alma_geo_primary_region', '_alma_geo_primary_city', '_alma_geo_primary_area', '_alma_geo_primary_poi', '_alma_geo_primary_lat', '_alma_geo_primary_lng', '_alma_geo_primary_place_id', '_alma_geo_provider', '_alma_geo_primary_provider', '_alma_geo_primary_formatted_address'].forEach(function (key) { setField(key, ''); });
-            $('#_alma_geo_enabled, #_alma_geo_widget_eligible').prop('checked', false);
-            setField('_alma_geo_geocoding_status', 'pending');
-            setField('_alma_geo_import_status', 'review');
+            if (!isInitialRender) {
+                $('#_alma_geo_enabled').prop('checked', false);
+            }
+            if (!isInitialRender) {
+                setField('_alma_geo_geocoding_status', 'pending');
+                setField('_alma_geo_import_status', 'review');
+            }
             $('.alma-geo-metabox').attr('data-has-primary-location', '0');
             return;
         }
@@ -175,11 +190,18 @@
         setField('_alma_geo_provider', primary.geo_provider);
         setField('_alma_geo_primary_provider', primary.geo_provider);
         setField('_alma_geo_primary_formatted_address', primary.formatted_address);
-        setField('_alma_geo_geocoding_status', primary.geocoding_status || 'pending');
-        setField('_alma_geo_source', primary.source || 'manual_google_search');
-        setField('_alma_geo_import_status', 'imported');
-        $('#_alma_geo_enabled, #_alma_geo_widget_eligible').prop('checked', true);
-        applyDerivedGeoFieldsFromPrimary(primary);
+        if (!isInitialRender) {
+            setField('_alma_geo_geocoding_status', primary.geocoding_status || 'pending');
+            setField('_alma_geo_source', primary.source || 'manual_google_search');
+            setField('_alma_geo_import_status', 'imported');
+        }
+        if (!isInitialRender) {
+            $('#_alma_geo_enabled').prop('checked', true);
+        }
+        if (primaryChanged || !field('_alma_geo_scope').val() || !field('_alma_geo_content_type').val() || !field('_alma_geo_commercial_intent').val()) {
+            applyDerivedGeoFieldsFromPrimary(primary);
+            primaryChanged = false;
+        }
         $('.alma-geo-metabox').attr('data-has-primary-location', '1');
     }
 
@@ -209,7 +231,9 @@
         ensureSinglePrimary();
         $('#alma_geo_associated_locations_json').val(JSON.stringify(locations));
         updatePrimaryFields();
-        updateBadges();
+        if (!isInitialRender) {
+            updateBadges();
+        }
     }
 
     function renderLocations() {
@@ -220,6 +244,7 @@
             var $row = $('<tr></tr>');
             $('<td></td>').append($('<label></label>').append(
                 $('<input type="radio" name="alma_geo_primary_location_choice">').prop('checked', truthy(item.is_primary)).on('change', function () {
+                    markPrimaryChanged();
                     locations.forEach(function (location, idx) {
                         location.is_primary = idx === index;
                         location.role = idx === index ? 'main_destination' : (location.role === 'main_destination' ? 'major_destination' : location.role);
@@ -253,6 +278,7 @@
                     locations[0].is_primary = true;
                     locations[0].role = 'main_destination';
                     locations[0].match_weight = 100;
+                    markPrimaryChanged();
                     setFeedback(strings('promoted'), 'warning');
                 } else {
                     setFeedback(strings('removed'), 'success');
@@ -269,7 +295,8 @@
             setFeedback(strings('limitReached'), 'warning');
             return;
         }
-        var item = normalizeLocation(data, locations.length === 0);
+        var willBePrimary = locations.length === 0;
+        var item = normalizeLocation(data, willBePrimary);
         var itemSig = signature(item);
         if (locations.some(function (location) { return signature(location) === itemSig; })) {
             setFeedback(strings('duplicate'), 'warning');
@@ -280,6 +307,10 @@
             item.match_weight = 70;
         }
         locations.push(item);
+        if (willBePrimary) {
+            markPrimaryChanged();
+        }
+        $('#_alma_geo_enabled').prop('checked', true);
         renderLocations();
         setFeedback(strings('associated'), 'success');
     }
@@ -353,6 +384,7 @@
         }
         locations = locations.map(function (item) { return normalizeLocation(item, item.is_primary); });
         renderLocations();
+        isInitialRender = false;
     }
 
     $(function () {

--- a/includes/class-geo-index-google-geocoder.php
+++ b/includes/class-geo-index-google-geocoder.php
@@ -6,6 +6,7 @@ if (!defined('ABSPATH')) { exit; }
  */
 class ALMA_Geo_Index_Google_Geocoder {
     const ENDPOINT = 'https://maps.googleapis.com/maps/api/geocode/json';
+    const PLACES_TEXT_SEARCH_ENDPOINT = 'https://places.googleapis.com/v1/places:searchText';
 
     private $api_key;
     private $timeout;
@@ -13,6 +14,70 @@ class ALMA_Geo_Index_Google_Geocoder {
     public function __construct($api_key = '', $timeout = 15) {
         $this->api_key = trim((string) $api_key);
         $this->timeout = max(1, absint($timeout));
+    }
+
+
+    private function places_text_search($query, $args = array()) {
+        $query = sanitize_text_field($query);
+        if ($query === '' || $this->api_key === '') {
+            return array('success' => false, 'status' => 'INVALID_QUERY', 'message' => __('Query Places vuota o API key mancante.', 'affiliate-link-manager-ai'), 'results' => array());
+        }
+
+        $body = array('textQuery' => $query, 'languageCode' => 'it');
+        if (!empty($args['region'])) {
+            $body['regionCode'] = strtoupper(sanitize_text_field($args['region']));
+        }
+
+        $started = microtime(true);
+        $response = wp_remote_post(self::PLACES_TEXT_SEARCH_ENDPOINT, array(
+            'timeout' => $this->timeout,
+            'headers' => array(
+                'Content-Type' => 'application/json',
+                'X-Goog-Api-Key' => $this->api_key,
+                'X-Goog-FieldMask' => 'places.id,places.displayName,places.formattedAddress,places.location,places.types,places.addressComponents',
+            ),
+            'body' => wp_json_encode($body),
+        ));
+        $duration_ms = (int) round((microtime(true) - $started) * 1000);
+
+        if (is_wp_error($response)) {
+            return array('success' => false, 'status' => 'HTTP_ERROR', 'message' => $response->get_error_message(), 'results' => array(), 'duration_ms' => $duration_ms);
+        }
+
+        $code = (int) wp_remote_retrieve_response_code($response);
+        $data = json_decode((string) wp_remote_retrieve_body($response), true);
+        if ($code < 200 || $code >= 300 || !is_array($data)) {
+            return array('success' => false, 'status' => 'HTTP_' . $code, 'message' => __('Ricerca Google Places non disponibile.', 'affiliate-link-manager-ai'), 'results' => array(), 'response_code' => $code, 'duration_ms' => $duration_ms);
+        }
+
+        $results = array();
+        foreach (array_slice(is_array($data['places'] ?? null) ? $data['places'] : array(), 0, 10) as $place) {
+            $results[] = $this->normalize_location_result($this->normalize_places_result($place));
+        }
+
+        return array('success' => true, 'status' => 'OK', 'message' => '', 'results' => $results, 'response_code' => $code, 'duration_ms' => $duration_ms);
+    }
+
+    private function normalize_places_result($place) {
+        $components = array();
+        foreach (is_array($place['addressComponents'] ?? null) ? $place['addressComponents'] : array() as $component) {
+            $components[] = array(
+                'long_name' => sanitize_text_field($component['longText'] ?? ''),
+                'short_name' => sanitize_text_field($component['shortText'] ?? ''),
+                'types' => array_map('sanitize_key', is_array($component['types'] ?? null) ? $component['types'] : array()),
+            );
+        }
+
+        return array(
+            'place_id' => sanitize_text_field($place['id'] ?? ''),
+            'formatted_address' => sanitize_text_field($place['formattedAddress'] ?? ''),
+            'name' => sanitize_text_field($place['displayName']['text'] ?? ''),
+            'displayName' => is_array($place['displayName'] ?? null) ? $place['displayName'] : array(),
+            'lat' => isset($place['location']['latitude']) ? (float) $place['location']['latitude'] : null,
+            'lng' => isset($place['location']['longitude']) ? (float) $place['location']['longitude'] : null,
+            'types' => array_map('sanitize_key', is_array($place['types'] ?? null) ? $place['types'] : array()),
+            'address_components' => $components,
+        );
     }
 
     public function geocode($query, $args = array()) {
@@ -53,6 +118,11 @@ class ALMA_Geo_Index_Google_Geocoder {
     }
 
     public function search_locations($query, $args = array()) {
+        $places_result = $this->places_text_search($query, $args);
+        if (!empty($places_result['success']) && !empty($places_result['results'])) {
+            return $places_result;
+        }
+
         $result = $this->geocode($query, $args);
         if (empty($result['success'])) {
             return $result;
@@ -68,7 +138,7 @@ class ALMA_Geo_Index_Google_Geocoder {
     public function normalize_location_result($item) {
         $components = is_array($item['address_components'] ?? null) ? $item['address_components'] : array();
         $type = $this->normalize_google_type(is_array($item['types'] ?? null) ? $item['types'] : array());
-        $name = $this->extract_name($components, $item['formatted_address'] ?? '');
+        $name = $this->extract_name($components, $item['formatted_address'] ?? '', $item, $type);
         $country = $this->extract_component($components, 'country', 'long_name');
         $country_code = $this->extract_component($components, 'country', 'short_name');
         $region = $this->extract_first_component($components, array('administrative_area_level_1', 'administrative_area_level_2'), 'long_name');
@@ -118,6 +188,7 @@ class ALMA_Geo_Index_Google_Geocoder {
             $normalized_results[] = array(
                 'place_id' => sanitize_text_field($result['place_id'] ?? ''),
                 'formatted_address' => sanitize_text_field($result['formatted_address'] ?? ''),
+                'name' => $this->extract_google_result_name($result),
                 'lat' => isset($location['lat']) ? (float) $location['lat'] : null,
                 'lng' => isset($location['lng']) ? (float) $location['lng'] : null,
                 'types' => array_map('sanitize_key', is_array($result['types'] ?? null) ? $result['types'] : array()),
@@ -168,10 +239,10 @@ class ALMA_Geo_Index_Google_Geocoder {
         if (in_array('route', $types, true)) {
             return 'route';
         }
-        if (array_intersect($types, array('tourist_attraction', 'point_of_interest', 'establishment', 'museum', 'church', 'stadium'))) {
+        if (array_intersect($types, array('tourist_attraction', 'point_of_interest', 'establishment', 'museum', 'church', 'stadium', 'lodging', 'restaurant', 'premise', 'park'))) {
             return 'poi';
         }
-        if (in_array('park', $types, true) || in_array('natural_feature', $types, true) || in_array('neighborhood', $types, true) || in_array('sublocality', $types, true)) {
+        if (in_array('natural_feature', $types, true) || in_array('neighborhood', $types, true) || in_array('sublocality', $types, true)) {
             return 'area';
         }
         return 'unknown';
@@ -196,13 +267,25 @@ class ALMA_Geo_Index_Google_Geocoder {
         return $map[$type] ?? 'destination_guide';
     }
 
-    private function extract_name($components, $fallback) {
+    private function extract_name($components, $fallback, $item = array(), $normalized_type = 'unknown') {
+        $explicit_name = $this->extract_google_result_name(is_array($item) ? $item : array());
+        if ($explicit_name !== '') {
+            return $explicit_name;
+        }
+
+        $poi_types = array('point_of_interest', 'establishment', 'tourist_attraction', 'museum', 'church', 'stadium', 'lodging', 'restaurant', 'premise', 'park');
         foreach ($components as $component) {
             $types = is_array($component['types'] ?? null) ? $component['types'] : array();
-            if (array_intersect($types, array('point_of_interest', 'establishment', 'tourist_attraction', 'museum', 'church', 'stadium'))) {
+            if (array_intersect($types, $poi_types)) {
                 return sanitize_text_field($component['long_name'] ?? $fallback);
             }
         }
+
+        if ($normalized_type === 'poi') {
+            $parts = explode(',', (string) $fallback);
+            return sanitize_text_field(trim($parts[0] ?? $fallback));
+        }
+
         foreach (array('locality', 'postal_town', 'administrative_area_level_1', 'country', 'natural_feature') as $type) {
             $name = $this->extract_component($components, $type, 'long_name');
             if ($name !== '') {
@@ -211,6 +294,32 @@ class ALMA_Geo_Index_Google_Geocoder {
         }
         $parts = explode(',', (string) $fallback);
         return sanitize_text_field(trim($parts[0] ?? $fallback));
+    }
+
+    private function extract_google_result_name($result) {
+        if (!is_array($result)) {
+            return '';
+        }
+        $candidates = array(
+            $result['displayName']['text'] ?? '',
+            $result['display_name']['text'] ?? '',
+            $result['displayName'] ?? '',
+            $result['name'] ?? '',
+            $result['structured_formatting']['main_text'] ?? '',
+            $result['placePrediction']['structuredFormat']['mainText']['text'] ?? '',
+            $result['placePrediction']['text']['text'] ?? '',
+        );
+        foreach ($candidates as $candidate) {
+            if (!is_string($candidate) || trim($candidate) === '') {
+                continue;
+            }
+            $candidate = trim($candidate);
+            if (strpos($candidate, 'places/') === 0) {
+                continue;
+            }
+            return sanitize_text_field($candidate);
+        }
+        return '';
     }
 
     private function extract_first_component($components, $types, $field = 'long_name') {

--- a/includes/class-geo-index-metabox.php
+++ b/includes/class-geo-index-metabox.php
@@ -176,6 +176,7 @@ class ALMA_Geo_Index_Metabox {
             <div class="alma-geo-section alma-geo-associated-section">
                 <h3><?php esc_html_e('Località associate al contenuto', 'affiliate-link-manager-ai'); ?></h3>
                 <input type="hidden" id="alma_geo_associated_locations_json" name="alma_geo[associated_locations_json]" value="<?php echo esc_attr(wp_json_encode($associated_locations)); ?>">
+                <input type="hidden" id="alma_geo_primary_changed" name="alma_geo[primary_changed]" value="0">
                 <p class="description"><?php esc_html_e('Associa fino a 10 località tramite Google Maps, scegli una sola principale e assegna un ruolo editoriale alle secondarie.', 'affiliate-link-manager-ai'); ?></p>
                 <table class="widefat striped alma-geo-associated-table" id="alma_geo_associated_locations_table">
                     <thead>
@@ -284,7 +285,7 @@ class ALMA_Geo_Index_Metabox {
                 'content_type' => $data['_alma_geo_content_type'],
                 'commercial_intent' => $data['_alma_geo_commercial_intent'],
                 'widget_eligible' => $data['_alma_geo_widget_eligible'],
-                'derive_from_primary' => true,
+                'derive_from_primary' => !empty($raw['primary_changed']),
             ), 'manual_google_search');
             foreach (self::meta_keys() as $key) {
                 if (!array_key_exists($key, $result['meta'] ?? array())) {

--- a/includes/class-geo-index-store.php
+++ b/includes/class-geo-index-store.php
@@ -133,6 +133,7 @@ class ALMA_Geo_Index_Store {
                    AND LOWER(city) = %s
                    AND LOWER(area) = %s
                    AND LOWER(poi) = %s
+                   AND LOWER(formatted_address) = %s
                  LIMIT 1",
                 $signature['canonical_name'],
                 $signature['type'],
@@ -140,7 +141,8 @@ class ALMA_Geo_Index_Store {
                 $signature['region'],
                 $signature['city'],
                 $signature['area'],
-                $signature['poi']
+                $signature['poi'],
+                $signature['formatted_address']
             ),
             ARRAY_A
         );
@@ -154,8 +156,10 @@ class ALMA_Geo_Index_Store {
         }
 
         $now = current_time('mysql');
-        $existing = $data['geo_provider_place_id'] !== '' ? $this->get_location_by_place_id($data['geo_provider_place_id'], $data['geo_provider']) : null;
-        if (!$existing) {
+        $existing = null;
+        if ($data['geo_provider_place_id'] !== '') {
+            $existing = $this->get_location_by_place_id($data['geo_provider_place_id'], $data['geo_provider']);
+        } else {
             $existing = $this->get_location_by_signature($data);
         }
         $formats = array('%s','%s','%s','%s','%s','%s','%s','%s','%f','%f','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s');
@@ -326,9 +330,12 @@ class ALMA_Geo_Index_Store {
         }
 
         $derive_from_primary = !empty($geo_data['derive_from_primary']);
-        $geo_scope = $derive_from_primary && $primary ? $this->default_geo_scope_for_type($primary['type']) : sanitize_key($geo_data['geo_scope'] ?? ($primary ? $this->default_geo_scope_for_type($primary['type']) : 'uncertain'));
-        $content_type = $derive_from_primary && $primary ? $this->default_content_type_for_type($primary['type']) : sanitize_key($geo_data['content_type'] ?? ($primary ? $this->default_content_type_for_type($primary['type']) : 'uncertain'));
-        $commercial_intent = sanitize_key($geo_data['commercial_intent'] ?? 'none');
+        $submitted_geo_scope = sanitize_key($geo_data['geo_scope'] ?? '');
+        $submitted_content_type = sanitize_key($geo_data['content_type'] ?? '');
+        $submitted_commercial_intent = sanitize_key($geo_data['commercial_intent'] ?? '');
+        $geo_scope = $submitted_geo_scope !== '' ? $submitted_geo_scope : ($primary ? $this->default_geo_scope_for_type($primary['type']) : 'uncertain');
+        $content_type = $submitted_content_type !== '' ? $submitted_content_type : ($primary ? $this->default_content_type_for_type($primary['type']) : 'uncertain');
+        $commercial_intent = $submitted_commercial_intent !== '' ? $submitted_commercial_intent : ($derive_from_primary && $primary ? 'high' : 'none');
         $widget_eligible = !empty($geo_data['widget_eligible']) && !in_array((string) $geo_data['widget_eligible'], array('no', '0', 'false', 'off'), true);
         $now = current_time('mysql');
         $updated_locations = array();
@@ -415,6 +422,7 @@ class ALMA_Geo_Index_Store {
 
     public function normalize_associated_locations($locations, $source = 'manual') {
         $normalized = array();
+        $seen = array();
         $has_primary = false;
         foreach (is_array($locations) ? $locations : array() as $location) {
             if (!is_array($location)) {
@@ -423,6 +431,13 @@ class ALMA_Geo_Index_Store {
             $item = $this->format_location_for_json($location);
             if ($item['name'] === '' && $item['canonical_name'] === '') {
                 continue;
+            }
+            $dedupe_key = $this->location_dedupe_key($item);
+            if ($dedupe_key !== '' && isset($seen[$dedupe_key])) {
+                continue;
+            }
+            if ($dedupe_key !== '') {
+                $seen[$dedupe_key] = true;
             }
             $item['source'] = $item['source'] ?: sanitize_text_field($source);
             if (!empty($item['is_primary']) && !$has_primary) {
@@ -476,6 +491,25 @@ class ALMA_Geo_Index_Store {
             'confidence' => isset($location['confidence']) && $location['confidence'] !== '' ? (float) $location['confidence'] : 1,
             'match_weight' => isset($location['match_weight']) && $location['match_weight'] !== '' ? (int) $location['match_weight'] : ($is_primary ? 100 : 70),
         );
+    }
+
+
+    private function location_dedupe_key($location) {
+        $location = $this->format_location_for_json($location);
+        if ($location['geo_provider_place_id'] !== '') {
+            return 'place:' . strtolower($location['geo_provider_place_id']);
+        }
+        $parts = array(
+            $location['canonical_name'] ?: $location['name'],
+            $location['type'],
+            $location['country_code'],
+            $location['region'],
+            $location['city'],
+            $location['area'],
+            $location['poi'],
+            $location['formatted_address'],
+        );
+        return 'text:' . strtolower(implode('|', array_map('trim', $parts)));
     }
 
     public static function get_location_role_labels() {
@@ -802,7 +836,7 @@ class ALMA_Geo_Index_Store {
 
     private function normalize_location_signature($data) {
         $data = $this->sanitize_location_data($data);
-        foreach (array('canonical_name', 'region', 'city', 'area', 'poi') as $key) {
+        foreach (array('canonical_name', 'region', 'city', 'area', 'poi', 'formatted_address') as $key) {
             $data[$key] = strtolower(trim($data[$key]));
         }
         return $data;


### PR DESCRIPTION
### Motivation
- Fix incorrect POI naming and UI/persistence bugs in the Geo Index metabox so Google POI are preserved as independent locations (not collapsed to the city), deduplication uses Place ID, and admin edits to advanced fields and the Widget eligible checkbox are not overwritten on load or save.
- Prevent the penultimate associated-location row from being overwritten during add/save operations and ensure all associated locations persist across draft/post saves with a single stable primary.

### Description
- Google provider: prefer Google Places Text Search when available and extract the most specific display name via `extract_google_result_name()`, extend POI type mapping and return `name`, `canonical_name`, `poi` and `formatted_address` from the provider result. (changes in `includes/class-geo-index-google-geocoder.php`).
- Store logic: prefer `geo_provider_place_id` for deduplication in `upsert_location()`, fall back to a textual signature that now includes `formatted_address`, add `location_dedupe_key()` and de-duplication inside `normalize_associated_locations()` to avoid overwriting POI with city records. (changes in `includes/class-geo-index-store.php`).
- Metabox save: stop forcing `derive_from_primary = true` unconditionally and instead use a new hidden flag `alma_geo[primary_changed]` so derived defaults are applied only when the primary was explicitly changed; preserve explicit advanced fields when submitted. (changes in `includes/class-geo-index-metabox.php`).
- Admin JS/UI: introduce stable keys and signatures (`place:` + Place ID or a full text signature), add `isInitialRender` and `primaryChanged` flags, avoid re-checking `_alma_geo_widget_eligible` and forcing badges during initial render, mark primary changes only on explicit user actions, always sync `alma_geo_associated_locations_json` before submit and prevent aggressive dedupe/row replacement. (changes in `assets/geo-index-admin.js`).
- Changelog: updated `CHANGELOG.md` with the POI naming, dedupe and persistence fixes.

### Testing
- Static PHP syntax checks were run with `php -l` on `affiliate-link-manager-ai.php`, `includes/class-geo-index-metabox.php`, `includes/class-geo-index-store.php`, `includes/class-geo-index-admin.php`, `includes/class-geo-index-geocoder.php` and `includes/class-geo-index-google-geocoder.php` and all reported no syntax errors. 
- JS static check was run with `node --check assets/geo-index-admin.js` and passed with no syntax errors. 
- Repository checks were run with `git diff --check` and no whitespace/merge errors were reported. 
- No automated browser/WordPress UI tests were run in this environment; manual admin scenarios described in the issue should be validated in a WP admin instance (e.g. verify POI names, Place ID dedupe, three-location add/save/reopen flows, primary change behavior and preservation of advanced fields and `Widget eligible`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2425a73e948332983163441e241f79)