### PR TITLE
v2.42.0: fix prioritari (tracking, sicurezza, concorrenza) e Widget Contestuale realmente contestuale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+## 2.42.0 - 2026-07-02
+
+### Tracking click affidabile
+- Incremento atomico del contatore `_click_count`: i click concorrenti non vengono più persi e le eventuali righe meta duplicate del primo click vengono ripulite automaticamente.
+- L'opzione "Non tracciare utenti anonimi" è ora applicata anche lato server, non solo in JavaScript.
+- Aggiunto filtro bot sullo user agent (mirato ai crawler noti, personalizzabile con il filtro `alma_is_bot_user_agent`) e rate limit breve per IP+user agent+link contro doppi eventi e replay.
+- Header `X-Forwarded-For` multi-valore ora parsato correttamente (primo IP pubblico valido).
+- La verifica della tabella analytics avviene una sola volta per versione (niente più `SHOW TABLES` a ogni click) e viene ritentata finché la creazione non riesce; gli insert falliti vengono loggati.
+- Frontend: rimosso il tracking del tasto destro (gonfiava i conteggi), middle-click tracciato via `auxclick`, `MutationObserver` al posto del deprecato `DOMNodeInserted`, eventi Google Analytics non inviati per click rifiutati dal server.
+
+### Fix bug
+- La rimozione degli shortcode alla cancellazione di un link non tocca più i link con ID più lunghi (eliminare il link 12 non rimuove più lo shortcode del link 123); stesso fix per i widget.
+- "Elimina per ID" nelle impostazioni ed eliminazione idee AI verificano il post type prima di `wp_delete_post`: non è più possibile cancellare definitivamente articoli o pagine per errore.
+- Il widget WordPress `affiliate_links_widget` viene ora registrato correttamente (l'aggancio arrivava a `widgets_init` già eseguito e il widget non compariva mai).
+- Rimosso l'evento cron giornaliero `alma_daily_optimization`, schedulato ma privo di handler; le occorrenze residue vengono ripulite automaticamente.
+- Le colonne "Click" e "AI Score" nell'elenco Link Affiliati ora ordinano davvero, preservando il filtro Source attivo e includendo i link mai cliccati.
+- Import GYG CSV: l'import non viene più marcato completato prima della fine del file; i job catturano anche errori fatali PHP e rilasciano sempre il lock.
+
+### Sicurezza
+- Le chiavi API possono essere definite in `wp-config.php` con `define('ALMA_OPENAI_API_KEY', '...')` e `define('ALMA_GEO_GOOGLE_MAPS_API_KEY', '...')`: hanno priorità sull'option e non passano dal database. La chiave OpenAI salvata via UI usa ora `autoload=no`.
+- Corretto XSS DOM nella dashboard admin (titoli dei link iniettati senza escaping).
+- Neutralizzata la formula injection (`=`, `+`, `-`, `@`) nei CSV esportati dal modulo GEO.
+- Rate limit per utente (15/minuto, finestra fissa) e cache breve dei risultati sulla ricerca località Google del metabox.
+
+### Modulo GEO — concorrenza e robustezza
+- Claim atomico degli item staging con token univoco: due batch concorrenti non processano più gli stessi record.
+- Lock anti-concorrenza sui batch di geocoding: elaborazioni parallele (due tab/utenti) non duplicano più le chiamate Google; la risposta bloccata riporta il numero reale di pending.
+- `REQUEST_DENIED` è ora trattato come errore permanente di configurazione (API key non valida / API non abilitata) con messaggio esplicito e interruzione del batch, invece di `retry_later` fuorviante.
+- Corretto il numero di format nell'insert degli item staging e il cap (ultime 500 righe) del report cumulativo di geocoding in user meta.
+
+### Sottosistema AI
+- `estimated_cost` è ora un costo reale in USD calcolato da una tabella prezzi per modello (estendibile con il filtro `alma_openai_model_prices`); i vecchi valori, che contenevano conteggi token, vengono azzerati una tantum per non falsare i totali.
+- L'indice affiliati elimina la riga alla cancellazione definitiva del link invece di reindicizzarla (niente più record orfani).
+- Il reindex della Knowledge Base rinfresca sempre i contenuti modificati di recente e in più avanza un cursore persistente di backfill sul resto del sito (prima indicizzava solo i 20 post più recenti per tipo).
+- Lock anti-stampede sulla chiamata OpenAI frontend del Bot Affiliate: visitatori simultanei sulla stessa pagina non generano più chiamate API multiple.
+- Whitelist dello stato documento TXT (`active`/`inactive`) nel toggle dell'AI Content Agent.
+- Versione plugin aggiornata a `2.42.0`.
+
 ## 2.41.8 - 2026-06-08
 
 - Aggiunto geocoding massivo delle località da Link Affiliati nella tab Geocoding, con sezione dedicata, progress bar, report cumulativo sessione corrente ed elaborazione interrompibile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 2.42.0 - 2026-07-02
 
+### Widget Link Contestuale — matching contestuale reale
+- Il Geo Index è ora il segnale dominante del matching: località condivise tra articolo e Link Affiliato valgono fino a 45 punti (città/località), 20 (regione), 10 (paese), con penalità per località esplicitamente diverse; senza dati geo il segnale è neutro e vale il matching testuale.
+- I candidati sono selezionati per pertinenza (località condivise + keyword via indice affiliati AI + recenti come riempimento) invece dei soli ultimi 200 link per data.
+- Scoring keyword graduato per quantità e rarità sul pool di candidati, con raddoppio per match nel titolo/heading; match solo a parola intera (niente più "roma" dentro "romantico").
+- Cache invalidata per singolo articolo al salvataggio (bump globale solo per Link Affiliati e impostazioni); l'opzione "Escludi link già presenti = No" ora funziona (penalità lieve invece dell'azzeramento); i click storici pesano al massimo 3 punti.
+- Aggiornata la descrizione nella pagina admin del Widget Contestuale con il nuovo funzionamento e il suggerimento di associare le località.
+
 ### Tracking click affidabile
 - Incremento atomico del contatore `_click_count`: i click concorrenti non vengono più persi e le eventuali righe meta duplicate del primo click vengono ripulite automaticamente.
 - L'opzione "Non tracciare utenti anonimi" è ora applicata anche lato server, non solo in JavaScript.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 ## 2.42.0 - 2026-07-02
 
