### PR TITLE
Add background Geo import for affiliate links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Aggiunto import in background delle località per Link Affiliati da CSV.
+- Aggiunto job log per import Geo Link Affiliati.
+- Aggiunta associazione delle località ai Link Affiliati tramite affiliate_link_id.
+- Preparato secondo passaggio di geocoding Google per località importate.
 - Corretto redirect dopo creazione e aggiornamento dei Link Affiliati.
 - Aggiunto marker temporaneo di salvataggio `affiliate_link` per fallback sicuro.
 - Rafforzata fallback admin solo per atterraggio immediato errato su `edit.php`.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@
 - Il metabox **Geolocalizzazione contenuto** sostituisce il JSON visibile delle località con una lista visuale di località associate: ricerca Google Maps, pulsante **Associa luogo**, radio per una sola località principale, ruoli sulle secondarie e persistenza in `alma_geo_locations`, `alma_geo_content_index` e `_alma_geo_locations_json` tecnico.
 - Il metabox **Geolocalizzazione contenuto** ora apre con **Cerca e associa località**, usa Google Maps server-side via AJAX admin protetto e compila automaticamente stato, località primaria, coordinate, Place ID e campi Geo Index al salvataggio.
 
+
+### Indice Geografico — Import Link Affiliati
+
+- Aggiunta la tab **Import Link Affiliati** in **Indice Geografico** per caricare CSV AI come `sothra_geo_affiliate_links_index.csv`, validare gli header obbligatori e mostrare la preview dei primi 10 record.
+- L’import crea un job persistente `affiliate_links_geo_import`, salva le righe in `alma_geo_import_job_items` e processa batch AJAX da 50 righe (massimo 100), con pausa, ripresa, annullamento, retry errori, progress bar e ultimi log.
+- Ogni riga valida viene associata al CPT `affiliate_link` tramite `affiliate_link_id`, aggiorna i post meta `_alma_geo_*`, salva `_alma_geo_activity_type`, crea/riusa località primarie e secondarie e aggiorna `alma_geo_locations` e `alma_geo_content_index` con `object_type=affiliate_link`.
+- L’import non chiama Google Maps: le località restano `pending` e vengono geocodificate solo nel passaggio separato della tab **Geocoding**, che ora evidenzia anche le località pending provenienti dai Link Affiliati.
+
 ### Indice Geografico — sincronizzazione geocoding
 - Le località `verified` sincronizzano i dati geocoding sui contenuti primari collegati tramite `alma_geo_content_index`, mantenendo compatibilità con i meta `_alma_geo_*` esistenti.
 - La tab **Geocoding** include il pulsante **Risincronizza geocoding nei contenuti**, che copia solo dati già salvati nelle località senza chiamare Google Maps.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -95,10 +95,12 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-shortcodes.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-editor-ajax.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-dashboard-widget.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-store.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-job-store.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-google-geocoder.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-geocoder.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-metabox.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-importer.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-affiliate-link-importer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-admin.php';
 
 /**
@@ -3930,6 +3932,7 @@ class AffiliateManagerAI {
         ALMA_AI_Usage_Logger::create_table();
         ALMA_Affiliate_Source_Manager::create_tables();
         ALMA_Geo_Index_Store::create_tables();
+        ALMA_Geo_Index_Job_Store::create_tables();
         ALMA_Contextual_Affiliate_Widget::maybe_set_default_options();
         $this->create_default_categories();
         update_option('alma_db_schema_version', '4');
@@ -3978,6 +3981,7 @@ class AffiliateManagerAI {
             ALMA_AI_Usage_Logger::create_table();
             ALMA_Affiliate_Source_Manager::create_tables();
             ALMA_Geo_Index_Store::create_tables();
+            ALMA_Geo_Index_Job_Store::create_tables();
             ALMA_Contextual_Affiliate_Widget::maybe_set_default_options();
             update_option('alma_db_schema_version', '4');
             update_option('alma_plugin_version', ALMA_VERSION);

--- a/includes/class-geo-index-admin.php
+++ b/includes/class-geo-index-admin.php
@@ -11,16 +11,22 @@ class ALMA_Geo_Index_Admin {
     private $store;
     private $importer;
     private $geocoder;
+    private $affiliate_importer;
+    private $job_store;
     private $notice = '';
 
     public function __construct($store = null) {
         $this->store = $store ?: new ALMA_Geo_Index_Store();
         $this->importer = new ALMA_Geo_Index_Importer($this->store);
         $this->geocoder = new ALMA_Geo_Index_Geocoder($this->store);
+        $this->affiliate_importer = new ALMA_Geo_Index_Affiliate_Link_Importer($this->store);
+        $this->job_store = new ALMA_Geo_Index_Job_Store();
     }
 
     public function init() {
         add_action('admin_menu', array($this, 'add_menu'));
+        add_action('wp_ajax_alma_geo_affiliate_import_status', array($this, 'ajax_affiliate_import_status'));
+        add_action('wp_ajax_alma_geo_affiliate_import_batch', array($this, 'ajax_affiliate_import_batch'));
     }
 
     public function add_menu() {
@@ -40,7 +46,7 @@ class ALMA_Geo_Index_Admin {
         }
 
         $tab = isset($_GET['tab']) ? sanitize_key($_GET['tab']) : 'dashboard';
-        if (!in_array($tab, array('dashboard', 'import', 'locations', 'geocoding', 'log'), true)) {
+        if (!in_array($tab, array('dashboard', 'import', 'affiliate_import', 'locations', 'geocoding', 'log'), true)) {
             $tab = 'dashboard';
         }
         $this->handle_actions($tab);
@@ -52,6 +58,7 @@ class ALMA_Geo_Index_Admin {
             <nav class="nav-tab-wrapper">
                 <?php $this->tab_link('dashboard', __('Dashboard', 'affiliate-link-manager-ai'), $tab); ?>
                 <?php $this->tab_link('import', __('Importa record articoli', 'affiliate-link-manager-ai'), $tab); ?>
+                <?php $this->tab_link('affiliate_import', __('Import Link Affiliati', 'affiliate-link-manager-ai'), $tab); ?>
                 <?php $this->tab_link('locations', __('Località', 'affiliate-link-manager-ai'), $tab); ?>
                 <?php $this->tab_link('geocoding', __('Geocoding', 'affiliate-link-manager-ai'), $tab); ?>
                 <?php $this->tab_link('log', __('Log / ultimi import', 'affiliate-link-manager-ai'), $tab); ?>
@@ -59,6 +66,8 @@ class ALMA_Geo_Index_Admin {
             <?php
             if ($tab === 'import') {
                 $this->render_import_tab();
+            } elseif ($tab === 'affiliate_import') {
+                $this->render_affiliate_import_tab();
             } elseif ($tab === 'locations') {
                 $this->render_locations_tab();
             } elseif ($tab === 'geocoding') {
@@ -85,6 +94,11 @@ class ALMA_Geo_Index_Admin {
             } elseif ($action === 'import') {
                 $this->handle_import_submit();
             }
+            return;
+        }
+        if ($tab === 'affiliate_import') {
+            check_admin_referer('alma_geo_affiliate_import');
+            $this->handle_affiliate_import_action($action);
             return;
         }
         if (in_array($tab, array('geocoding', 'locations'), true)) {
@@ -322,6 +336,9 @@ class ALMA_Geo_Index_Admin {
         }
         $settings = $this->geocoder->get_settings();
         $counts = $this->store->get_geocoding_status_counts();
+        $article_counts = $this->store->get_geocoding_status_counts_by_object_type('post');
+        $page_counts = $this->store->get_geocoding_status_counts_by_object_type('page');
+        $affiliate_counts = $this->store->get_geocoding_status_counts_by_object_type(ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK);
         $api_key = (string) get_option('alma_geo_google_maps_api_key', '');
         $masked_key = $api_key === '' ? __('Non configurata', 'affiliate-link-manager-ai') : sprintf(__('Configurata (termina con %s)', 'affiliate-link-manager-ai'), substr($api_key, -4));
         echo '<h2>' . esc_html__('Geocoding', 'affiliate-link-manager-ai') . '</h2>';
@@ -329,7 +346,9 @@ class ALMA_Geo_Index_Admin {
         $rows = array(
             __('Provider attivo', 'affiliate-link-manager-ai') => 'Google Maps',
             __('Google Maps API key', 'affiliate-link-manager-ai') => $masked_key,
-            __('Località pending', 'affiliate-link-manager-ai') => $counts['pending'],
+            __('Località pending totali', 'affiliate-link-manager-ai') => $counts['pending'],
+            __('Località pending da articoli/pagine', 'affiliate-link-manager-ai') => (int) $article_counts['pending'] + (int) $page_counts['pending'],
+            __('Località pending da Link Affiliati', 'affiliate-link-manager-ai') => $affiliate_counts['pending'],
             __('Località verified', 'affiliate-link-manager-ai') => $counts['verified'],
             __('Località ambiguous', 'affiliate-link-manager-ai') => $counts['ambiguous'],
             __('Località failed', 'affiliate-link-manager-ai') => $counts['failed'],
@@ -372,7 +391,7 @@ class ALMA_Geo_Index_Admin {
             <?php $this->render_geocoding_button('sync_verified_locations', __('Risincronizza geocoding nei contenuti', 'affiliate-link-manager-ai')); ?>
         </div>
         <?php
-        echo '<h3>' . esc_html__('Località pending/recenti', 'affiliate-link-manager-ai') . '</h3>';
+        echo '<h3 id="alma-geo-pending-locations">' . esc_html__('Località pending/recenti', 'affiliate-link-manager-ai') . '</h3>';
         $this->render_locations_table($this->store->get_locations(50), false);
     }
 
@@ -406,6 +425,325 @@ class ALMA_Geo_Index_Admin {
             echo '</td></tr>';
         }
         echo '</tbody></table></div>';
+    }
+
+
+    private function handle_affiliate_import_action($action) {
+        if (!current_user_can('manage_options')) {
+            $this->notice_error(__('Permessi insufficienti.', 'affiliate-link-manager-ai'));
+            return;
+        }
+        if ($action === 'preview_affiliate_csv') {
+            $validation = $this->affiliate_importer->validate_uploaded_csv($_FILES['alma_geo_affiliate_csv'] ?? array());
+            if (is_wp_error($validation)) {
+                $this->notice_error($this->format_upload_error_message($validation));
+                return;
+            }
+            $stored_file = $this->store_preview_upload($validation);
+            if (is_wp_error($stored_file)) {
+                $this->notice_error($stored_file->get_error_message());
+                return;
+            }
+            $parsed = $this->affiliate_importer->parse_csv_file($stored_file, 10, $validation['delimiter']);
+            $headers_validation = $this->affiliate_importer->validate_headers($parsed['headers']);
+            $preview = array(
+                'file' => $stored_file,
+                'file_name' => $validation['file_name'],
+                'total' => $parsed['total'],
+                'headers' => $parsed['headers'],
+                'rows' => $parsed['rows'],
+                'valid' => $headers_validation['valid'],
+                'missing' => $headers_validation['missing'],
+                'recommended_missing' => $headers_validation['recommended_missing'],
+                'delimiter' => $validation['delimiter'],
+                'mime' => $validation['mime'],
+            );
+            $old_preview = get_transient($this->affiliate_preview_key());
+            if (!empty($old_preview['file']) && file_exists($old_preview['file'])) {
+                wp_delete_file($old_preview['file']);
+            }
+            set_transient($this->affiliate_preview_key(), $preview, HOUR_IN_SECONDS);
+            $this->notice_success(__('CSV Link Affiliati caricato e validato. Controlla la preview e avvia il job in background.', 'affiliate-link-manager-ai'));
+            return;
+        }
+        if ($action === 'start_affiliate_import') {
+            $preview = get_transient($this->affiliate_preview_key());
+            if (empty($preview['file']) || !file_exists($preview['file']) || empty($preview['valid'])) {
+                $this->notice_error(__('Preview non valida o scaduta. Ricarica il CSV Link Affiliati.', 'affiliate-link-manager-ai'));
+                return;
+            }
+            $job_id = $this->affiliate_importer->create_job_from_csv($preview['file'], array(
+                'file_name' => $preview['file_name'],
+                'delimiter' => $preview['delimiter'] ?? null,
+                'overwrite' => !empty($_POST['alma_geo_affiliate_overwrite']),
+                'safe_only' => !empty($_POST['alma_geo_affiliate_safe_only']),
+                'batch_size' => absint($_POST['alma_geo_affiliate_batch_size'] ?? 50),
+            ));
+            if (file_exists($preview['file'])) {
+                wp_delete_file($preview['file']);
+            }
+            delete_transient($this->affiliate_preview_key());
+            $this->notice_success(sprintf(__('Job #%d creato. Il processamento batch parte in background dalla pagina aperta e può essere ripreso in seguito.', 'affiliate-link-manager-ai'), $job_id));
+            return;
+        }
+        $job_id = absint($_POST['job_id'] ?? 0);
+        if (!$job_id) {
+            $latest = $this->job_store->get_latest_job();
+            $job_id = absint($latest['id'] ?? 0);
+        }
+        if (!$job_id) {
+            $this->notice_error(__('Nessun job disponibile.', 'affiliate-link-manager-ai'));
+            return;
+        }
+        if ($action === 'download_affiliate_log') {
+            $this->download_affiliate_job_log($job_id);
+        } elseif ($action === 'pause_affiliate_job') {
+            $this->job_store->update_job_status($job_id, 'paused');
+            $this->notice_success(__('Job messo in pausa.', 'affiliate-link-manager-ai'));
+        } elseif ($action === 'resume_affiliate_job') {
+            $this->job_store->update_job_status($job_id, 'queued');
+            $this->notice_success(__('Job rimesso in coda. Il polling AJAX riprenderà il processamento.', 'affiliate-link-manager-ai'));
+        } elseif ($action === 'cancel_affiliate_job') {
+            $this->job_store->update_job_status($job_id, 'cancelled');
+            $this->notice_success(__('Job annullato.', 'affiliate-link-manager-ai'));
+        } elseif ($action === 'retry_affiliate_errors') {
+            $this->job_store->reset_error_items($job_id);
+            $this->job_store->update_job_status($job_id, 'queued');
+            $this->job_store->recount_job($job_id);
+            $this->notice_success(__('Righe in errore rimesse in coda.', 'affiliate-link-manager-ai'));
+        }
+    }
+
+
+    private function download_affiliate_job_log($job_id) {
+        if (!current_user_can('manage_options')) {
+            wp_die(esc_html__('Permessi insufficienti.', 'affiliate-link-manager-ai'));
+        }
+        $job = $this->job_store->get_job($job_id);
+        if (!$job) {
+            wp_die(esc_html__('Job non trovato.', 'affiliate-link-manager-ai'));
+        }
+        nocache_headers();
+        header('Content-Type: text/csv; charset=utf-8');
+        header('Content-Disposition: attachment; filename="alma-geo-affiliate-import-job-' . absint($job_id) . '-log.csv"');
+        $out = fopen('php://output', 'w');
+        fputcsv($out, array('id','job_id','row_number','object_id','object_type','status','action','message','processed_at'));
+        foreach ($this->job_store->get_items($job_id, 5000) as $item) {
+            fputcsv($out, array(
+                (int) $item['id'],
+                (int) $item['job_id'],
+                (int) $item['row_number'],
+                (int) $item['object_id'],
+                sanitize_key($item['object_type']),
+                sanitize_key($item['status']),
+                sanitize_key($item['action']),
+                sanitize_textarea_field($item['message']),
+                sanitize_text_field($item['processed_at']),
+            ));
+        }
+        fclose($out);
+        exit;
+    }
+
+    public function ajax_affiliate_import_status() {
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(array('message' => __('Permessi insufficienti.', 'affiliate-link-manager-ai')), 403);
+        }
+        check_ajax_referer('alma_geo_affiliate_import_ajax', 'nonce');
+        $job_id = absint($_POST['job_id'] ?? 0);
+        $job = $job_id ? $this->job_store->get_job($job_id) : $this->job_store->get_latest_job();
+        wp_send_json_success($this->format_affiliate_job_response($job));
+    }
+
+    public function ajax_affiliate_import_batch() {
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(array('message' => __('Permessi insufficienti.', 'affiliate-link-manager-ai')), 403);
+        }
+        check_ajax_referer('alma_geo_affiliate_import_ajax', 'nonce');
+        $job_id = absint($_POST['job_id'] ?? 0);
+        $batch_size = absint($_POST['batch_size'] ?? 50);
+        $result = $this->affiliate_importer->process_job_batch($job_id, $batch_size, !empty($_POST['retry_errors']));
+        if (is_wp_error($result)) {
+            wp_send_json_error(array('message' => $result->get_error_message()), 400);
+        }
+        wp_send_json_success($this->format_affiliate_job_response($result['job'] ?? null));
+    }
+
+    private function render_affiliate_import_tab() {
+        $preview = get_transient($this->affiliate_preview_key());
+        $job = $this->job_store->get_latest_job();
+        ?>
+        <h2><?php esc_html_e('Import Link Affiliati', 'affiliate-link-manager-ai'); ?></h2>
+        <p><?php esc_html_e('Importa località geografiche da CSV AI e associa ogni riga al CPT affiliate_link tramite affiliate_link_id. Nessuna chiamata Google Maps viene eseguita durante l’import.', 'affiliate-link-manager-ai'); ?></p>
+        <form method="post" enctype="multipart/form-data" class="postbox" style="padding:12px;">
+            <?php wp_nonce_field('alma_geo_affiliate_import'); ?>
+            <input type="hidden" name="alma_geo_index_action" value="preview_affiliate_csv">
+            <h3><?php esc_html_e('Upload CSV', 'affiliate-link-manager-ai'); ?></h3>
+            <input type="file" name="alma_geo_affiliate_csv" accept=".csv,text/csv,text/plain,application/csv,application/vnd.ms-excel" required>
+            <?php submit_button(__('Valida e mostra preview', 'affiliate-link-manager-ai'), 'secondary', 'submit', false); ?>
+        </form>
+        <?php
+        if (!empty($preview)) {
+            $this->render_affiliate_preview($preview);
+        }
+        $this->render_affiliate_job_panel($job);
+        $this->render_affiliate_job_script($job);
+    }
+
+    private function render_affiliate_preview($preview) {
+        echo '<div class="postbox"><div class="inside"><h3>' . esc_html__('Preview primi 10 record', 'affiliate-link-manager-ai') . '</h3>';
+        echo '<p><strong>' . esc_html__('File:', 'affiliate-link-manager-ai') . '</strong> ' . esc_html($preview['file_name']) . ' — <strong>' . esc_html__('Record totali:', 'affiliate-link-manager-ai') . '</strong> ' . esc_html((string) $preview['total']) . ' — <strong>' . esc_html__('Delimiter:', 'affiliate-link-manager-ai') . '</strong> ' . esc_html($preview['delimiter']) . '</p>';
+        if (empty($preview['valid'])) {
+            echo '<div class="notice notice-error inline"><p>' . esc_html__('Header mancanti:', 'affiliate-link-manager-ai') . ' ' . esc_html(implode(', ', $preview['missing'])) . '</p></div></div></div>';
+            return;
+        }
+        if (!empty($preview['recommended_missing'])) {
+            echo '<div class="notice notice-warning inline"><p>' . esc_html__('Header consigliati mancanti:', 'affiliate-link-manager-ai') . ' ' . esc_html(implode(', ', $preview['recommended_missing'])) . '</p></div>';
+        }
+        echo '<div style="max-width:100%;overflow:auto;"><table class="widefat striped"><thead><tr>';
+        foreach ($preview['headers'] as $header) {
+            echo '<th>' . esc_html($header) . '</th>';
+        }
+        echo '</tr></thead><tbody>';
+        foreach ($preview['rows'] as $row) {
+            echo '<tr>';
+            foreach ($preview['headers'] as $header) {
+                echo '<td>' . esc_html(wp_trim_words((string) ($row[$header] ?? ''), 12, '…')) . '</td>';
+            }
+            echo '</tr>';
+        }
+        echo '</tbody></table></div>';
+        ?>
+        <form method="post" style="margin-top:16px;">
+            <?php wp_nonce_field('alma_geo_affiliate_import'); ?>
+            <input type="hidden" name="alma_geo_index_action" value="start_affiliate_import">
+            <p><label><input type="checkbox" name="alma_geo_affiliate_overwrite" value="1"> <?php esc_html_e('Sovrascrivi dati Geo esistenti', 'affiliate-link-manager-ai'); ?></label></p>
+            <p><label><input type="checkbox" name="alma_geo_affiliate_safe_only" value="1" checked> <?php esc_html_e('Importa solo safe_import', 'affiliate-link-manager-ai'); ?></label></p>
+            <p><label><?php esc_html_e('Batch size', 'affiliate-link-manager-ai'); ?> <input type="number" name="alma_geo_affiliate_batch_size" min="1" max="100" value="50"></label></p>
+            <?php submit_button(__('Avvia import in background', 'affiliate-link-manager-ai'), 'primary', 'submit', false); ?>
+        </form>
+        <?php
+        echo '</div></div>';
+    }
+
+    private function render_affiliate_job_panel($job) {
+        echo '<div class="postbox"><div class="inside" id="alma-geo-affiliate-job" data-job-id="' . esc_attr((string) absint($job['id'] ?? 0)) . '">';
+        echo '<h3>' . esc_html__('Stato job corrente', 'affiliate-link-manager-ai') . '</h3>';
+        if (empty($job)) {
+            echo '<p>' . esc_html__('Nessun job Link Affiliati ancora creato.', 'affiliate-link-manager-ai') . '</p></div></div>';
+            return;
+        }
+        $this->render_affiliate_job_summary($job);
+        echo '<div style="display:flex;gap:8px;flex-wrap:wrap;margin:12px 0;">';
+        $this->render_affiliate_job_button('pause_affiliate_job', __('Pausa job', 'affiliate-link-manager-ai'), $job);
+        $this->render_affiliate_job_button('resume_affiliate_job', __('Riprendi job', 'affiliate-link-manager-ai'), $job);
+        $this->render_affiliate_job_button('cancel_affiliate_job', __('Annulla job', 'affiliate-link-manager-ai'), $job);
+        $this->render_affiliate_job_button('retry_affiliate_errors', __('Riprova errori', 'affiliate-link-manager-ai'), $job);
+        $this->render_affiliate_job_button('download_affiliate_log', __('Scarica log CSV', 'affiliate-link-manager-ai'), $job);
+        $geocoding_url = add_query_arg(array('post_type' => 'affiliate_link', 'page' => self::MENU_SLUG, 'tab' => 'geocoding'), admin_url('edit.php'));
+        echo '<a class="button" href="' . esc_url($geocoding_url) . '">' . esc_html__('Vai al Geocoding località pending', 'affiliate-link-manager-ai') . '</a>';
+        echo '<a class="button" href="' . esc_url($geocoding_url) . '#alma-geo-pending-locations">' . esc_html__('Vedi Località pending', 'affiliate-link-manager-ai') . '</a>';
+        echo '</div><div id="alma-geo-affiliate-job-live"></div>';
+        echo '<h4>' . esc_html__('Report finale / corrente', 'affiliate-link-manager-ai') . '</h4>';
+        $report = $this->job_store->get_report((int) $job['id']);
+        echo '<table class="widefat striped"><tbody>';
+        foreach ($report as $key => $value) {
+            echo '<tr><th>' . esc_html($key) . '</th><td>' . esc_html((string) $value) . '</td></tr>';
+        }
+        echo '</tbody></table>';
+        $this->render_affiliate_job_logs((int) $job['id']);
+        echo '</div></div>';
+    }
+
+    private function render_affiliate_job_summary($job) {
+        $total = max(1, (int) ($job['total_records'] ?? 0));
+        $processed = (int) ($job['processed_records'] ?? 0);
+        $percent = min(100, round(($processed / $total) * 100));
+        echo '<p><strong>Job #' . esc_html((string) $job['id']) . '</strong> — ' . esc_html($job['status']) . ' — ' . esc_html($job['file_name']) . '</p>';
+        echo '<div style="background:#f0f0f1;border:1px solid #c3c4c7;height:20px;max-width:640px;"><div style="background:#2271b1;height:20px;width:' . esc_attr((string) $percent) . '%;"></div></div>';
+        echo '<p>' . esc_html(sprintf(__('Avanzamento: %1$d/%2$d (%3$d%%) — importati %4$d, aggiornati %5$d, saltati %6$d, errori %7$d.', 'affiliate-link-manager-ai'), $processed, (int) $job['total_records'], $percent, (int) $job['imported_records'], (int) $job['updated_records'], (int) $job['skipped_records'], (int) $job['error_records'])) . '</p>';
+    }
+
+    private function render_affiliate_job_button($action, $label, $job) {
+        echo '<form method="post" style="display:inline-block;margin:0;">';
+        wp_nonce_field('alma_geo_affiliate_import');
+        echo '<input type="hidden" name="alma_geo_index_action" value="' . esc_attr($action) . '">';
+        echo '<input type="hidden" name="job_id" value="' . esc_attr((string) absint($job['id'] ?? 0)) . '">';
+        submit_button($label, 'secondary small', 'submit', false);
+        echo '</form>';
+    }
+
+    private function render_affiliate_job_logs($job_id) {
+        $items = $this->job_store->get_items($job_id, 50);
+        echo '<h4>' . esc_html__('Ultimi 50 log item', 'affiliate-link-manager-ai') . '</h4><div style="max-width:100%;overflow:auto;"><table class="widefat striped"><thead><tr><th>ID</th><th>Riga</th><th>Oggetto</th><th>Status</th><th>Azione</th><th>Messaggio</th><th>Processato</th></tr></thead><tbody>';
+        if (empty($items)) {
+            echo '<tr><td colspan="7">' . esc_html__('Nessun log.', 'affiliate-link-manager-ai') . '</td></tr>';
+        }
+        foreach ($items as $item) {
+            echo '<tr><td>' . esc_html((string) $item['id']) . '</td><td>' . esc_html((string) $item['row_number']) . '</td><td>' . esc_html((string) $item['object_id']) . '</td><td>' . esc_html($item['status']) . '</td><td>' . esc_html($item['action']) . '</td><td>' . esc_html($item['message']) . '</td><td>' . esc_html((string) $item['processed_at']) . '</td></tr>';
+        }
+        echo '</tbody></table></div>';
+    }
+
+    private function render_affiliate_job_script($job) {
+        if (empty($job) || !in_array($job['status'], array('queued','running'), true)) {
+            return;
+        }
+        $nonce = wp_create_nonce('alma_geo_affiliate_import_ajax');
+        ?>
+        <script>
+        (function(){
+            var jobId = <?php echo (int) $job['id']; ?>;
+            var nonce = <?php echo wp_json_encode($nonce); ?>;
+            var ajaxUrl = <?php echo wp_json_encode(admin_url('admin-ajax.php')); ?>;
+            var target = document.getElementById('alma-geo-affiliate-job-live');
+            function post(action, data) {
+                var body = new URLSearchParams(Object.assign({action: action, nonce: nonce, job_id: jobId, batch_size: 50}, data || {}));
+                return fetch(ajaxUrl, {method:'POST', credentials:'same-origin', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body: body.toString()}).then(function(r){return r.json();});
+            }
+            function render(data) {
+                if (!target || !data || !data.job) { return; }
+                var j = data.job;
+                var pct = j.total_records > 0 ? Math.min(100, Math.round((j.processed_records / j.total_records) * 100)) : 0;
+                target.innerHTML = '<p><strong>Live:</strong> ' + j.status + ' — ' + j.processed_records + '/' + j.total_records + ' (' + pct + '%)</p>';
+            }
+            function tick() {
+                post('alma_geo_affiliate_import_batch').then(function(resp){
+                    if (resp && resp.success) {
+                        render(resp.data);
+                        if (resp.data.job && (resp.data.job.status === 'queued' || resp.data.job.status === 'running')) {
+                            window.setTimeout(tick, 900);
+                        } else {
+                            window.setTimeout(function(){ window.location.reload(); }, 900);
+                        }
+                    }
+                }).catch(function(){ window.setTimeout(tick, 3000); });
+            }
+            tick();
+        })();
+        </script>
+        <?php
+    }
+
+    private function format_affiliate_job_response($job) {
+        if (empty($job)) {
+            return array('job' => null, 'items' => array(), 'report' => array());
+        }
+        return array(
+            'job' => array(
+                'id' => (int) $job['id'],
+                'status' => sanitize_key($job['status']),
+                'file_name' => sanitize_file_name($job['file_name']),
+                'total_records' => (int) $job['total_records'],
+                'processed_records' => (int) $job['processed_records'],
+                'imported_records' => (int) $job['imported_records'],
+                'updated_records' => (int) $job['updated_records'],
+                'skipped_records' => (int) $job['skipped_records'],
+                'error_records' => (int) $job['error_records'],
+            ),
+            'items' => $this->job_store->get_items((int) $job['id'], 50),
+            'report' => $this->job_store->get_report((int) $job['id']),
+        );
     }
 
     private function render_log_tab() {
@@ -467,6 +805,10 @@ class ALMA_Geo_Index_Admin {
 
     private function preview_key() {
         return self::PREVIEW_TRANSIENT_PREFIX . get_current_user_id();
+    }
+
+    private function affiliate_preview_key() {
+        return self::PREVIEW_TRANSIENT_PREFIX . 'affiliate_' . get_current_user_id();
     }
 
     private function notice_success($message) {

--- a/includes/class-geo-index-affiliate-link-importer.php
+++ b/includes/class-geo-index-affiliate-link-importer.php
@@ -1,0 +1,494 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+/**
+ * CSV importer for Geo Index affiliate_link associations.
+ *
+ * This class never calls Google Maps. Imported locations remain pending and are
+ * geocoded later by the existing Geo Index geocoding workflow.
+ */
+class ALMA_Geo_Index_Affiliate_Link_Importer {
+    const SOURCE = 'affiliate_geo_csv_import';
+    const MAX_ASSOCIATED_LOCATIONS = 10;
+
+    private $store;
+
+    public function __construct($store = null) {
+        $this->store = $store ?: new ALMA_Geo_Index_Store();
+    }
+
+    public static function required_headers() {
+        return array(
+            'affiliate_link_id',
+            'primary_name',
+            'primary_type',
+            'primary_country',
+            'primary_country_code',
+            'primary_suggested_geocoding_query',
+            'safe_for_auto_import',
+            'safe_for_auto_geocoding',
+            'final_bucket',
+        );
+    }
+
+    public static function recommended_headers() {
+        return array('activity_type','geo_scope','commercial_intent','widget_eligible','secondary_locations_json','confidence','match_weight','review_reason_code','geo_quality_flags');
+    }
+
+    public static function allowed_csv_mimes() {
+        return ALMA_Geo_Index_Importer::allowed_csv_mimes();
+    }
+
+    public function validate_headers($headers) {
+        $headers = array_map('sanitize_key', (array) $headers);
+        $headers = array_values(array_filter($headers));
+        $missing = array();
+        foreach (self::required_headers() as $required) {
+            if (!in_array($required, $headers, true)) {
+                $missing[] = $required;
+            }
+        }
+        $recommended_missing = array_values(array_diff(self::recommended_headers(), $headers));
+        return array('valid' => empty($missing), 'missing' => $missing, 'recommended_missing' => $recommended_missing, 'headers' => $headers);
+    }
+
+    public function validate_uploaded_csv($file) {
+        $article_importer = new ALMA_Geo_Index_Importer($this->store);
+        if (empty($file) || !is_array($file) || empty($file['name'])) {
+            return new WP_Error('geo_csv_missing_file', __('File mancante. Seleziona un file CSV da caricare.', 'affiliate-link-manager-ai'));
+        }
+        $upload_error = isset($file['error']) ? (int) $file['error'] : UPLOAD_ERR_NO_FILE;
+        if ($upload_error !== UPLOAD_ERR_OK) {
+            return new WP_Error('geo_csv_upload_error', __('Errore upload CSV. Riprova con un file valido.', 'affiliate-link-manager-ai'));
+        }
+        $file_name = sanitize_file_name($file['name']);
+        if (strtolower(pathinfo($file_name, PATHINFO_EXTENSION)) !== 'csv') {
+            return new WP_Error('geo_csv_invalid_extension', __('Estensione non valida. Carica solo file .csv.', 'affiliate-link-manager-ai'));
+        }
+        $tmp_name = $file['tmp_name'] ?? '';
+        if (!$tmp_name || !is_readable($tmp_name)) {
+            return new WP_Error('geo_csv_not_readable', __('File non leggibile. Riprova il caricamento del CSV.', 'affiliate-link-manager-ai'));
+        }
+        $content = $this->validate_csv_content($tmp_name);
+        if (is_wp_error($content)) {
+            return $content;
+        }
+        $mime = '';
+        if (function_exists('finfo_open')) {
+            $finfo = finfo_open(FILEINFO_MIME_TYPE);
+            if ($finfo) {
+                $mime = sanitize_mime_type((string) finfo_file($finfo, $tmp_name));
+                finfo_close($finfo);
+            }
+        }
+        $browser_mime = sanitize_mime_type($file['type'] ?? '');
+        if ($browser_mime && in_array($browser_mime, self::allowed_csv_mimes(), true)) {
+            $mime = $browser_mime;
+        }
+        if ($mime && !in_array($mime, self::allowed_csv_mimes(), true)) {
+            return new WP_Error('geo_csv_invalid_mime', __('MIME non consentito. Il file caricato non sembra un CSV valido.', 'affiliate-link-manager-ai'), array('mime' => $mime));
+        }
+        unset($article_importer);
+        return array('file_name' => $file_name, 'tmp_name' => $tmp_name, 'mime' => $mime, 'headers' => $content['headers'], 'delimiter' => $content['delimiter']);
+    }
+
+    public function validate_csv_content($file_path) {
+        if (!$file_path || !is_readable($file_path)) {
+            return new WP_Error('geo_csv_not_readable', __('File non leggibile.', 'affiliate-link-manager-ai'));
+        }
+        $delimiter = $this->detect_csv_delimiter($file_path);
+        $handle = fopen($file_path, 'r');
+        if (!$handle) {
+            return new WP_Error('geo_csv_not_readable', __('File non leggibile.', 'affiliate-link-manager-ai'));
+        }
+        $headers = fgetcsv($handle, 0, $delimiter);
+        fclose($handle);
+        if (isset($headers[0])) {
+            $headers[0] = preg_replace('/^\xEF\xBB\xBF/', '', $headers[0]);
+        }
+        $headers = array_map('sanitize_key', (array) $headers);
+        $headers = array_values(array_filter($headers));
+        if (empty($headers) || count($headers) < 2) {
+            return new WP_Error('geo_csv_missing_headers', __('CSV senza intestazioni.', 'affiliate-link-manager-ai'));
+        }
+        $validation = $this->validate_headers($headers);
+        if (!$validation['valid']) {
+            return new WP_Error('geo_csv_required_headers_missing', sprintf(__('Intestazioni obbligatorie mancanti: %s', 'affiliate-link-manager-ai'), implode(', ', $validation['missing'])), array('missing' => $validation['missing']));
+        }
+        return array('headers' => $headers, 'delimiter' => $delimiter);
+    }
+
+    public function parse_csv_file($file_path, $limit = 0, $delimiter = null) {
+        $rows = array();
+        $headers = array();
+        $total = 0;
+        $delimiter = $delimiter ?: $this->detect_csv_delimiter($file_path);
+        $handle = fopen($file_path, 'r');
+        if (!$handle) {
+            return array('headers' => array(), 'rows' => array(), 'total' => 0, 'error' => 'file_open_failed', 'delimiter' => $delimiter);
+        }
+        while (($data = fgetcsv($handle, 0, $delimiter)) !== false) {
+            if (empty($headers)) {
+                if (isset($data[0])) {
+                    $data[0] = preg_replace('/^\xEF\xBB\xBF/', '', $data[0]);
+                }
+                $headers = array_map('sanitize_key', $data);
+                continue;
+            }
+            if ($this->is_empty_csv_row($data)) {
+                continue;
+            }
+            $total++;
+            if (!$limit || count($rows) < $limit) {
+                $rows[] = $this->normalize_row(array_combine($headers, array_slice(array_pad($data, count($headers), ''), 0, count($headers))));
+            }
+        }
+        fclose($handle);
+        return array('headers' => $headers, 'rows' => $rows, 'total' => $total, 'error' => '', 'delimiter' => $delimiter);
+    }
+
+    public function normalize_row($row) {
+        $normalized = array();
+        foreach ((array) $row as $key => $value) {
+            $key = sanitize_key($key);
+            if (is_string($value)) {
+                $normalized[$key] = trim($value);
+            } else {
+                $normalized[$key] = $value;
+            }
+        }
+        $normalized['affiliate_link_id'] = absint($normalized['affiliate_link_id'] ?? 0);
+        $normalized['primary_type'] = sanitize_key($normalized['primary_type'] ?? 'unknown');
+        $normalized['primary_country_code'] = strtoupper(sanitize_text_field($normalized['primary_country_code'] ?? ''));
+        $normalized['final_bucket'] = sanitize_key($normalized['final_bucket'] ?? '');
+        return $normalized;
+    }
+
+    public function is_safe_row($row) {
+        return $this->to_bool($row['safe_for_auto_import'] ?? false) && sanitize_key($row['final_bucket'] ?? '') === 'safe_import';
+    }
+
+    public function create_job_from_csv($file_path, $args = array()) {
+        $args = wp_parse_args($args, array(
+            'file_name' => basename($file_path),
+            'delimiter' => null,
+            'overwrite' => false,
+            'safe_only' => true,
+            'batch_size' => 50,
+        ));
+        $job_store = new ALMA_Geo_Index_Job_Store();
+        $job_id = $job_store->create_job(ALMA_Geo_Index_Job_Store::JOB_TYPE_AFFILIATE_LINKS_GEO_IMPORT, $args['file_name'], array(
+            'overwrite' => !empty($args['overwrite']),
+            'safe_only' => !empty($args['safe_only']),
+            'batch_size' => max(1, min(100, absint($args['batch_size']))),
+        ), get_current_user_id());
+        $parsed = $this->parse_csv_file($file_path, 0, $args['delimiter']);
+        $row_number = 1;
+        foreach ($parsed['rows'] as $row) {
+            $row_number++;
+            $job_store->add_job_item($job_id, $row_number, $row, absint($row['affiliate_link_id'] ?? 0), ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK);
+        }
+        $job_store->set_total_records($job_id, (int) $parsed['total']);
+        return $job_id;
+    }
+
+    public function process_job_batch($job_id, $batch_size = 50, $retry_errors = false) {
+        $job_store = new ALMA_Geo_Index_Job_Store();
+        $job = $job_store->get_job($job_id);
+        if (!$job) {
+            return new WP_Error('alma_geo_job_not_found', __('Job non trovato.', 'affiliate-link-manager-ai'));
+        }
+        if (in_array($job['status'], array('paused','cancelled','completed','failed'), true)) {
+            return array('processed' => 0, 'job' => $job_store->get_job($job_id));
+        }
+        $job_store->update_job_status($job_id, 'running');
+        $options = is_array($job['options']) ? $job['options'] : array();
+        $batch_size = max(1, min(100, absint($batch_size ?: ($options['batch_size'] ?? 50))));
+        $items = $job_store->claim_items($job_id, $batch_size, $retry_errors ? array('queued','error') : array('queued'));
+        foreach ($items as $item) {
+            $row = $this->normalize_row($item['raw_payload']);
+            $result = $this->import_row($row, $options);
+            $job_store->update_item_result((int) $item['id'], $result['status'], $result['action'], $result['message'], $result['object_id'], ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK);
+        }
+        $job_store->recount_job($job_id);
+        $job = $job_store->maybe_complete_job($job_id);
+        return array('processed' => count($items), 'job' => $job, 'items' => $job_store->get_items($job_id, 50));
+    }
+
+    public function import_row($row, $args = array()) {
+        $args = wp_parse_args($args, array('overwrite' => false, 'safe_only' => true));
+        $row = $this->normalize_row($row);
+        $affiliate_link_id = absint($row['affiliate_link_id'] ?? 0);
+        if (!$affiliate_link_id) {
+            return $this->row_result('error', 'invalid_affiliate_link_id', 0);
+        }
+        if (!empty($args['safe_only']) && !$this->is_safe_row($row)) {
+            return $this->row_result('skipped', 'safe_import_skipped', $affiliate_link_id);
+        }
+        $post = get_post($affiliate_link_id);
+        if (!$post) {
+            return $this->row_result('error', 'affiliate_link_not_found', $affiliate_link_id);
+        }
+        if ($post->post_type !== ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK) {
+            return $this->row_result('error', 'object_not_affiliate_link', $affiliate_link_id);
+        }
+        if ($this->has_existing_geo($affiliate_link_id) && empty($args['overwrite'])) {
+            return $this->row_result('skipped', 'skipped_existing_geo existing_geo_skipped', $affiliate_link_id);
+        }
+
+        $before_locations = $this->count_locations();
+        $before_relations = $this->count_relations($affiliate_link_id);
+        $geo_data = $this->row_to_geo_data($row);
+        if (empty($geo_data['primary_location']['canonical_name']) && empty($geo_data['primary_location']['name'])) {
+            return $this->row_result('error', 'missing_primary_location', $affiliate_link_id);
+        }
+        $result = $this->store->save_geo_meta_for_object($affiliate_link_id, ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK, $geo_data, self::SOURCE);
+        update_post_meta($affiliate_link_id, '_alma_geo_activity_type', sanitize_key($row['activity_type'] ?? 'unknown'));
+        update_post_meta($affiliate_link_id, '_alma_geo_import_status', 'imported');
+        update_post_meta($affiliate_link_id, '_alma_geo_source', self::SOURCE);
+        update_post_meta($affiliate_link_id, '_alma_geo_primary_provider', sanitize_text_field($row['primary_provider'] ?? ''));
+        update_post_meta($affiliate_link_id, '_alma_geo_provider', sanitize_text_field($row['primary_provider'] ?? ''));
+
+        $after_locations = $this->count_locations();
+        $after_relations = $this->count_relations($affiliate_link_id);
+        $was_existing = !empty($args['overwrite']) && $before_relations > 0;
+        $message = $was_existing ? 'updated_existing_geo' : 'imported';
+        $message .= ' secondaries_imported=' . max(0, count($result['locations'] ?? array()) - 1);
+        if (!empty($geo_data['secondary_locations_json_invalid'])) {
+            $message .= ' secondary_locations_json_invalid';
+        }
+        $message .= ' locations_created=' . max(0, $after_locations - $before_locations);
+        $message .= ' locations_reused=' . max(0, count($result['locations'] ?? array()) - max(0, $after_locations - $before_locations));
+        $message .= ' relations_created=' . max(0, $after_relations - $before_relations);
+        $message .= ' relations_updated=' . ($was_existing ? max(1, $after_relations) : 0);
+
+        return $this->row_result($was_existing ? 'updated' : 'imported', $message, $affiliate_link_id);
+    }
+
+    public function import_primary_location($affiliate_link_id, $row, $args = array()) {
+        $geo_data = $this->row_to_geo_data($this->normalize_row($row));
+        $location_id = $this->store->upsert_location($this->location_to_store_row($geo_data['primary_location']));
+        if ($location_id) {
+            $this->store->upsert_content_index($affiliate_link_id, ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK, $location_id, array(
+                'is_primary' => 1,
+                'role' => 'main_destination',
+                'geo_scope' => $geo_data['geo_scope'],
+                'content_type' => 'affiliate_link',
+                'commercial_intent' => $geo_data['commercial_intent'],
+                'widget_eligible' => $geo_data['widget_eligible'],
+                'confidence' => $geo_data['primary_location']['confidence'],
+                'match_weight' => $geo_data['primary_location']['match_weight'],
+                'source' => self::SOURCE,
+                'raw_payload' => array('location' => $geo_data['primary_location'], 'row' => $row),
+            ));
+        }
+        return $location_id;
+    }
+
+    public function import_secondary_locations($affiliate_link_id, $row, $args = array()) {
+        $geo_data = $this->row_to_geo_data($this->normalize_row($row));
+        $ids = array();
+        foreach ($geo_data['secondary_locations'] as $secondary) {
+            $location_id = $this->store->upsert_location($this->location_to_store_row($secondary));
+            if ($location_id) {
+                $ids[] = $location_id;
+                $this->store->upsert_content_index($affiliate_link_id, ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK, $location_id, array(
+                    'is_primary' => 0,
+                    'role' => $secondary['role'],
+                    'geo_scope' => $geo_data['geo_scope'],
+                    'content_type' => 'affiliate_link',
+                    'commercial_intent' => $geo_data['commercial_intent'],
+                    'widget_eligible' => $geo_data['widget_eligible'],
+                    'confidence' => $secondary['confidence'],
+                    'match_weight' => $secondary['match_weight'],
+                    'source' => self::SOURCE,
+                    'raw_payload' => array('location' => $secondary, 'row' => $row),
+                ));
+            }
+        }
+        return $ids;
+    }
+
+    private function row_to_geo_data($row) {
+        $primary = array(
+            'name' => sanitize_text_field($row['primary_name'] ?? ''),
+            'canonical_name' => sanitize_text_field($row['primary_canonical_name'] ?? ($row['primary_name'] ?? '')),
+            'type' => $this->allowed_or_default($row['primary_type'] ?? '', ALMA_Geo_Index_Metabox::primary_types(), 'unknown'),
+            'country' => sanitize_text_field($row['primary_country'] ?? ''),
+            'country_code' => strtoupper(sanitize_text_field($row['primary_country_code'] ?? '')),
+            'region' => sanitize_text_field($row['primary_region'] ?? ''),
+            'city' => sanitize_text_field($row['primary_city'] ?? ''),
+            'area' => sanitize_text_field($row['primary_area'] ?? ''),
+            'poi' => sanitize_text_field($row['primary_poi'] ?? ''),
+            'lat' => isset($row['primary_lat']) ? $this->float_or_empty($row['primary_lat']) : '',
+            'lng' => isset($row['primary_lng']) ? $this->float_or_empty($row['primary_lng']) : '',
+            'geo_provider' => sanitize_key($row['primary_provider'] ?? ''),
+            'geo_provider_place_id' => sanitize_text_field($row['primary_place_id'] ?? ''),
+            'suggested_geocoding_query' => sanitize_text_field($row['primary_suggested_geocoding_query'] ?? ''),
+            'formatted_address' => sanitize_text_field($row['primary_formatted_address'] ?? ''),
+            'geocoding_status' => 'pending',
+            'role' => sanitize_key($row['primary_role'] ?? 'main_destination'),
+            'is_primary' => true,
+            'source' => self::SOURCE,
+            'confidence' => isset($row['confidence']) && $row['confidence'] !== '' ? min(1, max(0, (float) $row['confidence'])) : 1,
+            'match_weight' => isset($row['match_weight']) && $row['match_weight'] !== '' ? (int) $row['match_weight'] : 100,
+            'activity_type' => sanitize_key($row['activity_type'] ?? 'unknown'),
+        );
+        $secondary_info = $this->parse_secondary_locations($row);
+        $locations = array_merge(array($primary), $secondary_info['locations']);
+        $locations = $this->sort_and_limit_locations($locations);
+        $primary = array_shift($locations);
+        return array(
+            'geo_scope' => $this->allowed_or_default($row['geo_scope'] ?? '', ALMA_Geo_Index_Metabox::geo_scopes(), 'uncertain'),
+            'content_type' => 'affiliate_link',
+            'commercial_intent' => $this->allowed_or_default($row['commercial_intent'] ?? '', ALMA_Geo_Index_Metabox::commercial_intents(), 'none'),
+            'widget_eligible' => $this->to_bool($row['widget_eligible'] ?? false),
+            'activity_type' => sanitize_key($row['activity_type'] ?? 'unknown'),
+            'quality_flags' => sanitize_textarea_field($row['geo_quality_flags'] ?? ''),
+            'notes' => sanitize_textarea_field($row['notes'] ?? ''),
+            'primary_location' => $primary,
+            'secondary_locations' => $locations,
+            'secondary_locations_json_invalid' => $secondary_info['invalid'],
+            'locations' => array_merge(array($primary), $locations),
+            'raw_payload' => $row,
+        );
+    }
+
+    private function parse_secondary_locations($row) {
+        $raw = trim((string) ($row['secondary_locations_json'] ?? ''));
+        if ($raw === '') {
+            return array('locations' => array(), 'invalid' => false);
+        }
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            return array('locations' => array(), 'invalid' => true);
+        }
+        $locations = array();
+        foreach ($decoded as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+            $name = sanitize_text_field($item['name'] ?? ($item['canonical_name'] ?? ''));
+            $canonical = sanitize_text_field($item['canonical_name'] ?? $name);
+            if ($canonical === '' && $name === '') {
+                continue;
+            }
+            $locations[] = array(
+                'name' => $name,
+                'canonical_name' => $canonical,
+                'type' => $this->allowed_or_default($item['type'] ?? 'unknown', ALMA_Geo_Index_Metabox::primary_types(), 'unknown'),
+                'country' => sanitize_text_field($item['country'] ?? ($row['primary_country'] ?? '')),
+                'country_code' => strtoupper(sanitize_text_field($item['country_code'] ?? ($row['primary_country_code'] ?? ''))),
+                'region' => sanitize_text_field($item['region'] ?? ''),
+                'city' => sanitize_text_field($item['city'] ?? ''),
+                'area' => sanitize_text_field($item['area'] ?? ''),
+                'poi' => sanitize_text_field($item['poi'] ?? ''),
+                'lat' => isset($item['lat']) ? $this->float_or_empty($item['lat']) : '',
+                'lng' => isset($item['lng']) ? $this->float_or_empty($item['lng']) : '',
+                'geo_provider' => sanitize_key($item['geo_provider'] ?? ''),
+                'geo_provider_place_id' => sanitize_text_field($item['geo_provider_place_id'] ?? ($item['place_id'] ?? '')),
+                'suggested_geocoding_query' => sanitize_text_field($item['suggested_geocoding_query'] ?? ($item['query'] ?? '')),
+                'formatted_address' => sanitize_text_field($item['formatted_address'] ?? ''),
+                'geocoding_status' => 'pending',
+                'role' => sanitize_key($item['role'] ?? 'major_destination'),
+                'is_primary' => false,
+                'source' => self::SOURCE,
+                'confidence' => isset($item['confidence']) && $item['confidence'] !== '' ? min(1, max(0, (float) $item['confidence'])) : (isset($row['confidence']) ? (float) $row['confidence'] : 0.7),
+                'match_weight' => isset($item['match_weight']) && $item['match_weight'] !== '' ? (int) $item['match_weight'] : 70,
+            );
+        }
+        return array('locations' => $locations, 'invalid' => false);
+    }
+
+    private function sort_and_limit_locations($locations) {
+        $primary = array_shift($locations);
+        $weights = array('main_destination' => 1000, 'major_destination' => 800, 'excursion' => 700, 'nearby_place' => 600, 'route_stop' => 500, 'mentioned_destination' => 400, 'context_only' => 100);
+        usort($locations, function($a, $b) use ($weights) {
+            $aw = $weights[$a['role'] ?? ''] ?? 0;
+            $bw = $weights[$b['role'] ?? ''] ?? 0;
+            if ($aw === $bw) {
+                return (float) ($b['confidence'] ?? 0) <=> (float) ($a['confidence'] ?? 0);
+            }
+            return $bw <=> $aw;
+        });
+        $locations = array_slice($locations, 0, self::MAX_ASSOCIATED_LOCATIONS - 1);
+        return array_merge(array($primary), $locations);
+    }
+
+    private function location_to_store_row($location) {
+        return array(
+            'canonical_name' => $location['canonical_name'] ?: $location['name'],
+            'type' => $location['type'],
+            'country' => $location['country'],
+            'country_code' => $location['country_code'],
+            'region' => $location['region'],
+            'city' => $location['city'],
+            'area' => $location['area'],
+            'poi' => $location['poi'],
+            'lat' => $location['lat'],
+            'lng' => $location['lng'],
+            'geo_provider' => $location['geo_provider'],
+            'geo_provider_place_id' => $location['geo_provider_place_id'],
+            'suggested_geocoding_query' => $location['suggested_geocoding_query'],
+            'geocoding_status' => 'pending',
+            'formatted_address' => $location['formatted_address'],
+        );
+    }
+
+    private function has_existing_geo($affiliate_link_id) {
+        if (get_post_meta($affiliate_link_id, '_alma_geo_enabled', true) === 'yes') {
+            return true;
+        }
+        return (bool) $this->store->get_primary_location_for_object($affiliate_link_id, ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK);
+    }
+
+    private function row_result($status, $message, $object_id) {
+        return array('status' => sanitize_key($status), 'action' => sanitize_key(strtok($message, ' ')), 'message' => sanitize_textarea_field($message), 'object_id' => absint($object_id));
+    }
+
+    private function count_locations() {
+        global $wpdb;
+        return $this->store->tables_exist() ? (int) $wpdb->get_var("SELECT COUNT(*) FROM {$this->store->table_locations()}") : 0;
+    }
+
+    private function count_relations($object_id) {
+        global $wpdb;
+        return $this->store->tables_exist() ? (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$this->store->table_content_index()} WHERE object_id = %d AND object_type = %s", absint($object_id), ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK)) : 0;
+    }
+
+    private function detect_csv_delimiter($file_path) {
+        $line = '';
+        $handle = fopen($file_path, 'r');
+        if ($handle) {
+            $line = (string) fgets($handle);
+            fclose($handle);
+        }
+        return substr_count($line, ';') > substr_count($line, ',') ? ';' : ',';
+    }
+
+    private function is_empty_csv_row($row) {
+        foreach ((array) $row as $value) {
+            if (trim((string) $value) !== '') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private function allowed_or_default($value, $allowed, $default) {
+        $value = sanitize_key($value);
+        return in_array($value, $allowed, true) ? $value : $default;
+    }
+
+    private function to_bool($value) {
+        if (is_bool($value)) {
+            return $value;
+        }
+        $value = strtolower(trim((string) $value));
+        return in_array($value, array('1','true','yes','y','si','sì','on'), true);
+    }
+
+    private function float_or_empty($value) {
+        return $value === '' || $value === null ? '' : (string) (float) $value;
+    }
+}

--- a/includes/class-geo-index-job-store.php
+++ b/includes/class-geo-index-job-store.php
@@ -1,0 +1,299 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+/**
+ * Persistent background job store for Geo Index imports.
+ */
+class ALMA_Geo_Index_Job_Store {
+    const JOB_TYPE_AFFILIATE_LINKS_GEO_IMPORT = 'affiliate_links_geo_import';
+
+    public function table_jobs() {
+        global $wpdb;
+        return $wpdb->prefix . 'alma_geo_import_jobs';
+    }
+
+    public function table_items() {
+        global $wpdb;
+        return $wpdb->prefix . 'alma_geo_import_job_items';
+    }
+
+    public static function create_tables() {
+        $store = new self();
+        $store->install_tables();
+    }
+
+    public function install_tables() {
+        global $wpdb;
+        $charset_collate = $wpdb->get_charset_collate();
+        $jobs = $this->table_jobs();
+        $items = $this->table_items();
+
+        $sql_jobs = "CREATE TABLE $jobs (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            job_type VARCHAR(80) NOT NULL,
+            status VARCHAR(40) NOT NULL DEFAULT 'queued',
+            file_name VARCHAR(255) DEFAULT '',
+            total_records INT NOT NULL DEFAULT 0,
+            processed_records INT NOT NULL DEFAULT 0,
+            imported_records INT NOT NULL DEFAULT 0,
+            updated_records INT NOT NULL DEFAULT 0,
+            skipped_records INT NOT NULL DEFAULT 0,
+            error_records INT NOT NULL DEFAULT 0,
+            options LONGTEXT NULL,
+            created_by BIGINT UNSIGNED NULL,
+            created_at DATETIME NOT NULL,
+            started_at DATETIME NULL,
+            finished_at DATETIME NULL,
+            last_error TEXT NULL,
+            PRIMARY KEY  (id),
+            KEY job_type (job_type),
+            KEY status (status)
+        ) $charset_collate;";
+
+        $sql_items = "CREATE TABLE $items (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            job_id BIGINT UNSIGNED NOT NULL,
+            object_id BIGINT UNSIGNED NULL,
+            object_type VARCHAR(50) DEFAULT '',
+            row_number INT NOT NULL,
+            status VARCHAR(40) NOT NULL DEFAULT 'queued',
+            action VARCHAR(40) DEFAULT '',
+            message TEXT NULL,
+            raw_payload LONGTEXT NULL,
+            processed_at DATETIME NULL,
+            PRIMARY KEY  (id),
+            KEY job_id (job_id),
+            KEY status (status),
+            KEY object_lookup (object_id, object_type)
+        ) $charset_collate;";
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta($sql_jobs);
+        dbDelta($sql_items);
+    }
+
+    public function tables_exist() {
+        global $wpdb;
+        $jobs = $this->table_jobs();
+        $items = $this->table_items();
+        return $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $jobs)) === $jobs
+            && $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $items)) === $items;
+    }
+
+    public function create_job($job_type, $file_name, $options = array(), $created_by = 0) {
+        global $wpdb;
+        if (!$this->tables_exist()) {
+            $this->install_tables();
+        }
+        $wpdb->insert($this->table_jobs(), array(
+            'job_type' => sanitize_key($job_type),
+            'status' => 'queued',
+            'file_name' => sanitize_file_name($file_name),
+            'total_records' => 0,
+            'processed_records' => 0,
+            'imported_records' => 0,
+            'updated_records' => 0,
+            'skipped_records' => 0,
+            'error_records' => 0,
+            'options' => wp_json_encode(is_array($options) ? $options : array()),
+            'created_by' => absint($created_by),
+            'created_at' => current_time('mysql'),
+        ), array('%s','%s','%s','%d','%d','%d','%d','%d','%d','%s','%d','%s'));
+        return (int) $wpdb->insert_id;
+    }
+
+    public function add_job_item($job_id, $row_number, $payload, $object_id = 0, $object_type = '') {
+        global $wpdb;
+        $wpdb->insert($this->table_items(), array(
+            'job_id' => absint($job_id),
+            'object_id' => $object_id ? absint($object_id) : null,
+            'object_type' => sanitize_key($object_type),
+            'row_number' => absint($row_number),
+            'status' => 'queued',
+            'action' => '',
+            'message' => '',
+            'raw_payload' => wp_json_encode(is_array($payload) ? $payload : array()),
+            'processed_at' => null,
+        ), array('%d','%d','%s','%d','%s','%s','%s','%s','%s'));
+        return (int) $wpdb->insert_id;
+    }
+
+    public function set_total_records($job_id, $total) {
+        global $wpdb;
+        return $wpdb->update($this->table_jobs(), array('total_records' => absint($total)), array('id' => absint($job_id)), array('%d'), array('%d'));
+    }
+
+    public function get_job($job_id) {
+        global $wpdb;
+        $job = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$this->table_jobs()} WHERE id = %d", absint($job_id)), ARRAY_A);
+        if ($job) {
+            $job['options'] = json_decode((string) ($job['options'] ?? ''), true) ?: array();
+        }
+        return $job;
+    }
+
+    public function get_latest_job($job_type = self::JOB_TYPE_AFFILIATE_LINKS_GEO_IMPORT) {
+        global $wpdb;
+        $job = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$this->table_jobs()} WHERE job_type = %s ORDER BY id DESC LIMIT 1", sanitize_key($job_type)), ARRAY_A);
+        if ($job) {
+            $job['options'] = json_decode((string) ($job['options'] ?? ''), true) ?: array();
+        }
+        return $job;
+    }
+
+    public function update_job_status($job_id, $status, $last_error = '') {
+        global $wpdb;
+        $status = sanitize_key($status);
+        $allowed = array('queued','running','paused','completed','failed','cancelled');
+        if (!in_array($status, $allowed, true)) {
+            return false;
+        }
+        $row = array('status' => $status, 'last_error' => sanitize_textarea_field($last_error));
+        $formats = array('%s','%s');
+        if ($status === 'running') {
+            $row['started_at'] = current_time('mysql');
+            $formats[] = '%s';
+        }
+        if (in_array($status, array('completed','failed','cancelled'), true)) {
+            $row['finished_at'] = current_time('mysql');
+            $formats[] = '%s';
+        }
+        return $wpdb->update($this->table_jobs(), $row, array('id' => absint($job_id)), $formats, array('%d'));
+    }
+
+    public function claim_items($job_id, $limit = 50, $statuses = array('queued')) {
+        global $wpdb;
+        $limit = max(1, min(100, absint($limit)));
+        $statuses = array_map('sanitize_key', (array) $statuses);
+        $statuses = array_values(array_intersect($statuses, array('queued','error')));
+        if (empty($statuses)) {
+            $statuses = array('queued');
+        }
+        $placeholders = implode(',', array_fill(0, count($statuses), '%s'));
+        $params = array_merge(array(absint($job_id)), $statuses, array($limit));
+        $items = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$this->table_items()} WHERE job_id = %d AND status IN ($placeholders) ORDER BY id ASC LIMIT %d", $params), ARRAY_A);
+        foreach ($items as &$item) {
+            $wpdb->update($this->table_items(), array('status' => 'processing'), array('id' => (int) $item['id']), array('%s'), array('%d'));
+            $item['raw_payload'] = json_decode((string) ($item['raw_payload'] ?? ''), true) ?: array();
+        }
+        return $items;
+    }
+
+    public function update_item_result($item_id, $status, $action, $message, $object_id = 0, $object_type = '') {
+        global $wpdb;
+        $status = sanitize_key($status);
+        $allowed = array('queued','processing','imported','updated','skipped','error');
+        if (!in_array($status, $allowed, true)) {
+            $status = 'error';
+        }
+        return $wpdb->update($this->table_items(), array(
+            'object_id' => $object_id ? absint($object_id) : null,
+            'object_type' => sanitize_key($object_type),
+            'status' => $status,
+            'action' => sanitize_key($action),
+            'message' => sanitize_textarea_field($message),
+            'processed_at' => current_time('mysql'),
+        ), array('id' => absint($item_id)), array('%d','%s','%s','%s','%s','%s'), array('%d'));
+    }
+
+    public function recount_job($job_id) {
+        global $wpdb;
+        $job_id = absint($job_id);
+        $counts = array('processed' => 0, 'imported' => 0, 'updated' => 0, 'skipped' => 0, 'error' => 0, 'queued' => 0, 'processing' => 0);
+        $rows = $wpdb->get_results($wpdb->prepare("SELECT status, COUNT(*) AS total FROM {$this->table_items()} WHERE job_id = %d GROUP BY status", $job_id), ARRAY_A);
+        foreach ($rows as $row) {
+            $status = sanitize_key($row['status'] ?? '');
+            $total = (int) $row['total'];
+            if (isset($counts[$status])) {
+                $counts[$status] = $total;
+            }
+            if (in_array($status, array('imported','updated','skipped','error'), true)) {
+                $counts['processed'] += $total;
+            }
+        }
+        $wpdb->update($this->table_jobs(), array(
+            'processed_records' => $counts['processed'],
+            'imported_records' => $counts['imported'],
+            'updated_records' => $counts['updated'],
+            'skipped_records' => $counts['skipped'],
+            'error_records' => $counts['error'],
+        ), array('id' => $job_id), array('%d','%d','%d','%d','%d'), array('%d'));
+        return $counts;
+    }
+
+    public function maybe_complete_job($job_id) {
+        $job = $this->get_job($job_id);
+        if (!$job || in_array($job['status'], array('paused','cancelled','failed','completed'), true)) {
+            return $job;
+        }
+        $counts = $this->recount_job($job_id);
+        if ($counts['queued'] === 0 && $counts['processing'] === 0) {
+            $this->update_job_status($job_id, 'completed');
+        }
+        return $this->get_job($job_id);
+    }
+
+    public function get_items($job_id, $limit = 50, $statuses = array()) {
+        global $wpdb;
+        $limit = max(1, min(200, absint($limit)));
+        if (!empty($statuses)) {
+            $statuses = array_map('sanitize_key', (array) $statuses);
+            $placeholders = implode(',', array_fill(0, count($statuses), '%s'));
+            $params = array_merge(array(absint($job_id)), $statuses, array($limit));
+            $rows = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$this->table_items()} WHERE job_id = %d AND status IN ($placeholders) ORDER BY id DESC LIMIT %d", $params), ARRAY_A);
+        } else {
+            $rows = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$this->table_items()} WHERE job_id = %d ORDER BY id DESC LIMIT %d", absint($job_id), $limit), ARRAY_A);
+        }
+        return $rows ?: array();
+    }
+
+    public function reset_error_items($job_id) {
+        global $wpdb;
+        return $wpdb->update($this->table_items(), array('status' => 'queued', 'action' => 'retry', 'processed_at' => null), array('job_id' => absint($job_id), 'status' => 'error'), array('%s','%s','%s'), array('%d','%s'));
+    }
+
+    public function get_report($job_id) {
+        $job = $this->get_job($job_id);
+        if (!$job) {
+            return array();
+        }
+        $items = $this->get_items($job_id, 5000);
+        $report = array(
+            'date' => $job['finished_at'] ?: $job['created_at'],
+            'file' => $job['file_name'],
+            'records_read' => (int) $job['total_records'],
+            'records_processed' => (int) $job['processed_records'],
+            'imported' => (int) $job['imported_records'],
+            'updated' => (int) $job['updated_records'],
+            'skipped' => (int) $job['skipped_records'],
+            'errors' => (int) $job['error_records'],
+            'affiliate_link_not_found' => 0,
+            'object_not_affiliate_link' => 0,
+            'safe_import_skipped' => 0,
+            'existing_geo_skipped' => 0,
+            'secondaries_imported' => 0,
+            'secondary_locations_json_invalid' => 0,
+            'locations_created' => 0,
+            'locations_reused' => 0,
+            'relations_created' => 0,
+            'relations_updated' => 0,
+        );
+        foreach ($items as $item) {
+            $message = (string) ($item['message'] ?? '');
+            foreach (array('affiliate_link_not_found','object_not_affiliate_link','safe_import_skipped','existing_geo_skipped','secondary_locations_json_invalid') as $needle) {
+                if (strpos($message, $needle) !== false) {
+                    $report[$needle]++;
+                }
+            }
+            if (preg_match('/secondaries_imported=(\d+)/', $message, $m)) {
+                $report['secondaries_imported'] += (int) $m[1];
+            }
+            foreach (array('locations_created','locations_reused','relations_created','relations_updated') as $metric) {
+                if (preg_match('/' . $metric . '=(\d+)/', $message, $m)) {
+                    $report[$metric] += (int) $m[1];
+                }
+            }
+        }
+        return $report;
+    }
+}

