### PR TITLE
v2.48.0: fix modale "Inserisci Link Affiliato" + filtro per località geografica

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.48.0 - 2026-07-02
+
+### Modale "Inserisci Link Affiliato" — fix inserimento e filtro località
+- **Fix "Errore durante l'inserimento"**: l'inserimento in Gutenberg poteva fallire per API blocchi non disponibili al momento del click e per il contenuto RichText dei paragrafi (WP 6.5+) trattato come stringa. Ora ogni strategia (Gutenberg → TinyMCE → textarea) è isolata con fallback a cascata, in Gutenberg lo shortcode viene inserito come blocco dedicato subito dopo il blocco selezionato, e gli script `wp-data`/`wp-blocks` sono dipendenze garantite nel block editor.
+- **Niente più lavoro perso**: se nessun editor è raggiungibile, lo shortcode viene copiato negli appunti e mostrato nel messaggio, invece del solo errore.
+- **Nuovo filtro "📍 Località"**: il modale elenca le località con link affiliati collegati (ordinate per numero di link) e filtra i risultati per area geografica — la località scelta viene espansa a righe omonime e, per i paesi, a tutte le località di quel paese.
+- **Preselezione automatica**: se l'articolo in modifica è geolocalizzato, il filtro parte già sulla sua località primaria (con avviso e possibilità di rimuoverlo), mostrando subito i link della zona giusta.
+- **Badge località nei risultati**: ogni link mostra la sua località primaria (📍 Città, Paese) accanto a tipologia, click e utilizzi.
+- Versione plugin aggiornata a `2.48.0`.
+
 ## 2.47.0 - 2026-07-02
 
 ### Località — azioni corrette, sync degli stati e selezione massiva

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## 2.48.0 - 2026-07-02
+
+### Modale "Inserisci Link Affiliato" — fix inserimento e filtro località
+- **Fix "Errore durante l'inserimento"**: l'inserimento in Gutenberg poteva fallire per API blocchi non disponibili al momento del click e per il contenuto RichText dei paragrafi (WP 6.5+) trattato come stringa. Ora ogni strategia (Gutenberg → TinyMCE → textarea) è isolata con fallback a cascata, in Gutenberg lo shortcode viene inserito come blocco dedicato subito dopo il blocco selezionato, e gli script `wp-data`/`wp-blocks` sono dipendenze garantite nel block editor.
+- **Niente più lavoro perso**: se nessun editor è raggiungibile, lo shortcode viene copiato negli appunti e mostrato nel messaggio, invece del solo errore.
+- **Nuovo filtro "📍 Località"**: il modale elenca le località con link affiliati collegati (ordinate per numero di link) e filtra i risultati per area geografica — la località scelta viene espansa a righe omonime e, per i paesi, a tutte le località di quel paese.
+- **Preselezione automatica**: se l'articolo in modifica è geolocalizzato, il filtro parte già sulla sua località primaria (con avviso e possibilità di rimuoverlo), mostrando subito i link della zona giusta.
+- **Badge località nei risultati**: ogni link mostra la sua località primaria (📍 Città, Paese) accanto a tipologia, click e utilizzi.
+- Versione plugin aggiornata a `2.48.0`.
+
 ## 2.47.0 - 2026-07-02
 
 ### Località — azioni corrette, sync degli stati e selezione massiva

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.47.0
+ * Version: 2.48.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.47.0');
+define('ALMA_VERSION', '2.48.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/assets/editor.js
+++ b/assets/editor.js
@@ -172,6 +172,15 @@ jQuery(document).ready(function($) {
             const searchTerm = $('#alma-link-search').val();
             searchLinks(searchTerm);
         });
+
+        // Filtro località geografica
+        $(document).on('change.alma_editor', '#alma-geo-filter', function() {
+            if (!$(this).val()) {
+                $('#alma-geo-filter-hint').hide();
+            }
+            const searchTerm = $('#alma-link-search').val();
+            searchLinks(searchTerm);
+        });
         
         // Pulsante Cerca
         $(document).on('click.alma_editor', '#alma-search-btn', function() {
@@ -338,9 +347,12 @@ jQuery(document).ready(function($) {
                         <span class="dashicons dashicons-search" style="position:absolute;right:15px;top:50%;transform:translateY(-50%);color:#999;"></span>
                     </div>
                     
-                    <div class="alma-search-filters" style="display:flex;gap:10px;align-items:center;">
-                        <select id="alma-type-filter" style="flex:1;padding:8px 12px;border:1px solid #ddd;border-radius:4px;">
+                    <div class="alma-search-filters" style="display:flex;gap:10px;align-items:center;flex-wrap:wrap;">
+                        <select id="alma-type-filter" style="flex:1;min-width:160px;padding:8px 12px;border:1px solid #ddd;border-radius:4px;">
                             <option value="">Tutte le tipologie</option>
+                        </select>
+                        <select id="alma-geo-filter" title="Filtra per località geografica" style="flex:1;min-width:180px;padding:8px 12px;border:1px solid #ddd;border-radius:4px;">
+                            <option value="">📍 Tutte le località</option>
                         </select>
                         <button type="button" id="alma-search-btn" class="button">
                             Cerca
@@ -349,6 +361,7 @@ jQuery(document).ready(function($) {
                             Suggerisci AI
                         </button>
                     </div>
+                    <p id="alma-geo-filter-hint" style="display:none;margin:8px 0 0;font-size:12px;color:#2271b1;"></p>
                 </div>
                 
                 <div class="alma-results-section" style="flex:1;overflow-y:auto;padding:20px 25px;background:white;">
@@ -445,8 +458,52 @@ jQuery(document).ready(function($) {
         // Disabilita campi pulsante inizialmente
         $('#alma-button-text, #alma-button-size, #alma-button-align').prop('disabled', true);
 
-        // Carica le tipologie dopo aver creato il modal
+        // Carica tipologie e località dopo aver creato il modal
         loadLinkTypes();
+        loadGeoLocations();
+    }
+
+    /**
+     * Carica le località per il filtro geografico e preseleziona quella
+     * dell'articolo corrente (se localizzato).
+     */
+    function loadGeoLocations() {
+        $.ajax({
+            url: alma_editor.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'alma_editor_geo_locations',
+                nonce: alma_editor.nonce,
+                post_id: alma_editor.post_id || 0
+            },
+            success: function(response) {
+                if (!response.success || !response.data) {
+                    return;
+                }
+                const locations = response.data.locations || [];
+                if (!locations.length) {
+                    $('#alma-geo-filter').hide();
+                    return;
+                }
+                let optionsHtml = '<option value="">📍 Tutte le località</option>';
+                locations.forEach(function(loc) {
+                    const count = loc.count > 0 ? ' — ' + loc.count : '';
+                    optionsHtml += `<option value="${loc.id}">${escapeHtml(loc.label)}${count}</option>`;
+                });
+                $('#alma-geo-filter').html(optionsHtml);
+
+                // Preseleziona la località dell'articolo: mostra subito i link della zona.
+                const current = parseInt(response.data.current_location_id, 10) || 0;
+                if (current > 0 && $('#alma-geo-filter option[value="' + current + '"]').length) {
+                    $('#alma-geo-filter').val(String(current));
+                    const label = $('#alma-geo-filter option:selected').text();
+                    $('#alma-geo-filter-hint')
+                        .text('Filtro attivo sulla località dell\'articolo: ' + label + '. Scegli "Tutte le località" per rimuoverlo.')
+                        .show();
+                    searchLinks($('#alma-link-search').val() || '');
+                }
+            }
+        });
     }
     
     /**
@@ -516,7 +573,8 @@ jQuery(document).ready(function($) {
                 action: 'alma_search_links',
                 nonce: alma_editor.nonce,
                 search: searchTerm,
-                type_filter: typeFilter
+                type_filter: typeFilter,
+                geo_filter: $('#alma-geo-filter').val() || ''
             },
             success: function(response) {
                 if (response.success && response.data.length > 0) {
@@ -591,7 +649,8 @@ jQuery(document).ready(function($) {
 
                 <div class="alma-link-main" style="flex:1;min-width:0;">
                     <strong class="alma-link-title" style="display:block;font-size:14px;font-weight:600;color:#23282d;margin-bottom:5px;">${escapeHtml(link.title)}</strong>
-                    ${types ? `<span class="alma-link-type" style="display:inline-block;padding:2px 8px;background:#e0e0e0;color:#666;font-size:11px;border-radius:3px;">${escapeHtml(types)}</span>` : ''}
+                    ${types ? `<span class="alma-link-type" style="display:inline-block;padding:2px 8px;background:#e0e0e0;color:#666;font-size:11px;border-radius:3px;margin-right:6px;">${escapeHtml(types)}</span>` : ''}
+                    ${link.location ? `<span class="alma-link-location" style="display:inline-block;padding:2px 8px;background:#e7f0f8;color:#2271b1;font-size:11px;border-radius:3px;">📍 ${escapeHtml(link.location)}</span>` : ''}
                     <div class="alma-link-meta" style="margin-top:5px;">
                         <span class="alma-link-url" title="${escapeHtml(link.url || '')}" style="color:#666;font-size:12px;">
                             ${link.url ? escapeHtml(truncateUrl(link.url)) : 'URL non configurato'}
@@ -702,67 +761,94 @@ jQuery(document).ready(function($) {
                 closeModal();
             }, 1500);
         } else {
-            alert(alma_editor.strings.insert_error || 'Errore durante l\'inserimento');
+            // Nessun editor raggiungibile: lo shortcode non deve andare perso.
+            copyToClipboard(shortcode);
+            alert((alma_editor.strings.insert_error || 'Errore durante l\'inserimento') +
+                '\n\nLo shortcode è stato copiato negli appunti: incollalo dove serve.\n\n' + shortcode);
         }
     }
-    
+
     /**
-     * Inserisci nell'editor (Gutenberg o Classic)
+     * Inserisci nell'editor (Gutenberg o Classic).
+     * Ogni strategia è isolata: se una lancia un'eccezione si passa alla
+     * successiva invece di fallire tutto (era la causa di
+     * "Errore durante l'inserimento" con wp.blocks non disponibile o
+     * contenuto RichText non-stringa nei paragrafi di WP 6.5+).
      */
     function insertIntoEditor(shortcode) {
+        // 1) Gutenberg Block Editor
         try {
-            // Prova con Gutenberg Block Editor
-            if (typeof wp !== 'undefined' && wp.data && wp.data.select('core/block-editor')) {
-                const selectedBlock = wp.data.select('core/block-editor').getSelectedBlock();
-                
-                if (selectedBlock && selectedBlock.name === 'core/paragraph') {
-                    // Aggiungi al blocco paragrafo esistente
-                    const currentContent = selectedBlock.attributes.content || '';
-                    const newContent = currentContent + ' ' + shortcode;
-                    
-                    wp.data.dispatch('core/block-editor').updateBlockAttributes(
-                        selectedBlock.clientId,
-                        { content: newContent }
-                    );
-                } else {
-                    // Crea nuovo blocco shortcode
-                    const block = wp.blocks.createBlock('core/shortcode', {
-                        text: shortcode
-                    });
-                    wp.data.dispatch('core/block-editor').insertBlocks(block);
+            if (typeof wp !== 'undefined' && wp.data && typeof wp.data.select === 'function') {
+                const blockEditor = wp.data.select('core/block-editor');
+                const dispatcher = wp.data.dispatch && wp.data.dispatch('core/block-editor');
+                if (blockEditor && dispatcher && wp.blocks && typeof wp.blocks.createBlock === 'function') {
+                    const block = wp.blocks.createBlock('core/shortcode', { text: shortcode });
+                    const selectedBlock = blockEditor.getSelectedBlock ? blockEditor.getSelectedBlock() : null;
+                    if (selectedBlock && blockEditor.getBlockIndex) {
+                        // Subito dopo il blocco selezionato (non dentro: il contenuto
+                        // dei paragrafi non è più una semplice stringa in WP recenti).
+                        const index = blockEditor.getBlockIndex(selectedBlock.clientId) + 1;
+                        const rootClientId = blockEditor.getBlockRootClientId ? blockEditor.getBlockRootClientId(selectedBlock.clientId) : undefined;
+                        dispatcher.insertBlocks(block, index, rootClientId || undefined);
+                    } else {
+                        dispatcher.insertBlocks(block);
+                    }
+                    return true;
                 }
-                return true;
             }
-            
-            // Prova con Classic Editor (TinyMCE)
-            if (typeof tinyMCE !== 'undefined' && tinyMCE.activeEditor && !tinyMCE.activeEditor.isHidden()) {
+        } catch (error) {
+            console.error('ALMA: inserimento Gutenberg fallito, provo il fallback.', error);
+        }
+
+        // 2) Classic Editor (TinyMCE visuale)
+        try {
+            if (typeof tinyMCE !== 'undefined' && tinyMCE.activeEditor && !tinyMCE.activeEditor.isHidden() && !tinyMCE.activeEditor.removed) {
                 tinyMCE.activeEditor.execCommand('mceInsertContent', false, shortcode);
                 return true;
             }
-            
-            // Fallback: inserisci in textarea
+        } catch (error) {
+            console.error('ALMA: inserimento TinyMCE fallito, provo il fallback.', error);
+        }
+
+        // 3) Textarea (Classic Editor in modalità Testo)
+        try {
             const textarea = document.getElementById('content');
-            if (textarea) {
-                const start = textarea.selectionStart;
-                const end = textarea.selectionEnd;
+            if (textarea && textarea.offsetParent !== null) {
+                const start = textarea.selectionStart || 0;
+                const end = textarea.selectionEnd || 0;
                 const text = textarea.value;
-                
                 textarea.value = text.substring(0, start) + shortcode + text.substring(end);
                 textarea.selectionStart = textarea.selectionEnd = start + shortcode.length;
-                
-                // Trigger change event
-                const event = new Event('input', { bubbles: true });
-                textarea.dispatchEvent(event);
-                
+                textarea.dispatchEvent(new Event('input', { bubbles: true }));
                 return true;
             }
-            
-            return false;
-            
         } catch (error) {
-            console.error('Errore inserimento shortcode:', error);
-            return false;
+            console.error('ALMA: inserimento textarea fallito.', error);
         }
+
+        return false;
+    }
+
+    /**
+     * Copia negli appunti con fallback per browser/contesti senza Clipboard API.
+     */
+    function copyToClipboard(text) {
+        try {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(text);
+                return;
+            }
+        } catch (e) { /* fallback sotto */ }
+        try {
+            const helper = document.createElement('textarea');
+            helper.value = text;
+            helper.style.position = 'fixed';
+            helper.style.opacity = '0';
+            document.body.appendChild(helper);
+            helper.select();
+            document.execCommand('copy');
+            document.body.removeChild(helper);
+        } catch (e) { /* niente clipboard: lo shortcode è comunque nell'alert */ }
     }
     
     /**

--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -135,10 +135,17 @@ class ALMA_Assets {
 
         if ($screen && in_array($hook, array('post.php', 'post-new.php')) && in_array($screen->post_type, $allowed_types, true)) {
             if (file_exists(ALMA_PLUGIN_DIR . 'assets/editor.js')) {
+                // wp-data e wp-blocks garantiscono che l'inserimento del blocco
+                // shortcode in Gutenberg trovi sempre le API disponibili.
+                $editor_deps = array('jquery');
+                if (function_exists('get_current_screen') && $screen && method_exists($screen, 'is_block_editor') && $screen->is_block_editor()) {
+                    $editor_deps[] = 'wp-data';
+                    $editor_deps[] = 'wp-blocks';
+                }
                 wp_enqueue_script(
                     'alma-editor-script',
                     ALMA_PLUGIN_URL . 'assets/editor.js',
-                    array('jquery'),
+                    $editor_deps,
                     ALMA_VERSION,
                     true
                 );
@@ -147,11 +154,13 @@ class ALMA_Assets {
                     'ajax_url' => admin_url('admin-ajax.php'),
                     'nonce' => wp_create_nonce('alma_editor_search'),
                     'plugin_url' => ALMA_PLUGIN_URL,
+                    'post_id' => absint(get_the_ID() ?: ($_GET['post'] ?? 0)),
                     'strings' => array(
                         'button_text' => __('🔗 Link Affiliati', 'affiliate-link-manager-ai'),
                         'search_placeholder' => __('Cerca link affiliato...', 'affiliate-link-manager-ai'),
                         'no_results' => __('Nessun link trovato', 'affiliate-link-manager-ai'),
                         'insert' => __('Inserisci', 'affiliate-link-manager-ai'),
+                        'insert_error' => __('Impossibile inserire automaticamente lo shortcode nell\'editor.', 'affiliate-link-manager-ai'),
                         'loading' => __('Caricamento...', 'affiliate-link-manager-ai')
                     )
                 ));

--- a/includes/class-editor-ajax.php
+++ b/includes/class-editor-ajax.php
@@ -8,6 +8,7 @@ if (!defined('ABSPATH')) {
 
 class ALMA_Editor_Ajax {
     private $dashboard_stats;
+    private $geo_store_instance = null;
 
     public function __construct($dashboard_stats) {
         $this->dashboard_stats = $dashboard_stats;
@@ -16,6 +17,7 @@ class ALMA_Editor_Ajax {
     public function init() {
         add_action('wp_ajax_alma_search_links', array($this, 'ajax_search_links'));
         add_action('wp_ajax_alma_ai_suggest_links', array($this, 'ajax_ai_suggest_links'));
+        add_action('wp_ajax_alma_editor_geo_locations', array($this, 'ajax_editor_geo_locations'));
         add_action('admin_footer-post.php', array($this, 'add_editor_integration'));
         add_action('admin_footer-post-new.php', array($this, 'add_editor_integration'));
         add_action('admin_footer-page.php', array($this, 'add_editor_integration'));
@@ -55,6 +57,7 @@ class ALMA_Editor_Ajax {
 
         $search = isset($_POST['search']) ? sanitize_text_field(wp_unslash($_POST['search'])) : '';
         $type_filter = isset($_POST['type_filter']) ? absint($_POST['type_filter']) : 0;
+        $geo_filter = isset($_POST['geo_filter']) ? absint($_POST['geo_filter']) : 0;
 
         $args = array(
             'post_type' => 'affiliate_link',
@@ -76,6 +79,14 @@ class ALMA_Editor_Ajax {
                     'terms' => $type_filter
                 )
             );
+        }
+
+        if ($geo_filter > 0) {
+            $geo_link_ids = $this->get_link_ids_for_location_area($geo_filter);
+            if (empty($geo_link_ids)) {
+                wp_send_json_success(array());
+            }
+            $args['post__in'] = $geo_link_ids;
         }
 
         $query = new WP_Query($args);
@@ -111,7 +122,171 @@ class ALMA_Editor_Ajax {
             wp_reset_postdata();
         }
 
+        $results = $this->attach_location_labels($results);
+
         wp_send_json_success($results);
+    }
+
+    /**
+     * Località disponibili per il filtro geografico del modale (con conteggio
+     * link collegati) e località primaria del post corrente per la preselezione.
+     */
+    public function ajax_editor_geo_locations() {
+        $this->ajax_require_nonce('alma_editor_search');
+        $this->ajax_require_capability('edit_posts');
+
+        $store = $this->geo_store();
+        if (!$store || !$store->tables_exist()) {
+            wp_send_json_success(array('locations' => array(), 'current_location_id' => 0));
+        }
+
+        global $wpdb;
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT l.id, l.canonical_name, l.type, l.city, l.country, l.country_code, COUNT(DISTINCT ci.object_id) AS link_count
+             FROM {$store->table_locations()} l
+             INNER JOIN {$store->table_content_index()} ci ON ci.location_id = l.id AND ci.object_type = %s
+             GROUP BY l.id
+             ORDER BY link_count DESC, l.canonical_name ASC
+             LIMIT 150",
+            ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK
+        ), ARRAY_A);
+
+        $locations = array();
+        foreach ((array) $rows as $row) {
+            $label = sanitize_text_field($row['canonical_name']);
+            $country = sanitize_text_field($row['country'] ?: $row['country_code']);
+            if ($country !== '' && strcasecmp($country, $label) !== 0) {
+                $label .= ' (' . $country . ')';
+            }
+            $locations[] = array(
+                'id' => (int) $row['id'],
+                'label' => $label,
+                'count' => (int) $row['link_count'],
+            );
+        }
+
+        // Località primaria dell'articolo in modifica: preselezionata nel filtro.
+        $current_location_id = 0;
+        $post_id = isset($_POST['post_id']) ? absint($_POST['post_id']) : 0;
+        if ($post_id > 0 && current_user_can('edit_post', $post_id)) {
+            $post = get_post($post_id);
+            if ($post instanceof WP_Post) {
+                $object_type = $post->post_type === 'page' ? ALMA_Geo_Index_Store::OBJECT_TYPE_PAGE : ALMA_Geo_Index_Store::OBJECT_TYPE_POST;
+                $primary = $store->get_primary_location_for_object($post_id, $object_type);
+                $current_location_id = (int) ($primary['id'] ?? 0);
+                if ($current_location_id > 0 && !in_array($current_location_id, wp_list_pluck($locations, 'id'), true)) {
+                    // La località dell'articolo non ha link diretti: resta utile
+                    // come filtro perché l'area viene espansa (stessa città/paese).
+                    $location = $store->get_location($current_location_id);
+                    if ($location) {
+                        $label = sanitize_text_field($location['canonical_name']);
+                        $country = sanitize_text_field($location['country'] ?: $location['country_code']);
+                        if ($country !== '' && strcasecmp($country, $label) !== 0) {
+                            $label .= ' (' . $country . ')';
+                        }
+                        array_unshift($locations, array('id' => $current_location_id, 'label' => $label, 'count' => 0));
+                    }
+                }
+            }
+        }
+
+        wp_send_json_success(array('locations' => $locations, 'current_location_id' => $current_location_id));
+    }
+
+    /**
+     * Espande la località scelta alla sua "area" e ritorna gli ID dei link
+     * affiliati collegati: stessa riga, righe omonime (stessa città/canonical,
+     * import diversi) e — per località di tipo paese — tutte le località di
+     * quel paese.
+     */
+    private function get_link_ids_for_location_area($location_id) {
+        $store = $this->geo_store();
+        if (!$store || !$store->tables_exist()) {
+            return array();
+        }
+        $location = $store->get_location($location_id);
+        if (!$location) {
+            return array();
+        }
+
+        global $wpdb;
+        $conditions = array('l.id = %d');
+        $params = array(absint($location_id));
+
+        $city = trim((string) ($location['city'] ?: $location['canonical_name']));
+        if ($city !== '') {
+            $conditions[] = 'l.city = %s';
+            $conditions[] = 'l.canonical_name = %s';
+            array_push($params, $city, $city);
+        }
+        if (sanitize_key($location['type'] ?? '') === 'country') {
+            if ((string) $location['country_code'] !== '') {
+                $conditions[] = 'l.country_code = %s';
+                $params[] = (string) $location['country_code'];
+            }
+            $country_name = trim((string) ($location['country'] ?: $location['canonical_name']));
+            if ($country_name !== '') {
+                $conditions[] = 'l.country = %s';
+                $params[] = $country_name;
+            }
+        }
+
+        $params_final = array_merge(array(ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK), $params);
+        $ids = $wpdb->get_col($wpdb->prepare(
+            "SELECT DISTINCT ci.object_id
+             FROM {$store->table_content_index()} ci
+             INNER JOIN {$store->table_locations()} l ON l.id = ci.location_id
+             WHERE ci.object_type = %s AND (" . implode(' OR ', $conditions) . ') LIMIT 500',
+            $params_final
+        ));
+        return array_values(array_filter(array_map('absint', (array) $ids)));
+    }
+
+    /**
+     * Etichetta della località primaria per ciascun link nei risultati (una query).
+     */
+    private function attach_location_labels($results) {
+        if (empty($results)) {
+            return $results;
+        }
+        $store = $this->geo_store();
+        if (!$store || !$store->tables_exist()) {
+            return $results;
+        }
+        global $wpdb;
+        $ids = array_map('absint', wp_list_pluck($results, 'id'));
+        $placeholders = implode(',', array_fill(0, count($ids), '%d'));
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT ci.object_id, l.canonical_name, l.country, l.country_code
+             FROM {$store->table_content_index()} ci
+             INNER JOIN {$store->table_locations()} l ON l.id = ci.location_id
+             WHERE ci.object_type = %s AND ci.is_primary = 1 AND ci.object_id IN ($placeholders)",
+            array_merge(array(ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK), $ids)
+        ), ARRAY_A);
+        $labels = array();
+        foreach ((array) $rows as $row) {
+            $label = sanitize_text_field($row['canonical_name']);
+            $country = sanitize_text_field($row['country'] ?: $row['country_code']);
+            if ($country !== '' && strcasecmp($country, $label) !== 0) {
+                $label .= ', ' . $country;
+            }
+            $labels[absint($row['object_id'])] = $label;
+        }
+        foreach ($results as &$result) {
+            $result['location'] = $labels[$result['id']] ?? '';
+        }
+        unset($result);
+        return $results;
+    }
+
+    private function geo_store() {
+        if (!class_exists('ALMA_Geo_Index_Store')) {
+            return null;
+        }
+        if ($this->geo_store_instance === null) {
+            $this->geo_store_instance = new ALMA_Geo_Index_Store();
+        }
+        return $this->geo_store_instance;
     }
 
     public function ajax_ai_suggest_links() {


### PR DESCRIPTION
# Riepilogo

Versione **2.48.0**. Fix dell'errore segnalato nel modale "🔗 Inserisci Link Affiliato" dell'editor post, miglioramento UI e nuovo **filtro per località geografica**.

## Fix "Errore durante l'inserimento"

**Cause trovate:**
1. `editor.js` dichiarava solo `jquery` come dipendenza: in Gutenberg `wp.blocks` poteva non essere garantito al momento del click → `createBlock` lanciava un'eccezione.
2. Con un paragrafo selezionato, lo shortcode veniva **appeso al contenuto del paragrafo**: da WP 6.5 `attributes.content` è un oggetto RichTextData, non una stringa — comportamento fragile.
3. Un'unica eccezione in qualunque strategia abortiva **tutti** i fallback (un solo try/catch esterno) → sempre "Errore durante l'inserimento".

**Fix:**
- Ogni strategia (Gutenberg → TinyMCE → textarea) è isolata nel proprio try/catch con fallback a cascata.
- In Gutenberg lo shortcode viene inserito come **blocco `core/shortcode` dedicato subito dopo il blocco selezionato** (niente più mutazione del RichText), con guardie su `wp.data`/`wp.blocks`/dispatcher.
- `wp-data` e `wp-blocks` sono dipendenze dichiarate quando il block editor è attivo.
- **Niente lavoro perso**: se nessun editor è raggiungibile, lo shortcode viene copiato negli appunti e mostrato nel messaggio.

## Filtro per località geografica (nuovo)

- Select **"📍 Località"** accanto al filtro tipologia: elenca le località con link affiliati collegati, ordinate per numero di link (con conteggio).
- La località scelta viene **espansa alla sua area**: righe omonime create da import diversi e, per le località di tipo paese, tutte le località di quel paese.
- **Preselezione automatica**: se l'articolo in modifica è geolocalizzato, il filtro parte sulla sua località primaria (avviso visibile e rimozione con un click) — il modale si apre già sui link della zona giusta.
- Ogni risultato mostra il badge **📍 località primaria** accanto a tipologia, click e utilizzi.

## Sicurezza

- Nuovo endpoint `alma_editor_geo_locations` con nonce esistente `alma_editor_search` + capability `edit_posts` (e `edit_post` sul post specifico per la preselezione); query preparate con join su content index.

## Verifica

- `php -l` e `node --check` puliti; degradazione pulita senza tabelle GEO (filtro nascosto, nessun errore).
- Versione `2.47.0` → `2.48.0`; README e CHANGELOG aggiornati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_