### PR TITLE
v2.52.0: zoom di riempimento automatico, popup rifinito, stop ai redirect involontari, fix entità HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.52.0 - 2026-07-03
+
+### Mappa Geografica — zoom di riempimento, popup rifinito, fix entità HTML
+- **Zoom minimo calcolato da Leaflet**: al caricamento (e a ogni resize) la mappa calcola lo zoom al quale il planisfero riempie esattamente il contenitore — mai bande vuote, a qualunque larghezza/altezza, Europa correttamente centrata alla vista iniziale.
+- **Fix redirect involontari**: il "secondo click sul marker" apriva la pagina dei risultati anche quando si voleva solo chiudere il popup; la navigazione ora avviene esclusivamente dal pulsante "Vedi tutti gli articoli →".
+- **Popup**: rimosso il conteggio articoli sotto il nome della località; larghezza fissa (280px) così il caricamento di miniature e titoli non fa "saltare" la finestrella; pulsante di chiusura più evidente (cerchio grigio con X grande, rosso al passaggio del mouse).
+- **Fix caratteri speciali**: titoli ed estratti con entità HTML (es. "dell&amp;#8217;Isola") ora vengono decodificati e mostrati correttamente ("dell'Isola") sia nel popup sia nella pagina elenco.
+- Versione plugin aggiornata a `2.52.0`.
+
 ## 2.51.1 - 2026-07-03
 
 ### Mappa Geografica — planisfero ripetuto ed Europa al centro

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## 2.52.0 - 2026-07-03
+
+### Mappa Geografica — zoom di riempimento, popup rifinito, fix entità HTML
+- **Zoom minimo calcolato da Leaflet**: al caricamento (e a ogni resize) la mappa calcola lo zoom al quale il planisfero riempie esattamente il contenitore — mai bande vuote, a qualunque larghezza/altezza, Europa correttamente centrata alla vista iniziale.
+- **Fix redirect involontari**: il "secondo click sul marker" apriva la pagina dei risultati anche quando si voleva solo chiudere il popup; la navigazione ora avviene esclusivamente dal pulsante "Vedi tutti gli articoli →".
+- **Popup**: rimosso il conteggio articoli sotto il nome della località; larghezza fissa (280px) così il caricamento di miniature e titoli non fa "saltare" la finestrella; pulsante di chiusura più evidente (cerchio grigio con X grande, rosso al passaggio del mouse).
+- **Fix caratteri speciali**: titoli ed estratti con entità HTML (es. "dell&amp;#8217;Isola") ora vengono decodificati e mostrati correttamente ("dell'Isola") sia nel popup sia nella pagina elenco.
+- Versione plugin aggiornata a `2.52.0`.
+
 ## 2.51.1 - 2026-07-03
 
 ### Mappa Geografica — planisfero ripetuto ed Europa al centro

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.51.1
+ * Version: 2.52.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.51.1');
+define('ALMA_VERSION', '2.52.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/assets/geo-map.js
+++ b/assets/geo-map.js
@@ -40,9 +40,10 @@
     }
 
     function popupContent(markerData, container, articles, recommendedLine) {
-        var html = '<div class="alma-geo-map-info" style="max-width:300px;font-size:13px;line-height:1.45;">';
+        // Larghezza FISSA: lo stato di caricamento e quello finale hanno le
+        // stesse dimensioni, il popup non "salta" quando arrivano i contenuti.
+        var html = '<div class="alma-geo-map-info" style="width:280px;font-size:13px;line-height:1.45;">';
         html += '<strong style="font-size:16px;display:block;margin-bottom:1px;">📍 ' + escapeHtml(markerData.name) + '</strong>';
-        html += '<span style="color:#666;">' + escapeHtml(String(markerData.count)) + (markerData.count === 1 ? ' articolo' : ' articoli') + '</span>';
         if (recommendedLine) {
             html += '<div style="margin-top:4px;font-weight:600;color:#2271b1;">🎯 ' + escapeHtml(recommendedLine) + '</div>';
         }
@@ -73,8 +74,6 @@
         var zoom = parseInt(container.getAttribute('data-zoom'), 10) || 2;
         var ajaxUrl = container.getAttribute('data-ajax-url');
 
-        // Il planisfero si ripete orizzontalmente: a larghezze piene (100%) le
-        // proporzioni del mondo singolo lascerebbero bande vuote ai lati.
         var map = L.map(container, {
             center: DEFAULT_CENTER, // Europa al centro
             zoom: zoom,
@@ -86,6 +85,25 @@
         });
         map.on('focus click', function () { map.scrollWheelZoom.enable(); });
         map.on('blur', function () { map.scrollWheelZoom.disable(); });
+
+        // Zoom minimo dinamico: quello al quale il planisfero (256·2^z px)
+        // riempie esattamente il contenitore — mai bande vuote, a qualunque
+        // combinazione di larghezza/altezza. Ricalcolato al resize.
+        function applyFillZoom(recenter) {
+            var size = Math.max(container.clientWidth, container.clientHeight);
+            if (size < 1) { return; }
+            var fillZoom = Math.max(1, Math.ceil(Math.log(size / 256) / Math.LN2));
+            map.setMinZoom(fillZoom);
+            if (recenter || map.getZoom() < fillZoom) {
+                map.setView(DEFAULT_CENTER, Math.max(fillZoom, parseInt(container.getAttribute('data-zoom'), 10) || 2));
+            }
+        }
+        applyFillZoom(true);
+        var resizeTimer = null;
+        window.addEventListener('resize', function () {
+            if (resizeTimer) { clearTimeout(resizeTimer); }
+            resizeTimer = setTimeout(function () { applyFillZoom(false); }, 200);
+        });
 
         L.tileLayer(cfg().tileUrl || 'https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
             maxZoom: 19,
@@ -101,7 +119,7 @@
                     title: markerData.name + ' (' + markerData.count + ')'
                 }).addTo(map);
                 marker.almaData = markerData;
