### PR TITLE
Fix affiliate geo import job processing and redirect fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Corretto processamento background dell’import Geo Link Affiliati: gli item claimati avanzano da `queued` a esito finale e gli `skipped` contano come processati.
+- Aggiunti log diagnostici e messaggi errore persistenti per batch AJAX dell’import Geo Link Affiliati.
+- Migliorata progress bar dell’import Geo Link Affiliati con conteggio reale e marcatori 10%.
+- Corretta fallback redirect dei Link Affiliati per non intercettare visite intenzionali alla lista Articoli.
 - Corretto processamento background dell’import Geo Link Affiliati.
 - Aggiunto processamento AJAX batch con progress bar reale.
 - Aggiunti log visibili per i job di import.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@
 ### Indice Geografico — Import Link Affiliati
 
 - Aggiunta la tab **Import Link Affiliati** in **Indice Geografico** per caricare CSV AI come `sothra_geo_affiliate_links_index.csv`, validare gli header obbligatori e mostrare la preview dei primi 10 record.
-- L’import crea un job persistente `affiliate_links_geo_import`, salva le righe in `alma_geo_import_job_items` e processa batch AJAX da 50 righe (massimo 100), con pausa, ripresa, annullamento, retry errori, progress bar e ultimi log.
+- L’import crea un job persistente `affiliate_links_geo_import`, salva le righe in `alma_geo_import_job_items` e processa batch AJAX da 50 righe (massimo 100), con pausa, ripresa, annullamento, retry errori, progress bar reale con marcatori al 10%, conteggio `imported/updated/skipped/error`, diagnostica JSON del job e ultimi log item anche per righe ancora in coda.
 - Ogni riga valida viene associata al CPT `affiliate_link` tramite `affiliate_link_id`, aggiorna i post meta `_alma_geo_*`, salva `_alma_geo_activity_type`, crea/riusa località primarie e secondarie e aggiorna `alma_geo_locations` e `alma_geo_content_index` con `object_type=affiliate_link`.
 - L’import non chiama Google Maps: le località restano `pending` e vengono geocodificate solo nel passaggio separato della tab **Geocoding**, che ora evidenzia anche le località pending provenienti dai Link Affiliati.
