### PR TITLE
Fix Geo Index save and redirect for affiliate links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 
-- Corretto il salvataggio dei dati Geo Index sui Link Affiliati.
-- Corretto il redirect errato dopo aggiornamento dei Link Affiliati.
+- Corretto il salvataggio del metabox Geo Index su Link Affiliati, preservando `object_type=affiliate_link` nelle tabelle Geo Index.
+- Corretto il redirect dopo aggiornamento Link Affiliato per restare in `post.php?post={ID}&action=edit`, preservando `classic-editor`.
+- Reso robusto il callback `save_post` del Geo Index con `accepted_args=3` e fallback difensivo a `get_post()`.
 - Rafforzato l’export CSV Link Affiliati contro formule CSV potenzialmente pericolose.
 - Verificata/corretta la deduplica località Geo Index con Place ID e formatted address nullable.
 - Corretto il redirect dopo aggiornamento di un Link Affiliato quando il metabox Geo Index è attivo, preservando la schermata standard di modifica del CPT.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -1064,31 +1064,48 @@ class AffiliateManagerAI {
      * Mantiene il redirect standard di WordPress dopo aggiornamento Link Affiliato.
      */
     public function normalize_affiliate_link_update_redirect($location, $post_id) {
-        $post_id = absint($post_id ?: ($_POST['post_ID'] ?? 0));
-        if (!$post_id) {
+        if ((function_exists('wp_doing_ajax') && wp_doing_ajax()) || (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE)) {
             return $location;
         }
-        $post = get_post($post_id);
-        if (!$post || $post->post_type !== 'affiliate_link') {
+
+        $post_id = absint($post_id);
+        if (!$post_id && isset($_POST['post_ID'])) {
+            $post_id = absint(wp_unslash($_POST['post_ID']));
+        }
+        if (!$post_id && isset($_REQUEST['post'])) {
+            $post_id = absint(wp_unslash($_REQUEST['post']));
+        }
+        if (!$post_id || wp_is_post_autosave($post_id) || wp_is_post_revision($post_id)) {
+            return $location;
+        }
+        if (get_post_type($post_id) !== 'affiliate_link') {
+            return $location;
+        }
+
+        $request_action = isset($_REQUEST['action']) ? sanitize_key(wp_unslash($_REQUEST['action'])) : '';
+        $request_action2 = isset($_REQUEST['action2']) ? sanitize_key(wp_unslash($_REQUEST['action2'])) : '';
+        $blocked_actions = array('trash', 'delete', 'delete_all', 'untrash', 'bulk_edit', 'inline-save');
+        if (in_array($request_action, $blocked_actions, true) || in_array($request_action2, $blocked_actions, true)) {
+            return $location;
+        }
+        if ($request_action !== '' && $request_action !== 'editpost') {
+            return $location;
+        }
+        if (!$this->is_affiliate_link_post_php_update_request()) {
             return $location;
         }
 
         $parts = wp_parse_url($location);
-        $path = isset($parts['path']) ? basename($parts['path']) : '';
-        if ($path !== 'edit.php') {
-            return $location;
-        }
-
         $query_args = array();
         if (!empty($parts['query'])) {
             wp_parse_str($parts['query'], $query_args);
         }
-        if (($query_args['post_type'] ?? '') === 'affiliate_link') {
-            return $location;
+        $message = isset($query_args['message']) ? absint($query_args['message']) : 1;
+        if (!$message) {
+            $message = 1;
         }
 
-        $message = isset($query_args['message']) ? absint($query_args['message']) : 1;
-        return add_query_arg(
+        $redirect = add_query_arg(
             array(
                 'post' => $post_id,
                 'action' => 'edit',
@@ -1096,6 +1113,68 @@ class AffiliateManagerAI {
             ),
             admin_url('post.php')
         );
+        if ($this->affiliate_link_update_requested_classic_editor() && strpos($redirect, 'classic-editor') === false) {
+            $redirect .= (strpos($redirect, '?') === false ? '?' : '&') . 'classic-editor';
+        }
+
+        // Diagnostic-only normalization: prevents Geo Index/admin hooks from sending affiliate_link updates to edit.php.
+        if (class_exists('ALMA_Logger')) {
+            ALMA_Logger::debug('Normalized affiliate_link update redirect.', array(
+                'post_id' => $post_id,
+                'from' => $location,
+                'to' => $redirect,
+                'request_action' => $request_action,
+            ));
+        }
+
+        return $redirect;
+    }
+
+    private function is_affiliate_link_post_php_update_request() {
+        $paths = array();
+        if (!empty($_SERVER['REQUEST_URI'])) {
+            $request_path = wp_parse_url(wp_unslash($_SERVER['REQUEST_URI']), PHP_URL_PATH);
+            if ($request_path) {
+                $paths[] = basename($request_path);
+            }
+        }
+        foreach (array('_wp_http_referer', 'HTTP_REFERER') as $key) {
+            $value = $key === 'HTTP_REFERER' ? ($_SERVER[$key] ?? '') : ($_REQUEST[$key] ?? '');
+            if ($value === '') {
+                continue;
+            }
+            $referer_path = wp_parse_url(wp_unslash($value), PHP_URL_PATH);
+            if ($referer_path) {
+                $paths[] = basename($referer_path);
+            }
+        }
+
+        return in_array('post.php', $paths, true);
+    }
+
+    private function affiliate_link_update_requested_classic_editor() {
+        if (isset($_REQUEST['classic-editor'])) {
+            return true;
+        }
+
+        foreach (array('_wp_http_referer', 'HTTP_REFERER') as $key) {
+            $value = $key === 'HTTP_REFERER' ? ($_SERVER[$key] ?? '') : ($_REQUEST[$key] ?? '');
+            if ($value === '') {
+                continue;
+            }
+            $value = wp_unslash($value);
+            $query = wp_parse_url($value, PHP_URL_QUERY);
+            if ($query === false || $query === null) {
+                continue;
+            }
+            $query_args = array();
+            wp_parse_str($query, $query_args);
+            if (array_key_exists('classic-editor', $query_args) || strpos($query, 'classic-editor') !== false) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function get_affiliate_link_export_counts() {

--- a/includes/class-geo-index-metabox.php
+++ b/includes/class-geo-index-metabox.php
@@ -17,7 +17,7 @@ class ALMA_Geo_Index_Metabox {
 
     public function init() {
         add_action('add_meta_boxes', array($this, 'add_meta_boxes'));
-        add_action('save_post', array($this, 'save'), 30, 2);
+        add_action('save_post', array($this, 'save'), 30, 3);
         add_action('wp_ajax_alma_geo_search_location', array($this, 'ajax_search_location'));
         add_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
     }
@@ -239,7 +239,20 @@ class ALMA_Geo_Index_Metabox {
         <?php
     }
 
-    public function save($post_id, $post) {
+    public function save($post_id, $post = null, $update = false) {
+        $post_id = absint($post_id);
+        if (!$post_id) {
+            return;
+        }
+
+        if (!$post instanceof WP_Post) {
+            $post = get_post($post_id);
+        }
+
+        if (!$post instanceof WP_Post) {
+            return;
+        }
+
         if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
             return;
         }


### PR DESCRIPTION
### Motivation
- Il metabox Geo Index non riceveva sempre il parametro `$post` al `save_post`, causando salvataggi incompleti per il CPT `affiliate_link` e redirect errati dopo l'aggiornamento. 
- Il redirect dopo l'aggiornamento di un `affiliate_link` veniva normalizzato verso la lista standard (`edit.php`) invece di rimanere sulla pagina di modifica `post.php?post={ID}&action=edit`, con perdita del flag `classic-editor`.

### Description
- Registra l'hook con tutti gli argomenti passando `add_action('save_post', array($this, 'save'), 30, 3);` e rende la callback difensiva cambiando la firma in `public function save($post_id, $post = null, $update = false)` e recuperando il post con `get_post()` quando necessario (file `includes/class-geo-index-metabox.php`).
- Rafforza i controlli iniziali di `save()` eseguendo `absint($post_id)`, verificando che `$post` sia un `WP_Post`, preservando nonce/capability/guards (autosave/revision) e mantenendo il salvataggio Geo per `post`, `page` e `affiliate_link` senza sovrascrivere altri meta non-Geo (file `includes/class-geo-index-metabox.php`).
- Rafforza `normalize_affiliate_link_update_redirect()` per recuperare `post_id` anche da `$_POST['post_ID']` e `$_REQUEST['post']`, ignorare AJAX/autosave/revision/trash/bulk flows, rilevare aggiornamenti provenienti da `post.php` e forzare il redirect verso `admin_url('post.php?post={ID}&action=edit&message=1')` preservando `classic-editor` e aggiungendo un log diagnostico (file `affiliate-link-manager-ai.php`).
- Aggiornato `CHANGELOG.md` con le note di correzione e hardening correlate ai salvataggi Geo e al redirect.

### Testing
- Eseguiti i controlli di sintassi PHP con `php -l` su `affiliate-link-manager-ai.php`, `includes/class-geo-index-metabox.php`, `includes/class-geo-index-store.php`, `includes/class-geo-index-admin.php`, `includes/class-geo-index-geocoder.php` e `includes/class-geo-index-google-geocoder.php`, tutti passati senza errori.
- Nessun test automatico end-to-end su WordPress admin è stato eseguito nel container (solo verifiche statiche/automatizzate di sintassi PHP eseguite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2435c544188332be8c134b463d7062)