### PR TITLE
Fix GEO job items table SQL schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.41.7 - 2026-06-07
+
+### Fix GEO job items table SQL schema
+- Fix sintassi SQL tabella `alma_geo_import_job_items`: la colonna fisica `row_number` è stata sostituita con `csv_row_number` nella `CREATE TABLE` e nell’indice `row_lookup` per evitare errori MySQL/MariaDB vicino a `row_number`.
+- Fix falso positivo `dbDelta` “Created table”: il repair è riuscito solo se le tabelle esistono fisicamente dopo `SHOW TABLES LIKE` e non rimane un errore SQL bloccante in `$wpdb->last_error`.
+- Migliorata diagnostica repair negli Strumenti avanzati con tabella richiesta, esistenza prima/dopo, risultato `dbDelta`, `$wpdb->last_error`, MySQL/SQLSTATE, varianti e messaggio operativo.
+- Blocco prepare se lo schema GEO resta mancante dopo un repair difensivo, evitando insert staging destinati a fallire e senza toccare Affiliate Sources/GetYourGuide CSV.
+- Versione plugin aggiornata a `2.41.7`.
+
 ## 2.41.6 - 2026-06-07
 
 ### Fix GEO schema repair for missing job items table

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 
 - **Controllo tabelle GEO**: l’import verifica le tabelle `alma_geo_import_jobs` e `alma_geo_import_job_items` in attivazione, upgrade, prima di “Prepara import GEO” e negli strumenti avanzati. La tabella `alma_geo_import_job_items` è obbligatoria perché contiene la staging dei record prima dei batch manuali.
-- **Ripara tabelle GEO**: in **G. Strumenti avanzati** sono mostrati stato tabella jobs e job items con il pulsante “Ripara tabelle GEO”. Il repair usa `SHOW TABLES LIKE` prima/dopo, richiama `dbDelta`, rispetta charset/collation WordPress, non elimina dati e può essere usato se appare “tabella staging mancante”.
-- **Errore staging mancante**: se la tabella `alma_geo_import_job_items` manca e l’auto-repair non riesce, “Prepara import GEO” tenta un solo repair difensivo, si blocca prima degli insert e mostra che nessun Link Affiliato è stato modificato invece di generare migliaia di `sql_insert_failed`.
-- **Diagnostica SQL staging**: gli errori di insert staging salvano operazione, tabella e ultimo errore aggregato con esempi limitati negli strumenti avanzati. Se `dbDelta` non crea `alma_geo_import_job_items`, la diagnostica avanzata mostra tabella richiesta, esistenza prima/dopo, risultato `dbDelta`, `wpdb->last_error`, eventuale errore MySQL/SQLSTATE, tabelle con nome diverso e messaggio operativo non tecnico.
+- **Ripara tabelle GEO**: in **G. Strumenti avanzati** sono mostrati stato tabella jobs e job items con il pulsante “Ripara tabelle GEO”. Il repair crea/corregge la tabella staging `alma_geo_import_job_items`, usa `SHOW TABLES LIKE` prima/dopo, richiama `dbDelta`, rispetta charset/collation WordPress, non elimina dati e può essere usato se appare “tabella staging mancante”.
+- **Errore staging mancante**: se la tabella `alma_geo_import_job_items` manca e l’auto-repair non riesce, “Prepara import GEO” tenta un solo repair difensivo, considera riuscito `dbDelta()` solo se la tabella esiste fisicamente dopo il repair e si blocca prima degli insert, mostrando che nessun Link Affiliato è stato modificato invece di generare migliaia di `sql_insert_failed`.
+- **Diagnostica SQL staging**: gli errori di insert staging salvano operazione, tabella e ultimo errore aggregato con esempi limitati negli strumenti avanzati. Se `dbDelta` non crea `alma_geo_import_job_items`, la diagnostica avanzata mostra tabella richiesta, esistenza prima/dopo, risultato `dbDelta`, `wpdb->last_error`, eventuale errore MySQL/SQLSTATE, tabelle con nome diverso e messaggio operativo non tecnico. Se negli Strumenti avanzati compare un errore SQL, copia il messaggio operativo/`wpdb->last_error`, verifica i permessi `CREATE/ALTER` del database e rilancia il repair dopo backup, senza usare DROP TABLE.
 - **Fix duplicati staging**: i motivi di scarto sono conteggiati con matching prioritario mutualmente esclusivo, quindi `staging_duplicate_staging_item` non incrementa anche il contatore generico `duplicate`.
 - **Fix fallback località primaria**: l’import batch usa `primary_city`, `primary_area`, `primary_poi`, `primary_port` o `primary_airport` come nome/canonical quando `primary_name` e `primary_canonical_name` sono vuoti, mantenendo il tipo coerente.
 - **Workflow snello**: la pagina Import GEO Link Affiliati è organizzata in **A. Carica CSV**, **B. Preview**, **C. Prepara import**, **D. Importazione**, **E. Report**, **F. Geocoding Google** e **G. Strumenti avanzati**.
