### PR TITLE
v2.51.0: mondo singolo sulla mappa, popup con miniature e riga "Consigliati" per località

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.51.0 - 2026-07-03
+
+### Mappa Geografica — mondo singolo, popup ridisegnato e "Consigliati"
+- **Il planisfero non si ripete più**: tile con `noWrap`, confini rigidi sul mondo (`maxBounds` con viscosità piena) e zoom minimo 2 — niente copie dei continenti ai lati.
+- **Popup articoli ridisegnato**: eliminato l'elenco puntato; ogni articolo è una riga cliccabile con **miniatura a sinistra** (48px, angoli arrotondati, placeholder 📄 se assente) e titolo in evidenza; pulsante "Vedi tutti gli articoli →" a bottone.
+- **Riga "Consigliati" per località**: sotto il titolo della località, nel popup e nella pagina elenco, compare ad es. "🎯 Consigliati: 3 tour, 2 avventure" — il conteggio dei link affiliati associati a quella località raggruppati per Tipologia Link (max 6 tipologie, ordinate per quantità).
+- Versione plugin aggiornata a `2.51.0`.
+
 ## 2.50.1 - 2026-07-03
 
 ### Fix Mappa Geografica — tile non visualizzate

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## 2.51.0 - 2026-07-03
+
+### Mappa Geografica — mondo singolo, popup ridisegnato e "Consigliati"
+- **Il planisfero non si ripete più**: tile con `noWrap`, confini rigidi sul mondo (`maxBounds` con viscosità piena) e zoom minimo 2 — niente copie dei continenti ai lati.
+- **Popup articoli ridisegnato**: eliminato l'elenco puntato; ogni articolo è una riga cliccabile con **miniatura a sinistra** (48px, angoli arrotondati, placeholder 📄 se assente) e titolo in evidenza; pulsante "Vedi tutti gli articoli →" a bottone.
+- **Riga "Consigliati" per località**: sotto il titolo della località, nel popup e nella pagina elenco, compare ad es. "🎯 Consigliati: 3 tour, 2 avventure" — il conteggio dei link affiliati associati a quella località raggruppati per Tipologia Link (max 6 tipologie, ordinate per quantità).
+- Versione plugin aggiornata a `2.51.0`.
+
 ## 2.50.1 - 2026-07-03
 
 ### Fix Mappa Geografica — tile non visualizzate

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.50.1
+ * Version: 2.51.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.50.1');
+define('ALMA_VERSION', '2.51.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/assets/geo-map.js
+++ b/assets/geo-map.js
@@ -38,22 +38,31 @@
         return base + (base.indexOf('?') === -1 ? '?' : '&') + 'alma_location=' + encodeURIComponent(ids);
     }
 