--- a/includes/class-geo-index-metabox.php
+++ b/includes/class-geo-index-metabox.php
@@ -222,6 +222,7 @@ class ALMA_Geo_Index_Metabox {
                     <?php $this->render_input('_alma_geo_confidence', __('Confidence', 'affiliate-link-manager-ai'), $values, 'number', 'step="0.001" min="0" max="1"'); ?>
                     <?php $this->render_input('_alma_geo_match_weight', __('Match weight', 'affiliate-link-manager-ai'), $values, 'number'); ?>
                     <?php $this->render_input('_alma_geo_source', __('Fonte dati', 'affiliate-link-manager-ai'), $values); ?>
+                    <?php $this->render_input('_alma_geo_activity_type', __('Activity type', 'affiliate-link-manager-ai'), $values); ?>
                     <?php $this->render_select('_alma_geo_import_status', __('Stato import tecnico', 'affiliate-link-manager-ai'), $values, self::geo_import_statuses()); ?>
                     <?php $this->render_select('_alma_geo_geocoding_status', __('Stato geocoding tecnico', 'affiliate-link-manager-ai'), array_merge($values, array('_alma_geo_geocoding_status' => $effective_geocoding_status)), self::geocoding_statuses()); ?>
                     <?php $this->render_input('_alma_geo_primary_type', __('Tipo località tecnico', 'affiliate-link-manager-ai'), $display_values); ?>
@@ -433,7 +434,7 @@ class ALMA_Geo_Index_Metabox {
         $data['_alma_geo_import_status'] = $this->sanitize_allowed($raw['_alma_geo_import_status'] ?? '', self::geo_import_statuses(), 'review');
         $data['_alma_geo_geocoding_status'] = $this->sanitize_allowed($raw['_alma_geo_geocoding_status'] ?? '', self::geocoding_statuses(), 'pending');
 
-        foreach (array('_alma_geo_primary_name','_alma_geo_primary_canonical_name','_alma_geo_primary_country','_alma_geo_primary_country_code','_alma_geo_primary_region','_alma_geo_primary_city','_alma_geo_primary_area','_alma_geo_primary_poi','_alma_geo_primary_place_id','_alma_geo_provider','_alma_geo_primary_provider','_alma_geo_primary_formatted_address','_alma_geo_source') as $key) {
+        foreach (array('_alma_geo_primary_name','_alma_geo_primary_canonical_name','_alma_geo_primary_country','_alma_geo_primary_country_code','_alma_geo_primary_region','_alma_geo_primary_city','_alma_geo_primary_area','_alma_geo_primary_poi','_alma_geo_primary_place_id','_alma_geo_provider','_alma_geo_primary_provider','_alma_geo_primary_formatted_address','_alma_geo_source','_alma_geo_activity_type') as $key) {
             $data[$key] = sanitize_text_field($raw[$key] ?? '');
         }
         $data['_alma_geo_primary_country_code'] = strtoupper($data['_alma_geo_primary_country_code']);
@@ -456,13 +457,13 @@ class ALMA_Geo_Index_Metabox {
         return array(
             '_alma_geo_enabled','_alma_geo_scope','_alma_geo_content_type','_alma_geo_commercial_intent','_alma_geo_widget_eligible',
             '_alma_geo_primary_name','_alma_geo_primary_canonical_name','_alma_geo_primary_type','_alma_geo_primary_country','_alma_geo_primary_country_code','_alma_geo_primary_region','_alma_geo_primary_city','_alma_geo_primary_area','_alma_geo_primary_poi','_alma_geo_primary_lat','_alma_geo_primary_lng','_alma_geo_primary_place_id','_alma_geo_provider','_alma_geo_primary_provider','_alma_geo_primary_formatted_address',
-            '_alma_geo_confidence','_alma_geo_match_weight','_alma_geo_geocoding_status','_alma_geo_import_status','_alma_geo_locations_json','_alma_geo_quality_flags','_alma_geo_notes','_alma_geo_source','_alma_geo_updated_at'
+            '_alma_geo_confidence','_alma_geo_match_weight','_alma_geo_geocoding_status','_alma_geo_import_status','_alma_geo_locations_json','_alma_geo_quality_flags','_alma_geo_notes','_alma_geo_source','_alma_geo_activity_type','_alma_geo_updated_at'
         );
     }
 
     public static function geo_scopes() { return array('world','continent','country','region','city','area','poi','itinerary_multi_location','non_geo','uncertain'); }
     public static function primary_types() { return array('continent','country','region','city','area','island','poi','airport','port','route','unknown'); }
-    public static function content_types() { return array('destination_guide','country_guide','region_guide','city_guide','area_guide','poi_guide','itinerary','itinerary_multi_location','cruise_ship','cruise_company','travel_advice','honeymoon','informational','generic_travel','non_travel','uncertain'); }
+    public static function content_types() { return array('destination_guide','country_guide','region_guide','city_guide','area_guide','poi_guide','itinerary','itinerary_multi_location','cruise_ship','cruise_company','travel_advice','honeymoon','informational','generic_travel','affiliate_link','non_travel','uncertain'); }
     public static function commercial_intents() { return array('high','medium','low','none'); }
     public static function geo_import_statuses() { return array('imported','active','ready','review','discard','needs_geocoding','geocoding_failed'); }
     public static function geocoding_statuses() { return array('pending','verified','ambiguous','manual_required','failed','not_required'); }
@@ -475,7 +476,7 @@ class ALMA_Geo_Index_Metabox {
         if (($data['_alma_geo_scope'] ?? 'uncertain') !== 'uncertain' || ($data['_alma_geo_content_type'] ?? 'uncertain') !== 'uncertain' || ($data['_alma_geo_commercial_intent'] ?? 'none') !== 'none' || ($data['_alma_geo_import_status'] ?? 'review') !== 'review' || ($data['_alma_geo_geocoding_status'] ?? 'pending') !== 'pending' || ($data['_alma_geo_primary_type'] ?? 'unknown') !== 'unknown') {
             return true;
         }
-        foreach (array('_alma_geo_primary_name','_alma_geo_primary_canonical_name','_alma_geo_primary_country','_alma_geo_primary_country_code','_alma_geo_primary_region','_alma_geo_primary_city','_alma_geo_primary_area','_alma_geo_primary_poi','_alma_geo_primary_lat','_alma_geo_primary_lng','_alma_geo_primary_place_id','_alma_geo_confidence','_alma_geo_match_weight','_alma_geo_locations_json','_alma_geo_quality_flags','_alma_geo_notes','_alma_geo_source') as $key) {
+        foreach (array('_alma_geo_primary_name','_alma_geo_primary_canonical_name','_alma_geo_primary_country','_alma_geo_primary_country_code','_alma_geo_primary_region','_alma_geo_primary_city','_alma_geo_primary_area','_alma_geo_primary_poi','_alma_geo_primary_lat','_alma_geo_primary_lng','_alma_geo_primary_place_id','_alma_geo_confidence','_alma_geo_match_weight','_alma_geo_activity_type','_alma_geo_locations_json','_alma_geo_quality_flags','_alma_geo_notes','_alma_geo_source') as $key) {
             if (!empty($data[$key])) {
                 return true;
             }

--- a/includes/class-geo-index-store.php
+++ b/includes/class-geo-index-store.php
@@ -382,7 +382,7 @@ class ALMA_Geo_Index_Store {
                 'confidence' => $location['confidence'],
                 'match_weight' => $location['match_weight'],
                 'source' => $location['source'] ?: $source,
-                'raw_payload' => array('location' => $location),
+                'raw_payload' => array('location' => $location, 'activity_type' => sanitize_key($geo_data['activity_type'] ?? ''), 'import_payload' => isset($geo_data['raw_payload']) ? $geo_data['raw_payload'] : array()),
             ));
             if (!$content_index_id) {
                 $this->log_geo_store_event('warning', 'Geo Index Store could not upsert content index relation.', $object_id, $object_type);
@@ -420,6 +420,9 @@ class ALMA_Geo_Index_Store {
             '_alma_geo_primary_formatted_address' => $primary['formatted_address'] ?? '',
             '_alma_geo_confidence' => $primary['confidence'] ?? '',
             '_alma_geo_match_weight' => $primary['match_weight'] ?? '',
+            '_alma_geo_quality_flags' => sanitize_textarea_field($geo_data['quality_flags'] ?? ''),
+            '_alma_geo_notes' => sanitize_textarea_field($geo_data['notes'] ?? ''),
+            '_alma_geo_activity_type' => sanitize_key($geo_data['activity_type'] ?? ''),
             '_alma_geo_locations_json' => wp_json_encode($updated_locations),
             '_alma_geo_source' => $primary['source'] ?? $source,
             '_alma_geo_updated_at' => $now,
@@ -740,6 +743,7 @@ class ALMA_Geo_Index_Store {
             update_post_meta($object_id, '_alma_geo_primary_provider', (string) ($location['geo_provider'] ?? ''));
             update_post_meta($object_id, '_alma_geo_primary_formatted_address', (string) ($location['formatted_address'] ?? ''));
             update_post_meta($object_id, '_alma_geo_updated_at', current_time('mysql'));
+            $this->sync_locations_json_for_object($object_id, $object_type);
             $report['objects_updated']++;
         }
 
@@ -783,6 +787,42 @@ class ALMA_Geo_Index_Store {
             }
         }
         return $counts;
+    }
+
+    public function get_geocoding_status_counts_by_object_type($object_type) {
+        global $wpdb;
+        $object_type = sanitize_key($object_type);
+        $counts = array('pending' => 0, 'verified' => 0, 'ambiguous' => 0, 'manual_required' => 0, 'failed' => 0, 'not_required' => 0);
+        if (!$this->tables_exist() || $object_type === '') {
+            return $counts;
+        }
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT l.geocoding_status, COUNT(DISTINCT l.id) AS total
+                 FROM {$this->table_locations()} l
+                 INNER JOIN {$this->table_content_index()} ci ON ci.location_id = l.id
+                 WHERE ci.object_type = %s
+                 GROUP BY l.geocoding_status",
+                $object_type
+            ),
+            ARRAY_A
+        );
+        foreach ($rows as $row) {
+            $status = sanitize_key($row['geocoding_status'] ?? '');
+            if (isset($counts[$status])) {
+                $counts[$status] = (int) $row['total'];
+            }
+        }
+        return $counts;
+    }
+
+    public function sync_locations_json_for_object($object_id, $object_type) {
+        $locations = $this->get_associated_locations_for_object($object_id, $object_type);
+        if (empty($locations)) {
+            return false;
+        }
+        update_post_meta(absint($object_id), '_alma_geo_locations_json', wp_json_encode($locations));
+        return true;
     }
 
     public function update_location_geocoding($location_id, $result) {


### PR DESCRIPTION
### Motivation
- Fornire un importer CSV dedicato che associ località geografiche ai CPT `affiliate_link` usando `affiliate_link_id` e che lavori in background senza eseguire geocoding con Google durante l’import.
- Creare un sistema di job persistente con log/report, retry e controllo batch per permettere import di grandi CSV senza bloccare richieste admin.

### Description
- Aggiunte due nuove classi: `includes/class-geo-index-job-store.php` che introduce le tabelle `{$wpdb->prefix}alma_geo_import_jobs` e `{$wpdb->prefix}alma_geo_import_job_items` e API per creare/claim/contare/aggiornare job/item, e `includes/class-geo-index-affiliate-link-importer.php` che valida il CSV, crea job, popola job items e processa batch con le regole `safe_import` e `final_bucket` senza chiamare Google. 
- Estesa l’interfaccia admin `Indice Geografico` (`includes/class-geo-index-admin.php`) con la nuova tab `Import Link Affiliati` che mostra upload CSV, preview primi 10 record, opzioni `Sovrascrivi`/`Importa solo safe_import`, avvio job background, pulsanti `Pausa/Riprendi/Annulla/Riprova errori` e possibilità di scaricare il log CSV; aggiunti gli endpoint AJAX protetti `alma_geo_affiliate_import_status` e `alma_geo_affiliate_import_batch` per polling e batch processing. 
- Integrato il job store nella procedura di attivazione/upgrade (creazione tabelle idempotente via `dbDelta`) e collegato il flusso di import al `ALMA_Geo_Index_Store` per upsert delle località in `alma_geo_locations`, relazioni in `alma_geo_content_index` con `object_type = affiliate_link`, aggiornamento dei meta `_alma_geo_*` (incluso `_alma_geo_activity_type`, `_alma_geo_quality_flags`, `_alma_geo_notes`) e sincronizzazione JSON tecnico `_alma_geo_locations_json`. 
- Aggiornata la logica di geocoding/sync: l’import lascia località con `geocoding_status = pending` e la tab `Geocoding` mostra conteggi distinti per oggetti (articoli/pagine/link affiliati) e può eseguire il secondo passaggio di geocoding già esistente; inoltre il metodo di sincronizzazione ora aggiorna gli `affiliate_link` collegati. 

### Testing
- Eseguiti i controlli di sintassi PHP con `php -l` su `affiliate-link-manager-ai.php`, `includes/class-geo-index-affiliate-link-importer.php`, `includes/class-geo-index-job-store.php`, `includes/class-geo-index-store.php`, `includes/class-geo-index-admin.php`, `includes/class-geo-index-metabox.php`, `includes/class-geo-index-geocoder.php` e `includes/class-geo-index-google-geocoder.php`, tutti risultanti senza errori.
- Verificato `git diff --check` per segnalare problemi di whitespace o diff-check e non sono stati rilevati errori automatici. 
- L’admin UI include controlli nonce/capability e gli endpoint AJAX restituiscono strutture JSON coerenti durante i test locali di polling/batch (simulati con `fetch` nella pagina di job).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2519b4627483328b4c86e4bbd034aa)