### PR TITLE
v2.45.0: geolocalizzazione completa degli import Viator API e arricchimento località CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.45.0 - 2026-07-02
+
+### Geolocalizzazione completa dei link importati (Viator API e CSV)
+- **Risoluzione destinazioni Viator**: i prodotti Viator espongono solo ref numerici di destinazione (es. `684`); il nuovo resolver scarica una volta il catalogo `/destinations` (cachato 30 giorni in option), risale l'albero città→regione→paese e salva sul link i meta `_alma_destination`, `_alma_viator_destination_name/region/country`. I link importati da Viator API vengono così geolocalizzati e geocodificati automaticamente come quelli GYG.
+- **Fallback per i link Viator già importati**: durante l'indicizzazione automatica i ref nel `_alma_metadata_json` vengono risolti con il catalogo cachato, senza dover re-importare.
+- **Regione e paese nel geocoding**: la colonna Regione del CSV GetYourGuide (`_alma_gyg_csv_region`) e i dati Viator arricchiscono la località (regione, paese e query di geocoding suggerita), migliorando la disambiguazione delle città omonime e la qualità del geocoding Google.
+- `format_location_for_json` conserva ora `suggested_geocoding_query` lungo il flusso di salvataggio.
+- Versione plugin aggiornata a `2.45.0`.
+
 ## 2.44.0 - 2026-07-02
 
 ### Indice Geografico — geocoding automatico e interfaccia razionalizzata

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## 2.45.0 - 2026-07-02
+
+### Geolocalizzazione completa dei link importati (Viator API e CSV)
+
+- **Import Viator API ora geolocalizzato**: i prodotti Viator non contengono nomi di località ma solo ref numerici (es. `684`). Il nuovo resolver scarica il catalogo destinazioni Viator una sola volta (cache 30 giorni), risolve il ref primario in nome/regione/paese risalendo l'albero delle destinazioni e lo salva sul link al momento dell'import: da lì la catena automatica (associazione → geocoding Google) procede da sola come per gli import CSV.
+- **Link Viator già presenti**: l'indicizzazione automatica risolve i ref anche per i link importati in passato, leggendo il metadata JSON — senza re-import.
+- **Città omonime disambiguate**: la colonna Regione del CSV (opzionale) e regione/paese Viator entrano nella località e nella query di geocoding suggerita ("Copenaghen, Hovedstaden, Danimarca" invece di solo "Copenaghen").
+- Versione plugin aggiornata a `2.45.0`.
+
 ## 2.44.0 - 2026-07-02
 
 ### Indice Geografico — geocoding automatico e interfaccia razionalizzata

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.44.0
+ * Version: 2.45.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.44.0');
+define('ALMA_VERSION', '2.45.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -66,6 +66,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-client-
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-client-viator.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-client-getyourguide.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-viator-field-catalog.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-viator-destination-resolver.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-getyourguide-field-catalog.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-viator-media-resolver.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-getyourguide-media-resolver.php';

--- a/includes/class-affiliate-source-importer.php
+++ b/includes/class-affiliate-source-importer.php
@@ -23,6 +23,19 @@ class ALMA_Affiliate_Source_Importer {
         if (!empty($normalized['affiliate_url'])) { update_post_meta($post_id, '_affiliate_url', $normalized['affiliate_url']); update_post_meta($post_id, '_alma_affiliate_url', $normalized['affiliate_url']); }
         update_post_meta($post_id, '_alma_original_url', $normalized['original_url']); update_post_meta($post_id, '_alma_import_status', $status); update_post_meta($post_id, '_alma_last_sync_at', current_time('mysql')); update_post_meta($post_id, '_alma_import_mode', sanitize_text_field($mode));
         foreach ($normalized['meta'] as $key => $value) update_post_meta($post_id, $key, $value);
+        // Viator espone solo ref numerici di destinazione: risolti qui in nomi
+        // (catalogo /destinations cachato) così il link nasce con la località e
+        // la geolocalizzazione automatica può agganciarlo subito.
+        if ($provider === 'viator' && class_exists('ALMA_Affiliate_Source_Viator_Destination_Resolver')) {
+            $viator_location = ALMA_Affiliate_Source_Viator_Destination_Resolver::resolve_primary_location($normalized['raw_item'] ?? array(), $source);
+            if (!empty($viator_location['name'])) {
+                update_post_meta($post_id, '_alma_destination', sanitize_text_field($viator_location['name']));
+                update_post_meta($post_id, '_alma_viator_destination_name', sanitize_text_field($viator_location['name']));
+                update_post_meta($post_id, '_alma_viator_destination_type', sanitize_key($viator_location['type']));
+                update_post_meta($post_id, '_alma_viator_destination_region', sanitize_text_field($viator_location['region']));
+                update_post_meta($post_id, '_alma_viator_destination_country', sanitize_text_field($viator_location['country']));
+            }
+        }
         $image_result = $this->maybe_import_featured_image($post_id, $normalized, $source, $settings, $options);
         if ($build_ai_context) { $builder = new ALMA_Affiliate_Link_AI_Context_Builder(); $builder->maybe_build_and_store($post_id, $normalized, $source); }
         if (empty(get_post_meta($post_id, '_alma_ai_visibility', true))) update_post_meta($post_id, '_alma_ai_visibility', 'available');

--- a/includes/class-affiliate-source-viator-destination-resolver.php
+++ b/includes/class-affiliate-source-viator-destination-resolver.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Risolve i ref numerici delle destinazioni Viator in nomi di località.
+ *
+ * I prodotti Viator (products/search) contengono solo `destinations[].ref`
+ * (es. "684"): senza risoluzione i link importati non hanno alcun nome di
+ * località e la geolocalizzazione automatica non può agganciarli. Il catalogo
+ * completo delle destinazioni (GET /destinations) viene scaricato una volta e
+ * cachato in option per 30 giorni.
+ */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALMA_Affiliate_Source_Viator_Destination_Resolver {
+    const CATALOG_OPTION = 'alma_viator_destinations_catalog';
+    const CATALOG_TTL = 30 * DAY_IN_SECONDS;
+
+    /** Memoizzazione per request. */
+    private static $catalog_cache = null;
+
+    /**
+     * Risolve la destinazione primaria di un item Viator in una località
+     * pronta per il Geo Index.
+     *
+     * @param array $item   Item prodotto Viator (con destinations[].ref).
+     * @param array $source Riga source (per credenziali/ambiente).
+     * @return array array vuoto oppure {name, type, city, region, country}
+     */
+    public static function resolve_primary_location($item, $source) {
+        $refs = self::extract_refs($item);
+        if (empty($refs)) {
+            return array();
+        }
+        $catalog = self::get_catalog($source);
+        if (empty($catalog)) {
+            return array();
+        }
+
+        $primary_ref = $refs['primary'] !== '' ? $refs['primary'] : ($refs['all'][0] ?? '');
+        if ($primary_ref === '' || !isset($catalog[$primary_ref])) {
+            return array();
+        }
+
+        $node = $catalog[$primary_ref];
+        $location = array(
+            'name' => $node['name'],
+            'type' => self::map_type($node['type']),
+            'city' => self::map_type($node['type']) === 'city' ? $node['name'] : '',
+            'region' => '',
+            'country' => '',
+        );
+
+        // Risali l'albero delle destinazioni per regione e paese.
+        $parent_id = $node['parent'];
+        $depth = 0;
+        while ($parent_id !== '' && isset($catalog[$parent_id]) && $depth < 6) {
+            $parent = $catalog[$parent_id];
+            $parent_type = strtoupper($parent['type']);
+            if ($location['region'] === '' && in_array($parent_type, array('REGION', 'STATE', 'PROVINCE'), true)) {
+                $location['region'] = $parent['name'];
+            }
+            if ($location['country'] === '' && $parent_type === 'COUNTRY') {
+                $location['country'] = $parent['name'];
+            }
+            $parent_id = $parent['parent'];
+            $depth++;
+        }
+        return $location;
+    }
+
+    public static function extract_refs($item) {
+        $refs = array('primary' => '', 'all' => array());
+        foreach ((array) ($item['destinations'] ?? array()) as $destination) {
+            if (!is_array($destination)) {
+                continue;
+            }
+            $ref = sanitize_text_field((string) ($destination['ref'] ?? ($destination['destinationId'] ?? '')));
+            if ($ref === '') {
+                continue;
+            }
+            $refs['all'][] = $ref;
+            if (!empty($destination['primary']) && $refs['primary'] === '') {
+                $refs['primary'] = $ref;
+            }
+        }
+        $refs['all'] = array_values(array_unique($refs['all']));
+        return empty($refs['all']) ? array() : $refs;
+    }
+
+    /**
+     * Catalogo destinationId => {name, type, parent}. Cachato in option;
+     * scaricato via API con le credenziali della source solo se assente/scaduto.
+     */
+    public static function get_catalog($source) {
+        if (self::$catalog_cache !== null) {
+            return self::$catalog_cache;
+        }
+        $stored = get_option(self::CATALOG_OPTION, array());
+        if (is_array($stored) && !empty($stored['map']) && (time() - (int) ($stored['fetched_at'] ?? 0)) < self::CATALOG_TTL) {
+            self::$catalog_cache = $stored['map'];
+            return self::$catalog_cache;
+        }
+
+        $map = self::fetch_catalog($source);
+        if (empty($map)) {
+            // Fetch fallito: riusa un catalogo scaduto se disponibile (meglio
+            // di niente), senza sovrascrivere l'option.
+            self::$catalog_cache = is_array($stored['map'] ?? null) ? $stored['map'] : array();
+            return self::$catalog_cache;
+        }
+        update_option(self::CATALOG_OPTION, array('map' => $map, 'fetched_at' => time()), false);
+        self::$catalog_cache = $map;
+        return self::$catalog_cache;
+    }
+
+    private static function fetch_catalog($source) {
+        $settings = json_decode((string) ($source['settings'] ?? '{}'), true) ?: array();
+        $credentials = json_decode((string) ($source['credentials'] ?? '{}'), true) ?: array();
+        $api_key = sanitize_text_field($credentials['api_key'] ?? '');
+        if ($api_key === '') {
+            return array();
+        }
+        $environment = sanitize_key($settings['environment'] ?? ALMA_Affiliate_Source_Provider_Client_Viator::ENV_SANDBOX);
+        $base = $environment === ALMA_Affiliate_Source_Provider_Client_Viator::ENV_PRODUCTION ? 'https://api.viator.com/partner' : 'https://api.sandbox.viator.com/partner';
+        $api_version = sanitize_text_field($settings['api_version'] ?? '2.0');
+        $lang = sanitize_text_field($settings['accept_language'] ?? 'it');
+
+        $response = wp_remote_get($base . '/destinations', array(
+            'headers' => array(
+                'exp-api-key' => $api_key,
+                'Accept' => 'application/json;version=' . $api_version,
+                'Accept-Language' => $lang !== '' ? $lang : 'it',
+            ),
+            'timeout' => 30,
+        ));
+        if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
+            if (class_exists('ALMA_Logger')) {
+                ALMA_Logger::warning('Viator destinations catalog fetch failed.', array(
+                    'error' => is_wp_error($response) ? $response->get_error_message() : ('HTTP ' . wp_remote_retrieve_response_code($response)),
+                ));
+            }
+            return array();
+        }
+        $data = json_decode(wp_remote_retrieve_body($response), true);
+        if (!is_array($data) || empty($data['destinations']) || !is_array($data['destinations'])) {
+            return array();
+        }
+
+        $map = array();
+        foreach ($data['destinations'] as $destination) {
+            if (!is_array($destination)) {
+                continue;
+            }
+            $id = sanitize_text_field((string) ($destination['destinationId'] ?? ($destination['ref'] ?? '')));
+            $name = sanitize_text_field((string) ($destination['name'] ?? ''));
+            if ($id === '' || $name === '') {
+                continue;
+            }
+            $map[$id] = array(
+                'name' => $name,
+                'type' => sanitize_text_field((string) ($destination['type'] ?? '')),
+                'parent' => sanitize_text_field((string) ($destination['parentDestinationId'] ?? '')),
+            );
+        }
+        return $map;
+    }
+
+    private static function map_type($viator_type) {
+        $viator_type = strtoupper((string) $viator_type);
+        $map = array(
+            'CITY' => 'city',
+            'TOWN' => 'city',
+            'VILLAGE' => 'city',
+            'REGION' => 'region',
+            'STATE' => 'region',
+            'PROVINCE' => 'region',
+            'COUNTRY' => 'country',
+            'ISLAND' => 'area',
+            'NATIONAL_PARK' => 'area',
+            'DISTRICT' => 'area',
+            'NEIGHBORHOOD' => 'area',
+        );
+        return $map[$viator_type] ?? 'city';
+    }
+}

--- a/includes/class-geo-auto-indexer.php
+++ b/includes/class-geo-auto-indexer.php
@@ -279,8 +279,16 @@ class ALMA_Geo_Auto_Indexer {
      * ------------------------------------------------------------------ */
 
     public function locations_from_provider_meta($post_id) {
+        // Contesto geografico aggiuntivo dichiarato dal provider: regione e paese
+        // migliorano il geocoding e la disambiguazione delle città omonime.
+        $provider_region = trim((string) get_post_meta($post_id, '_alma_gyg_csv_region', true));
+        if ($provider_region === '') {
+            $provider_region = trim((string) get_post_meta($post_id, '_alma_viator_destination_region', true));
+        }
+        $provider_country = trim((string) get_post_meta($post_id, '_alma_viator_destination_country', true));
+
         $names = array();
-        foreach (array('_alma_destination', '_alma_gyg_csv_city') as $meta_key) {
+        foreach (array('_alma_destination', '_alma_gyg_csv_city', '_alma_viator_destination_name') as $meta_key) {
             $value = trim((string) get_post_meta($post_id, $meta_key, true));
             if ($value !== '') {
                 $names[] = $value;
@@ -297,6 +305,22 @@ class ALMA_Geo_Auto_Indexer {
                     if (!empty($decoded[$field]) && is_scalar($decoded[$field])) {
                         $names[] = (string) $decoded[$field];
                     }
+                }
+            }
+        }
+
+        // Fallback per i link Viator importati prima della risoluzione automatica:
+        // i ref numerici nel metadata JSON vengono risolti in nomi tramite il
+        // catalogo destinazioni (cachato in option, una sola chiamata API).
+        if (empty($names)) {
+            $viator_location = $this->resolve_viator_refs_for_post($post_id);
+            if (!empty($viator_location['name'])) {
+                $names[] = $viator_location['name'];
+                if ($provider_region === '' && $viator_location['region'] !== '') {
+                    $provider_region = $viator_location['region'];
+                }
+                if ($provider_country === '' && $viator_location['country'] !== '') {
+                    $provider_country = $viator_location['country'];
                 }
             }
         }
@@ -322,9 +346,10 @@ class ALMA_Geo_Auto_Indexer {
                     'canonical_name' => $name,
                     'type' => 'city',
                     'city' => $name,
-                    'country' => '',
+                    'country' => $provider_country,
                     'country_code' => '',
-                    'region' => '',
+                    'region' => $provider_region,
+                    'suggested_geocoding_query' => trim(implode(', ', array_filter(array($name, $provider_region, $provider_country)))),
                     'geocoding_status' => 'pending',
                     'confidence' => self::CONFIDENCE_HIGH,
                     'source' => self::SOURCE_PROVIDER,
@@ -335,6 +360,32 @@ class ALMA_Geo_Auto_Indexer {
             $locations[0]['is_primary'] = true;
         }
         return $locations;
+    }
+
+    /**
+     * Risolve i ref destinazione Viator (metadata JSON) per link importati
+     * prima dell'introduzione della risoluzione in fase di import.
+     */
+    private function resolve_viator_refs_for_post($post_id) {
+        if (!class_exists('ALMA_Affiliate_Source_Viator_Destination_Resolver')) {
+            return array();
+        }
+        if (get_post_meta($post_id, '_alma_provider', true) !== 'viator') {
+            return array();
+        }
+        $raw = get_post_meta($post_id, '_alma_metadata_json', true);
+        $item = is_string($raw) && $raw !== '' ? json_decode($raw, true) : null;
+        if (!is_array($item) || empty($item['destinations'])) {
+            return array();
+        }
+        $source_id = absint(get_post_meta($post_id, '_alma_source_id', true));
+        $source = array();
+        if ($source_id > 0) {
+            global $wpdb;
+            $source = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}alma_affiliate_sources WHERE id = %d", $source_id), ARRAY_A) ?: array();
+        }
+        $location = ALMA_Affiliate_Source_Viator_Destination_Resolver::resolve_primary_location($item, $source);
+        return is_array($location) ? $location : array();
     }
 
     /* ---------------------------------------------------------------------

--- a/includes/class-geo-index-store.php
+++ b/includes/class-geo-index-store.php
@@ -563,6 +563,7 @@ class ALMA_Geo_Index_Store {
             'geo_provider' => $provider,
             'geo_provider_place_id' => $place_id,
             'formatted_address' => sanitize_text_field($location['formatted_address'] ?? ''),
+            'suggested_geocoding_query' => sanitize_text_field($location['suggested_geocoding_query'] ?? ''),
             'geocoding_status' => sanitize_key($location['geocoding_status'] ?? 'pending'),
             'role' => sanitize_key($location['role'] ?? ($is_primary ? 'main_destination' : 'major_destination')),
             'is_primary' => $is_primary,


### PR DESCRIPTION
# Riepilogo

Versione **2.45.0**. Risponde alla verifica: *"i link importati da CSV e da Viator API vengono geolocalizzati completamente?"* — per il CSV la risposta era "sì, se la colonna Città è compilata"; per **Viator API la risposta era no**: i prodotti Viator contengono solo ref numerici di destinazione (es. `684`), nessun nome di località, quindi il livello provider dell'auto-indicizzazione non aveva nulla da agganciare.

## Risoluzione destinazioni Viator

- Nuova classe `ALMA_Affiliate_Source_Viator_Destination_Resolver`: scarica il catalogo `GET /destinations` con le credenziali della source (una chiamata, cache in option per 30 giorni, riuso del catalogo scaduto se il refresh fallisce), risolve il ref primario e risale l'albero delle destinazioni per ricavare **città → regione → paese**.
- **All'import**: l'importer salva sul link `_alma_destination` + `_alma_viator_destination_name/type/region/country` → da lì la catena automatica esistente (associazione → coda geocoding Google) completa da sola, come già avviene per il CSV GetYourGuide.
- **Per i link Viator già importati**: durante l'indicizzazione automatica i ref presenti in `_alma_metadata_json` vengono risolti col catalogo cachato (source recuperata da `_alma_source_id`) — nessun re-import necessario.

## Arricchimento località CSV

- La colonna **Regione** del CSV (opzionale, `_alma_gyg_csv_region`) e regione/paese Viator entrano ora nella località creata e nella **query di geocoding suggerita** ("Copenaghen, Hovedstaden, Danimarca" invece di "Copenaghen"): meno ambiguità per le città omonime e geocoding Google più preciso.
- `format_location_for_json` conserva `suggested_geocoding_query` lungo il flusso di salvataggio (prima veniva perso nella normalizzazione).

## Stato risultante della geolocalizzazione degli import

| Origine | Prima | Dopo |
|---|---|---|
| CSV con colonna Città | ✅ automatica | ✅ automatica + regione nella query |
| CSV senza Città | ⚠️ solo gazetteer sul titolo | ⚠️ invariato (gazetteer/AI in batch) |
| Viator API | ❌ nessuna località | ✅ automatica (resolver destinazioni) |
| GetYourGuide API | ✅ se il payload ha city/location | ✅ invariato |

## Versione e documentazione

- Versione plugin: `2.44.0` → `2.45.0`; sezione 2.45.0 in README e CHANGELOG.

## Verifica

- `php -l` pulito su tutti i file nuovi/modificati.
- Retrocompatibilità: nessun cambiamento per i flussi esistenti senza credenziali Viator (il resolver ritorna vuoto senza errori); meta aggiuntivi, nessuno rimosso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_