### PR TITLE
v2.50.1: fix mappa grigia — esc_url_raw rimuoveva i placeholder {z}/{x}/{y} delle tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.50.1 - 2026-07-03
+
+### Fix Mappa Geografica — tile non visualizzate
+- Fix mappa grigia con soli marker visibili: l'URL template delle tile passava per `esc_url_raw`, che rimuove le parentesi graffe dei placeholder — `https://tile.openstreetmap.org/{z}/{x}/{y}.png` diventava `.../z/x/y.png` e tutte le richieste tile andavano in 404. Nuova validazione dedicata che preserva `{z}/{x}/{y}`, impone https e blocca input pericolosi (fallback al default OpenStreetMap).
+- Versione plugin aggiornata a `2.50.1`.
+
 ## 2.50.0 - 2026-07-03
 
 ### Mappa Geografica — motore Leaflet + OpenStreetMap (niente API key)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.50.1 - 2026-07-03
+
+### Fix Mappa Geografica — tile non visualizzate
+- Fix mappa grigia con soli marker visibili: l'URL template delle tile passava per `esc_url_raw`, che rimuove le parentesi graffe dei placeholder — `https://tile.openstreetmap.org/{z}/{x}/{y}.png` diventava `.../z/x/y.png` e tutte le richieste tile andavano in 404. Nuova validazione dedicata che preserva `{z}/{x}/{y}`, impone https e blocca input pericolosi (fallback al default OpenStreetMap).
+- Versione plugin aggiornata a `2.50.1`.
+
 ## 2.50.0 - 2026-07-03
 
 ### Mappa Geografica — motore Leaflet + OpenStreetMap (niente API key)

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.50.0
+ * Version: 2.50.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.50.0');
+define('ALMA_VERSION', '2.50.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-geo-map.php
+++ b/includes/class-geo-map.php
@@ -102,6 +102,22 @@ class ALMA_Geo_Map {
     }
 
     /**
+     * Valida il template URL delle tile PRESERVANDO i placeholder {z}/{x}/{y}:
+     * esc_url_raw rimuove le parentesi graffe e trasformava l'URL in
+     * ".../z/x/y.png" — tutte le tile andavano in 404 e la mappa restava grigia
+     * con i soli marker visibili. Il valore viene emesso via wp_localize_script
+     * (JSON-encoded), quindi qui basta validare schema e caratteri.
+     */
+    private function sanitize_tile_url($url) {
+        $default = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+        $url = trim((string) $url);
+        if (preg_match('#^https://[a-z0-9.\-]+/[a-z0-9._\-/{}?&=%]*\{z\}[a-z0-9._\-/{}?&=%]*\{x\}[a-z0-9._\-/{}?&=%]*\{y\}[a-z0-9._\-/{}?&=%]*$#i', $url)) {
+            return $url;
+        }
+        return $default;
+    }
+
+    /**
      * Dimensioni CSS sicure per lo shortcode: numeri con unità px/%/vh/vw/em/rem
      * (default px se l'unità manca).
      */
@@ -127,7 +143,7 @@ class ALMA_Geo_Map {
                  * traffico moderato (tile usage policy OSMF); per siti ad alto
                  * traffico impostare un provider dedicato con questi filtri.
                  */
-                'tileUrl' => esc_url_raw(apply_filters('alma_geo_map_tile_url', 'https://tile.openstreetmap.org/{z}/{x}/{y}.png')),
+                'tileUrl' => $this->sanitize_tile_url(apply_filters('alma_geo_map_tile_url', 'https://tile.openstreetmap.org/{z}/{x}/{y}.png')),
                 'tileAttribution' => wp_kses_post(apply_filters('alma_geo_map_tile_attribution', '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors')),
             ));
         }


### PR DESCRIPTION
# Riepilogo

Versione **2.50.1** (patch). Fix del problema segnalato: **mappa non visualizzata (sfondo grigio), ma marker e link funzionanti**.

## Causa

L'URL template delle tile passava per `esc_url_raw`, che **rimuove le parentesi graffe** (non sono tra i caratteri ammessi da `esc_url`):

```
https://tile.openstreetmap.org/{z}/{x}/{y}.png  →  https://tile.openstreetmap.org/z/x/y.png
```

Tutte le richieste tile andavano in 404 → nessuna immagine di mappa, solo i marker (che non dipendono dalle tile). Riprodotto e verificato con la regex del core WP.

## Fix

Nuovo validatore dedicato `sanitize_tile_url()` che:
- **preserva i placeholder `{z}/{x}/{y}`** (richiesti da Leaflet)
- impone `https://` e un set di caratteri sicuri (query string dei provider inclusa)
- fa fallback al default OpenStreetMap per qualunque input non valido

L'output resta sicuro: il valore è emesso via `wp_localize_script` (JSON-encoded).

## Verifica

Test del validatore: template validi passano intatti (incluso provider custom con `?key=`); `http://`, `javascript:`, injection HTML e stringa vuota → fallback al default. `php -l` pulito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_