### PR TITLE
Fix GEO import database schema and staging inserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.41.5 - 2026-06-07
+
+### Fix GEO import database schema and staging inserts
+- Fix creazione tabella staging GEO `alma_geo_import_job_items` con migrazione `dbDelta` idempotente per jobs e job items, senza drop e senza cancellare dati.
+- Fix import GEO Link Affiliati che scartava tutte le righe per errore SQL quando la tabella staging mancava: ora lo schema viene verificato prima della prepare e l’import si blocca con messaggio chiaro se il repair fallisce.
+- Aggiunto repair schema GEO in **Strumenti avanzati** con stato tabella jobs/job items, nonce, capability admin e pulsante “Ripara tabelle GEO”.
+- Migliorata diagnostica SQL degli insert staging con tabella, operazione, ultimo errore aggregato ed esempi limitati.
+- Fix doppio conteggio duplicati: i motivi scarto usano matching prioritario mutualmente esclusivo e `staging_duplicate_staging_item` non incrementa anche `duplicate`.
+- Fix fallback località primaria: righe con `primary_city`, `primary_area`, `primary_poi`, `primary_port` o `primary_airport` ma senza `primary_name` non falliscono più con `missing_primary_name`.
+- Versione plugin aggiornata a `2.41.5`.
+
 ## 2.41.4 - 2026-06-07
 
 ### Fix GEO CSV header normalization and staging creation

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 ### Fix Import GEO Link Affiliati
 
+
+- **Controllo tabelle GEO**: l’import verifica le tabelle `alma_geo_import_jobs` e `alma_geo_import_job_items` in attivazione, upgrade, prima di “Prepara import GEO” e negli strumenti avanzati. La tabella `alma_geo_import_job_items` è obbligatoria perché contiene la staging dei record prima dei batch manuali.
+- **Ripara tabelle GEO**: in **G. Strumenti avanzati** sono mostrati stato tabella jobs e job items con il pulsante “Ripara tabelle GEO”. Il repair usa `dbDelta`, rispetta charset/collation WordPress, non elimina dati e può essere usato se appare “tabella staging mancante”.
+- **Errore staging mancante**: se la tabella `alma_geo_import_job_items` manca e l’auto-repair non riesce, “Prepara import GEO” si blocca prima degli insert e mostra che nessun Link Affiliato è stato modificato invece di generare migliaia di `sql_insert_failed`.
+- **Diagnostica SQL staging**: gli errori di insert staging salvano operazione, tabella e ultimo errore aggregato con esempi limitati negli strumenti avanzati.
+- **Fix duplicati staging**: i motivi di scarto sono conteggiati con matching prioritario mutualmente esclusivo, quindi `staging_duplicate_staging_item` non incrementa anche il contatore generico `duplicate`.
+- **Fix fallback località primaria**: l’import batch usa `primary_city`, `primary_area`, `primary_poi`, `primary_port` o `primary_airport` come nome/canonical quando `primary_name` e `primary_canonical_name` sono vuoti, mantenendo il tipo coerente.
 - **Workflow snello**: la pagina Import GEO Link Affiliati è organizzata in **A. Carica CSV**, **B. Preview**, **C. Prepara import**, **D. Importazione**, **E. Report**, **F. Geocoding Google** e **G. Strumenti avanzati**.
 - **Preview vs prepare vs batch**: “Valida e mostra preview” carica il CSV e mostra al massimo 10 record con le colonne principali; “Prepara import GEO” crea gli item staging processabili; “Importa prossimo batch” claim-a solo item reali in stato `queued` e importa un batch manuale alla volta.
 - **Fix staging 0/2212**: preview e preparazione ora condividono la stessa normalizzazione header, rimuovono BOM UTF-8, spazi e caratteri invisibili, normalizzano in lowercase con underscore coerenti e applicano gli stessi alias; colonne come `affiliate_link_id`, `post_title`, `affiliate_url`, `primary_name`, `final_bucket` e `safe_for_auto_import` vengono quindi riconosciute anche dalla creazione staging.
@@ -13,7 +20,7 @@
 - **Download completi**: “Scarica report CSV” e “Scarica log JSON” esportano in pagine controllate fino a esaurimento righe, senza troncamento silenzioso a 50.000 record.
 - **Pausa legacy**: l’endpoint AJAX legacy di pausa restituisce un errore controllato perché il nuovo workflow manuale non ha job automatici da mettere in pausa; il pulsante pausa non è nella UI principale.
 - **Geocoding Google separato**: l’import salva/predispone località sorgente, località normalizzata, regione, paese, lat/lng, Google Place ID, formatted address, stato/confidence geocoding, ultimo geocoding ed errore, ma non chiama Google API durante i batch.