-                marker.bindPopup(popupContent(markerData, container, null, ''), { maxWidth: 340 });
+                marker.bindPopup(popupContent(markerData, container, null, ''), { minWidth: 296, maxWidth: 320 });
                 marker.on('click', function () {
                     openMarker(entry, marker);
                 });
@@ -116,15 +134,10 @@
     function openMarker(entry, marker) {
         var data = marker.almaData;
         var container = entry.container;
-        var pageUrl = listPageUrl(container, data.ids);
 
-        // Secondo click sul marker già aperto: vai direttamente alla pagina elenco.
-        if (pageUrl && entry.lastOpened === marker && marker.isPopupOpen()) {
-            window.location.href = pageUrl;
-            return;
-        }
-        entry.lastOpened = marker;
-
+        // La navigazione alla pagina elenco avviene SOLO tramite il pulsante
+        // esplicito nel popup: il "secondo click sul marker" causava redirect
+        // involontari (es. click per chiudere il popup).
         marker.setPopupContent(popupContent(data, container, null, ''));
         marker.openPopup();
 
@@ -182,7 +195,6 @@
             if (input.value === '') {
                 entry.map.setView(DEFAULT_CENTER, parseInt(entry.container.getAttribute('data-zoom'), 10) || 2);
                 entry.map.closePopup();
-                entry.lastOpened = null;
             }
         });
     }