@@ -20,7 +20,8 @@
 - **Download completi**: “Scarica report CSV” e “Scarica log JSON” esportano in pagine controllate fino a esaurimento righe, senza troncamento silenzioso a 50.000 record.
 - **Pausa legacy**: l’endpoint AJAX legacy di pausa restituisce un errore controllato perché il nuovo workflow manuale non ha job automatici da mettere in pausa; il pulsante pausa non è nella UI principale.
 - **Geocoding Google separato**: l’import salva/predispone località sorgente, località normalizzata, regione, paese, lat/lng, Google Place ID, formatted address, stato/confidence geocoding, ultimo geocoding ed errore, ma non chiama Google API durante i batch.
-- Versione plugin aggiornata a `2.41.6`.
+- **Fix SQL staging job items**: la colonna fisica del numero riga CSV è `csv_row_number`, evitando incompatibilità con host MySQL/MariaDB che trattano `row_number` come nome problematico; il codice mantiene `row_number` come dato logico nei report/UI.
+- Versione plugin aggiornata a `2.41.7`.
 
 ## 2.41.0 - 2026-06-06
 

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.41.6
+ * Version: 2.41.7
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.41.6');
+define('ALMA_VERSION', '2.41.7');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -4128,7 +4128,7 @@ class AffiliateManagerAI {
         $installed_version = get_option('alma_plugin_version', '0.0.0');
         $geo_import_schema_version = get_option('alma_geo_import_schema_version', '0');
         $geo_job_store = new ALMA_Geo_Index_Job_Store();
-        if (version_compare($installed_version, ALMA_VERSION, '<') || version_compare((string) $geo_import_schema_version, '3', '<') || !$geo_job_store->tables_exist()) {
+        if (version_compare($installed_version, ALMA_VERSION, '<') || version_compare((string) $geo_import_schema_version, '4', '<') || !$geo_job_store->tables_exist()) {
             ALMA_AI_Content_Agent_Store::install();
             $this->clear_deprecated_trend_cron_events();
             $this->create_analytics_table();

--- a/includes/class-geo-index-job-store.php
+++ b/includes/class-geo-index-job-store.php
@@ -63,19 +63,19 @@ class ALMA_Geo_Index_Job_Store {
             job_id bigint(20) unsigned NOT NULL,
             object_id bigint(20) unsigned NULL,
             object_type varchar(50) DEFAULT '',
-            row_number int(11) NOT NULL,
+            csv_row_number int(11) NOT NULL,
             status varchar(40) NOT NULL DEFAULT 'queued',
             action varchar(40) DEFAULT '',
             message text NULL,
             raw_payload longtext NULL,
-            created_at datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+            created_at datetime NOT NULL,
             processed_at datetime NULL,
             PRIMARY KEY  (id),
             KEY job_id (job_id),
             KEY status (status),
             KEY job_status (job_id, status),
             KEY object_lookup (object_id, object_type),
-            KEY row_lookup (job_id, row_number),
+            KEY row_lookup (job_id, csv_row_number),
             KEY created_at (created_at)
         ) $charset_collate;";
 
@@ -86,13 +86,13 @@ class ALMA_Geo_Index_Job_Store {
         $last_error = (string) $wpdb->last_error;
         $after = $this->schema_status();
         $variant_tables = $this->find_variant_item_tables();
-        $success = !empty($after['jobs_exists']) && !empty($after['items_exists']);
+        $success = !empty($after['jobs_exists']) && !empty($after['items_exists']) && $last_error === '';
         $message = $success
             ? __('Schema riparato correttamente.', 'affiliate-link-manager-ai')
             : $this->repair_failure_message($before, $after, $dbdelta_items, $last_error, $variant_tables);
 
         if ($success) {
-            update_option('alma_geo_import_schema_version', '3', false);
+            update_option('alma_geo_import_schema_version', '4', false);
         }
 
         return array_merge($after, array(
@@ -151,6 +151,44 @@ class ALMA_Geo_Index_Job_Store {
             }
         }
         return $found;
+    }
+
+
+    public function item_row_number_column() {
+        $columns = $this->item_table_columns();
+        if (isset($columns['csv_row_number'])) {
+            return 'csv_row_number';
+        }
+        if (isset($columns['row_number'])) {
+            return 'row_number';
+        }
+        return 'csv_row_number';
+    }
+
+    private function item_table_columns() {
+        global $wpdb;
+        if (!$this->table_exists($this->table_items())) {
+            return array();
+        }
+        $rows = $wpdb->get_results('SHOW COLUMNS FROM ' . $this->backtick_identifier($this->table_items()), ARRAY_A);
+        $columns = array();
+        foreach ((array) $rows as $row) {
+            if (!empty($row['Field'])) {
+                $columns[(string) $row['Field']] = true;
+            }
+        }
+        return $columns;
+    }
+
+    private function backtick_identifier($identifier) {
+        return '`' . str_replace('`', '``', (string) $identifier) . '`';
+    }
+
+    private function normalize_item_row_number($item) {
+        if (is_array($item) && !isset($item['row_number']) && isset($item['csv_row_number'])) {
+            $item['row_number'] = $item['csv_row_number'];
+        }
+        return $item;
     }
 
     private function repair_failure_message($before, $after, $dbdelta_items, $last_error, $variant_tables) {
@@ -259,18 +297,19 @@ class ALMA_Geo_Index_Job_Store {
         if (!in_array($status, array('queued','processing','imported','updated','skipped','error'), true)) {
             $status = 'error';
         }
-        $inserted = $wpdb->insert($this->table_items(), array(
+        $data = array(
             'job_id' => absint($job_id),
             'object_id' => $object_id ? absint($object_id) : null,
             'object_type' => sanitize_key($object_type),
-            'row_number' => absint($row_number),
+            $this->item_row_number_column() => absint($row_number),
             'status' => $status,
             'action' => sanitize_key($action),
             'message' => sanitize_textarea_field($message),
             'raw_payload' => wp_json_encode(is_array($payload) ? $payload : array()),
             'created_at' => current_time('mysql'),
             'processed_at' => null,
-        ), array('%d','%d','%s','%d','%s','%s','%s','%s','%s','%s'));
+        );
+        $inserted = $wpdb->insert($this->table_items(), $data, array('%d','%d','%s','%d','%s','%s','%s','%s','%s','%s'));
         return $inserted ? (int) $wpdb->insert_id : 0;
     }
 
@@ -369,6 +408,7 @@ class ALMA_Geo_Index_Job_Store {
             $items = array();
         }
         foreach ($items as &$item) {
+            $item = $this->normalize_item_row_number($item);
             $decoded_payload = json_decode((string) ($item['raw_payload'] ?? ''), true);
             $item['raw_payload'] = is_array($decoded_payload) ? $decoded_payload : array();
         }
@@ -479,7 +519,12 @@ class ALMA_Geo_Index_Job_Store {
         } else {
             $rows = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$this->table_items()} WHERE job_id = %d ORDER BY id DESC LIMIT %d", absint($job_id), $limit), ARRAY_A);
         }
-        return $rows ?: array();
+        $rows = $rows ?: array();
+        foreach ($rows as &$row) {
+            $row = $this->normalize_item_row_number($row);
+        }
+        unset($row);
+        return $rows;
     }
 
 
@@ -488,7 +533,9 @@ class ALMA_Geo_Index_Job_Store {
         $job_id = absint($job_id);
         $job = $this->get_job($job_id);
         $counts = $this->get_item_status_counts($job_id);
-        $latest_item = $wpdb->get_row($wpdb->prepare("SELECT id, row_number, object_id, object_type, status, action, message, processed_at FROM {$this->table_items()} WHERE job_id = %d ORDER BY id DESC LIMIT 1", $job_id), ARRAY_A);
+        $row_number_column = $this->item_row_number_column();
+        $row_number_sql = $this->backtick_identifier($row_number_column);
+        $latest_item = $wpdb->get_row($wpdb->prepare("SELECT id, {$row_number_sql} AS row_number, object_id, object_type, status, action, message, processed_at FROM {$this->table_items()} WHERE job_id = %d ORDER BY id DESC LIMIT 1", $job_id), ARRAY_A);
         return array_merge(array(
             'job_id' => $job_id,
             'total_item_rows' => array_sum(array_map('intval', $counts)),
@@ -540,6 +587,7 @@ class ALMA_Geo_Index_Job_Store {
         $offset = max(0, absint($offset));
         $items = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$this->table_items()} WHERE job_id = %d ORDER BY id ASC LIMIT %d OFFSET %d", $job_id, $limit, $offset), ARRAY_A) ?: array();
         foreach ($items as &$item) {
+            $item = $this->normalize_item_row_number($item);
             $payload = json_decode((string) ($item['raw_payload'] ?? ''), true);
             $item['raw_payload'] = is_array($payload) ? $payload : array();
         }


### PR DESCRIPTION
### Motivation

- Risolvere il fallimento di `CREATE TABLE` per la tabella staging GEO `{$wpdb->prefix}alma_geo_import_job_items` dovuto a un identificatore/DDL non compatibile intorno alla colonna `row_number` e rimuovere i falsi positivi di `dbDelta()` che mostrano "Created table" anche se la tabella non è stata materialmente creata.

### Description

- La colonna fisica numero riga nella query `CREATE TABLE` è stata rinominata in `csv_row_number` e l’indice `row_lookup` è aggiornato a `(job_id, csv_row_number)` per evitare errori di sintassi/compatibilità su MySQL/MariaDB; la colonna `created_at` ora non usa il valore di default non standard. (file: `includes/class-geo-index-job-store.php`)
- Aggiunta logica di compatibilità che rileva quale colonna fisica è presente (`csv_row_number` o `row_number`) e la espone sempre come campo logico `row_number` per UI/report/insert (`item_row_number_column()`, `item_table_columns()`, `normalize_item_row_number()`). I metodi di inserimento/lettura (`add_job_item`, `get_items`, `get_items_with_payload`, diagnostica) usano questa astrazione. (file: `includes/class-geo-index-job-store.php`)
- Migliorato criterio di successo del repair: oltre a chiamare `dbDelta()` si verifica fisicamente l’esistenza delle tabelle (`SHOW TABLES LIKE`) e si richiede che `$wpdb->last_error` sia vuoto per considerare il repair riuscito; in caso contrario viene restituito errore operativo con diagnostica. Lo schema GEO è avanzato a versione `4`. (file: `includes/class-geo-index-job-store.php`, `affiliate-link-manager-ai.php`)
- Documentazione aggiornata: `README.md` e `CHANGELOG.md` descrivono la correzione della DDL, il comportamento difensivo del repair/diagnostica e l’aggiornamento versione plugin a `2.41.7`. (file: `README.md`, `CHANGELOG.md`, `affiliate-link-manager-ai.php`)

### Testing

- Eseguiti controlli statici e di coerenza sul codice: `php -l` su tutti i file PHP (tutti passati), `git diff --check` (nessun warning) e verifiche con uno script Python che asserisce la presenza di `csv_row_number`, dell’indice `row_lookup (job_id, csv_row_number)` e della condizione di gating del repair (`$last_error === ''`); queste verifiche sono passate con successo.
- Non sono stati eseguiti test WordPress/DB end-to-end nel container; per completare la validazione è richiesto un test su istanza WordPress con DB MySQL/MariaDB: seguire la checklist manuale nel changelog/README (Ripara tabelle GEO, carica CSV GEO, Prepara import GEO, Importa prossimo batch) per verificare che la tabella venga creata, che non compaia più l’errore SQL vicino a `row_number` e che gli item staging vengano effettivamente inseriti e processati.
- Nota sui rischi residui: verificare permessi DB `CREATE/ALTER` e installazioni legacy con colonne ibride; il codice gestisce entrambi i casi ma si raccomanda di controllare la diagnostica avanzata mostrata in Strumenti avanzati se si riscontrano errori SQL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a259446f9c48332b6bb728dc9d60746)