-- Versione plugin aggiornata a `2.41.4`.
+- Versione plugin aggiornata a `2.41.5`.
 
 ## 2.41.0 - 2026-06-06
 

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.41.4
+ * Version: 2.41.5
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.41.4');
+define('ALMA_VERSION', '2.41.5');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -4087,7 +4087,7 @@ class AffiliateManagerAI {
         ALMA_Geo_Index_Job_Store::create_tables();
         ALMA_Contextual_Affiliate_Widget::maybe_set_default_options();
         $this->create_default_categories();
-        update_option('alma_db_schema_version', '4');
+        update_option('alma_db_schema_version', '5');
         update_option('alma_plugin_version', ALMA_VERSION);
         flush_rewrite_rules();
     }
@@ -4126,7 +4126,8 @@ class AffiliateManagerAI {
 
     public function maybe_run_update_tasks() {
         $installed_version = get_option('alma_plugin_version', '0.0.0');
-        if (version_compare($installed_version, ALMA_VERSION, '<')) {
+        $geo_import_schema_version = get_option('alma_geo_import_schema_version', '0');
+        if (version_compare($installed_version, ALMA_VERSION, '<') || version_compare((string) $geo_import_schema_version, '2', '<')) {
             ALMA_AI_Content_Agent_Store::install();
             $this->clear_deprecated_trend_cron_events();
             $this->create_analytics_table();
@@ -4135,7 +4136,7 @@ class AffiliateManagerAI {
             ALMA_Geo_Index_Store::create_tables();
             ALMA_Geo_Index_Job_Store::create_tables();
             ALMA_Contextual_Affiliate_Widget::maybe_set_default_options();
-            update_option('alma_db_schema_version', '4');
+            update_option('alma_db_schema_version', '5');
             update_option('alma_plugin_version', ALMA_VERSION);
         }
     }

--- a/includes/class-geo-index-admin.php
+++ b/includes/class-geo-index-admin.php
@@ -474,7 +474,21 @@ class ALMA_Geo_Index_Admin {
             $this->notice_success(__('CSV GEO Link Affiliati caricato e validato. Controlla la preview e crea una sessione di import manuale.', 'affiliate-link-manager-ai'));
             return;
         }
+        if ($action === 'repair_geo_import_tables') {
+            $status = $this->job_store->install_tables();
+            if (!empty($status['jobs_exists']) && !empty($status['items_exists'])) {
+                $this->notice_success(__('Tabelle GEO riparate/verificate correttamente. Nessun dato esistente è stato eliminato.', 'affiliate-link-manager-ai'));
+            } else {
+                $this->notice_error(__('Riparazione tabelle GEO non riuscita. Verifica permessi database e riprova.', 'affiliate-link-manager-ai'));
+            }
+            return;
+        }
         if ($action === 'start_affiliate_import') {
+            $schema_ready = $this->job_store->ensure_tables(true);
+            if (is_wp_error($schema_ready)) {
+                $this->notice_error($schema_ready->get_error_message());
+                return;
+            }
             $preview = get_transient($this->affiliate_preview_key());
             if (empty($preview['file']) || !file_exists($preview['file']) || empty($preview['valid'])) {
                 $this->notice_error(__('Preview non valida o scaduta. Ricarica il CSV Link Affiliati.', 'affiliate-link-manager-ai'));
@@ -737,10 +751,14 @@ class ALMA_Geo_Index_Admin {
 
     private function render_affiliate_import_tab() {
         $preview = get_transient($this->affiliate_preview_key());
-        $job = $this->job_store->get_latest_job();
+        $schema_status = $this->job_store->schema_status();
+        $job = (!empty($schema_status['jobs_exists']) && !empty($schema_status['items_exists'])) ? $this->job_store->get_latest_job() : array();
         ?>
         <h2><?php esc_html_e('Import GEO Link Affiliati', 'affiliate-link-manager-ai'); ?></h2>
         <p><?php esc_html_e('Importa manualmente a batch le località geografiche da CSV AI, ad esempio sothra_geo_affiliate_links_index.csv, e associa ogni riga al CPT affiliate_link tramite affiliate_link_id. Nessuna chiamata Google Maps viene eseguita durante l’import.', 'affiliate-link-manager-ai'); ?></p>
+        <?php if (empty($schema_status['items_exists'])) : ?>
+            <div class="notice notice-warning inline"><p><?php echo esc_html(sprintf(__('La tabella staging GEO non esiste: %s. Clicca Ripara tabelle GEO in Strumenti avanzati o disattiva/riattiva il plugin. Nessun Link Affiliato è stato modificato.', 'affiliate-link-manager-ai'), $schema_status['items_table'])); ?></p></div>
+        <?php endif; ?>
         <form method="post" enctype="multipart/form-data" class="postbox" style="padding:12px;">
             <?php wp_nonce_field('alma_geo_affiliate_import'); ?>
             <input type="hidden" name="alma_geo_index_action" value="preview_affiliate_csv">
@@ -801,7 +819,11 @@ class ALMA_Geo_Index_Admin {
         echo '<div class="postbox"><div class="inside" id="alma-geo-affiliate-job" data-job-id="' . esc_attr((string) absint($job['id'] ?? 0)) . '">';
         echo '<h3>' . esc_html__('A. Carica CSV', 'affiliate-link-manager-ai') . '</h3>';
         if (empty($job)) {
-            echo '<p>' . esc_html__('Nessuna sessione Import GEO Link Affiliati ancora creata.', 'affiliate-link-manager-ai') . '</p></div></div>';
+            echo '<p>' . esc_html__('Nessuna sessione Import GEO Link Affiliati ancora creata.', 'affiliate-link-manager-ai') . '</p>';
+            echo '<hr><details style="margin-top:12px;" open><summary><strong>' . esc_html__('G. Strumenti avanzati', 'affiliate-link-manager-ai') . '</strong></summary>';
+            echo '<div style="margin-top:12px;">';
+            $this->render_geo_import_schema_tools();
+            echo '</div></details></div></div>';
             return;
         }
         $total = (int) ($job['total_records'] ?? 0);
@@ -831,6 +853,7 @@ class ALMA_Geo_Index_Admin {
 
         echo '<hr><details style="margin-top:12px;"><summary><strong>' . esc_html__('G. Strumenti avanzati', 'affiliate-link-manager-ai') . '</strong></summary>';
         echo '<div style="margin-top:12px;">';
+        $this->render_geo_import_schema_tools();
         $this->render_affiliate_job_button('reset_affiliate_import', __('Reset import', 'affiliate-link-manager-ai'), $job);
         $this->render_affiliate_job_diagnostic((int) $job['id']);
         $this->render_affiliate_job_logs((int) $job['id']);
@@ -929,6 +952,26 @@ class ALMA_Geo_Index_Admin {
             echo '<li><code>' . esc_html($key) . '</code> — ' . esc_html($label) . '</li>';
         }
         echo '</ul></div></div>';
+    }
+
+
+    private function render_geo_import_schema_tools() {
+        $status = $this->job_store->schema_status();
+        $jobs_state = !empty($status['jobs_exists']) ? __('presente', 'affiliate-link-manager-ai') : __('mancante', 'affiliate-link-manager-ai');
+        $items_state = !empty($status['items_exists']) ? __('presente', 'affiliate-link-manager-ai') : __('mancante', 'affiliate-link-manager-ai');
+        echo '<h4>' . esc_html__('Stato tabelle GEO', 'affiliate-link-manager-ai') . '</h4>';
+        echo '<table class="widefat striped" style="max-width:720px;margin-bottom:10px;"><tbody>';
+        echo '<tr><th>' . esc_html__('Tabella jobs', 'affiliate-link-manager-ai') . '</th><td><code>' . esc_html($status['jobs_table']) . '</code> — ' . esc_html($jobs_state) . '</td></tr>';
+        echo '<tr><th>' . esc_html__('Tabella job items', 'affiliate-link-manager-ai') . '</th><td><code>' . esc_html($status['items_table']) . '</code> — ' . esc_html($items_state) . '</td></tr>';
+        echo '</tbody></table>';
+        if (empty($status['items_exists'])) {
+            echo '<div class="notice notice-warning inline"><p>' . esc_html(sprintf(__('La tabella staging GEO non esiste: %s. Clicca Ripara tabelle GEO o disattiva/riattiva il plugin. Nessun Link Affiliato è stato modificato.', 'affiliate-link-manager-ai'), $status['items_table'])) . '</p></div>';
+        }
+        echo '<form method="post" style="display:inline-block;margin:0 8px 12px 0;">';
+        wp_nonce_field('alma_geo_affiliate_import');
+        echo '<input type="hidden" name="alma_geo_index_action" value="repair_geo_import_tables">';
+        submit_button(__('Ripara tabelle GEO', 'affiliate-link-manager-ai'), 'secondary small', 'submit', false);
+        echo '</form>';
     }
 
     private function render_affiliate_job_diagnostic($job_id) {

--- a/includes/class-geo-index-affiliate-link-importer.php
+++ b/includes/class-geo-index-affiliate-link-importer.php
@@ -248,7 +248,16 @@ class ALMA_Geo_Index_Affiliate_Link_Importer {
             'discard_examples' => array(),
             'sql_errors' => array(),
         );
+
+        $schema_ready = $job_store->ensure_tables(true);
+        if (is_wp_error($schema_ready)) {
+            return $this->schema_missing_error($schema_ready);
+        }
+
         $job_id = $job_store->create_job(ALMA_Geo_Index_Job_Store::JOB_TYPE_AFFILIATE_LINKS_GEO_IMPORT, $args['file_name'], $options, get_current_user_id());
+        if (is_wp_error($job_id)) {
+            return $job_id;
+        }
 
         $handle = fopen($file_path, 'r');
         if (!$handle) {
@@ -292,8 +301,10 @@ class ALMA_Geo_Index_Affiliate_Link_Importer {
                 $reason = 'sql_insert_failed';
                 $this->record_staging_discard($options, $row_number, $row, $reason);
                 if (!empty($wpdb->last_error)) {
-                    $options['sql_errors'][] = sanitize_textarea_field($wpdb->last_error);
-                    $options['sql_errors'] = array_slice($options['sql_errors'], -10);
+                    $this->record_sql_error($options, $job_store->table_items(), 'insert_staging_item', $wpdb->last_error);
+                    if (stripos((string) $wpdb->last_error, $job_store->table_items()) !== false || stripos((string) $wpdb->last_error, 'doesn') !== false) {
+                        break;
+                    }
                 }
             }
         }
@@ -302,6 +313,7 @@ class ALMA_Geo_Index_Affiliate_Link_Importer {
         $options['rows_read'] = $total;
         $options['items_created'] = $inserted;
         $options['rows_discarded'] = $discarded;
+        unset($options['_sql_error_keys']);
         $job_store->set_total_records($job_id, $total);
         $job_store->update_job_options($job_id, $options);
         if ($total > 0 && $inserted === 0) {
@@ -309,6 +321,41 @@ class ALMA_Geo_Index_Affiliate_Link_Importer {
             $job_store->update_job_status($job_id, 'needs_review', $message);
         }
         return $job_id;
+    }
+
+    private function schema_missing_error($error) {
+        $data = is_wp_error($error) ? $error->get_error_data() : array();
+        $missing = array_map('sanitize_text_field', (array) ($data['missing_tables'] ?? array()));
+        $items_table = '';
+        foreach ($missing as $table) {
+            if (strpos($table, 'alma_geo_import_job_items') !== false) {
+                $items_table = $table;
+                break;
+            }
+        }
+        $message = $items_table
+            ? sprintf(__('La tabella staging GEO non esiste: %s. Clicca Ripara tabelle GEO o disattiva/riattiva il plugin. Nessun Link Affiliato è stato modificato.', 'affiliate-link-manager-ai'), $items_table)
+            : __('Le tabelle staging GEO non esistono. Clicca Ripara tabelle GEO o disattiva/riattiva il plugin. Nessun Link Affiliato è stato modificato.', 'affiliate-link-manager-ai');
+        return new WP_Error('alma_geo_import_schema_missing', $message, $data);
+    }
+
+    private function record_sql_error(&$options, $table, $operation, $error) {
+        $entry = array(
+            'table' => sanitize_text_field($table),
+            'operation' => sanitize_key($operation),
+            'error' => sanitize_textarea_field($error),
+        );
+        $key = md5(wp_json_encode($entry));
+        if (empty($options['_sql_error_keys']) || !is_array($options['_sql_error_keys'])) {
+            $options['_sql_error_keys'] = array();
+        }
+        if (isset($options['_sql_error_keys'][$key])) {
+            $options['_sql_error_keys'][$key]++;
+            return;
+        }
+        $options['_sql_error_keys'][$key] = 1;
+        $options['sql_errors'][] = sprintf('%1$s %2$s: %3$s', $entry['operation'], $entry['table'], $entry['error']);
+        $options['sql_errors'] = array_slice($options['sql_errors'], -5);
     }
 
     private function zero_staging_message($options) {
@@ -320,7 +367,7 @@ class ALMA_Geo_Index_Affiliate_Link_Importer {
             'safe_import_false' => __('Tutte le righe sono state scartate perché il filtro safe_import non riconosce righe processabili in safe_for_auto_import/final_bucket.', 'affiliate-link-manager-ai'),
             'affiliate_link_not_found' => __('Tutte le righe sono state scartate perché gli affiliate_link_id non esistono nel database del sito corrente.', 'affiliate-link-manager-ai'),
             'object_not_affiliate_link' => __('Tutte le righe sono state scartate perché gli ID trovati non sono CPT affiliate_link.', 'affiliate-link-manager-ai'),
-            'sql_insert_failed' => __('Tutte le righe sono state scartate per errore SQL durante l’inserimento staging.', 'affiliate-link-manager-ai'),
+            'sql_insert_failed' => __('La tabella staging GEO non è disponibile o l’inserimento staging è fallito. Clicca Ripara tabelle GEO o disattiva/riattiva il plugin. Nessun Link Affiliato è stato modificato.', 'affiliate-link-manager-ai'),
             'missing_affiliate_url' => __('Tutte le righe sono state scartate perché affiliate_url è vuoto.', 'affiliate-link-manager-ai'),
             'invalid_affiliate_url' => __('Tutte le righe sono state scartate perché affiliate_url non è valido.', 'affiliate-link-manager-ai'),
             'missing_primary_location' => __('Tutte le righe sono state scartate perché manca una località primaria riconosciuta.', 'affiliate-link-manager-ai'),
@@ -621,10 +668,21 @@ class ALMA_Geo_Index_Affiliate_Link_Importer {
     }
 
     private function row_to_geo_data($row) {
+        $fallback = $this->primary_location_fallback($row);
+        $primary_name = sanitize_text_field($row['primary_name'] ?? '');
+        $primary_canonical = sanitize_text_field($row['primary_canonical_name'] ?? ($row['primary_name'] ?? ''));
+        if ($primary_name === '' && $primary_canonical === '' && $fallback['value'] !== '') {
+            $primary_name = $fallback['value'];
+            $primary_canonical = $fallback['value'];
+        }
+        $primary_type = sanitize_key($row['primary_type'] ?? '');
+        if (($primary_type === '' || $primary_type === 'unknown') && $fallback['type'] !== '') {
+            $primary_type = $fallback['type'];
+        }
         $primary = array(
-            'name' => sanitize_text_field($row['primary_name'] ?? ''),
-            'canonical_name' => sanitize_text_field($row['primary_canonical_name'] ?? ($row['primary_name'] ?? '')),
-            'type' => $this->allowed_or_default($row['primary_type'] ?? '', ALMA_Geo_Index_Metabox::primary_types(), 'unknown'),
+            'name' => $primary_name,
+            'canonical_name' => $primary_canonical,
+            'type' => $this->allowed_or_default($primary_type, ALMA_Geo_Index_Metabox::primary_types(), 'unknown'),
             'country' => sanitize_text_field($row['primary_country'] ?? ''),
             'country_code' => strtoupper(sanitize_text_field($row['primary_country_code'] ?? '')),
             'region' => sanitize_text_field($row['primary_region'] ?? ''),
@@ -751,13 +809,27 @@ class ALMA_Geo_Index_Affiliate_Link_Importer {
     }
 
     private function primary_location_value($row) {
-        foreach (self::primary_location_headers() as $header) {
+        $fallback = $this->primary_location_fallback($row);
+        return $fallback['value'];
+    }
+
+    private function primary_location_fallback($row) {
+        $map = array(
+            'primary_name' => '',
+            'primary_canonical_name' => '',
+            'primary_city' => 'city',
+            'primary_area' => 'area',
+            'primary_poi' => 'poi',
+            'primary_port' => 'port',
+            'primary_airport' => 'airport',
+        );
+        foreach ($map as $header => $type) {
             $value = trim((string) ($row[$header] ?? ''));
             if ($value !== '') {
-                return $value;
+                return array('value' => sanitize_text_field($value), 'type' => $type);
             }
         }
-        return '';
+        return array('value' => '', 'type' => '');
     }
 
     private function has_existing_geo($affiliate_link_id) {

--- a/includes/class-geo-index-job-store.php
+++ b/includes/class-geo-index-job-store.php
@@ -21,7 +21,7 @@ class ALMA_Geo_Index_Job_Store {
 
     public static function create_tables() {
         $store = new self();
-        $store->install_tables();
+        return $store->install_tables();
     }
 
     public function install_tables() {
@@ -31,63 +31,106 @@ class ALMA_Geo_Index_Job_Store {
         $items = $this->table_items();
 
         $sql_jobs = "CREATE TABLE $jobs (
-            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-            job_type VARCHAR(80) NOT NULL,
-            status VARCHAR(40) NOT NULL DEFAULT 'queued',
-            file_name VARCHAR(255) DEFAULT '',
-            total_records INT NOT NULL DEFAULT 0,
-            processed_records INT NOT NULL DEFAULT 0,
-            imported_records INT NOT NULL DEFAULT 0,
-            updated_records INT NOT NULL DEFAULT 0,
-            skipped_records INT NOT NULL DEFAULT 0,
-            error_records INT NOT NULL DEFAULT 0,
-            options LONGTEXT NULL,
-            created_by BIGINT UNSIGNED NULL,
-            created_at DATETIME NOT NULL,
-            started_at DATETIME NULL,
-            finished_at DATETIME NULL,
-            last_error TEXT NULL,
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            job_type varchar(80) NOT NULL,
+            status varchar(40) NOT NULL DEFAULT 'queued',
+            file_name varchar(255) DEFAULT '',
+            total_records int(11) NOT NULL DEFAULT 0,
+            processed_records int(11) NOT NULL DEFAULT 0,
+            imported_records int(11) NOT NULL DEFAULT 0,
+            updated_records int(11) NOT NULL DEFAULT 0,
+            skipped_records int(11) NOT NULL DEFAULT 0,
+            error_records int(11) NOT NULL DEFAULT 0,
+            options longtext NULL,
+            created_by bigint(20) unsigned NULL,
+            created_at datetime NOT NULL,
+            started_at datetime NULL,
+            finished_at datetime NULL,
+            last_error text NULL,
             PRIMARY KEY  (id),
             KEY job_type (job_type),
-            KEY status (status)
+            KEY status (status),
+            KEY created_at (created_at)
         ) $charset_collate;";
 
         $sql_items = "CREATE TABLE $items (
-            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-            job_id BIGINT UNSIGNED NOT NULL,
-            object_id BIGINT UNSIGNED NULL,
-            object_type VARCHAR(50) DEFAULT '',
-            row_number INT NOT NULL,
-            status VARCHAR(40) NOT NULL DEFAULT 'queued',
-            action VARCHAR(40) DEFAULT '',
-            message TEXT NULL,
-            raw_payload LONGTEXT NULL,
-            processed_at DATETIME NULL,
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            job_id bigint(20) unsigned NOT NULL,
+            object_id bigint(20) unsigned NULL,
+            object_type varchar(50) DEFAULT '',
+            row_number int(11) NOT NULL,
+            status varchar(40) NOT NULL DEFAULT 'queued',
+            action varchar(40) DEFAULT '',
+            message text NULL,
+            raw_payload longtext NULL,
+            processed_at datetime NULL,
             PRIMARY KEY  (id),
             KEY job_id (job_id),
             KEY status (status),
-            KEY object_lookup (object_id, object_type)
+            KEY job_status (job_id, status),
+            KEY object_lookup (object_id, object_type),
+            KEY row_lookup (job_id, row_number)
         ) $charset_collate;";
 
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         dbDelta($sql_jobs);
         dbDelta($sql_items);
+        update_option('alma_geo_import_schema_version', '2', false);
+
+        return $this->schema_status();
     }
 
-    public function tables_exist() {
+    public function schema_status() {
         global $wpdb;
         $jobs = $this->table_jobs();
         $items = $this->table_items();
-        return $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $jobs)) === $jobs
-            && $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $items)) === $items;
+        return array(
+            'jobs_table' => $jobs,
+            'items_table' => $items,
+            'jobs_exists' => $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $jobs)) === $jobs,
+            'items_exists' => $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $items)) === $items,
+            'schema_version' => (string) get_option('alma_geo_import_schema_version', ''),
+            'last_error' => sanitize_textarea_field($wpdb->last_error),
+        );
+    }
+
+    public function tables_exist() {
+        $status = $this->schema_status();
+        return !empty($status['jobs_exists']) && !empty($status['items_exists']);
+    }
+
+    public function ensure_tables($repair = true) {
+        $status = $this->schema_status();
+        if (!empty($status['jobs_exists']) && !empty($status['items_exists'])) {
+            return true;
+        }
+        if ($repair) {
+            $status = $this->install_tables();
+            if (!empty($status['jobs_exists']) && !empty($status['items_exists'])) {
+                return true;
+            }
+        }
+        $missing = array();
+        if (empty($status['jobs_exists'])) {
+            $missing[] = $this->table_jobs();
+        }
+        if (empty($status['items_exists'])) {
+            $missing[] = $this->table_items();
+        }
+        return new WP_Error(
+            'alma_geo_import_schema_missing',
+            __('Le tabelle staging GEO non sono disponibili. Clicca Ripara tabelle GEO o disattiva/riattiva il plugin. Nessun Link Affiliato è stato modificato.', 'affiliate-link-manager-ai'),
+            array('missing_tables' => $missing, 'schema_status' => $status)
+        );
     }
 
     public function create_job($job_type, $file_name, $options = array(), $created_by = 0) {
         global $wpdb;
-        if (!$this->tables_exist()) {
-            $this->install_tables();
+        $schema_ready = $this->ensure_tables(true);
+        if (is_wp_error($schema_ready)) {
+            return $schema_ready;
         }
-        $wpdb->insert($this->table_jobs(), array(
+        $inserted = $wpdb->insert($this->table_jobs(), array(
             'job_type' => sanitize_key($job_type),
             'status' => 'queued',
             'file_name' => sanitize_file_name($file_name),
@@ -101,6 +144,13 @@ class ALMA_Geo_Index_Job_Store {
             'created_by' => absint($created_by),
             'created_at' => current_time('mysql'),
         ), array('%s','%s','%s','%d','%d','%d','%d','%d','%d','%s','%d','%s'));
+        if (!$inserted) {
+            return new WP_Error('alma_geo_import_job_insert_failed', __('Impossibile creare la sessione staging GEO.', 'affiliate-link-manager-ai'), array(
+                'table' => $this->table_jobs(),
+                'operation' => 'insert_job',
+                'sql_error' => sanitize_textarea_field($wpdb->last_error),
+            ));
+        }
         return (int) $wpdb->insert_id;
     }
 
@@ -110,7 +160,7 @@ class ALMA_Geo_Index_Job_Store {
         if (!in_array($status, array('queued','processing','imported','updated','skipped','error'), true)) {
             $status = 'error';
         }
-        $wpdb->insert($this->table_items(), array(
+        $inserted = $wpdb->insert($this->table_items(), array(
             'job_id' => absint($job_id),
             'object_id' => $object_id ? absint($object_id) : null,
             'object_type' => sanitize_key($object_type),
@@ -121,7 +171,7 @@ class ALMA_Geo_Index_Job_Store {
             'raw_payload' => wp_json_encode(is_array($payload) ? $payload : array()),
             'processed_at' => null,
         ), array('%d','%d','%s','%d','%s','%s','%s','%s','%s'));
-        return (int) $wpdb->insert_id;
+        return $inserted ? (int) $wpdb->insert_id : 0;
     }
 
     public function set_total_records($job_id, $total) {
@@ -441,6 +491,44 @@ class ALMA_Geo_Index_Job_Store {
         return 'ready';
     }
 
+
+    private function primary_message_reason($message) {
+        $message = sanitize_textarea_field((string) $message);
+        if ($message === '') {
+            return '';
+        }
+        $reasons = array(
+            'duplicate_staging_item',
+            'missing_affiliate_link_id',
+            'invalid_affiliate_link_id',
+            'missing_affiliate_url',
+            'affiliate_link_not_found',
+            'object_not_affiliate_link',
+            'safe_import_false',
+            'safe_import_skipped',
+            'final_bucket_discard',
+            'existing_geo_skipped',
+            'secondary_locations_json_invalid',
+            'invalid_affiliate_url',
+            'invalid_url',
+            'incomplete_record',
+            'missing_primary_location',
+            'missing_primary_name',
+            'unknown_location',
+            'missing_region',
+            'duplicate',
+            'sql_insert_failed',
+            'unknown_error',
+            'needs_review',
+        );
+        foreach ($reasons as $reason) {
+            if (preg_match('/(^|[^a-z0-9_])' . preg_quote($reason, '/') . '($|[^a-z0-9_])/', $message)) {
+                return $reason;
+            }
+        }
+        return '';
+    }
+
     public function get_report($job_id) {
         $job = $this->get_job($job_id);
         if (!$job) {
@@ -473,6 +561,8 @@ class ALMA_Geo_Index_Job_Store {
             'existing_geo_skipped' => 0,
             'already_present' => 0,
             'duplicates' => 0,
+            'duplicate_staging_item' => 0,
+            'duplicate' => 0,
             'invalid_urls' => 0,
             'incomplete_records' => 0,
             'unknown_locations' => 0,
@@ -510,17 +600,18 @@ class ALMA_Geo_Index_Job_Store {
                 );
                 $report['discard_examples'] = array_slice($report['discard_examples'], -10);
             }
-            foreach (array('missing_affiliate_link_id','invalid_affiliate_link_id','missing_affiliate_url','affiliate_link_not_found','object_not_affiliate_link','safe_import_false','safe_import_skipped','final_bucket_discard','existing_geo_skipped','secondary_locations_json_invalid','invalid_affiliate_url','invalid_url','incomplete_record','missing_primary_location','missing_primary_name','unknown_location','missing_region','duplicate_staging_item','duplicate','sql_insert_failed','unknown_error','needs_review') as $needle) {
-                if (strpos($message, $needle) !== false) {
-                    if (isset($report[$needle])) { $report[$needle]++; }
-                    if ($needle === 'existing_geo_skipped') { $report['already_present']++; }
-                    if ($needle === 'invalid_url' || $needle === 'invalid_affiliate_url') { $report['invalid_urls']++; }
-                    if ($needle === 'incomplete_record') { $report['incomplete_records']++; }
-                    if ($needle === 'unknown_location' || $needle === 'missing_primary_name' || $needle === 'missing_primary_location') { $report['unknown_locations']++; }
-                    if ($needle === 'missing_region') { $report['missing_region']++; }
-                    if ($needle === 'duplicate' || $needle === 'duplicate_staging_item') { $report['duplicates']++; }
-                    if ($needle === 'needs_review') { $report['needs_review']++; }
+            $primary_reason = $this->primary_message_reason($message);
+            if ($primary_reason !== '') {
+                if (isset($report[$primary_reason])) {
+                    $report[$primary_reason]++;
                 }
+                if ($primary_reason === 'existing_geo_skipped') { $report['already_present']++; }
+                if (in_array($primary_reason, array('invalid_url','invalid_affiliate_url'), true)) { $report['invalid_urls']++; }
+                if ($primary_reason === 'incomplete_record') { $report['incomplete_records']++; }
+                if (in_array($primary_reason, array('unknown_location','missing_primary_name','missing_primary_location'), true)) { $report['unknown_locations']++; }
+                if ($primary_reason === 'missing_region') { $report['missing_region']++; }
+                if (in_array($primary_reason, array('duplicate','duplicate_staging_item'), true)) { $report['duplicates']++; }
+                if ($primary_reason === 'needs_review') { $report['needs_review']++; }
             }
             if (preg_match('/secondaries_imported=(\d+)/', $message, $m)) {
                 $report['secondaries_imported'] += (int) $m[1];


### PR DESCRIPTION
### Motivation
- The affiliate GEO import was reading the CSV correctly but all rows were discarded because staging inserts failed with SQL errors due to a missing staging table `alma_geo_import_job_items`.
- The import flow must be defensive: ensure the staging schema exists before creating items, provide a clear admin repair path, and avoid thousands of failing INSERT attempts.
- Also address two review issues: duplicate reason double-counting and fallback primary-location name when `primary_name` is missing.

### Description
- Added idempotent schema management for GEO import staging in `ALMA_Geo_Index_Job_Store`: `install_tables()` creates `alma_geo_import_jobs` and `alma_geo_import_job_items` using `dbDelta` with WordPress charset/collation and sensible indexes, stores schema version, and returns `schema_status()`; `ensure_tables()` attempts auto-repair once and returns a `WP_Error` if missing. (file: `includes/class-geo-index-job-store.php`) 
- Guarded job/session creation by verifying/repairing schema before inserts; `create_job_from_csv()` now calls `ensure_tables()` and returns a clear error if repair fails. (file: `includes/class-geo-index-affiliate-link-importer.php`) 
- Improved SQL diagnostics for staging insert failures: aggregate and limit stored SQL error messages, record operation/table/last error and stop attempting repeated inserts when the table is absent. (file: `includes/class-geo-index-affiliate-link-importer.php`) 
- Added admin-facing repair tooling: status display for `jobs` and `job_items` and a nonce-protected “Ripara tabelle GEO” button in the Import GEO admin tools that invokes the migration (`dbDelta`). Also show a clear warning when the items table is missing. (file: `includes/class-geo-index-admin.php`) 
- Fixed duplicate counting in the import report by selecting a single primary reason per item via `primary_message_reason()` and dedicated counters (`duplicate_staging_item` and `duplicate`). (file: `includes/class-geo-index-job-store.php`) 
- Fixed primary-location fallback so `row_to_geo_data()` will populate `primary_name`/`primary_canonical_name` and pick a coherent `primary_type` from `primary_city`, `primary_area`, `primary_poi`, `primary_port`, `primary_airport` when explicit primary name fields are empty. (file: `includes/class-geo-index-affiliate-link-importer.php`) 
- Defensive changes to admin/upgrade/activation flow to ensure the GEO import schema migration runs on activation and upgrade and to track the import schema version. Plugin version bumped to `2.41.5`. (file: `affiliate-link-manager-ai.php`) 
- Documentation updates in `README.md` and `CHANGELOG.md` describing the checks, repair action and fixes.

### Testing
- Ran static and syntax checks: `php -l` for modified PHP files (succeeded). 
- Ran repository checks: `git diff --check` (no issues) and ensured Affiliate Sources/GetYourGuide areas were not modified. 
- Committed changes on branch `fix-geo-import-schema-staging` (commit `9e68573`). 
- Note: full end-to-end WordPress runtime tests with the real CSV and DB were not executed in this environment; follow the manual test steps below to validate on a WordPress instance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a258cb71b2c833298d91e2c6c5daff8)