+### Widget Link Contestuale — matching realmente contestuale alla pagina
+
+- **Geo Index come segnale dominante**: il widget ora confronta le località associate all'articolo (metabox Geolocalizzazione contenuto / import GEO) con quelle dei Link Affiliati. Stessa città o località: fino a 45 punti; stessa regione: 20; stesso paese: 10; località esplicitamente diverse: penalità. Senza dati geografici da una delle due parti il segnale è neutro e vale il matching testuale (retrocompatibile).
+- **Candidati selezionati per pertinenza, non per data**: la rosa dei candidati unisce i link che condividono località con l'articolo, quelli pertinenti per keyword secondo l'indice affiliati AI e, come riempimento, i più recenti (comportamento storico). Cade il limite pratico degli "ultimi 200 per data": un link pertinente ma importato tempo fa ora viene considerato.
+- **Scoring graduato per quantità e rarità**: le keyword in comune non danno più bonus fissi al primo match; ogni keyword pesa in base alla sua rarità sul pool di candidati (un nome di città vale molto, "tour" quasi nulla) e raddoppia se compare nel titolo o negli heading. Un link affine solo per tipologia non supera più la soglia di default.
+- **Match a parola intera**: eliminato il confronto per sottostringa che produceva falsi positivi sistematici ("roma" dentro "romantico").
+- **Cache per articolo**: il salvataggio di un articolo invalida solo la sua cache (via data di modifica nell'hash); il bump globale avviene solo per salvataggi di Link Affiliati e impostazioni. Prima ogni salvataggio azzerava la cache dell'intero sito.
+- **Fix opzione "Escludi link già presenti" = No**: i link già presenti nell'articolo ora possono comparire con una lieve penalità; prima la penalità di −100 li azzerava sempre, rendendo l'opzione inefficace.
+- La popolarità (click storici) contribuisce al massimo 3 punti: non domina più la contestualità a parità di pertinenza.
+
 ### Affidabilità, sicurezza e concorrenza
 
 - **Tracking click affidabile**: incremento atomico del contatore (i click concorrenti non si perdono più), opzione "non tracciare utenti anonimi" applicata anche lato server, filtro bot sui crawler noti (personalizzabile via filtro `alma_is_bot_user_agent`), rate limit breve anti-doppio evento, parsing corretto di `X-Forwarded-For` multi-valore e niente più `SHOW TABLES` a ogni click. Lato frontend il tasto destro non viene più conteggiato, il middle-click usa `auxclick` e il deprecato `DOMNodeInserted` è stato sostituito da `MutationObserver`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+## 2.42.0 - 2026-07-02
+
+### Affidabilità, sicurezza e concorrenza
+
+- **Tracking click affidabile**: incremento atomico del contatore (i click concorrenti non si perdono più), opzione "non tracciare utenti anonimi" applicata anche lato server, filtro bot sui crawler noti (personalizzabile via filtro `alma_is_bot_user_agent`), rate limit breve anti-doppio evento, parsing corretto di `X-Forwarded-For` multi-valore e niente più `SHOW TABLES` a ogni click. Lato frontend il tasto destro non viene più conteggiato, il middle-click usa `auxclick` e il deprecato `DOMNodeInserted` è stato sostituito da `MutationObserver`.
+- **Fix distruttivi**: la pulizia degli shortcode non rimuove più shortcode di link con ID più lunghi (12 vs 123); "Elimina per ID" e l'eliminazione idee AI verificano il post type prima della cancellazione definitiva.
+- **Widget `affiliate_links_widget` registrato correttamente**: l'aggancio arrivava a `widgets_init` già passato e il widget non risultava mai disponibile.
+- **Colonne ordinabili funzionanti**: "Click" e "AI Score" ordinano davvero l'elenco Link Affiliati, preservando il filtro Source attivo e mantenendo in lista i link mai cliccati.
+- **API key in wp-config.php**: `define('ALMA_OPENAI_API_KEY', '...')` e `define('ALMA_GEO_GOOGLE_MAPS_API_KEY', '...')` hanno priorità sulle option e tengono i segreti fuori dal database; la chiave OpenAI salvata via UI usa `autoload=no`.
+- **Sicurezza**: corretto XSS DOM nella dashboard admin, anti formula-injection nei CSV esportati dal modulo GEO, throttle e cache sulla ricerca località Google del metabox.
+- **Concorrenza GEO**: claim atomico con token univoco sugli item staging (niente doppio import), lock sui batch di geocoding (niente chiamate Google duplicate da elaborazioni parallele), `REQUEST_DENIED` segnalato come errore di configurazione con stop del batch invece di "riprova più tardi".
+- **Costi AI reali**: `estimated_cost` è ora in USD, calcolato da una tabella prezzi per modello estendibile con il filtro `alma_openai_model_prices`; i vecchi valori (conteggi token) vengono azzerati una tantum.
+- **Indici AI**: la cancellazione definitiva di un link rimuove la riga dall'affiliate index; il reindex della Knowledge Base copre progressivamente tutto il sito con un cursore persistente, continuando a rinfrescare i contenuti modificati di recente.
+- **Bot Affiliate**: lock anti-stampede sulla chiamata OpenAI in frontend; l'import GYG CSV non si conclude più in anticipo e i job rilasciano sempre il lock anche su errori fatali.
+- Versione plugin aggiornata a `2.42.0`.
+
 ## Unreleased
 
 

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.41.8
+ * Version: 2.42.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.41.8');
+define('ALMA_VERSION', '2.42.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-contextual-affiliate-matcher.php
+++ b/includes/class-contextual-affiliate-matcher.php
@@ -1,6 +1,13 @@
 <?php
 /**
  * Deterministic contextual affiliate link matcher for the sidebar widget.
+ *
+ * v2: il matching è ancorato alla pagina corrente su tre livelli:
+ * 1. Geo Index (segnale dominante): località condivise tra articolo e link.
+ * 2. Selezione candidati per pertinenza (Geo Index + affiliate index AI),
+ *    non più solo gli ultimi N link per data.
+ * 3. Scoring graduato: le keyword in comune pesano per quantità e rarità
+ *    sul pool di candidati, con match a parola intera.
  */
 if (!defined('ABSPATH')) {
     exit;
@@ -8,8 +15,14 @@ if (!defined('ABSPATH')) {
 
 class ALMA_Contextual_Affiliate_Matcher {
     const DEFAULT_CANDIDATE_LIMIT = 200;
+    const MAX_POOL_SIZE = 300;
+    // Inclusa nell'hash della cache del widget: cambiarla invalida i risultati
+    // calcolati con versioni precedenti dell'algoritmo.
+    const MATCHER_VERSION = 2;
 
     private $settings;
+    private $geo_store = null;
+    private $geo_tables_exist = null;
 
     public function __construct($settings = array()) {
         $this->settings = wp_parse_args($settings, array(
@@ -31,16 +44,51 @@ class ALMA_Contextual_Affiliate_Matcher {
 
         $settings = wp_parse_args($settings, $this->settings);
         $signals = $this->extract_post_signals($post);
-        $candidates = $this->get_candidates(absint($settings['candidate_limit']));
+        $signals['locations'] = $this->get_object_locations($post->ID, $post->post_type);
+        $candidates = $this->get_candidates($signals, absint($settings['candidate_limit']));
+        if (empty($candidates)) {
+            return array();
+        }
+
+        $profiles = array();
+        foreach ($candidates as $candidate) {
+            $profile = $this->build_candidate_profile($candidate, $signals, $settings);
+            if ($profile) {
+                $profiles[] = $profile;
+            }
+        }
+        if (empty($profiles)) {
+            return array();
+        }
+
+        // Document frequency delle keyword sul pool: le parole presenti in quasi
+        // tutti i candidati (es. "tour") pesano poco, quelle rare (es. un nome
+        // di città) pesano molto.
+        $df = array();
+        foreach ($profiles as $profile) {
+            foreach (array_unique($profile['keywords']) as $keyword) {
+                $df[$keyword] = ($df[$keyword] ?? 0) + 1;
+            }
+        }
+        $pool_size = count($profiles);
+
+        $geo_map = $this->get_locations_for_links(wp_list_pluck($profiles, 'id'));
+
         $results = array();
         $min_score = max(0, min(100, absint($settings['min_score'])));
-
-        foreach ($candidates as $candidate) {
-            $scored = $this->score_candidate($candidate, $signals, $settings);
-            if (!$scored || $scored['score'] < $min_score) {
+        foreach ($profiles as $profile) {
+            $score = $this->score_profile($profile, $signals, $df, $pool_size, $geo_map[$profile['id']] ?? array());
+            if ($score < $min_score) {
                 continue;
             }
-            $results[] = $scored;
+            $results[] = array(
+                'id' => $profile['id'],
+                'score' => $score,
+                'click_count' => $profile['click_count'],
+                'title' => $profile['display_title'],
+                'affiliate_url' => $profile['affiliate_url'],
+                'has_image' => $profile['has_image'],
+            );
         }
 
         usort($results, array($this, 'sort_results'));
@@ -74,24 +122,122 @@ class ALMA_Contextual_Affiliate_Matcher {
             'taxonomy_terms' => array_values(array_unique($taxonomy_terms)),
             'keywords' => $this->extract_keywords($combined, 60),
             'combined' => $combined,
+            'locations' => array(),
         );
     }
 
-    private function get_candidates($limit) {
+    /**
+     * Selezione dei candidati orientata alla pagina: prima i link che condividono
+     * una località con l'articolo, poi quelli pertinenti per keyword secondo
+     * l'affiliate index AI, infine i più recenti come riempimento (comportamento
+     * storico, garantisce che il pool non sia mai peggiore di prima).
+     */
+    private function get_candidates($signals, $limit) {
         $limit = max(1, min(self::DEFAULT_CANDIDATE_LIMIT, $limit));
+        $ids = array();
+
+        foreach ($this->get_geo_candidate_ids($signals['locations'], 150) as $id) {
+            $ids[$id] = true;
+        }
+        foreach ($this->get_keyword_candidate_ids($signals['keywords'], 150) as $id) {
+            $ids[$id] = true;
+        }
+
+        if (count($ids) < self::MAX_POOL_SIZE) {
+            $recent = get_posts(array(
+                'post_type' => 'affiliate_link',
+                'post_status' => 'publish',
+                'posts_per_page' => $limit,
+                'orderby' => 'date',
+                'order' => 'DESC',
+                'no_found_rows' => true,
+                'fields' => 'ids',
+            ));
+            foreach ($recent as $id) {
+                if (count($ids) >= self::MAX_POOL_SIZE) {
+                    break;
+                }
+                $ids[absint($id)] = true;
+            }
+        }
+
+        $ids = array_slice(array_keys($ids), 0, self::MAX_POOL_SIZE);
+        if (empty($ids)) {
+            return array();
+        }
+
         return get_posts(array(
             'post_type' => 'affiliate_link',
             'post_status' => 'publish',
-            'posts_per_page' => $limit,
-            'orderby' => 'date',
-            'order' => 'DESC',
+            'post__in' => $ids,
+            'posts_per_page' => count($ids),
+            'orderby' => 'post__in',
             'no_found_rows' => true,
             'update_post_meta_cache' => true,
             'update_post_term_cache' => true,
         ));
     }
 
-    private function score_candidate($candidate, $signals, $settings) {
+    private function get_geo_candidate_ids($post_locations, $limit) {
+        if (empty($post_locations) || !$this->geo_tables_available()) {
+            return array();
+        }
+        $location_ids = array();
+        foreach ($post_locations as $location) {
+            $location_id = absint($location['location_id'] ?? 0);
+            if ($location_id > 0) {
+                $location_ids[] = $location_id;
+            }
+        }
+        $location_ids = array_values(array_unique($location_ids));
+        if (empty($location_ids)) {
+            return array();
+        }
+
+        global $wpdb;
+        $store = $this->get_geo_store();
+        $placeholders = implode(',', array_fill(0, count($location_ids), '%d'));
+        $params = array_merge(array(ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK), $location_ids, array(max(1, absint($limit))));
+        $ids = $wpdb->get_col($wpdb->prepare(
+            "SELECT DISTINCT object_id FROM {$store->table_content_index()} WHERE object_type = %s AND location_id IN ($placeholders) LIMIT %d",
+            $params
+        ));
+        return array_map('absint', (array) $ids);
+    }
+
+    private function get_keyword_candidate_ids($keywords, $limit) {
+        if (empty($keywords) || !class_exists('ALMA_AI_Content_Agent_Affiliate_Index')) {
+            return array();
+        }
+        $table = ALMA_AI_Content_Agent_Affiliate_Index::table_name();
+        if (in_array($table, ALMA_AI_Content_Agent_Store::missing_tables(), true)) {
+            return array();
+        }
+
+        global $wpdb;
+        $conditions = array();
+        $params = array(ALMA_AI_Content_Agent_Affiliate_Index::STATUS_ACTIVE);
+        foreach (array_slice((array) $keywords, 0, 10) as $keyword) {
+            $keyword = $this->normalize_text($keyword);
+            if (strlen($keyword) < 4) {
+                continue;
+            }
+            $like = '%' . $wpdb->esc_like($keyword) . '%';
+            $conditions[] = '(title LIKE %s OR keywords LIKE %s OR normalized_text LIKE %s)';
+            array_push($params, $like, $like, $like);
+        }
+        if (empty($conditions)) {
+            return array();
+        }
+        $params[] = max(1, absint($limit));
+        $ids = $wpdb->get_col($wpdb->prepare(
+            "SELECT affiliate_link_id FROM {$table} WHERE status = %s AND post_status = 'publish' AND affiliate_url_present = 1 AND affiliate_link_id > 0 AND (" . implode(' OR ', $conditions) . ") LIMIT %d",
+            $params
+        ));
+        return array_map('absint', (array) $ids);
+    }
+
+    private function build_candidate_profile($candidate, $signals, $settings) {
         if (!$candidate instanceof WP_Post || $candidate->post_type !== 'affiliate_link' || $candidate->post_status !== 'publish') {
             return null;
         }
@@ -111,52 +257,242 @@ class ALMA_Contextual_Affiliate_Matcher {
         $ai_context = $this->normalize_text((string) get_post_meta($candidate->ID, '_alma_ai_context', true));
         $source_text = $this->normalize_text($this->get_candidate_source_text($candidate->ID));
         $link_types = $this->get_link_type_terms($candidate->ID);
-        $candidate_keywords = $this->extract_keywords(trim($link_title . ' ' . $link_content . ' ' . $ai_context . ' ' . $source_text . ' ' . implode(' ', $link_types)), 30);
-        $score = 0;
-
-        if ($link_title !== '' && $this->contains_phrase($signals['title'], $link_title)) {
-            $score += 35;
-        }
-
-        if ($this->has_keyword_overlap($candidate_keywords, array($signals['title']))) {
-            $score += 25;
-        }
-
-        if (($link_title !== '' && $this->contains_phrase(implode(' ', $signals['headings']), $link_title)) || $this->has_keyword_overlap($candidate_keywords, $signals['headings'])) {
-            $score += 25;
-        }
-
-        if ($this->has_term_overlap($link_types, $signals['taxonomy_terms'])) {
-            $score += 25;
-        }
-
-        if ($this->has_keyword_overlap($candidate_keywords, array($signals['content']))) {
-            $score += 15;
-        }
-
-        if ($ai_context !== '' && $this->context_matches($ai_context, $signals)) {
-            $score += 20;
-        }
-
-        $click_count = absint(get_post_meta($candidate->ID, '_click_count', true));
-        if ($click_count > 0) {
-            $score += min(5, (int) floor(log($click_count + 1, 2)));
-        }
-
-        if ($already_present) {
-            $score -= 100;
-        }
-
-        $score = max(0, min(100, $score));
 
         return array(
             'id' => (int) $candidate->ID,
-            'score' => $score,
-            'click_count' => $click_count,
-            'title' => get_the_title($candidate),
+            'title' => $link_title,
+            'display_title' => get_the_title($candidate),
             'affiliate_url' => $affiliate_url,
+            'ai_context' => $ai_context,
+            'link_types' => $link_types,
+            'keywords' => $this->extract_keywords(trim($link_title . ' ' . $link_content . ' ' . $ai_context . ' ' . $source_text . ' ' . implode(' ', $link_types)), 30),
+            'click_count' => absint(get_post_meta($candidate->ID, '_click_count', true)),
             'has_image' => has_post_thumbnail($candidate->ID),
+            'already_present' => $already_present,
         );
+    }
+
+    private function score_profile($profile, $signals, $df, $pool_size, $link_locations) {
+        $score = 0;
+
+        // 1) Geo Index: il segnale dominante (fino a 45, penalità se le località
+        //    sono esplicitamente diverse). 0 quando una delle due parti non ha dati.
+        $score += $this->geo_score($signals['locations'], $link_locations);
+
+        // 2) Frase esatta: titolo del link contenuto nel titolo o negli heading.
+        if ($profile['title'] !== '' && $this->contains_phrase($signals['title'], $profile['title'])) {
+            $score += 25;
+        } elseif ($profile['title'] !== '' && $this->contains_phrase(implode(' ', $signals['headings']), $profile['title'])) {
+            $score += 18;
+        }
+
+        // 3) Keyword graduate per quantità e rarità (fino a 30).
+        $score += $this->keyword_score($profile['keywords'], $signals, $df, $pool_size);
+
+        // 4) Tipologia link ↔ categorie/tag dell'articolo.
+        if ($this->has_term_overlap($profile['link_types'], $signals['taxonomy_terms'])) {
+            $score += 10;
+        }
+
+        // 5) Contesto AI del link presente nel titolo/contenuto dell'articolo.
+        if ($profile['ai_context'] !== '' && $this->context_matches($profile['ai_context'], $signals)) {
+            $score += 10;
+        }
+
+        // 6) Popolarità: contributo minimo, non deve dominare la contestualità.
+        if ($profile['click_count'] > 0) {
+            $score += min(3, (int) floor(log($profile['click_count'] + 1, 2)));
+        }
+
+        // Con "escludi link già presenti" = no, il link può comparire ma viene
+        // leggermente penalizzato (il vecchio -100 lo azzerava sempre, rendendo
+        // l'opzione di fatto inefficace).
+        if ($profile['already_present']) {
+            $score -= 15;
+        }
+
+        return max(0, min(100, $score));
+    }
+
+    /**
+     * Confronta le località dell'articolo con quelle del link.
+     * Ritorna il punteggio migliore trovato (non additivo):
+     * stessa località/città 40 (+5 se primaria per entrambi), stessa regione 20,
+     * stesso paese 10, nessuna sovrapposizione con dati presenti da entrambe
+     * le parti -15.
+     */
+    private function geo_score($post_locations, $link_locations) {
+        if (empty($post_locations) || empty($link_locations)) {
+            return 0;
+        }
+
+        $post_index = $this->build_location_index($post_locations);
+        $link_index = $this->build_location_index($link_locations);
+
+        if (!empty(array_intersect($post_index['location_ids'], $link_index['location_ids']))
+            || !empty(array_intersect($post_index['cities'], $link_index['cities']))) {
+            $primary_match = !empty(array_intersect($post_index['primary_cities'], $link_index['primary_cities']))
+                || !empty(array_intersect($post_index['primary_location_ids'], $link_index['primary_location_ids']));
+            return $primary_match ? 45 : 40;
+        }
+
+        if (!empty(array_intersect($post_index['regions'], $link_index['regions']))) {
+            return 20;
+        }
+
+        if (!empty(array_intersect($post_index['countries'], $link_index['countries']))) {
+            return 10;
+        }
+
+        // Entrambe le parti dichiarano località ma senza alcun punto in comune:
+        // è un segnale esplicito di non pertinenza geografica.
+        return -15;
+    }
+
+    private function build_location_index($locations) {
+        $index = array(
+            'location_ids' => array(),
+            'primary_location_ids' => array(),
+            'cities' => array(),
+            'primary_cities' => array(),
+            'regions' => array(),
+            'countries' => array(),
+        );
+        foreach ((array) $locations as $location) {
+            $location = (array) $location;
+            $location_id = absint($location['location_id'] ?? 0);
+            $city = $this->normalize_text((string) ($location['city'] ?? ''));
+            if ($city === '') {
+                // Per località non-città (POI, aree) usa il nome canonico come chiave.
+                $city = $this->normalize_text((string) ($location['canonical_name'] ?? ($location['name'] ?? '')));
+            }
+            $country = $this->normalize_text((string) ($location['country_code'] ?? ''));
+            $region = $this->normalize_text((string) ($location['region'] ?? ''));
+            $is_primary = !empty($location['is_primary']) || (($location['role'] ?? '') === 'main_destination');
+
+            if ($location_id > 0) {
+                $index['location_ids'][] = $location_id;
+                if ($is_primary) {
+                    $index['primary_location_ids'][] = $location_id;
+                }
+            }
+            if ($city !== '') {
+                $city_key = $city . '|' . $country;
+                $index['cities'][] = $city_key;
+                if ($is_primary) {
+                    $index['primary_cities'][] = $city_key;
+                }
+            }
+            if ($region !== '') {
+                $index['regions'][] = $region . '|' . $country;
+            }
+            if ($country !== '') {
+                $index['countries'][] = $country;
+            }
+        }
+        foreach ($index as $key => $values) {
+            $index[$key] = array_values(array_unique($values));
+        }
+        return $index;
+    }
+
+    /**
+     * Punteggio keyword graduato (0-30): ogni keyword del link trovata come
+     * parola intera nell'articolo vale 1-6 punti in base alla sua rarità sul
+     * pool di candidati; il valore raddoppia se compare nel titolo o negli heading.
+     */
+    private function keyword_score($keywords, $signals, $df, $pool_size) {
+        if ($pool_size < 1) {
+            return 0;
+        }
+        $content_hay = ' ' . $signals['combined'] . ' ';
+        $title_hay = ' ' . $signals['title'] . ' ';
+        $headings_hay = ' ' . implode(' ', $signals['headings']) . ' ';
+        $total = 0.0;
+        foreach (array_unique((array) $keywords) as $keyword) {
+            if (strlen($keyword) < 4) {
+                continue;
+            }
+            $needle = ' ' . $keyword . ' ';
+            if (strpos($content_hay, $needle) === false) {
+                continue;
+            }
+            $rarity = 1 - (($df[$keyword] ?? 1) / max(1, $pool_size));
+            $points = 1 + 5 * $rarity;
+            if (strpos($title_hay, $needle) !== false || strpos($headings_hay, $needle) !== false) {
+                $points *= 2;
+            }
+            $total += $points;
+        }
+        return (int) min(30, round($total));
+    }
+
+    private function get_object_locations($object_id, $object_type) {
+        if (!$this->geo_tables_available()) {
+            return array();
+        }
+        $object_type = sanitize_key($object_type);
+        if (!in_array($object_type, array(ALMA_Geo_Index_Store::OBJECT_TYPE_POST, ALMA_Geo_Index_Store::OBJECT_TYPE_PAGE, ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK), true)) {
+            return array();
+        }
+        return (array) $this->get_geo_store()->get_associated_locations_for_object($object_id, $object_type);
+    }
+
+    /**
+     * Località di tutti i link candidati in una sola query (evita una query per candidato).
+     * Ritorna una mappa link_id => array di località.
+     */
+    private function get_locations_for_links($link_ids) {
+        $link_ids = array_values(array_filter(array_map('absint', (array) $link_ids)));
+        if (empty($link_ids) || !$this->geo_tables_available()) {
+            return array();
+        }
+
+        global $wpdb;
+        $store = $this->get_geo_store();
+        $placeholders = implode(',', array_fill(0, count($link_ids), '%d'));
+        $params = array_merge(array(ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK), $link_ids);
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT ci.object_id, ci.is_primary, l.id AS location_id, l.canonical_name, l.city, l.region, l.country_code
+             FROM {$store->table_content_index()} ci
+             LEFT JOIN {$store->table_locations()} l ON l.id = ci.location_id
+             WHERE ci.object_type = %s AND ci.object_id IN ($placeholders)",
+            $params
+        ), ARRAY_A);
+
+        $map = array();
+        foreach ((array) $rows as $row) {
+            $object_id = absint($row['object_id'] ?? 0);
+            if ($object_id < 1) {
+                continue;
+            }
+            $map[$object_id][] = array(
+                'location_id' => absint($row['location_id'] ?? 0),
+                'canonical_name' => (string) ($row['canonical_name'] ?? ''),
+                'city' => (string) ($row['city'] ?? ''),
+                'region' => (string) ($row['region'] ?? ''),
+                'country_code' => (string) ($row['country_code'] ?? ''),
+                'is_primary' => !empty($row['is_primary']),
+            );
+        }
+        return $map;
+    }
+
+    private function get_geo_store() {
+        if ($this->geo_store === null) {
+            $this->geo_store = new ALMA_Geo_Index_Store();
+        }
+        return $this->geo_store;
+    }
+
+    private function geo_tables_available() {
+        if (!class_exists('ALMA_Geo_Index_Store')) {
+            return false;
+        }
+        if ($this->geo_tables_exist === null) {
+            $this->geo_tables_exist = $this->get_geo_store()->tables_exist();
+        }
+        return $this->geo_tables_exist;
     }
 
     private function sort_results($a, $b) {
@@ -281,7 +617,9 @@ class ALMA_Contextual_Affiliate_Matcher {
             return false;
         }
 
-        return strpos(' ' . $haystack . ' ', ' ' . $needle . ' ') !== false || strpos($haystack, $needle) !== false;
+        // Solo match a parola/frasi intere: il fallback substring produceva
+        // falsi positivi sistematici ("roma" dentro "romantico").
+        return strpos(' ' . $haystack . ' ', ' ' . $needle . ' ') !== false;
     }
 
     private function extract_keywords($text, $limit = 30) {
@@ -321,7 +659,7 @@ class ALMA_Contextual_Affiliate_Matcher {
             return $stopwords;
         }
 
-        $words = array('alla','allo','agli','alle','anche','avere','come','con','dai','dal','dalla','delle','degli','dei','del','dell','dello','dove','dopo','esta','fare','gli','hai','che','chi','cosa','come','dalla','delle','dentro','essere','il','la','lo','le','li','un','una','uno','per','piu','nel','nella','nelle','negli','non','sono','sul','sulla','sulle','tra','fra','the','and','for','with','from','this','that','your','you','are','was','were','have','has','will','not');
+        $words = array('alla','allo','agli','alle','anche','avere','come','con','dai','dal','dalla','delle','degli','dei','del','dell','dello','dove','dopo','esta','fare','gli','hai','che','chi','cosa','come','dalla','delle','dentro','essere','il','la','lo','le','li','un','una','uno','per','piu','nel','nella','nelle','negli','non','sono','sul','sulla','sulle','tra','fra','the','and','for','with','from','this','that','your','you','are','was','were','have','has','will','not','quando','perche','ancora','molto','sempre','tutti','tutte','tutto','questa','questo','queste','questi','loro','essere','stato','stata','della','dalle','dagli','migliori','migliore','guida','cose','vedere','giorni','giorno');
         $stopwords = array_fill_keys($words, true);
         return $stopwords;
     }

--- a/includes/class-contextual-affiliate-widget.php
+++ b/includes/class-contextual-affiliate-widget.php
@@ -211,6 +211,11 @@ class ALMA_Contextual_Affiliate_Widget extends WP_Widget {
         $hash_settings = $settings;
         unset($hash_settings['title'], $hash_settings['button_text']);
         $hash_settings['cache_version'] = absint(get_option(self::CACHE_VERSION_OPTION, 1));
+        // La versione del matcher invalida i risultati calcolati con l'algoritmo
+        // precedente; la data di modifica invalida la cache del singolo articolo
+        // al suo salvataggio, senza azzerare la cache di tutto il sito.
+        $hash_settings['matcher_version'] = ALMA_Contextual_Affiliate_Matcher::MATCHER_VERSION;
+        $hash_settings['post_modified'] = (string) $post->post_modified_gmt;
         $hash = md5(wp_json_encode($hash_settings));
         $cache_key = 'alma_contextual_widget_' . absint($post->ID) . '_' . $hash;
         $cached = get_transient($cache_key);
@@ -317,8 +322,9 @@ class ALMA_Contextual_Affiliate_Widget extends WP_Widget {
             <?php endif; ?>
             <div class="card">
                 <h2><?php esc_html_e('Matching locale senza AI', 'affiliate-link-manager-ai'); ?></h2>
-                <p><?php esc_html_e('Il widget legge titolo, slug, categorie, tag, contenuto e heading H2/H3 dell’articolo corrente, assegna uno score ai Link Affiliati pubblicati e mostra solo quelli sopra soglia. Non modifica gli articoli e non usa OpenAI.', 'affiliate-link-manager-ai'); ?></p>
-                <p><span class="alma-badge"><?php esc_html_e('Cache per post', 'affiliate-link-manager-ai'); ?></span> <?php esc_html_e('La cache usa una versione interna invalidata al salvataggio di articoli supportati, Link Affiliati e impostazioni.', 'affiliate-link-manager-ai'); ?></p>
+                <p><?php esc_html_e('Il widget seleziona i Link Affiliati pertinenti alla pagina corrente in tre passaggi: prima le località condivise tramite l’Indice Geografico (segnale dominante), poi le keyword in comune pesate per specificità (titolo, heading H2/H3, categorie, tag e contenuto), infine tipologie e contesto AI. Mostra solo i link sopra soglia. Non modifica gli articoli e non usa OpenAI.', 'affiliate-link-manager-ai'); ?></p>
+                <p><span class="alma-badge"><?php esc_html_e('Cache per post', 'affiliate-link-manager-ai'); ?></span> <?php esc_html_e('La cache del singolo articolo si invalida al suo salvataggio; la cache globale si invalida al salvataggio di Link Affiliati e impostazioni.', 'affiliate-link-manager-ai'); ?></p>
+                <p><span class="alma-badge"><?php esc_html_e('Suggerimento', 'affiliate-link-manager-ai'); ?></span> <?php esc_html_e('Per il matching geografico associa le località ad articoli e Link Affiliati dal metabox Geolocalizzazione contenuto o tramite gli import GEO; senza dati geografici il widget usa il solo matching testuale.', 'affiliate-link-manager-ai'); ?></p>
             </div>
             <form method="post" action="">
                 <?php wp_nonce_field('alma_contextual_widget_settings', 'alma_contextual_widget_nonce'); ?>
@@ -403,8 +409,11 @@ class ALMA_Contextual_Affiliate_Widget extends WP_Widget {
         if (wp_is_post_autosave($post_id) || wp_is_post_revision($post_id) || !$post instanceof WP_Post) {
             return;
         }
-        $settings = self::get_global_settings();
-        if ($post->post_type === 'affiliate_link' || in_array($post->post_type, $settings['post_types'], true)) {
+        // Bump globale solo quando cambia un Link Affiliato (influisce su tutte le
+        // pagine). Il salvataggio di un articolo invalida solo la propria cache,
+        // tramite post_modified nell'hash: prima ogni salvataggio azzerava la
+        // cache dell'intero sito, rendendola quasi sempre fredda.
+        if ($post->post_type === 'affiliate_link') {
             self::bump_cache_version();
         }
     }


### PR DESCRIPTION
# Riepilogo

Questa PR deriva da un'analisi completa del plugin (core, AI Content Agent, import sorgenti affiliate, modulo GEO) e implementa le migliorie prioritarie individuate, mantenendo piena retrocompatibilità: nessuna modifica di schema DB, nessuna option/API rimossa, fallback ovunque. Include inoltre la riscrittura del matcher del **Widget Link Contestuale** per renderlo realmente contestuale alla pagina visualizzata.

## Tracking click affidabile
- Incremento **atomico** di `_click_count` (i click concorrenti non si perdono più) con pulizia delle righe meta duplicate del primo click.
- Opzione "non tracciare utenti anonimi" applicata anche **lato server**; filtro bot sui crawler noti (personalizzabile con `alma_is_bot_user_agent`); rate limit breve per IP+UA+link contro doppi eventi e replay.
- Parsing corretto di `X-Forwarded-For` multi-valore; verifica tabelle una volta per versione (niente `SHOW TABLES` a ogni click) con retry finché la creazione non riesce; insert falliti loggati.
- Frontend: right-click non più conteggiato, middle-click via `auxclick`, `MutationObserver` al posto del deprecato `DOMNodeInserted`, eventi GA non inviati per click rifiutati dal server.

## Fix bug critici
- La regex di cleanup shortcode non rimuove più i link con ID più lunghi (eliminare il link 12 cancellava anche lo shortcode del link 123).
- "Elimina per ID" ed eliminazione idee AI verificano il post type prima di `wp_delete_post` (era possibile cancellare definitivamente articoli/pagine).
- Il widget `affiliate_links_widget` viene ora registrato davvero (l'hook arrivava a `widgets_init` già eseguito).
- Rimosso il cron giornaliero `alma_daily_optimization`, schedulato ma privo di handler, con pulizia delle occorrenze residue.
- Le colonne "Click" e "AI Score" ora ordinano davvero, preservando il filtro Source attivo e includendo i link mai cliccati.
- Import GYG CSV: niente più chiusura anticipata prima dell'EOF; i job catturano `Throwable` e rilasciano il lock in `finally`.

## Sicurezza
- API key definibili in `wp-config.php` (`ALMA_OPENAI_API_KEY`, `ALMA_GEO_GOOGLE_MAPS_API_KEY`) con priorità sull'option; chiave OpenAI salvata con `autoload=no`.
- Corretto XSS DOM nella dashboard admin (titoli link iniettati senza escaping).
- Anti formula-injection nei CSV esportati dal modulo GEO.
- Throttle per utente (finestra fissa per minuto) + cache breve sulla ricerca località Google del metabox.

## Modulo GEO — concorrenza
- Claim atomico degli item staging con token univoco (due batch concorrenti non processano più gli stessi record).
- Lock sui batch di geocoding (elaborazioni parallele non duplicano le chiamate Google), con `remaining_pending` reale nella risposta bloccata.
- `REQUEST_DENIED` trattato come errore permanente di configurazione con stop del batch e messaggio esplicito, invece di `retry_later` fuorviante.
- Corretto il conteggio format nell'insert staging e cap (500 righe) al report cumulativo in user meta.

## Sottosistema AI
- `estimated_cost` ora in **USD reali** da tabella prezzi per modello (filtro `alma_openai_model_prices`); i vecchi valori (conteggi token) vengono azzerati una tantum.
- L'affiliate index elimina la riga alla cancellazione del link invece di reindicizzarla; il reindex della Knowledge Base copre progressivamente tutto il sito con cursore persistente, continuando a rinfrescare i contenuti recenti.
- Lock anti-stampede sulla chiamata OpenAI frontend del Bot Affiliate; whitelist dello stato documento TXT.

## Widget Link Contestuale — matcher v2
- **Geo Index come segnale dominante**: località condivise articolo↔link valgono fino a 45 punti (città/POI), 20 (regione), 10 (paese), penalità per località esplicitamente diverse; neutro senza dati geo (fallback al matching testuale, retrocompatibile).
- **Candidati per pertinenza**: località condivise + keyword via indice affiliati AI + recenti come riempimento — superato il limite "ultimi 200 per data".
- **Scoring graduato**: le keyword pesano per quantità e rarità sul pool (un nome di città vale molto, "tour" quasi nulla), raddoppiate se nel titolo/heading; match solo a parola intera ("roma" non matcha più "romantico").
- **Cache per articolo** (invalidazione mirata via `post_modified`), fix dell'opzione "Escludi link già presenti = No", click storici limitati a 3 punti.

## Versione e documentazione
- Versione plugin: `2.41.8` → `2.42.0`; README e CHANGELOG aggiornati con la sezione 2.42.0.

## Verifica
- `php -l` pulito su tutti i file modificati; `node --check` su tracking.js.
- Code review interna multi-angolo sul diff: gli 8 rilievi confermati (ordinamento che annullava il filtro Source, perdita della API key con costante definita, tabelle mai ritentate, doppia riga contatore, stub di lock fuorviante, batch non interrotto su REQUEST_DENIED, falsi positivi bot, unità miste nei costi) sono stati corretti prima del merge dei commit.
- 14/14 test sulla logica pura del nuovo matcher (geo_score, keyword_score, word boundary, indicizzazione POI) superati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_