+- Con **Importa solo safe_import** attivo, le righe non sicure vengono marcate `skipped` e contate come processate, quindi il job può completare anche quando molte righe sono saltate.
+- Gli errori AJAX batch restano visibili nel box **Errore ultimo batch** con HTTP status, timestamp e risposta raw troncata; l’auto-processing si ferma e lascia il pulsante **Riprova batch**.
 
 ### Indice Geografico — sincronizzazione geocoding
 - Le località `verified` sincronizzano i dati geocoding sui contenuti primari collegati tramite `alma_geo_content_index`, mantenendo compatibilità con i meta `_alma_geo_*` esistenti.

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -1119,6 +1119,9 @@ class AffiliateManagerAI {
             'created_at' => time(),
             'update' => $update ? 1 : 0,
             'message' => $message,
+            'needs_recovery' => 0,
+            'wrong_landing_expected' => 0,
+            'handled' => 0,
             'classic_editor' => $this->affiliate_link_update_requested_classic_editor() ? 1 : 0,
             'request_uri' => isset($_SERVER['REQUEST_URI']) ? esc_url_raw(wp_unslash($_SERVER['REQUEST_URI'])) : '',
             'referer' => wp_get_referer(),
@@ -1172,33 +1175,16 @@ class AffiliateManagerAI {
         if ($bypass_reason === '') {
             $transient_result = $this->resolve_affiliate_link_recovery_from_transient($data, $age);
             if (!empty($transient_result['post_id'])) {
-                $method = 'transient';
+                $method = 'transient_explicit_recovery';
                 $post_id = absint($transient_result['post_id']);
                 $message = absint($transient_result['message'] ?? 1) ?: 1;
                 $classic_editor = !empty($transient_result['classic_editor']);
             } else {
-                if ($transient_key && is_array($data) && in_array($transient_result['bypass_reason'] ?? '', array('stale_transient', 'invalid_transient_post'), true)) {
+                if ($transient_key && is_array($data) && in_array($transient_result['bypass_reason'] ?? '', array('stale_transient', 'invalid_transient_post', 'handled_transient'), true)) {
                     delete_transient($transient_key);
                     $context['transient_deleted'] = true;
                 }
-
-                $referer_result = $this->resolve_affiliate_link_recovery_from_post_php_referer($referer);
-                if (!empty($referer_result['post_id'])) {
-                    $method = 'referer_post_php';
-                    $post_id = absint($referer_result['post_id']);
-                    $message = 1;
-                    $classic_editor = !empty($referer_result['classic_editor']);
-                } else {
-                    $new_referer_result = $this->resolve_affiliate_link_recovery_from_post_new_referer($referer);
-                    if (!empty($new_referer_result['post_id'])) {
-                        $method = 'latest_affiliate_link_from_post_new_referer';
-                        $post_id = absint($new_referer_result['post_id']);
-                        $message = 6;
-                        $classic_editor = !empty($new_referer_result['classic_editor']);
-                    } else {
-                        $bypass_reason = $transient_result['bypass_reason'] ?? ($referer_result['bypass_reason'] ?? ($new_referer_result['bypass_reason'] ?? 'no_recovery_signal'));
-                    }
-                }
+                $bypass_reason = $transient_result['bypass_reason'] ?? 'no_explicit_recovery_signal';
             }
         }
 
@@ -1260,6 +1246,17 @@ class AffiliateManagerAI {
         }
         if ($age === null || $age >= self::AFFILIATE_LINK_SAVE_FALLBACK_MAX_AGE) {
             return array('bypass_reason' => 'stale_transient');
+        }
+        if (!empty($data['handled'])) {
+            return array('bypass_reason' => 'handled_transient');
+        }
+        if (empty($data['needs_recovery']) && empty($data['wrong_landing_expected'])) {
+            return array('bypass_reason' => 'missing_explicit_recovery_signal');
+        }
+        global $pagenow;
+        $current_post_type = isset($_GET['post_type']) ? sanitize_key(wp_unslash($_GET['post_type'])) : '';
+        if ($pagenow !== 'edit.php' || $current_post_type !== '') {
+            return array('bypass_reason' => 'not_immediate_plain_edit_landing');
         }
         $post_id = absint($data['post_id']);
         if (!$post_id || get_post_type($post_id) !== 'affiliate_link') {
@@ -1379,6 +1376,21 @@ class AffiliateManagerAI {
         );
     }
 
+
+    private function mark_affiliate_link_save_transient_handled($post_id) {
+        $key = $this->get_affiliate_link_save_transient_key();
+        $data = $key ? get_transient($key) : false;
+        if (!is_array($data)) {
+            return false;
+        }
+        if (!empty($post_id) && absint($data['post_id'] ?? 0) !== absint($post_id)) {
+            return false;
+        }
+        $data['handled'] = 1;
+        $data['needs_recovery'] = 0;
+        return set_transient($key, $data, self::AFFILIATE_LINK_SAVE_TRANSIENT_TTL);
+    }
+
     private function get_affiliate_link_save_transient_key($user_id = 0) {
         $user_id = $user_id ? absint($user_id) : get_current_user_id();
         return self::AFFILIATE_LINK_SAVE_TRANSIENT_PREFIX . $user_id;
@@ -1400,6 +1412,7 @@ class AffiliateManagerAI {
         $transient_deleted = false;
         if ($bypass_reason === '') {
             $final_location = $this->build_affiliate_link_edit_redirect($post_id, $location);
+            $this->mark_affiliate_link_save_transient_handled($post_id);
             $transient_deleted = delete_transient($this->get_affiliate_link_save_transient_key());
         }
 
@@ -1435,6 +1448,7 @@ class AffiliateManagerAI {
             $is_wrong_admin_edit = $path && basename($path) === 'edit.php' && $target_post_type === '';
             if ($is_wrong_admin_edit) {
                 $final_location = $this->build_affiliate_link_edit_redirect($post_id, $location);
+                $this->mark_affiliate_link_save_transient_handled($post_id);
                 $diagnostic_context['transient_deleted'] = delete_transient($this->get_affiliate_link_save_transient_key());
             } else {
                 $bypass_reason = 'not_plain_edit_php_redirect';

--- a/includes/class-geo-index-admin.php
+++ b/includes/class-geo-index-admin.php
@@ -586,7 +586,18 @@ class ALMA_Geo_Index_Admin {
         if (is_wp_error($result)) {
             wp_send_json_error(array('message' => $result->get_error_message()), 400);
         }
-        wp_send_json_success($this->format_affiliate_job_response($result['job'] ?? null, (int) ($result['processed'] ?? 0), __('Batch processato.', 'affiliate-link-manager-ai')));
+        $job = $result['job'] ?? $this->job_store->get_job($job_id);
+        $counts = $result['counts'] ?? $this->job_store->get_item_status_counts($job_id);
+        $claimed = (int) ($result['claimed'] ?? 0);
+        $processed = (int) ($result['processed'] ?? 0);
+        $message = __('Batch processato.', 'affiliate-link-manager-ai');
+        $terminal = !empty($job['status']) && in_array($job['status'], array('completed','paused','cancelled','failed'), true);
+        if ($claimed === 0 && !empty($counts['queued'])) {
+            $message = __('Nessun item claimato nonostante esistano item in coda.', 'affiliate-link-manager-ai');
+        } elseif ($processed === 0 && !$terminal) {
+            $message = __('Il batch non ha processato righe: verifica diagnostica e log item.', 'affiliate-link-manager-ai');
+        }
+        wp_send_json_success($this->format_affiliate_job_response($job, $processed, $message, $result));
     }
 
     public function ajax_cancel_affiliate_import_job() {
@@ -723,19 +734,20 @@ class ALMA_Geo_Index_Admin {
     private function render_affiliate_job_summary($job) {
         $total = (int) ($job['total_records'] ?? 0);
         $processed = (int) ($job['processed_records'] ?? 0);
-        $percent = $total > 0 ? min(100, (int) floor(($processed / $total) * 100)) : 0;
+        $percent = $total > 0 ? min(100, round(($processed / $total) * 100, 1)) : 0;
         echo '<div id="alma-geo-affiliate-summary" data-job-id="' . esc_attr((string) absint($job['id'] ?? 0)) . '">';
         echo '<p><strong>Job #' . esc_html((string) $job['id']) . '</strong> — <span data-alma-job-status>' . esc_html($job['status']) . '</span> — ' . esc_html($job['file_name']) . '</p>';
         echo '<div class="alma-geo-progress" style="position:relative;background:#f0f0f1;border:1px solid #c3c4c7;height:24px;max-width:720px;overflow:hidden;">';
         echo '<div data-alma-progress-bar style="background:#2271b1;height:24px;width:' . esc_attr((string) $percent) . '%;transition:width .2s ease;"></div>';
-        echo '<span data-alma-progress-label style="position:absolute;left:8px;top:3px;font-weight:600;color:#1d2327;">' . esc_html(sprintf(__('%1$d%% — %2$d/%3$d record', 'affiliate-link-manager-ai'), $percent, $processed, $total)) . '</span></div>';
+        echo '<span data-alma-progress-label style="position:absolute;left:8px;top:3px;font-weight:600;color:#1d2327;">' . esc_html(sprintf(__('%1$s%% — %2$d/%3$d record', 'affiliate-link-manager-ai'), (string) $percent, $processed, $total)) . '</span></div>';
         echo '<div style="display:flex;justify-content:space-between;max-width:720px;font-size:11px;color:#646970;margin-top:2px;" aria-hidden="true">';
         foreach (range(0, 100, 10) as $mark) {
             echo '<span>' . esc_html((string) $mark) . '</span>';
         }
         echo '</div>';
-        echo '<p data-alma-progress-text>' . esc_html(sprintf(__('Avanzamento: %1$d/%2$d (%3$d%%) — importati %4$d, aggiornati %5$d, saltati %6$d, errori %7$d.', 'affiliate-link-manager-ai'), $processed, $total, $percent, (int) $job['imported_records'], (int) $job['updated_records'], (int) $job['skipped_records'], (int) $job['error_records'])) . '</p>';
+        echo '<p data-alma-progress-text>' . esc_html(sprintf(__('Avanzamento: %1$d/%2$d (%3$s%%) — importati %4$d, aggiornati %5$d, saltati %6$d, errori %7$d.', 'affiliate-link-manager-ai'), $processed, $total, (string) $percent, (int) $job['imported_records'], (int) $job['updated_records'], (int) $job['skipped_records'], (int) $job['error_records'])) . '</p>';
         echo '<p data-alma-job-message>' . esc_html($this->affiliate_job_status_message($job)) . '</p>';
+        echo '<div data-alma-last-batch-error style="display:none;border-left:4px solid #b32d2e;background:#fcf0f1;padding:10px 12px;margin:12px 0;max-width:720px;"><strong>' . esc_html__('Errore ultimo batch', 'affiliate-link-manager-ai') . '</strong><div data-alma-last-batch-error-body></div></div>';
         echo '</div>';
         $this->render_affiliate_job_counts($job);
     }
@@ -785,21 +797,31 @@ class ALMA_Geo_Index_Admin {
             var running = false;
             var autoEnabled = <?php echo in_array($job['status'], array('queued','running'), true) ? 'true' : 'false'; ?>;
             var processButton = document.getElementById('alma-geo-affiliate-process-next');
+            var lastBatchFailed = false;
 
             function text(value) {
                 return String(value == null ? '' : value).replace(/[&<>'"]/g, function(c){ return {'&':'&amp;','<':'&lt;','>':'&gt;',"'":'&#039;','"':'&quot;'}[c]; });
             }
             function percent(job) {
-                return job && job.total_records > 0 ? Math.min(100, Math.floor((job.processed_records / job.total_records) * 100)) : 0;
+                return job && job.total_records > 0 ? Math.min(100, Math.round((job.processed_records / job.total_records) * 1000) / 10) : 0;
             }
             function post(action, data) {
                 var body = new URLSearchParams(Object.assign({action: action, nonce: nonce, job_id: jobId, batch_size: 50}, data || {}));
                 return fetch(ajaxUrl, {method:'POST', credentials:'same-origin', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body: body.toString()}).then(function(r){
                     return r.text().then(function(raw){
                         var parsed;
-                        try { parsed = JSON.parse(raw); } catch (e) { throw new Error('<?php echo esc_js(__('Risposta AJAX non valida.', 'affiliate-link-manager-ai')); ?>' + ' HTTP ' + r.status); }
+                        try { parsed = JSON.parse(raw); } catch (e) {
+                            var invalid = new Error('<?php echo esc_js(__('Risposta AJAX non valida.', 'affiliate-link-manager-ai')); ?>');
+                            invalid.httpStatus = r.status;
+                            invalid.raw = raw;
+                            throw invalid;
+                        }
                         if (!r.ok || !parsed.success) {
-                            throw new Error((parsed.data && parsed.data.message) ? parsed.data.message : ('HTTP ' + r.status));
+                            var ajaxError = new Error((parsed.data && parsed.data.message) ? parsed.data.message : ('HTTP ' + r.status));
+                            ajaxError.httpStatus = r.status;
+                            ajaxError.raw = raw;
+                            ajaxError.data = parsed.data || null;
+                            throw ajaxError;
                         }
                         return parsed.data;
                     });
@@ -819,7 +841,9 @@ class ALMA_Geo_Index_Admin {
                 if (bar) { bar.style.width = pct + '%'; }
                 if (label) { label.textContent = pct + '% — ' + j.processed_records + '/' + j.total_records + ' record'; }
                 if (progress) { progress.textContent = 'Avanzamento: ' + j.processed_records + '/' + j.total_records + ' (' + pct + '%) — importati ' + j.imported_records + ', aggiornati ' + j.updated_records + ', saltati ' + j.skipped_records + ', errori ' + j.error_records + '.'; }
-                if (message) { message.textContent = data.message || ''; }
+                clearError();
+                if (message) { message.textContent = data.message || ''; message.style.color = ''; }
+                updateButtonState(j, false);
                 if (data.counts) {
                     Object.keys(data.counts).forEach(function(key){
                         var cell = document.querySelector('[data-alma-count="' + key + '"]');
@@ -832,28 +856,69 @@ class ALMA_Geo_Index_Admin {
                     }).join('') : '<tr><td colspan="6"><?php echo esc_js(__('Nessun log.', 'affiliate-link-manager-ai')); ?></td></tr>';
                 }
             }
+            function clearError() {
+                var box = document.querySelector('[data-alma-last-batch-error]');
+                var body = document.querySelector('[data-alma-last-batch-error-body]');
+                lastBatchFailed = false;
+                if (box) { box.style.display = 'none'; }
+                if (body) { body.innerHTML = ''; }
+            }
+            function isTerminal(job) {
+                return job && ['completed','cancelled','paused','failed'].indexOf(job.status) !== -1;
+            }
+            function updateButtonState(job, inFlight) {
+                if (!processButton) { return; }
+                if (inFlight) {
+                    processButton.disabled = true;
+                    processButton.textContent = '<?php echo esc_js(__('Processamento…', 'affiliate-link-manager-ai')); ?>';
+                    return;
+                }
+                processButton.textContent = isTerminal(job) ? '<?php echo esc_js(__('Batch non disponibile', 'affiliate-link-manager-ai')); ?>' : (lastBatchFailed ? '<?php echo esc_js(__('Riprova batch', 'affiliate-link-manager-ai')); ?>' : '<?php echo esc_js(__('Processa prossimo batch', 'affiliate-link-manager-ai')); ?>');
+                processButton.disabled = isTerminal(job);
+                if (isTerminal(job)) {
+                    processButton.title = '<?php echo esc_js(__('Job completato, annullato, in pausa o fallito.', 'affiliate-link-manager-ai')); ?>';
+                } else {
+                    processButton.title = '';
+                }
+            }
             function showError(error) {
+                autoEnabled = false;
+                lastBatchFailed = true;
+                var msg = error && error.message ? error.message : '<?php echo esc_js(__('Errore sconosciuto.', 'affiliate-link-manager-ai')); ?>';
+                var status = error && error.httpStatus ? error.httpStatus : '';
+                var raw = error && error.raw ? String(error.raw).slice(0, 1200) : '';
+                var now = new Date().toLocaleString();
                 var message = document.querySelector('[data-alma-job-message]');
+                var box = document.querySelector('[data-alma-last-batch-error]');
+                var body = document.querySelector('[data-alma-last-batch-error-body]');
                 if (message) {
-                    message.textContent = '<?php echo esc_js(__('Il batch non è stato processato. Controlla i log del job o riprova.', 'affiliate-link-manager-ai')); ?> ' + (error && error.message ? error.message : '');
+                    message.textContent = '<?php echo esc_js(__('Il batch non è stato processato. Auto-processing fermato: usa “Riprova batch”.', 'affiliate-link-manager-ai')); ?> ' + msg;
                     message.style.color = '#b32d2e';
+                }
+                if (box && body) {
+                    box.style.display = 'block';
+                    body.innerHTML = '<p><strong><?php echo esc_js(__('Messaggio:', 'affiliate-link-manager-ai')); ?></strong> ' + text(msg) + '</p>' +
+                        '<p><strong>HTTP status:</strong> ' + text(status || '<?php echo esc_js(__('n/d', 'affiliate-link-manager-ai')); ?>') + '</p>' +
+                        '<p><strong>Timestamp:</strong> ' + text(now) + '</p>' +
+                        (raw ? '<p><strong><?php echo esc_js(__('Risposta raw troncata:', 'affiliate-link-manager-ai')); ?></strong></p><pre style="white-space:pre-wrap;max-height:180px;overflow:auto;">' + text(raw) + '</pre>' : '') +
+                        '<p><?php echo esc_js(__('Suggerimento: apri console/network o scarica log.', 'affiliate-link-manager-ai')); ?></p>';
                 }
             }
             function processOnce(manual) {
                 if (running) { return Promise.resolve(); }
                 running = true;
-                if (processButton) { processButton.disabled = true; }
+                updateButtonState(null, true);
                 return post('alma_geo_process_affiliate_link_import_job').then(function(data){
                     render(data);
                     var j = data.job;
                     running = false;
-                    if (processButton) { processButton.disabled = false; }
-                    if (!manual && j && (j.status === 'queued' || j.status === 'running')) {
+                    updateButtonState(j, false);
+                    if (!manual && autoEnabled && j && (j.status === 'queued' || j.status === 'running')) {
                         window.setTimeout(function(){ processOnce(false); }, 700);
                     }
                 }).catch(function(error){
                     running = false;
-                    if (processButton) { processButton.disabled = false; }
+                    updateButtonState(null, false);
                     showError(error);
                 });
             }
@@ -868,13 +933,13 @@ class ALMA_Geo_Index_Admin {
         <?php
     }
 
-    private function format_affiliate_job_response($job, $batch_processed = 0, $message = '') {
+    private function format_affiliate_job_response($job, $batch_processed = 0, $message = '', $batch_result = array()) {
         if (empty($job)) {
-            return array('job' => null, 'items' => array(), 'counts' => array(), 'report' => array(), 'message' => __('Job non trovato.', 'affiliate-link-manager-ai'));
+            return array('processed' => 0, 'claimed' => 0, 'job' => null, 'counts' => array(), 'items' => array(), 'report' => array(), 'debug' => array(), 'diagnostic' => array(), 'message' => __('Job non trovato.', 'affiliate-link-manager-ai'));
         }
         $total = (int) $job['total_records'];
         $processed = (int) $job['processed_records'];
-        $percent = $total > 0 ? min(100, (int) floor(($processed / $total) * 100)) : 0;
+        $percent = $total > 0 ? min(100, round(($processed / $total) * 100, 1)) : 0;
         $items = array();
         foreach ($this->job_store->get_items((int) $job['id'], 50) as $item) {
             $items[] = array(
@@ -888,6 +953,7 @@ class ALMA_Geo_Index_Admin {
         }
         return array(
             'processed' => (int) $batch_processed,
+            'claimed' => (int) ($batch_result['claimed'] ?? 0),
             'total_records' => $total,
             'processed_records' => $processed,
             'imported_records' => (int) $job['imported_records'],
@@ -909,9 +975,11 @@ class ALMA_Geo_Index_Admin {
                 'error_records' => (int) $job['error_records'],
                 'percent' => $percent,
             ),
-            'counts' => $this->job_store->get_item_status_counts((int) $job['id']),
+            'counts' => !empty($batch_result['counts']) && is_array($batch_result['counts']) ? $batch_result['counts'] : $this->job_store->get_item_status_counts((int) $job['id']),
             'items' => $items,
             'report' => $this->job_store->get_report((int) $job['id']),
+            'debug' => !empty($batch_result['debug']) && is_array($batch_result['debug']) ? $batch_result['debug'] : array(),
+            'diagnostic' => !empty($batch_result['diagnostic']) && is_array($batch_result['diagnostic']) ? $batch_result['diagnostic'] : $this->job_store->get_job_diagnostic((int) $job['id'], array('last_ajax_message' => $message)),
         );
     }
 

--- a/includes/class-geo-index-affiliate-link-importer.php
+++ b/includes/class-geo-index-affiliate-link-importer.php
@@ -202,20 +202,75 @@ class ALMA_Geo_Index_Affiliate_Link_Importer {
             return new WP_Error('alma_geo_invalid_job_type', __('Tipo job non valido.', 'affiliate-link-manager-ai'));
         }
         if (in_array($job['status'], array('paused','cancelled','completed','failed'), true)) {
-            return array('processed' => 0, 'job' => $job_store->get_job($job_id));
+            $counts = $job_store->get_item_status_counts($job_id);
+            return array(
+                'processed' => 0,
+                'claimed' => 0,
+                'job' => $job_store->get_job($job_id),
+                'items' => $job_store->get_items($job_id, 50),
+                'counts' => $counts,
+                'debug' => array('status_guard' => sanitize_key($job['status'])),
+                'diagnostic' => $job_store->get_job_diagnostic($job_id, array('last_ajax_message' => 'status_guard')),
+            );
         }
+        $recovered = $job_store->recover_stale_processing_items($job_id, 10);
         $job_store->update_job_status($job_id, 'running');
         $options = is_array($job['options']) ? $job['options'] : array();
         $batch_size = max(1, min(100, absint($batch_size ?: ($options['batch_size'] ?? 50))));
         $items = $job_store->claim_items($job_id, $batch_size, $retry_errors ? array('queued','error') : array('queued'));
+        $claimed = count($items);
+        $processed = 0;
+        $item_results = array();
         foreach ($items as $item) {
-            $row = $this->normalize_row($item['raw_payload']);
-            $result = $this->import_row($row, $options);
-            $job_store->update_item_result((int) $item['id'], $result['status'], $result['action'], $result['message'], $result['object_id'], ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK);
+            $item_id = (int) ($item['id'] ?? 0);
+            $object_id = absint($item['object_id'] ?? 0);
+            try {
+                $row = $this->normalize_row($item['raw_payload'] ?? array());
+                $result = $this->import_row($row, $options);
+                if (!is_array($result) || empty($result['status'])) {
+                    $result = $this->row_result('error', 'invalid_import_row_result', absint($row['affiliate_link_id'] ?? $object_id));
+                }
+            } catch (Throwable $e) {
+                $result = $this->row_result('error', 'exception ' . $e->getMessage(), $object_id);
+            } catch (Exception $e) {
+                $result = $this->row_result('error', 'exception ' . $e->getMessage(), $object_id);
+            }
+
+            $status = sanitize_key($result['status'] ?? 'error');
+            if (!in_array($status, array('imported','updated','skipped','error'), true)) {
+                $status = 'error';
+                $result['message'] = trim((string) ($result['message'] ?? '') . ' invalid_final_status');
+            }
+            $result['status'] = $status;
+            $job_store->update_item_result($item_id, $result['status'], $result['action'] ?? $result['status'], $result['message'] ?? '', $result['object_id'] ?? $object_id, ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK);
+            $processed++;
+            $item_results[] = array(
+                'item_id' => $item_id,
+                'row_number' => (int) ($item['row_number'] ?? 0),
+                'affiliate_link_id' => absint($result['object_id'] ?? $object_id),
+                'status' => $result['status'],
+                'action' => sanitize_key($result['action'] ?? $result['status']),
+                'message' => sanitize_textarea_field($result['message'] ?? ''),
+            );
         }
-        $job_store->recount_job($job_id);
+        $counts = $job_store->recount_job($job_id);
         $job = $job_store->maybe_complete_job($job_id);
-        return array('processed' => count($items), 'job' => $job, 'items' => $job_store->get_items($job_id, 50));
+        $debug = array(
+            'batch_size' => $batch_size,
+            'retry_errors' => (bool) $retry_errors,
+            'stale_processing_recovered' => (int) $recovered,
+            'claim' => $job_store->get_last_claim_debug(),
+            'item_results' => $item_results,
+        );
+        return array(
+            'processed' => $processed,
+            'claimed' => $claimed,
+            'job' => $job,
+            'counts' => $counts,
+            'items' => $job_store->get_items($job_id, 50),
+            'debug' => $debug,
+            'diagnostic' => $job_store->get_job_diagnostic($job_id, array('last_ajax_message' => 'batch_processed')),
+        );
     }
 
     public function import_row($row, $args = array()) {
@@ -249,8 +304,9 @@ class ALMA_Geo_Index_Affiliate_Link_Importer {
         update_post_meta($affiliate_link_id, '_alma_geo_activity_type', sanitize_key($row['activity_type'] ?? 'unknown'));
         update_post_meta($affiliate_link_id, '_alma_geo_import_status', 'imported');
         update_post_meta($affiliate_link_id, '_alma_geo_source', self::SOURCE);
-        update_post_meta($affiliate_link_id, '_alma_geo_primary_provider', sanitize_text_field($row['primary_provider'] ?? ''));
-        update_post_meta($affiliate_link_id, '_alma_geo_provider', sanitize_text_field($row['primary_provider'] ?? ''));
+        $provider = sanitize_text_field($row['primary_provider'] ?? ($row['provider'] ?? ($row['source_name'] ?? '')));
+        update_post_meta($affiliate_link_id, '_alma_geo_primary_provider', $provider);
+        update_post_meta($affiliate_link_id, '_alma_geo_provider', $provider);
 
         $after_locations = $this->count_locations();
         $after_relations = $this->count_relations($affiliate_link_id);
@@ -325,7 +381,7 @@ class ALMA_Geo_Index_Affiliate_Link_Importer {
             'poi' => sanitize_text_field($row['primary_poi'] ?? ''),
             'lat' => isset($row['primary_lat']) ? $this->float_or_empty($row['primary_lat']) : '',
             'lng' => isset($row['primary_lng']) ? $this->float_or_empty($row['primary_lng']) : '',
-            'geo_provider' => sanitize_key($row['primary_provider'] ?? ''),
+            'geo_provider' => sanitize_key($row['primary_provider'] ?? ($row['provider'] ?? '')),
             'geo_provider_place_id' => sanitize_text_field($row['primary_place_id'] ?? ''),
             'suggested_geocoding_query' => sanitize_text_field($row['primary_suggested_geocoding_query'] ?? ''),
             'formatted_address' => sanitize_text_field($row['primary_formatted_address'] ?? ''),

--- a/includes/class-geo-index-job-store.php
+++ b/includes/class-geo-index-job-store.php
@@ -7,6 +7,8 @@ if (!defined('ABSPATH')) { exit; }
 class ALMA_Geo_Index_Job_Store {
     const JOB_TYPE_AFFILIATE_LINKS_GEO_IMPORT = 'affiliate_links_geo_import';
 
+    private $last_claim_debug = array();
+
     public function table_jobs() {
         global $wpdb;
         return $wpdb->prefix . 'alma_geo_import_jobs';
@@ -164,6 +166,16 @@ class ALMA_Geo_Index_Job_Store {
     public function claim_items($job_id, $limit = 50, $statuses = array('queued')) {
         global $wpdb;
         $job_id = absint($job_id);
+        $this->last_claim_debug = array(
+            'job_id' => $job_id,
+            'requested_limit' => absint($limit),
+            'requested_statuses' => array_values(array_map('sanitize_key', (array) $statuses)),
+            'eligible_ids_found' => 0,
+            'eligible_ids' => array(),
+            'updated_to_processing' => 0,
+            'items_returned' => 0,
+            'wpdb_last_error' => '',
+        );
         $limit = max(1, min(100, absint($limit)));
         $statuses = array_map('sanitize_key', (array) $statuses);
         $statuses = array_values(array_intersect($statuses, array('queued','error')));
@@ -174,17 +186,31 @@ class ALMA_Geo_Index_Job_Store {
         $params = array_merge(array($job_id), $statuses, array($limit));
         $ids = $wpdb->get_col($wpdb->prepare("SELECT id FROM {$this->table_items()} WHERE job_id = %d AND status IN ($placeholders) ORDER BY id ASC LIMIT %d", $params));
         $ids = array_values(array_filter(array_map('absint', (array) $ids)));
+        $this->last_claim_debug['normalized_statuses'] = $statuses;
+        $this->last_claim_debug['eligible_ids_found'] = count($ids);
+        $this->last_claim_debug['eligible_ids'] = $ids;
         if (empty($ids)) {
+            $this->last_claim_debug['wpdb_last_error'] = (string) $wpdb->last_error;
             return array();
         }
         $id_placeholders = implode(',', array_fill(0, count($ids), '%d'));
         $update_params = array_merge(array('processing', 'claimed_for_processing', current_time('mysql'), $job_id), $ids);
-        $wpdb->query($wpdb->prepare("UPDATE {$this->table_items()} SET status = %s, action = %s, processed_at = %s WHERE job_id = %d AND id IN ($id_placeholders)", $update_params));
+        $updated = $wpdb->query($wpdb->prepare("UPDATE {$this->table_items()} SET status = %s, action = %s, processed_at = %s WHERE job_id = %d AND id IN ($id_placeholders)", $update_params));
+        $this->last_claim_debug['updated_to_processing'] = (int) $updated;
+        $this->last_claim_debug['wpdb_last_error'] = (string) $wpdb->last_error;
         $items = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$this->table_items()} WHERE job_id = %d AND id IN ($id_placeholders) ORDER BY id ASC", array_merge(array($job_id), $ids)), ARRAY_A);
         foreach ($items as &$item) {
-            $item['raw_payload'] = json_decode((string) ($item['raw_payload'] ?? ''), true) ?: array();
+            $decoded_payload = json_decode((string) ($item['raw_payload'] ?? ''), true);
+            $item['raw_payload'] = is_array($decoded_payload) ? $decoded_payload : array();
         }
+        unset($item);
+        $this->last_claim_debug['items_returned'] = count($items ?: array());
+        $this->last_claim_debug['wpdb_last_error'] = (string) $wpdb->last_error;
         return $items ?: array();
+    }
+
+    public function get_last_claim_debug() {
+        return $this->last_claim_debug;
     }
 
     public function update_item_result($item_id, $status, $action, $message, $object_id = 0, $object_type = '') {
@@ -281,6 +307,41 @@ class ALMA_Geo_Index_Job_Store {
             $rows = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$this->table_items()} WHERE job_id = %d ORDER BY id DESC LIMIT %d", absint($job_id), $limit), ARRAY_A);
         }
         return $rows ?: array();
+    }
+
+
+    public function get_job_diagnostic($job_id, $extra = array()) {
+        global $wpdb;
+        $job_id = absint($job_id);
+        $job = $this->get_job($job_id);
+        $counts = $this->get_item_status_counts($job_id);
+        $latest_item = $wpdb->get_row($wpdb->prepare("SELECT id, row_number, object_id, object_type, status, action, message, processed_at FROM {$this->table_items()} WHERE job_id = %d ORDER BY id DESC LIMIT 1", $job_id), ARRAY_A);
+        return array_merge(array(
+            'job_id' => $job_id,
+            'total_item_rows' => array_sum(array_map('intval', $counts)),
+            'queued' => (int) $counts['queued'],
+            'processing' => (int) $counts['processing'],
+            'imported' => (int) $counts['imported'],
+            'updated' => (int) $counts['updated'],
+            'skipped' => (int) $counts['skipped'],
+            'error' => (int) $counts['error'],
+            'latest_item_status' => !empty($latest_item['status']) ? sanitize_key($latest_item['status']) : '',
+            'latest_item' => is_array($latest_item) ? array(
+                'id' => (int) $latest_item['id'],
+                'row_number' => (int) $latest_item['row_number'],
+                'affiliate_link_id' => (int) $latest_item['object_id'],
+                'object_type' => sanitize_key($latest_item['object_type']),
+                'status' => sanitize_key($latest_item['status']),
+                'action' => sanitize_key($latest_item['action']),
+                'message' => sanitize_textarea_field($latest_item['message']),
+                'processed_at' => sanitize_text_field($latest_item['processed_at']),
+            ) : array(),
+            'last_error' => sanitize_textarea_field($job['last_error'] ?? ''),
+            'batch_size' => isset($job['options']['batch_size']) ? (int) $job['options']['batch_size'] : 0,
+            'safe_only' => !empty($job['options']['safe_only']),
+            'overwrite' => !empty($job['options']['overwrite']),
+            'last_claim' => $this->get_last_claim_debug(),
+        ), is_array($extra) ? $extra : array());
     }
 
     public function reset_error_items($job_id) {


### PR DESCRIPTION
### Motivation
- The affiliate-geo CSV import created jobs but claimed items were not reliably processed and the UI stayed at 0/total; the flow needed robust claim/update/finalize semantics and better diagnostics. 
- The referer-based redirect fallback for affiliate_link saved pages could erroneously intercept intentional visits to the posts list and needed an explicit recovery signal and a safe handled/cleanup path.

### Description
- Reliable claim/update flow: `claim_items()` now records eligible IDs, updates them to `processing`, returns the exact claimed rows with `raw_payload` decoded and exposes claim diagnostics via `get_last_claim_debug()`; stale `processing` items are recovered before a batch. (files: `includes/class-geo-index-job-store.php`, `includes/class-geo-index-affiliate-link-importer.php`)
- Defensive per-row processing: `process_job_batch()` wraps each item processing in try/catch, ensures every claimed item is moved to a terminal status (`imported|updated|skipped|error`), collects per-item results and a debug payload, and recounts the job so `skipped` rows count toward `processed_records`. (file: `includes/class-geo-index-affiliate-link-importer.php`)
- AJAX + UI improvements: the batch endpoint `ajax_affiliate_import_batch` now returns `processed`, `claimed`, `counts`, `items`, `debug` and `diagnostic` fields and emits clear diagnostic messages when claim/processed = 0 despite queued items; the admin JS shows a persistent **Errore ultimo batch** box (HTTP status, raw truncated response, timestamp), updates progress bar with one-decimal percent and 10% markers, disables the batch button only while requests are in flight and stops auto-processing on errors. (file: `includes/class-geo-index-admin.php`)
- Job diagnostics and recovery: added `get_job_diagnostic()` with totals, per-status counts, latest item and last claim debug; `recover_stale_processing_items()` is invoked before processing a batch. (file: `includes/class-geo-index-job-store.php`)
- CSV/provider handling: import reads `primary_provider` and falls back to `provider`/`source_name` and preserves `safe_only` semantics (rows not safe become `skipped`). (file: `includes/class-geo-index-affiliate-link-importer.php`)
- Redirect fallback hardening: the affiliate-link save transient now includes explicit flags (`needs_recovery`, `wrong_landing_expected`, `handled`) and `maybe_recover_affiliate_link_wrong_edit_redirect()` requires an explicit recent recovery signal to activate; when `redirect_post_location` or the wp_redirect guard handles the redirect the transient is marked/treated as handled to avoid accidental recovery on an intentional visit. (file: `affiliate-link-manager-ai.php`)
- Docs: updated `CHANGELOG.md` and `README.md` with import/diagnostic/redirect changes. (files: `CHANGELOG.md`, `README.md`)

### Testing
- Ran PHP lint on modified files with `php -l` and all returned no syntax errors for: `affiliate-link-manager-ai.php`, `includes/class-geo-index-admin.php`, `includes/class-geo-index-affiliate-link-importer.php`, `includes/class-geo-index-job-store.php`, `includes/class-geo-index-store.php`, `includes/class-geo-index-metabox.php` (all OK).
- Ran repository pre-flight checks (`git diff --check`) and fixed whitespace/format where needed.
- No automated integration tests were available; manual QA plan (described in the issue) should be followed to verify with `sothra_geo_affiliate_links_index.csv` that processed counts advance (>0 in first batch), skipped rows are counted, progress reaches 2212/2212 when safe-only is enabled, the batch error box persists on malformed AJAX, and that saving an Affiliate Link then intentionally visiting the Posts list is no longer intercepted by the fallback.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a252c9b355c8332a6b1afbe395c3a90)