### PR TITLE
v2.43.0: fix matching geografico del Widget Contestuale (caso Copenaghen) + convenzioni progetto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Auto-indicizzazione deterministica dei nuovi Link Affiliati importati e degli articoli pubblicati al salvataggio (elaborata a shutdown, dopo la scrittura dei meta provider).
 - Colonna "Geo" e filtro "senza località / con località / in revisione" nelle liste admin di articoli e Link Affiliati.
 
+### Widget Link Contestuale — fix matching geografico (matcher v3)
+- Fix del caso "stessa città, metadati diversi": un articolo su Copenaghen (località geocodificata con paese DK) e link su Copenaghen importati senza country code non facevano match e subivano perfino la penalità "località diverse", tenendo il widget sotto soglia. Ora le città si confrontano per nome con paesi "compatibili" (paese sconosciuto = jolly) e la penalità -15 scatta solo quando entrambe le parti dichiarano paesi noti e disgiunti.
+- I candidati geografici vengono trovati anche quando la stessa città esiste come righe località diverse (import differenti): il join confronta anche city/canonical_name, non solo il location_id.
+- Fix invalidazione cache: le associazioni geografiche scritte da import GEO, auto-indexer e metabox ora invalidano la cache del widget (meta `_alma_geo_updated_at` nell'hash per gli articoli, bump globale per i Link Affiliati); prima il widget poteva servire per giorni risultati calcolati prima dell'associazione.
+
 ### Widget Link Contestuale — matching contestuale reale
 - Il Geo Index è ora il segnale dominante del matching: località condivise tra articolo e Link Affiliato valgono fino a 45 punti (città/località), 20 (regione), 10 (paese), con penalità per località esplicitamente diverse; senza dati geo il segnale è neutro e vale il matching testuale.
 - I candidati sono selezionati per pertinenza (località condivise + keyword via indice affiliati AI + recenti come riempimento) invece dei soli ultimi 200 link per data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.42.0 - 2026-07-02
+## 2.43.0 - 2026-07-02
 
 ### Indice Geografico — Copertura e indicizzazione automatica
 - Nuova tab **Copertura** con contatori di indicizzazione geografica per articoli e Link Affiliati pubblicati (totale/indicizzati/non indicizzati/da rivedere) ed elaborazione batch AJAX interrompibile con cursore persistente e lock.
@@ -11,6 +11,9 @@
 - Fix del caso "stessa città, metadati diversi": un articolo su Copenaghen (località geocodificata con paese DK) e link su Copenaghen importati senza country code non facevano match e subivano perfino la penalità "località diverse", tenendo il widget sotto soglia. Ora le città si confrontano per nome con paesi "compatibili" (paese sconosciuto = jolly) e la penalità -15 scatta solo quando entrambe le parti dichiarano paesi noti e disgiunti.
 - I candidati geografici vengono trovati anche quando la stessa città esiste come righe località diverse (import differenti): il join confronta anche city/canonical_name, non solo il location_id.
 - Fix invalidazione cache: le associazioni geografiche scritte da import GEO, auto-indexer e metabox ora invalidano la cache del widget (meta `_alma_geo_updated_at` nell'hash per gli articoli, bump globale per i Link Affiliati); prima il widget poteva servire per giorni risultati calcolati prima dell'associazione.
+- Versione plugin aggiornata a `2.43.0`.
+
+## 2.42.0 - 2026-07-02
 
 ### Widget Link Contestuale — matching contestuale reale
 - Il Geo Index è ora il segnale dominante del matching: località condivise tra articolo e Link Affiliato valgono fino a 45 punti (città/località), 20 (regione), 10 (paese), con penalità per località esplicitamente diverse; senza dati geo il segnale è neutro e vale il matching testuale.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# Convenzioni di lavoro — Affiliate Link Manager AI
+
+- **Ogni blocco di modifiche richiede sempre**: bump della versione del plugin (header `Version:` e costante `ALMA_VERSION` in `affiliate-link-manager-ai.php`), voce dedicata in `CHANGELOG.md` e `README.md` (in italiano, nuova sezione `## X.Y.Z - data` in cima), e una **pull request** verso `main`.
+- Feature nuove: bump minor (2.42.0 → 2.43.0). Soli bugfix: bump patch.
+- Mantenere la retrocompatibilità: nessuna rimozione di option/API esistenti, fallback quando si cambia comportamento, mai sovrascrivere dati inseriti manualmente dagli utenti.
+- Documentazione e stringhe UI in italiano; text domain `affiliate-link-manager-ai`.
+- Verificare sempre con `php -l` i file modificati; per la logica pura aggiungere test standalone con shim WordPress (vedi pattern usati per matcher e auto-indexer).
+- Batch admin su grandi dataset: AJAX iterativi interrompibili con cursore persistente e lock via `add_option` atomica con TTL (pattern esistente in geocoding/auto-indexer), mai job invisibili.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 - **Colonna e filtro "Geo"**: le liste admin di articoli e Link Affiliati mostrano la località primaria (o "In revisione") con filtro "senza località / con località / in revisione".
 - Le località nuove create dall'indicizzazione automatica entrano in stato `pending` geocoding e si processano con il batch Google esistente; l'uso AI è tracciato nel log usage con costo stimato reale.
 
+### Widget Link Contestuale — fix matching geografico (matcher v3)
+
+- **Città uguale, metadati diversi ora fanno match**: un articolo su Copenaghen (località geocodificata, paese DK) e link su Copenaghen importati senza country code non superavano la soglia — il confronto per `nome|paese` falliva e scattava perfino la penalità "località diverse". Ora le città si confrontano per nome con paesi compatibili (paese mancante = jolly) e la penalità vale solo per disaccordo esplicito tra paesi noti.
+- **Candidati anche tra righe località duplicate**: la stessa città creata da import diversi (righe distinte in `alma_geo_locations`) viene riconosciuta confrontando anche city/canonical name, non solo l'ID località.
+- **Cache invalidata dalle associazioni geografiche**: associare località a un articolo o a un Link Affiliato (metabox, import GEO, auto-indexer) ora invalida subito la cache del widget; prima i risultati pre-associazione restavano serviti fino a scadenza TTL (anche 7 giorni).
+
 ### Widget Link Contestuale — matching realmente contestuale alla pagina
 
 - **Geo Index come segnale dominante**: il widget ora confronta le località associate all'articolo (metabox Geolocalizzazione contenuto / import GEO) con quelle dei Link Affiliati. Stessa città o località: fino a 45 punti; stessa regione: 20; stesso paese: 10; località esplicitamente diverse: penalità. Senza dati geografici da una delle due parti il segnale è neutro e vale il matching testuale (retrocompatibile).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## 2.42.0 - 2026-07-02
+## 2.43.0 - 2026-07-02
 
 ### Indice Geografico — Copertura e indicizzazione automatica
 
@@ -15,6 +15,9 @@
 - **Città uguale, metadati diversi ora fanno match**: un articolo su Copenaghen (località geocodificata, paese DK) e link su Copenaghen importati senza country code non superavano la soglia — il confronto per `nome|paese` falliva e scattava perfino la penalità "località diverse". Ora le città si confrontano per nome con paesi compatibili (paese mancante = jolly) e la penalità vale solo per disaccordo esplicito tra paesi noti.
 - **Candidati anche tra righe località duplicate**: la stessa città creata da import diversi (righe distinte in `alma_geo_locations`) viene riconosciuta confrontando anche city/canonical name, non solo l'ID località.
 - **Cache invalidata dalle associazioni geografiche**: associare località a un articolo o a un Link Affiliato (metabox, import GEO, auto-indexer) ora invalida subito la cache del widget; prima i risultati pre-associazione restavano serviti fino a scadenza TTL (anche 7 giorni).
+- Versione plugin aggiornata a `2.43.0`.
+
+## 2.42.0 - 2026-07-02
 
 ### Widget Link Contestuale — matching realmente contestuale alla pagina
 

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.42.0
+ * Version: 2.43.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.42.0');
+define('ALMA_VERSION', '2.43.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-contextual-affiliate-matcher.php
+++ b/includes/class-contextual-affiliate-matcher.php
@@ -18,7 +18,7 @@ class ALMA_Contextual_Affiliate_Matcher {
     const MAX_POOL_SIZE = 300;
     // Inclusa nell'hash della cache del widget: cambiarla invalida i risultati
     // calcolati con versioni precedenti dell'algoritmo.
-    const MATCHER_VERSION = 2;
+    const MATCHER_VERSION = 3;
 
     private $settings;
     private $geo_store = null;
@@ -183,23 +183,47 @@ class ALMA_Contextual_Affiliate_Matcher {
             return array();
         }
         $location_ids = array();
+        $location_names = array();
         foreach ($post_locations as $location) {
+            $location = (array) $location;
             $location_id = absint($location['location_id'] ?? 0);
             if ($location_id > 0) {
                 $location_ids[] = $location_id;
             }
+            foreach (array('city', 'canonical_name', 'name') as $field) {
+                $name = trim((string) ($location[$field] ?? ''));
+                if ($name !== '' && mb_strlen($name) >= 3) {
+                    $location_names[] = $name;
+                }
+            }
         }
         $location_ids = array_values(array_unique($location_ids));
-        if (empty($location_ids)) {
+        $location_names = array_slice(array_values(array_unique($location_names)), 0, 10);
+        if (empty($location_ids) && empty($location_names)) {
             return array();
         }
 
         global $wpdb;
         $store = $this->get_geo_store();
-        $placeholders = implode(',', array_fill(0, count($location_ids), '%d'));
-        $params = array_merge(array(ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK), $location_ids, array(max(1, absint($limit))));
+        $conditions = array();
+        $params = array(ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK);
+        if (!empty($location_ids)) {
+            $conditions[] = 'ci.location_id IN (' . implode(',', array_fill(0, count($location_ids), '%d')) . ')';
+            $params = array_merge($params, $location_ids);
+        }
+        if (!empty($location_names)) {
+            // Stesse città salvate come righe località diverse (import differenti,
+            // es. "Copenaghen" da CSV e da geocoding): match anche per nome.
+            $name_placeholders = implode(',', array_fill(0, count($location_names), '%s'));
+            $conditions[] = "l.city IN ($name_placeholders)";
+            $conditions[] = "l.canonical_name IN ($name_placeholders)";
+            $params = array_merge($params, $location_names, $location_names);
+        }
+        $params[] = max(1, absint($limit));
         $ids = $wpdb->get_col($wpdb->prepare(
-            "SELECT DISTINCT object_id FROM {$store->table_content_index()} WHERE object_type = %s AND location_id IN ($placeholders) LIMIT %d",
+            "SELECT DISTINCT ci.object_id FROM {$store->table_content_index()} ci
+             LEFT JOIN {$store->table_locations()} l ON l.id = ci.location_id
+             WHERE ci.object_type = %s AND (" . implode(' OR ', $conditions) . ') LIMIT %d',
             $params
         ));
         return array_map('absint', (array) $ids);
@@ -318,8 +342,11 @@ class ALMA_Contextual_Affiliate_Matcher {
      * Confronta le località dell'articolo con quelle del link.
      * Ritorna il punteggio migliore trovato (non additivo):
      * stessa località/città 40 (+5 se primaria per entrambi), stessa regione 20,
-     * stesso paese 10, nessuna sovrapposizione con dati presenti da entrambe
-     * le parti -15.
+     * stesso paese 10. La penalità -15 scatta SOLO quando entrambe le parti
+     * dichiarano paesi (non vuoti) e questi sono del tutto disgiunti: metadati
+     * incompleti (es. country_code mancante su un lato) non devono mai punire
+     * un match altrimenti valido — era il caso "Copenaghen (DK)" vs
+     * "Copenaghen (country vuoto)" che azzerava il segnale geografico.
      */
     private function geo_score($post_locations, $link_locations) {
         if (empty($post_locations) || empty($link_locations)) {
@@ -329,33 +356,68 @@ class ALMA_Contextual_Affiliate_Matcher {
         $post_index = $this->build_location_index($post_locations);
         $link_index = $this->build_location_index($link_locations);
 
-        if (!empty(array_intersect($post_index['location_ids'], $link_index['location_ids']))
-            || !empty(array_intersect($post_index['cities'], $link_index['cities']))) {
-            $primary_match = !empty(array_intersect($post_index['primary_cities'], $link_index['primary_cities']))
-                || !empty(array_intersect($post_index['primary_location_ids'], $link_index['primary_location_ids']));
+        if (!empty(array_intersect($post_index['location_ids'], $link_index['location_ids']))) {
+            $primary_match = !empty(array_intersect($post_index['primary_location_ids'], $link_index['primary_location_ids']));
             return $primary_match ? 45 : 40;
         }
 
-        if (!empty(array_intersect($post_index['regions'], $link_index['regions']))) {
-            return 20;
+        // Match per nome città: i paesi devono essere "compatibili" (uguali,
+        // oppure sconosciuti da almeno una parte), non necessariamente identici.
+        $city_match = false;
+        $city_primary_match = false;
+        foreach ($post_index['cities'] as $name => $post_entry) {
+            if (!isset($link_index['cities'][$name])) {
+                continue;
+            }
+            $link_entry = $link_index['cities'][$name];
+            if (!$this->countries_compatible($post_entry['countries'], $link_entry['countries'])) {
+                continue;
+            }
+            $city_match = true;
+            if ($post_entry['primary'] && $link_entry['primary']) {
+                $city_primary_match = true;
+                break;
+            }
+        }
+        if ($city_match) {
+            return $city_primary_match ? 45 : 40;
+        }
+
+        foreach ($post_index['regions'] as $name => $post_countries) {
+            if (isset($link_index['regions'][$name]) && $this->countries_compatible($post_countries, $link_index['regions'][$name])) {
+                return 20;
+            }
         }
 
         if (!empty(array_intersect($post_index['countries'], $link_index['countries']))) {
             return 10;
         }
 
-        // Entrambe le parti dichiarano località ma senza alcun punto in comune:
-        // è un segnale esplicito di non pertinenza geografica.
-        return -15;
+        // Penalità solo per disaccordo esplicito: entrambe le parti dichiarano
+        // paesi noti e non hanno nulla in comune.
+        if (!empty($post_index['countries']) && !empty($link_index['countries'])) {
+            return -15;
+        }
+        return 0;
+    }
+
+    /**
+     * Due insiemi di country code sono compatibili se almeno uno è vuoto
+     * (paese sconosciuto = jolly) o se hanno un codice in comune.
+     */
+    private function countries_compatible($left, $right) {
+        if (empty($left) || empty($right)) {
+            return true;
+        }
+        return !empty(array_intersect($left, $right));
     }
 
     private function build_location_index($locations) {
         $index = array(
             'location_ids' => array(),
             'primary_location_ids' => array(),
-            'cities' => array(),
-            'primary_cities' => array(),
-            'regions' => array(),
+            'cities' => array(),   // nome normalizzato => array('countries' => [], 'primary' => bool)
+            'regions' => array(),  // nome normalizzato => array di country code
             'countries' => array(),
         );
         foreach ((array) $locations as $location) {
@@ -377,21 +439,36 @@ class ALMA_Contextual_Affiliate_Matcher {
                 }
             }
             if ($city !== '') {
-                $city_key = $city . '|' . $country;
-                $index['cities'][] = $city_key;
+                if (!isset($index['cities'][$city])) {
+                    $index['cities'][$city] = array('countries' => array(), 'primary' => false);
+                }
+                if ($country !== '') {
+                    $index['cities'][$city]['countries'][] = $country;
+                }
                 if ($is_primary) {
-                    $index['primary_cities'][] = $city_key;
+                    $index['cities'][$city]['primary'] = true;
                 }
             }
             if ($region !== '') {
-                $index['regions'][] = $region . '|' . $country;
+                if (!isset($index['regions'][$region])) {
+                    $index['regions'][$region] = array();
+                }
+                if ($country !== '') {
+                    $index['regions'][$region][] = $country;
+                }
             }
             if ($country !== '') {
                 $index['countries'][] = $country;
             }
         }
-        foreach ($index as $key => $values) {
-            $index[$key] = array_values(array_unique($values));
+        $index['location_ids'] = array_values(array_unique($index['location_ids']));
+        $index['primary_location_ids'] = array_values(array_unique($index['primary_location_ids']));
+        $index['countries'] = array_values(array_unique($index['countries']));
+        foreach ($index['cities'] as $name => $entry) {
+            $index['cities'][$name]['countries'] = array_values(array_unique($entry['countries']));
+        }
+        foreach ($index['regions'] as $name => $countries) {
+            $index['regions'][$name] = array_values(array_unique($countries));
         }
         return $index;
     }

--- a/includes/class-contextual-affiliate-widget.php
+++ b/includes/class-contextual-affiliate-widget.php
@@ -216,6 +216,10 @@ class ALMA_Contextual_Affiliate_Widget extends WP_Widget {
         // al suo salvataggio, senza azzerare la cache di tutto il sito.
         $hash_settings['matcher_version'] = ALMA_Contextual_Affiliate_Matcher::MATCHER_VERSION;
         $hash_settings['post_modified'] = (string) $post->post_modified_gmt;
+        // Le associazioni geografiche (import GEO, auto-indexer, metabox) scrivono
+        // _alma_geo_updated_at senza toccare post_modified: va incluso nell'hash,
+        // altrimenti il widget serve risultati calcolati prima dell'associazione.
+        $hash_settings['geo_updated'] = (string) get_post_meta($post->ID, '_alma_geo_updated_at', true);
         $hash = md5(wp_json_encode($hash_settings));
         $cache_key = 'alma_contextual_widget_' . absint($post->ID) . '_' . $hash;
         $cached = get_transient($cache_key);

--- a/includes/class-geo-index-store.php
+++ b/includes/class-geo-index-store.php
@@ -430,6 +430,14 @@ class ALMA_Geo_Index_Store {
         foreach ($meta as $key => $value) {
             update_post_meta($object_id, $key, $value);
         }
+
+        // Le località di un Link Affiliato influenzano il matching del Widget
+        // Contestuale su tutte le pagine: la cache globale va invalidata anche
+        // quando l'associazione arriva da import/auto-indexer (nessun save_post).
+        if ($object_type === self::OBJECT_TYPE_AFFILIATE_LINK && class_exists('ALMA_Contextual_Affiliate_Widget')) {
+            ALMA_Contextual_Affiliate_Widget::bump_cache_version();
+        }
+
         return array('location_id' => $primary_location_id, 'content_index_id' => $primary_content_index_id, 'locations' => $updated_locations, 'meta' => $meta);
     }
 


### PR DESCRIPTION
# Riepilogo

Versione **2.43.0**. Contiene il fix del matching geografico del **Widget Link Contestuale** per il caso reale segnalato: articolo su Copenaghen con località correttamente associata, link affiliati su Copenaghen con località associata, soglia minima 40 — e il widget non compariva.

## Widget Contestuale — fix matching geografico (matcher v3)

Tre cause corrette:

1. **Città uguale, metadati diversi**: il confronto usava la chiave composta `nome|country_code`, quindi "Copenaghen (DK)" geocodificata e "Copenaghen (country vuoto)" da import CSV non combaciavano (`copenaghen|dk` ≠ `copenaghen|`) e facevano perfino scattare la penalità −15 "località diverse". Ora le città si confrontano per nome normalizzato con **paesi compatibili** (paese sconosciuto = jolly): stessa città primaria = 45 punti, sopra soglia. La penalità −15 scatta solo per disaccordo esplicito (entrambe le parti con paesi noti e disgiunti).
2. **Candidati per solo location_id**: se la stessa città esiste come righe località diverse (import differenti), i link non entravano nella rosa dei candidati. La query ora fa join con la tabella località e matcha anche per city/canonical name.
3. **Cache mai invalidata dalle associazioni geo**: import GEO, auto-indexer e metabox scrivono le località senza salvare il post, quindi il widget serviva risultati pre-associazione fino a 7 giorni. Ora `_alma_geo_updated_at` entra nell'hash per-articolo e i salvataggi geo dei Link Affiliati bumpano la versione cache globale. `MATCHER_VERSION=3` invalida al deploy tutti i risultati v2.

## Versione, documentazione, convenzioni

- Versione plugin: `2.42.0` → `2.43.0`; sezione 2.43.0 dedicata in README e CHANGELOG.
- Nuovo `CLAUDE.md` con le convenzioni di progetto: bump di versione + changelog + PR per ogni blocco di modifiche, retrocompatibilità, mai sovrascrivere dati manuali, pattern batch con lock, test con shim.

## Verifica

- `php -l` pulito su tutti i file modificati.
- **18/18 test** sulla logica pura del matcher, incluso lo scenario segnalato: `Copenaghen DK vs Copenaghen senza paese = 45 (era −15)`, `stessa città non primaria = 40`, `stesso nome ma paese esplicitamente diverso = −15`, `città diversa senza paese = 0 neutro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_