-    function popupContent(markerData, container, articles) {
-        var html = '<div class="alma-geo-map-info" style="max-width:280px;font-size:13px;line-height:1.45;">';
-        html += '<strong style="font-size:15px;display:block;margin-bottom:2px;">📍 ' + escapeHtml(markerData.name) + '</strong>';
+    function popupContent(markerData, container, articles, recommendedLine) {
+        var html = '<div class="alma-geo-map-info" style="max-width:300px;font-size:13px;line-height:1.45;">';
+        html += '<strong style="font-size:16px;display:block;margin-bottom:1px;">📍 ' + escapeHtml(markerData.name) + '</strong>';
         html += '<span style="color:#666;">' + escapeHtml(String(markerData.count)) + (markerData.count === 1 ? ' articolo' : ' articoli') + '</span>';
+        if (recommendedLine) {
+            html += '<div style="margin-top:4px;font-weight:600;color:#2271b1;">🎯 ' + escapeHtml(recommendedLine) + '</div>';
+        }
         if (articles === null) {
-            html += '<p style="margin:8px 0 0;color:#666;">Caricamento articoli…</p>';
+            html += '<p style="margin:10px 0 0;color:#666;">Caricamento articoli…</p>';
         } else if (articles.length) {
-            html += '<ul style="margin:8px 0 0;padding-left:18px;">';
+            html += '<div style="margin-top:10px;display:flex;flex-direction:column;gap:8px;">';
             articles.slice(0, 5).forEach(function (article) {
-                html += '<li style="margin-bottom:4px;"><a href="' + escapeHtml(article.url) + '">' + escapeHtml(article.title) + '</a></li>';
+                var thumb = article.thumbnail
+                    ? '<img src="' + escapeHtml(article.thumbnail) + '" alt="" loading="lazy" style="width:48px;height:48px;object-fit:cover;border-radius:6px;flex-shrink:0;" />'
+                    : '<span style="width:48px;height:48px;border-radius:6px;background:#eef1f5;display:flex;align-items:center;justify-content:center;flex-shrink:0;font-size:18px;">📄</span>';
+                html += '<a href="' + escapeHtml(article.url) + '" style="display:flex;align-items:center;gap:10px;text-decoration:none;padding:4px;border-radius:6px;">' +
+                    thumb +
+                    '<span style="font-weight:600;line-height:1.3;color:#1d2327;">' + escapeHtml(article.title) + '</span>' +
+                    '</a>';
             });
-            html += '</ul>';
+            html += '</div>';
         }
         var pageUrl = listPageUrl(container, markerData.ids);
         if (pageUrl) {
-            html += '<p style="margin:10px 0 0;"><a href="' + escapeHtml(pageUrl) + '" style="font-weight:600;">Vedi tutti gli articoli →</a></p>';
+            html += '<p style="margin:12px 0 0;text-align:center;"><a href="' + escapeHtml(pageUrl) + '" style="display:inline-block;padding:7px 14px;background:#2271b1;color:#fff;border-radius:6px;font-weight:600;text-decoration:none;">Vedi tutti gli articoli →</a></p>';
         }
         html += '</div>';
         return html;
@@ -66,8 +75,10 @@
         var map = L.map(container, {
             center: WORLD_CENTER, // vista mondo, continenti visibili
             zoom: zoom,
-            minZoom: 1,
-            worldCopyJump: true,
+            minZoom: 2,
+            // Il mondo non si ripete: confini rigidi sull'intero planisfero.
+            maxBounds: [[-85, -180], [85, 180]],
+            maxBoundsViscosity: 1.0,
             // Lo scroll della pagina non deve zoomare per errore: zoom con
             // ctrl+rotella, doppio click o controlli.
             scrollWheelZoom: false
@@ -77,6 +88,8 @@
 
         L.tileLayer(cfg().tileUrl || 'https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
             maxZoom: 19,
+            noWrap: true, // niente copie ripetute del planisfero ai bordi
+            bounds: [[-85, -180], [85, 180]],
             attribution: cfg().tileAttribution || '&copy; OpenStreetMap contributors'
         }).addTo(map);
 
@@ -89,7 +102,7 @@
                     title: markerData.name + ' (' + markerData.count + ')'
                 }).addTo(map);
                 marker.almaData = markerData;
-                marker.bindPopup(popupContent(markerData, container, null), { maxWidth: 320 });
+                marker.bindPopup(popupContent(markerData, container, null, ''), { maxWidth: 340 });
                 marker.on('click', function () {
                     openMarker(entry, marker);
                 });
@@ -113,15 +126,16 @@
         }
         entry.lastOpened = marker;
 
-        marker.setPopupContent(popupContent(data, container, null));
+        marker.setPopupContent(popupContent(data, container, null, ''));
         marker.openPopup();
 
         var ajaxUrl = container.getAttribute('data-ajax-url');
         fetchJson(ajaxUrl + '?action=alma_geo_map_articles&location_ids=' + encodeURIComponent(data.ids)).then(function (response) {
-            var articles = response && response.success && response.data && Array.isArray(response.data.items) ? response.data.items : [];
-            marker.setPopupContent(popupContent(data, container, articles));
+            var payload = response && response.success && response.data ? response.data : {};
+            var articles = Array.isArray(payload.items) ? payload.items : [];
+            marker.setPopupContent(popupContent(data, container, articles, payload.recommended_line || ''));
         }).catch(function () {
-            marker.setPopupContent(popupContent(data, container, []));
+            marker.setPopupContent(popupContent(data, container, [], ''));
         });
     }
 

--- a/includes/class-geo-map.php
+++ b/includes/class-geo-map.php
@@ -226,6 +226,55 @@ class ALMA_Geo_Map {
         wp_send_json_success($articles);
     }
 