--- a/includes/class-geo-map.php
+++ b/includes/class-geo-map.php
@@ -133,6 +133,28 @@ class ALMA_Geo_Map {
     private function enqueue_map_assets() {
         // Leaflet è incluso nel plugin: nessun CDN, nessuna chiave, nessun costo.
         wp_enqueue_style('alma-leaflet', ALMA_PLUGIN_URL . 'assets/vendor/leaflet/leaflet.css', array(), '1.9.4');
+        // Icona di chiusura del popup più evidente: cerchio bianco con X grande.
+        wp_add_inline_style('alma-leaflet', '
+            .alma-geo-map .leaflet-popup-close-button {
+                width: 28px !important;
+                height: 28px !important;
+                top: 8px !important;
+                right: 8px !important;
+                font-size: 20px !important;
+                font-weight: 700;
+                line-height: 26px !important;
+                color: #1d2327 !important;
+                background: #f0f0f1 !important;
+                border-radius: 50%;
+                box-shadow: 0 1px 3px rgba(0,0,0,.25);
+                text-align: center;
+            }
+            .alma-geo-map .leaflet-popup-close-button:hover {
+                background: #d63638 !important;
+                color: #fff !important;
+            }
+            .alma-geo-map .leaflet-popup-content { margin: 14px 18px; }
+        ');
         wp_enqueue_script('alma-leaflet', ALMA_PLUGIN_URL . 'assets/vendor/leaflet/leaflet.js', array(), '1.9.4', true);
         if (file_exists(ALMA_PLUGIN_DIR . 'assets/geo-map.js')) {
             wp_enqueue_script('alma-geo-map', ALMA_PLUGIN_URL . 'assets/geo-map.js', array('alma-leaflet'), ALMA_VERSION, true);
@@ -207,7 +229,7 @@ class ALMA_Geo_Map {
         foreach ((array) $rows as $row) {
             $ids = implode(',', array_map('absint', array_filter(explode(',', (string) $row['location_ids']))));
             $markers[] = array(
-                'name' => sanitize_text_field($row['name']),
+                'name' => html_entity_decode(sanitize_text_field($row['name']), ENT_QUOTES, 'UTF-8'),
                 'lat' => (float) $row['rlat'],
                 'lng' => (float) $row['rlng'],
                 'count' => (int) $row['article_count'],
@@ -318,10 +340,12 @@ class ALMA_Geo_Map {
         foreach ($query->posts as $post) {
             $items[] = array(
                 'id' => (int) $post->ID,
-                'title' => get_the_title($post),
+                // Decodifica le entità HTML (&#8217; ecc.): il JS inserisce i titoli
+                // come testo, quindi le entità arriverebbero letterali a schermo.
+                'title' => html_entity_decode(get_the_title($post), ENT_QUOTES, 'UTF-8'),
                 'url' => get_permalink($post),
                 'date' => get_the_date('', $post),
-                'excerpt' => wp_trim_words(wp_strip_all_tags(get_the_excerpt($post)), 24, '…'),
+                'excerpt' => html_entity_decode(wp_trim_words(wp_strip_all_tags(get_the_excerpt($post)), 24, '…'), ENT_QUOTES, 'UTF-8'),
                 'thumbnail' => get_the_post_thumbnail_url($post, 'medium') ?: '',
             );
         }


### PR DESCRIPTION
# Riepilogo

Versione **2.52.0**. Tutti i punti segnalati sulla Mappa Geografica.

## 1. Zoom minimo calcolato da Leaflet

Al caricamento (e a ogni resize della finestra, con debounce) la mappa calcola lo zoom al quale il planisfero (256·2^z px) **riempie esattamente il contenitore** — `max(larghezza, altezza)` — e lo imposta come zoom minimo: niente bande vuote a nessuna combinazione di dimensioni. La vista iniziale viene applicata a quel zoom con l'**Europa correttamente centrata** (48°N, 10°E).

## 2. Stop ai redirect involontari

Il comportamento "secondo click sul marker già aperto → vai alla pagina risultati" scattava anche quando si cliccava il marker per **chiudere** il popup. Rimosso: la navigazione avviene **solo** dal pulsante "Vedi tutti gli articoli →".

## 3. Popup rifinito

- **Rimosso il conteggio articoli** sotto il nome della località (resta la riga 🎯 Consigliati).
- **Larghezza fissa 280px** (+ `minWidth` sul popup): lo stato "Caricamento articoli…" e quello finale con miniature e titoli hanno le stesse dimensioni — la finestrella non salta più.
- **Pulsante di chiusura evidente**: cerchio grigio con X grande (28px), rosso al passaggio del mouse.

## 4. Fix caratteri speciali

"I Misteri dell&amp;#8217;Isola di Pasqua…" appariva letterale perché i titoli arrivano entity-encoded da `get_the_title` e il JS li inserisce come testo. Decodifica server-side (`html_entity_decode`) su titoli, estratti, nomi marker e pagina elenco — verificato sull'esempio esatto segnalato: ora "I Misteri dell'Isola di Pasqua: Tra Moai e Paesaggi Lunari".

## Verifica

- `php -l` e `node --check` puliti; decodifica testata sul titolo segnalato.
- Versione `2.51.1` → `2.52.0`; README e CHANGELOG aggiornati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_