### PR TITLE
v2.51.1: planisfero ripetuto ripristinato ed Europa al centro della mappa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.51.1 - 2026-07-03
+
+### Mappa Geografica — planisfero ripetuto ed Europa al centro
+- Ripristinata la ripetizione orizzontale del planisfero: con i confini rigidi le proporzioni del mondo singolo non riempivano i contenitori a larghezza piena (100%) e restavano bande vuote ai lati.
+- Vista iniziale centrata sull'Europa (48°N, 10°E) invece che sull'equatore; il reset della ricerca torna alla stessa vista.
+- Versione plugin aggiornata a `2.51.1`.
+
 ## 2.51.0 - 2026-07-03
 
 ### Mappa Geografica — mondo singolo, popup ridisegnato e "Consigliati"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## 2.51.1 - 2026-07-03
+
+### Mappa Geografica — planisfero ripetuto ed Europa al centro
+- Ripristinata la ripetizione orizzontale del planisfero: con i confini rigidi le proporzioni del mondo singolo non riempivano i contenitori a larghezza piena (100%) e restavano bande vuote ai lati.
+- Vista iniziale centrata sull'Europa (48°N, 10°E) invece che sull'equatore; il reset della ricerca torna alla stessa vista.
+- Versione plugin aggiornata a `2.51.1`.
+
 ## 2.51.0 - 2026-07-03
 
 ### Mappa Geografica — mondo singolo, popup ridisegnato e "Consigliati"

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.51.0
+ * Version: 2.51.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.51.0');
+define('ALMA_VERSION', '2.51.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/assets/geo-map.js
+++ b/assets/geo-map.js
@@ -8,7 +8,8 @@
 (function () {
     'use strict';
 
-    var WORLD_CENTER = [22, 8];
+    // Centro iniziale sull'Europa (l'utente può comunque spostarsi ovunque).
+    var DEFAULT_CENTER = [48, 10];
 
     function cfg() {
         return window.almaGeoMapCfg || {};
@@ -72,13 +73,13 @@
         var zoom = parseInt(container.getAttribute('data-zoom'), 10) || 2;
         var ajaxUrl = container.getAttribute('data-ajax-url');
 
+        // Il planisfero si ripete orizzontalmente: a larghezze piene (100%) le
+        // proporzioni del mondo singolo lascerebbero bande vuote ai lati.
         var map = L.map(container, {
-            center: WORLD_CENTER, // vista mondo, continenti visibili
+            center: DEFAULT_CENTER, // Europa al centro
             zoom: zoom,
-            minZoom: 2,
-            // Il mondo non si ripete: confini rigidi sull'intero planisfero.
-            maxBounds: [[-85, -180], [85, 180]],
-            maxBoundsViscosity: 1.0,
+            minZoom: 1,
+            worldCopyJump: true,
             // Lo scroll della pagina non deve zoomare per errore: zoom con
             // ctrl+rotella, doppio click o controlli.
             scrollWheelZoom: false
@@ -88,8 +89,6 @@
 
         L.tileLayer(cfg().tileUrl || 'https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
             maxZoom: 19,
-            noWrap: true, // niente copie ripetute del planisfero ai bordi
-            bounds: [[-85, -180], [85, 180]],
             attribution: cfg().tileAttribution || '&copy; OpenStreetMap contributors'
         }).addTo(map);
 
@@ -181,7 +180,7 @@
         input.addEventListener('input', function () {
             if (feedback) { feedback.style.display = 'none'; }
             if (input.value === '') {
-                entry.map.setView(WORLD_CENTER, parseInt(entry.container.getAttribute('data-zoom'), 10) || 2);
+                entry.map.setView(DEFAULT_CENTER, parseInt(entry.container.getAttribute('data-zoom'), 10) || 2);
                 entry.map.closePopup();
                 entry.lastOpened = null;
             }


### PR DESCRIPTION
# Riepilogo

Versione **2.51.1** (patch). Come richiesto:

- **Ripristinata la ripetizione orizzontale del planisfero**: con i confini rigidi introdotti nella 2.51.0, le proporzioni fisse del mondo singolo non riempivano i contenitori a larghezza piena (100%) e restavano bande vuote ai lati. Rimossi `noWrap`/`maxBounds`, ripristinati `worldCopyJump` e zoom minimo 1.
- **Europa al centro**: la vista iniziale è ora centrata su 48°N, 10°E (Europa centrale) invece che sull'equatore; anche il reset del campo di ricerca torna a questa vista.

Restano invariati popup con miniature, riga "🎯 Consigliati", ricerca e pagina elenco (2.51.0).

## Verifica

- `node --check` pulito; versione `2.51.0` → `2.51.1`; README e CHANGELOG aggiornati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_