+    /**
+     * Link affiliati associati alle località, raggruppati per tipologia:
+     * alimenta la riga "Consigliati: 3 tour, 2 avventure".
+     */
+    public function get_recommended_link_counts($location_ids) {
+        global $wpdb;
+        $location_ids = array_values(array_filter(array_map('absint', (array) $location_ids)));
+        if (empty($location_ids) || !$this->store->tables_exist()) {
+            return array();
+        }
+        $placeholders = implode(',', array_fill(0, count($location_ids), '%d'));
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT t.name AS label, COUNT(DISTINCT p.ID) AS total
+             FROM {$this->store->table_content_index()} ci
+             INNER JOIN {$wpdb->posts} p ON p.ID = ci.object_id AND p.post_type = 'affiliate_link' AND p.post_status = 'publish'
+             INNER JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID
+             INNER JOIN {$wpdb->term_taxonomy} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id AND tt.taxonomy = 'link_type'
+             INNER JOIN {$wpdb->terms} t ON t.term_id = tt.term_id
+             WHERE ci.object_type = %s AND ci.location_id IN ($placeholders)
+             GROUP BY t.term_id
+             ORDER BY total DESC, t.name ASC
+             LIMIT 6",
+            array_merge(array(ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK), $location_ids)
+        ), ARRAY_A);
+
+        $recommended = array();
+        foreach ((array) $rows as $row) {
+            $recommended[] = array(
+                'label' => sanitize_text_field($row['label']),
+                'count' => (int) $row['total'],
+            );
+        }
+        return $recommended;
+    }
+
+    /**
+     * Riga "Consigliati: 3 tour, 2 avventure" pronta per la stampa.
+     */
+    public function format_recommended_line($recommended) {
+        if (empty($recommended)) {
+            return '';
+        }
+        $parts = array();
+        foreach ($recommended as $entry) {
+            $parts[] = (int) $entry['count'] . ' ' . mb_strtolower($entry['label']);
+        }
+        return __('Consigliati:', 'affiliate-link-manager-ai') . ' ' . implode(', ', $parts);
+    }
+
     private function sanitize_location_ids($raw) {
         $ids = array_values(array_filter(array_map('absint', explode(',', (string) $raw))));
         return array_slice($ids, 0, 20);
@@ -276,10 +325,13 @@ class ALMA_Geo_Map {
                 'thumbnail' => get_the_post_thumbnail_url($post, 'medium') ?: '',
             );
         }
+        $recommended = $this->get_recommended_link_counts($location_ids);
         return array(
             'items' => $items,
             'total' => (int) $query->found_posts,
             'location_name' => $this->location_label($location_ids),
+            'recommended' => $recommended,
+            'recommended_line' => $this->format_recommended_line($recommended),
         );
     }
 
@@ -320,7 +372,10 @@ class ALMA_Geo_Map {
         <div class="alma-geo-location-articles">
             <?php if ($data['location_name'] !== '') : ?>
                 <h2 class="alma-geo-location-articles__title">📍 <?php echo esc_html($data['location_name']); ?></h2>
-                <p class="alma-geo-location-articles__count"><?php echo esc_html(sprintf(_n('%d articolo', '%d articoli', $data['total'], 'affiliate-link-manager-ai'), $data['total'])); ?></p>
+                <p class="alma-geo-location-articles__count" style="margin:0 0 4px;color:#555;"><?php echo esc_html(sprintf(_n('%d articolo', '%d articoli', $data['total'], 'affiliate-link-manager-ai'), $data['total'])); ?></p>
+                <?php if ($data['recommended_line'] !== '') : ?>
+                    <p class="alma-geo-location-articles__recommended" style="margin:0 0 18px;font-weight:600;color:#2271b1;">🎯 <?php echo esc_html($data['recommended_line']); ?></p>
+                <?php endif; ?>
             <?php endif; ?>
             <?php if (empty($data['items'])) : ?>
                 <p><?php esc_html_e('Nessun articolo trovato per questa località.', 'affiliate-link-manager-ai'); ?></p>


### PR DESCRIPTION
# Riepilogo

Versione **2.51.0**. Tre migliorie richieste sulla Mappa Geografica.

## 1. Il planisfero non si ripete più

- `noWrap: true` sul tile layer (niente copie del mondo ai bordi) + `bounds` sul layer;
- `maxBounds [[-85,-180],[85,180]]` con `maxBoundsViscosity: 1.0`: il pan si ferma ai confini del mondo, senza rimbalzi;
- `minZoom: 2` per ridurre le bande vuote su schermi molto larghi.

## 2. Popup articoli ridisegnato

- **Eliminato l'elenco puntato**: ogni articolo è ora una **riga cliccabile** con la **miniatura a sinistra** (48×48px, angoli arrotondati, placeholder 📄 quando l'articolo non ha immagine) e il titolo in evidenza accanto;
- "Vedi tutti gli articoli →" trasformato in **pulsante** centrato;
- titolo località più grande e gerarchia visiva più chiara.

## 3. Riga "Consigliati" per località

Sotto il titolo della località — **sia nel popup della mappa sia nella pagina elenco** (`[alma_geo_location_articles]`) — compare ad esempio:

> 🎯 **Consigliati: 3 tour, 2 avventure**

È il conteggio dei **link affiliati associati a quella località**, raggruppati per **Tipologia Link** (max 6 tipologie, ordinate per quantità): una sola query preparata con GROUP BY su content index + tassonomia, solo link pubblicati. La riga non compare se la località non ha link associati.

## Verifica

- `php -l` e `node --check` puliti.
- Versione `2.50.1` → `2.51.0`; README e CHANGELOG aggiornati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_