### PR TITLE
v2.44.0: geocoding automatico all'associazione e Indice Geografico razionalizzato (7→4 tab)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.44.0 - 2026-07-02
+
+### Indice Geografico — geocoding automatico e interfaccia razionalizzata
+- **Niente più doppio passaggio associazione → geocoding manuale**: le località che restano `pending` dopo un'associazione (import CSV massivi, import da API, auto-indicizzazione, metabox, creazione post/link) vengono geocodificate automaticamente in background da una coda WP-Cron a lotti (20 per run), con lock condiviso con i batch manuali, backoff su rate limit e stop su `REQUEST_DENIED`.
+- **Automatismo visibile e controllabile**: toggle "Geocoding automatico" nelle impostazioni (attivo di default, richiede API key); la tab Panoramica mostra stato, località in attesa, prossima esecuzione e ultimo report. I batch manuali restano come fallback.
+- **Località dal metabox già verificate**: le località scelte tramite la ricerca Google (che arrivano con coordinate e Place ID) vengono salvate direttamente come `verified`, senza passare dalla coda.
+- **Merge conservativo in upsert_location**: un re-import con dati meno completi non degrada più una località `verified` a `pending` azzerandone le coordinate (evitando ri-geocoding e costi ripetuti).
+- **UI da 7 a 4 tab**: Panoramica (stato geocoding automatico + copertura + revisione + dashboard), Import (Link Affiliati e articoli con sotto-navigazione), Località, Impostazioni & Log (configurazione, strumenti manuali, log e ultimi report raggruppati). I vecchi slug delle tab restano come alias: nessun link o form esistente si rompe.
+- Versione plugin aggiornata a `2.44.0`.
+
 ## 2.43.0 - 2026-07-02
 
 ### Indice Geografico — Copertura e indicizzazione automatica

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+## 2.44.0 - 2026-07-02
+
+### Indice Geografico — geocoding automatico e interfaccia razionalizzata
+
+- **Geocoding contestuale all'associazione**: eliminato il doppio passaggio "associa località, poi lancia il geocoding". Ogni località `pending` — da import CSV massivi, import API, inserimento manuale di link, creazione di post o auto-indicizzazione — viene geocodificata automaticamente in background (coda WP-Cron a lotti di 20, lock condiviso con i batch manuali, attesa su rate limit, stop con messaggio chiaro su `REQUEST_DENIED`).
+- **Controllo e trasparenza**: toggle "Geocoding automatico" nelle impostazioni (attivo di default con API key configurata); la Panoramica mostra stato dell'automatismo, località in attesa, prossima esecuzione programmata e ultimo report. I batch manuali restano disponibili come fallback.
+- **Metabox senza attese**: le località scelte dalla ricerca Google arrivano già con coordinate e Place ID e vengono salvate direttamente come `verified`.
+- **Protezione dei dati geocodificati**: i re-import non degradano più le località già verificate (merge conservativo: stato e coordinate restano se il record in ingresso è meno completo).
+- **Interfaccia snellita da 7 a 4 tab**: **Panoramica** (geocoding automatico, copertura, coda di revisione, dashboard), **Import** (Link Affiliati e articoli con sotto-navigazione), **Località**, **Impostazioni & Log** (configurazione, strumenti manuali e tutti i log raggruppati). I vecchi indirizzi delle tab funzionano ancora (alias automatici).
+- Versione plugin aggiornata a `2.44.0`.
+
 ## 2.43.0 - 2026-07-02
 
 ### Indice Geografico — Copertura e indicizzazione automatica

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.43.0
+ * Version: 2.44.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.43.0');
+define('ALMA_VERSION', '2.44.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -103,6 +103,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-importer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-affiliate-link-importer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-auto-indexer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-ai-location-extractor.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-geo-geocoding-queue.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-admin.php';
 
 /**
@@ -142,6 +143,7 @@ class AffiliateManagerAI {
         $this->geo_index_admin = new ALMA_Geo_Index_Admin($this->geo_index_store);
         $this->geo_auto_indexer = new ALMA_Geo_Auto_Indexer($this->geo_index_store);
         $this->geo_auto_indexer->init_hooks();
+        ALMA_Geo_Geocoding_Queue::init();
         add_action('init', array($this, 'init'));
         add_action('widgets_init', array('ALMA_Contextual_Affiliate_Widget', 'register_widget'));
         // Registrato qui (prima che `widgets_init` scatti) perché ALMA_Shortcodes::init()
@@ -4297,6 +4299,7 @@ class AffiliateManagerAI {
     public function deactivate() {
         // Rimuovi cron jobs
         wp_clear_scheduled_hook('alma_daily_optimization');
+        ALMA_Geo_Geocoding_Queue::unschedule();
         $this->clear_deprecated_trend_cron_events();
         flush_rewrite_rules();
     }

--- a/includes/class-geo-geocoding-queue.php
+++ b/includes/class-geo-geocoding-queue.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Coda di geocoding automatico.
+ *
+ * Elimina il doppio passaggio "associa località → poi lancia il geocoding":
+ * ogni volta che una località viene associata (metabox, import CSV/API,
+ * auto-indexer, creazione post/link) e resta in stato `pending`, viene
+ * schedulato un drain asincrono via WP-Cron che geocodifica le località
+ * pending a piccoli lotti finché la coda non è vuota.
+ *
+ * Non è un job invisibile: stato, ultimo report e prossima esecuzione sono
+ * mostrati nella tab Panoramica dell'Indice Geografico, e l'automatismo è
+ * disattivabile dalle impostazioni (option `alma_geo_auto_geocoding`).
+ */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALMA_Geo_Geocoding_Queue {
+    const CRON_HOOK = 'alma_geo_drain_geocoding_queue';
+    const ENABLED_OPTION = 'alma_geo_auto_geocoding';
+    const LAST_RUN_OPTION = 'alma_geo_auto_geocoding_last_run';
+    const BATCH_SIZE = 20;
+    const RESCHEDULE_DELAY = 60;        // coda ancora piena → riparti presto
+    const RATE_LIMIT_DELAY = 300;       // quota/rate limit → attendi 5 minuti
+
+    public static function init() {
+        add_action(self::CRON_HOOK, array(__CLASS__, 'drain'));
+    }
+
+    public static function is_enabled() {
+        if (get_option(self::ENABLED_OPTION, 'yes') !== 'yes') {
+            return false;
+        }
+        return trim((string) get_option('alma_geo_google_maps_api_key', '')) !== '';
+    }
+
+    /**
+     * Schedula un drain a breve se non già in programma. Chiamata dal punto
+     * unico di associazione località (store) e quindi coprente metabox,
+     * import massivi CSV, import API, auto-indexer e creazione contenuti.
+     */
+    public static function maybe_schedule($delay = 10) {
+        if (!self::is_enabled()) {
+            return;
+        }
+        if (!wp_next_scheduled(self::CRON_HOOK)) {
+            wp_schedule_single_event(time() + max(5, absint($delay)), self::CRON_HOOK);
+        }
+    }
+
+    public static function next_run_timestamp() {
+        $timestamp = wp_next_scheduled(self::CRON_HOOK);
+        return $timestamp ? (int) $timestamp : 0;
+    }
+
+    public static function get_last_run_report() {
+        $report = get_option(self::LAST_RUN_OPTION, array());
+        return is_array($report) ? $report : array();
+    }
+
+    /**
+     * Handler cron: geocodifica un lotto di località pending e si ri-schedula
+     * finché la coda non è vuota. Riusa il lock del geocoder, quindi non può
+     * sovrapporsi ai batch manuali lanciati dall'admin.
+     */
+    public static function drain() {
+        if (!self::is_enabled()) {
+            return;
+        }
+        $geocoder = new ALMA_Geo_Index_Geocoder();
+        $report = $geocoder->geocode_batch(self::BATCH_SIZE, 'pending');
+        $report['ran_at'] = current_time('mysql');
+        $report['trigger'] = 'auto';
+        update_option(self::LAST_RUN_OPTION, $report, false);
+
+        if (!empty($report['locked'])) {
+            // Un batch manuale è in corso: riprova più tardi senza rumore.
+            self::reschedule(self::RATE_LIMIT_DELAY);
+            return;
+        }
+        if (!empty($report['configuration_error'])) {
+            // API key non valida / API non abilitata: fermarsi, l'errore è
+            // permanente e visibile in Panoramica. Ripartirà al prossimo
+            // salvataggio di impostazioni o associazione.
+            if (class_exists('ALMA_Logger')) {
+                ALMA_Logger::warning('Auto geocoding interrotto: REQUEST_DENIED (configurazione).', array('report' => array('processed' => (int) ($report['processed'] ?? 0))));
+            }
+            return;
+        }
+
+        $pending = self::count_pending();
+        if ($pending > 0) {
+            $rate_limited = !empty($report['errors']) && self::report_mentions_rate_limit($report);
+            self::reschedule($rate_limited ? self::RATE_LIMIT_DELAY : self::RESCHEDULE_DELAY);
+        }
+    }
+
+    public static function count_pending() {
+        global $wpdb;
+        $store = new ALMA_Geo_Index_Store();
+        if (!$store->tables_exist()) {
+            return 0;
+        }
+        return (int) $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM {$store->table_locations()} WHERE geocoding_status = %s",
+            'pending'
+        ));
+    }
+
+    private static function report_mentions_rate_limit($report) {
+        foreach ((array) ($report['errors'] ?? array()) as $error) {
+            $message = strtolower((string) (is_array($error) ? ($error['message'] ?? '') : $error));
+            if (strpos($message, 'quota') !== false || strpos($message, 'rate limit') !== false || strpos($message, 'over_query_limit') !== false) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static function reschedule($delay) {
+        if (!wp_next_scheduled(self::CRON_HOOK)) {
+            wp_schedule_single_event(time() + max(5, absint($delay)), self::CRON_HOOK);
+        }
+    }
+
+    public static function unschedule() {
+        wp_clear_scheduled_hook(self::CRON_HOOK);
+    }
+}

--- a/includes/class-geo-index-admin.php
+++ b/includes/class-geo-index-admin.php
@@ -58,42 +58,128 @@ class ALMA_Geo_Index_Admin {
             wp_die(esc_html__('Permessi insufficienti.', 'affiliate-link-manager-ai'));
         }
 
-        $tab = isset($_GET['tab']) ? sanitize_key($_GET['tab']) : 'dashboard';
-        if (!in_array($tab, array('dashboard', 'coverage', 'import', 'affiliate_import', 'locations', 'geocoding', 'log'), true)) {
-            $tab = 'dashboard';
+        $tab = isset($_GET['tab']) ? sanitize_key($_GET['tab']) : 'overview';
+        // Alias dei vecchi slug: i link esistenti (bottoni, bookmark, form)
+        // continuano a funzionare dopo il raggruppamento delle tab.
+        $aliases = array(
+            'dashboard' => 'overview',
+            'coverage' => 'overview',
+            'affiliate_import' => 'import',
+            'geocoding' => 'settings',
+            'log' => 'settings',
+        );
+        if (isset($aliases[$tab])) {
+            $tab = $aliases[$tab];
+        }
+        if (!in_array($tab, array('overview', 'import', 'locations', 'settings'), true)) {
+            $tab = 'overview';
         }
         $this->handle_actions($tab);
         ?>
         <div class="wrap">
-            <h1><?php echo esc_html($tab === 'affiliate_import' ? __('Import GEO Link Affiliati', 'affiliate-link-manager-ai') : __('Indice Geografico', 'affiliate-link-manager-ai')); ?></h1>
-            <p><?php esc_html_e('Modulo di fondazione per collegare articoli, pagine e Link Affiliati a località geografiche. Il geocoding usa Google Maps API solo da admin e solo su azione esplicita.', 'affiliate-link-manager-ai'); ?></p>
+            <h1><?php esc_html_e('Indice Geografico', 'affiliate-link-manager-ai'); ?></h1>
+            <p><?php esc_html_e('Collega articoli, pagine e Link Affiliati a località geografiche. L\'associazione e il geocoding Google avvengono automaticamente all\'import e alla creazione dei contenuti; qui trovi copertura, revisione, località e configurazione.', 'affiliate-link-manager-ai'); ?></p>
             <?php echo $this->notice; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
             <nav class="nav-tab-wrapper">
-                <?php $this->tab_link('dashboard', __('Dashboard', 'affiliate-link-manager-ai'), $tab); ?>
-                <?php $this->tab_link('coverage', __('Copertura', 'affiliate-link-manager-ai'), $tab); ?>
-                <?php $this->tab_link('import', __('Importa record articoli', 'affiliate-link-manager-ai'), $tab); ?>
-                <?php $this->tab_link('affiliate_import', __('Import GEO Link Affiliati', 'affiliate-link-manager-ai'), $tab); ?>
+                <?php $this->tab_link('overview', __('Panoramica', 'affiliate-link-manager-ai'), $tab); ?>
+                <?php $this->tab_link('import', __('Import', 'affiliate-link-manager-ai'), $tab); ?>
                 <?php $this->tab_link('locations', __('Località', 'affiliate-link-manager-ai'), $tab); ?>
-                <?php $this->tab_link('geocoding', __('Geocoding', 'affiliate-link-manager-ai'), $tab); ?>
-                <?php $this->tab_link('log', __('Log / ultimi import', 'affiliate-link-manager-ai'), $tab); ?>
+                <?php $this->tab_link('settings', __('Impostazioni & Log', 'affiliate-link-manager-ai'), $tab); ?>
             </nav>
             <?php
-            if ($tab === 'coverage') {
-                $this->render_coverage_tab();
-            } elseif ($tab === 'import') {
-                $this->render_import_tab();
-            } elseif ($tab === 'affiliate_import') {
-                $this->render_affiliate_import_tab();
+            if ($tab === 'import') {
+                $this->render_import_group_tab();
             } elseif ($tab === 'locations') {
                 $this->render_locations_tab();
-            } elseif ($tab === 'geocoding') {
-                $this->render_geocoding_tab();
-            } elseif ($tab === 'log') {
-                $this->render_log_tab();
+            } elseif ($tab === 'settings') {
+                $this->render_settings_group_tab();
             } else {
-                $this->render_dashboard_tab();
+                $this->render_overview_tab();
             }
             ?>
+        </div>
+        <?php
+    }
+
+    /**
+     * Panoramica: stato geocoding automatico + dashboard + copertura/revisione.
+     * È il centro operativo del workflow quotidiano.
+     */
+    private function render_overview_tab() {
+        $this->render_auto_geocoding_status();
+        $this->render_coverage_tab();
+        $this->render_dashboard_tab();
+    }
+
+    /**
+     * Import: i due flussi (Link Affiliati e articoli) raggruppati in un'unica
+     * tab con sotto-navigazione.
+     */
+    private function render_import_group_tab() {
+        $flow = isset($_GET['flow']) ? sanitize_key($_GET['flow']) : 'links';
+        if (!in_array($flow, array('links', 'articles'), true)) {
+            $flow = 'links';
+        }
+        $base = admin_url('edit.php?post_type=affiliate_link&page=' . self::MENU_SLUG . '&tab=import');
+        ?>
+        <ul class="subsubsub" style="margin-bottom:12px;">
+            <li><a href="<?php echo esc_url($base . '&flow=links'); ?>" <?php echo $flow === 'links' ? 'class="current"' : ''; ?>><?php esc_html_e('Import GEO Link Affiliati', 'affiliate-link-manager-ai'); ?></a> |</li>
+            <li><a href="<?php echo esc_url($base . '&flow=articles'); ?>" <?php echo $flow === 'articles' ? 'class="current"' : ''; ?>><?php esc_html_e('Import record articoli', 'affiliate-link-manager-ai'); ?></a></li>
+        </ul>
+        <div style="clear:both;"></div>
+        <?php
+        if ($flow === 'articles') {
+            $this->render_import_tab();
+        } else {
+            $this->render_affiliate_import_tab();
+        }
+    }
+
+    /**
+     * Impostazioni & Log: configurazione geocoding (con automatismo), strumenti
+     * manuali di fallback e log/ultimi report raggruppati.
+     */
+    private function render_settings_group_tab() {
+        $this->render_geocoding_tab();
+        echo '<hr style="margin:24px 0;">';
+        echo '<h2>' . esc_html__('Log / ultimi import', 'affiliate-link-manager-ai') . '</h2>';
+        $this->render_log_tab();
+    }
+
+    /**
+     * Pannello stato del geocoding automatico in Panoramica.
+     */
+    private function render_auto_geocoding_status() {
+        $enabled = ALMA_Geo_Geocoding_Queue::is_enabled();
+        $pending = ALMA_Geo_Geocoding_Queue::count_pending();
+        $next = ALMA_Geo_Geocoding_Queue::next_run_timestamp();
+        $last = ALMA_Geo_Geocoding_Queue::get_last_run_report();
+        $api_key_missing = trim((string) get_option('alma_geo_google_maps_api_key', '')) === '';
+        $settings_url = admin_url('edit.php?post_type=affiliate_link&page=' . self::MENU_SLUG . '&tab=settings');
+        ?>
+        <div class="card" style="max-width:960px;">
+            <h2><?php esc_html_e('Geocoding automatico', 'affiliate-link-manager-ai'); ?></h2>
+            <?php if ($api_key_missing) : ?>
+                <p><span class="dashicons dashicons-warning" style="color:#d63638;"></span> <?php esc_html_e('API key Google Maps non configurata: le località restano in attesa finché non la salvi nelle impostazioni.', 'affiliate-link-manager-ai'); ?> <a href="<?php echo esc_url($settings_url); ?>"><?php esc_html_e('Vai alle impostazioni', 'affiliate-link-manager-ai'); ?></a></p>
+            <?php elseif (!$enabled) : ?>
+                <p><span class="dashicons dashicons-controls-pause" style="color:#996800;"></span> <?php esc_html_e('Geocoding automatico disattivato: le località nuove restano pending finché non lanci un batch manuale o riattivi l\'automatismo.', 'affiliate-link-manager-ai'); ?> <a href="<?php echo esc_url($settings_url); ?>"><?php esc_html_e('Vai alle impostazioni', 'affiliate-link-manager-ai'); ?></a></p>
+            <?php else : ?>
+                <p><span class="dashicons dashicons-yes-alt" style="color:#00a32a;"></span> <?php esc_html_e('Attivo: le località associate da import, API, metabox e auto-indicizzazione vengono geocodificate automaticamente in background.', 'affiliate-link-manager-ai'); ?></p>
+            <?php endif; ?>
+            <ul style="margin-left:1.4em;list-style:disc;">
+                <li><?php printf(esc_html__('Località in attesa di geocoding: %s', 'affiliate-link-manager-ai'), '<strong>' . esc_html(number_format_i18n($pending)) . '</strong>'); ?></li>
+                <?php if ($next) : ?>
+                    <li><?php printf(esc_html__('Prossima esecuzione automatica: %s', 'affiliate-link-manager-ai'), esc_html(get_date_from_gmt(gmdate('Y-m-d H:i:s', $next), 'd/m/Y H:i:s'))); ?></li>
+                <?php elseif ($enabled && $pending > 0) : ?>
+                    <li><?php esc_html_e('Prossima esecuzione: alla prossima associazione di località (o avvia un batch manuale dalle impostazioni).', 'affiliate-link-manager-ai'); ?></li>
+                <?php endif; ?>
+                <?php if (!empty($last['ran_at'])) : ?>
+                    <li><?php printf(esc_html__('Ultima esecuzione automatica: %1$s — %2$d processate, %3$d verificate, %4$d ambigue, %5$d fallite.', 'affiliate-link-manager-ai'), esc_html($last['ran_at']), (int) ($last['processed'] ?? 0), (int) ($last['verified'] ?? 0), (int) ($last['ambiguous'] ?? 0), (int) ($last['failed'] ?? 0)); ?></li>
+                <?php endif; ?>
+                <?php if (!empty($last['configuration_error'])) : ?>
+                    <li style="color:#d63638;"><?php esc_html_e('Ultimo run interrotto: Google ha rifiutato la richiesta (REQUEST_DENIED). Verifica API key e abilitazione della Geocoding API nelle impostazioni.', 'affiliate-link-manager-ai'); ?></li>
+                <?php endif; ?>
+            </ul>
         </div>
         <?php
     }
@@ -104,20 +190,22 @@ class ALMA_Geo_Index_Admin {
         }
         $action = sanitize_key(wp_unslash($_POST['alma_geo_index_action']));
         if ($tab === 'import') {
-            check_admin_referer('alma_geo_index_import');
-            if ($action === 'preview') {
-                $this->handle_preview_upload();
-            } elseif ($action === 'import') {
-                $this->handle_import_submit();
+            // I due flussi convivono nella stessa tab: le action articoli
+            // (preview/import) e quelle Link Affiliati hanno nomi disgiunti.
+            if (in_array($action, array('preview', 'import'), true)) {
+                check_admin_referer('alma_geo_index_import');
+                if ($action === 'preview') {
+                    $this->handle_preview_upload();
+                } else {
+                    $this->handle_import_submit();
+                }
+                return;
             }
-            return;
-        }
-        if ($tab === 'affiliate_import') {
             check_admin_referer('alma_geo_affiliate_import');
             $this->handle_affiliate_import_action($action);
             return;
         }
-        if (in_array($tab, array('geocoding', 'locations'), true)) {
+        if (in_array($tab, array('settings', 'locations', 'overview'), true)) {
             check_admin_referer('alma_geo_index_geocoding');
             $this->handle_geocoding_action($action);
         }
@@ -139,6 +227,11 @@ class ALMA_Geo_Index_Admin {
             update_option('alma_geo_geocoding_delay_ms', max(0, min(5000, absint($_POST['alma_geo_geocoding_delay_ms'] ?? 200))), false);
             update_option('alma_geo_geocoding_overwrite_verified', !empty($_POST['alma_geo_geocoding_overwrite_verified']) ? 'yes' : 'no', false);
             update_option('alma_geo_geocoding_country_bias', sanitize_text_field(wp_unslash($_POST['alma_geo_geocoding_country_bias'] ?? '')), false);
+            update_option(ALMA_Geo_Geocoding_Queue::ENABLED_OPTION, !empty($_POST['alma_geo_auto_geocoding']) ? 'yes' : 'no', false);
+            // Se l'automatismo è attivo e ci sono località in attesa, riparte subito.
+            if (ALMA_Geo_Geocoding_Queue::is_enabled() && ALMA_Geo_Geocoding_Queue::count_pending() > 0) {
+                ALMA_Geo_Geocoding_Queue::maybe_schedule(5);
+            }
             $this->notice_success($api_key === '' && get_option('alma_geo_google_maps_api_key', '') === '' ? __('Impostazioni salvate. API key non configurata.', 'affiliate-link-manager-ai') : __('Impostazioni geocoding salvate.', 'affiliate-link-manager-ai'));
             return;
         }
@@ -364,7 +457,7 @@ class ALMA_Geo_Index_Admin {
         $affiliate_counts = $this->store->get_geocoding_status_counts_by_object_type(ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK);
         $api_key = (string) get_option('alma_geo_google_maps_api_key', '');
         $masked_key = $api_key === '' ? __('Non configurata', 'affiliate-link-manager-ai') : sprintf(__('Configurata (termina con %s)', 'affiliate-link-manager-ai'), substr($api_key, -4));
-        echo '<h2>' . esc_html__('Geocoding', 'affiliate-link-manager-ai') . '</h2>';
+        echo '<h2>' . esc_html__('Configurazione geocoding', 'affiliate-link-manager-ai') . '</h2>';
         echo '<div class="postbox"><div class="inside"><h3>' . esc_html__('Stato configurazione', 'affiliate-link-manager-ai') . '</h3><table class="widefat striped"><tbody>';
         $rows = array(
             __('Provider attivo', 'affiliate-link-manager-ai') => 'Google Maps',
@@ -404,6 +497,7 @@ class ALMA_Geo_Index_Admin {
                 <tr><th><label for="alma_geo_geocoding_delay_ms"><?php esc_html_e('Pausa tra richieste (ms)', 'affiliate-link-manager-ai'); ?></label></th><td><input type="number" min="0" max="5000" id="alma_geo_geocoding_delay_ms" name="alma_geo_geocoding_delay_ms" value="<?php echo esc_attr((string) $settings['delay_ms']); ?>"></td></tr>
                 <tr><th><label for="alma_geo_geocoding_country_bias"><?php esc_html_e('Country bias opzionale', 'affiliate-link-manager-ai'); ?></label></th><td><input type="text" id="alma_geo_geocoding_country_bias" name="alma_geo_geocoding_country_bias" value="<?php echo esc_attr($settings['country_bias']); ?>" class="small-text" maxlength="10"></td></tr>
                 <tr><th><?php esc_html_e('Sovrascrittura', 'affiliate-link-manager-ai'); ?></th><td><label><input type="checkbox" name="alma_geo_geocoding_overwrite_verified" value="1" <?php checked($settings['overwrite_verified'], 'yes'); ?>> <?php esc_html_e('Permetti sovrascrittura località già verified', 'affiliate-link-manager-ai'); ?></label></td></tr>
+                <tr><th><?php esc_html_e('Geocoding automatico', 'affiliate-link-manager-ai'); ?></th><td><label><input type="checkbox" name="alma_geo_auto_geocoding" value="1" <?php checked(get_option(ALMA_Geo_Geocoding_Queue::ENABLED_OPTION, 'yes'), 'yes'); ?>> <?php esc_html_e('Geocodifica automaticamente in background le località associate da import, API, metabox e auto-indicizzazione (nessun secondo passaggio manuale).', 'affiliate-link-manager-ai'); ?></label><p class="description"><?php esc_html_e('Richiede la API key. Lo stato è visibile nella tab Panoramica; i batch manuali qui sotto restano disponibili come fallback.', 'affiliate-link-manager-ai'); ?></p></td></tr>
             </tbody></table>
             <?php submit_button(__('Salva impostazioni geocoding', 'affiliate-link-manager-ai'), 'primary', 'submit', false); ?>
         </form>

--- a/includes/class-geo-index-store.php
+++ b/includes/class-geo-index-store.php
@@ -188,13 +188,37 @@ class ALMA_Geo_Index_Store {
         );
 
         if ($existing) {
+            // Merge conservativo: se il record in ingresso non porta dati di
+            // geocoding (import/associazioni con soli nomi) non deve degradare
+            // una località già geocodificata a pending azzerandone le coordinate
+            // (che il geocoding automatico rigeocodificherebbe pagando quota).
+            $existing_status = sanitize_key($existing['geocoding_status'] ?? 'pending');
+            $incoming_has_geo = $data['lat'] !== null && $data['lng'] !== null && $data['geo_provider_place_id'] !== '';
+            if (!$incoming_has_geo && $existing_status !== 'pending' && $row['geocoding_status'] === 'pending') {
+                foreach (array('lat', 'lng', 'geo_provider', 'geo_provider_place_id', 'geocoding_status', 'formatted_address', 'address_components', 'geocoded_at', 'geocoding_error') as $geo_field) {
+                    $row[$geo_field] = $existing[$geo_field] ?? $row[$geo_field];
+                }
+            }
             $wpdb->update($this->table_locations(), $row, array('id' => (int) $existing['id']), $formats, array('%d'));
+            $this->maybe_queue_auto_geocoding($row['geocoding_status']);
             return (int) $existing['id'];
         }
 
         $row['created_at'] = $now;
         $wpdb->insert($this->table_locations(), $row, array_merge($formats, array('%s')));
+        $this->maybe_queue_auto_geocoding($row['geocoding_status']);
         return (int) $wpdb->insert_id;
+    }
+
+    /**
+     * Geocoding automatico: ogni località che nasce o resta in stato pending
+     * schedula il drain in background. Copre tutti i flussi (metabox, import
+     * CSV/API, auto-indexer, creazione contenuti) perché passano tutti da qui.
+     */
+    private function maybe_queue_auto_geocoding($geocoding_status) {
+        if ($geocoding_status === 'pending' && class_exists('ALMA_Geo_Geocoding_Queue')) {
+            ALMA_Geo_Geocoding_Queue::maybe_schedule();
+        }
     }
 
     public function upsert_content_index($object_id, $object_type, $location_id, $data) {
@@ -322,6 +346,21 @@ class ALMA_Geo_Index_Store {
 
         $source = sanitize_text_field($source);
         $locations = $this->normalize_associated_locations($locations, $source);
+        // Località selezionate dalla ricerca Google del metabox (o comunque già
+        // complete di coordinate e Place ID): sono già geocodificate, non ha
+        // senso rimetterle in coda pending per un secondo passaggio.
+        foreach ($locations as &$location_ref) {
+            if (($location_ref['geocoding_status'] ?? 'pending') === 'pending'
+                && ($location_ref['lat'] ?? '') !== ''
+                && ($location_ref['lng'] ?? '') !== ''
+                && ($location_ref['geo_provider_place_id'] ?? '') !== '') {
+                $location_ref['geocoding_status'] = 'verified';
+                if (($location_ref['geo_provider'] ?? '') === '') {
+                    $location_ref['geo_provider'] = 'google_maps';
+                }
+            }
+        }
+        unset($location_ref);
         if (empty($locations)) {
             $this->log_geo_store_event('info', 'Geo Index Store save received no associated locations.', $object_id, $object_type);
         }


### PR DESCRIPTION
# Riepilogo

Versione **2.44.0**. Razionalizza la sezione **Indice Geografico** eliminando il doppio passaggio "geolocalizzazione → geocoding Google manuale" e riorganizzando l'interfaccia da 7 a 4 tab.

## Geocoding automatico all'associazione

Nuova coda `ALMA_Geo_Geocoding_Queue` (WP-Cron): ogni località che resta `pending` dopo un'associazione viene geocodificata automaticamente in background, qualunque sia l'origine:

- **import CSV massivi** di Link Affiliati
- **import da API** (Viator/GetYourGuide)
- **inserimento diretto di link** e **creazione di post** (metabox + auto-indicizzazione)

Il trigger è in `ALMA_Geo_Index_Store::upsert_location`, punto di passaggio unico di tutti i flussi. Caratteristiche:

- lotti da 20 località per esecuzione, auto-concatenazione finché la coda non è vuota
- lock condiviso con i batch manuali (nessuna sovrapposizione), backoff 5 minuti su quota/rate limit, **stop con errore visibile su `REQUEST_DENIED`**
- **non è un job invisibile**: toggle nelle impostazioni (attivo di default con API key), stato/pending/prossima esecuzione/ultimo report nella tab Panoramica, batch manuali sempre disponibili come fallback, cron rimosso alla disattivazione del plugin

## Fix di qualità dati che rendono sicura l'automazione

- Le località scelte dalla **ricerca Google del metabox** (già complete di coordinate e Place ID) vengono salvate direttamente come `verified`: niente coda, niente attesa.
- **Merge conservativo in `upsert_location`**: un re-import con dati meno completi non degrada più una località `verified` a `pending` azzerandone le coordinate — evita ri-geocoding automatici e costi Google ripetuti.

## UI: da 7 tab a 4

| Prima | Dopo |
|---|---|
| Dashboard, Copertura | **Panoramica** (stato geocoding automatico + copertura + coda revisione + dashboard) |
| Importa record articoli, Import GEO Link Affiliati | **Import** (sotto-navigazione: Link Affiliati / articoli) |
| Località | **Località** |
| Geocoding, Log | **Impostazioni & Log** (configurazione, strumenti manuali, tutti i log) |

I vecchi slug delle tab sono alias dei nuovi: link, bookmark e form esistenti continuano a funzionare. I due flussi import convivono nella stessa tab con action a nomi disgiunti instradate ciascuna sul proprio nonce.

## Versione e documentazione

- Versione plugin: `2.43.0` → `2.44.0`; sezione 2.44.0 in README e CHANGELOG.

## Verifica

- `php -l` pulito su tutti i file nuovi/modificati (plugin principale, store, admin, coda).
- Retrocompatibilità: nessuna option rimossa, alias per tutti i vecchi slug tab, batch manuali invariati, automatismo disattivabile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_