### PR TITLE
Trova il tuo viaggio: ricerca a faccette combinate + integrazione BeTheme (v2.53.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.53.0 - 2026-07-03
+
+### Trova il tuo viaggio (ricerca a faccette) e integrazione con il tema (BeTheme)
+- **Nuovo shortcode `[alma_trip_finder]`**: ricerca a faccette combinate sulle tassonomie degli articoli (su sothra.it: Dove, Come, Cosa, Perché, Quando, Durata). Il visitatore incrocia più dimensioni (es. Quando=Primavera + Durata=Weekend + Perché=Enogastronomia) e vede solo gli articoli che le soddisfano tutte — cosa impossibile con il menu attuale, una dimensione alla volta.
+- **Contatori intelligenti**: ogni opzione mostra quanti articoli restano scegliendola (es. "Primavera (43)"), calcolati sulla selezione corrente delle altre faccette; le combinazioni senza risultati sono disabilitate. Le tassonomie gerarchiche (es. Dove: Italia → Puglia → Salento) sono indentate e un articolo taggato sulla foglia conta anche per gli antenati, senza doppi conteggi. Conteggi in cache 10 minuti, invalidata al salvataggio degli articoli.
+- **Aggiornamento senza ricaricare la pagina**: risultati e contatori si aggiornano via AJAX, l'URL resta condivisibile (`?alma_f[dove]=…`); **senza JavaScript il form funziona comunque** con l'invio GET classico. Griglia risultati con miniature, chip dei filtri attivi rimovibili, paginazione.
+- **Pagina impostazioni "Trova Viaggio"**: scelta delle tassonomie faccetta (tutte quelle pubbliche dei post, incluse le custom), pagina che ospita lo shortcode, categorie da escludere, articoli per pagina, attivazione chip.
+- **Chip faccette negli articoli (opt-in, default disattivo)**: in cima a ogni articolo le sue faccette come chip cliccabili (es. "Dove: Algeria · Quando: Primavera") che portano alla pagina Trova Viaggio pre-filtrata (fallback: archivio del termine). Nessun cambiamento agli articoli finché non viene attivato.
+- **Colore accento configurabile** (impostazioni Mappa Geografica): pulsanti ed evidenziazioni di popup mappa, pagina elenco e Trova Viaggio si allineano alla palette del tema (es. `#2E8CCB` per BeTheme di sothra.it). Default `#2271b1` invariato (retrocompatibile).
+- **Integrazione BeTheme/Muffin Builder**: classi CSS stabili su tutti gli elementi del popup mappa (`alma-geo-popup-*`) e del Trova Viaggio (`alma-trip-finder__*`) personalizzabili dal Custom CSS del tema, come già avviene per gli altri componenti ALMA; nelle impostazioni istruzioni per l'inserimento degli shortcode in sezioni full-width del Builder.
+- Versione plugin aggiornata a `2.53.0`.
+
 ## 2.52.0 - 2026-07-03
 
 ### Mappa Geografica — zoom di riempimento, popup rifinito, fix entità HTML

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## 2.53.0 - 2026-07-03
+
+### Trova il tuo viaggio (ricerca a faccette) e integrazione con il tema (BeTheme)
+- Nuovo shortcode `[alma_trip_finder]`: ricerca a faccette combinate sulle tassonomie degli articoli (Dove, Come, Cosa, Perché, Quando, Durata su sothra.it) — più dimensioni incrociate insieme, con contatori per opzione, combinazioni impossibili disabilitate e gerarchie indentate.
+- Risultati e contatori aggiornati via AJAX con URL condivisibile; senza JavaScript il form GET funziona comunque. Pagina impostazioni "Trova Viaggio" (tassonomie, pagina, categorie escluse, articoli per pagina).
+- Chip faccette in cima agli articoli (opt-in, default disattivo) verso la pagina Trova Viaggio pre-filtrata.
+- Colore accento configurabile per popup mappa, pagina elenco e Trova Viaggio; classi CSS stabili per il Custom CSS del tema (BeTheme/Muffin Builder), con istruzioni di inserimento nel Builder.
+- Versione plugin aggiornata a `2.53.0`.
+
 ## 2.52.0 - 2026-07-03
 
 ### Mappa Geografica — zoom di riempimento, popup rifinito, fix entità HTML

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.52.0
+ * Version: 2.53.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.52.0');
+define('ALMA_VERSION', '2.53.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -106,6 +106,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-geo-auto-indexer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-ai-location-extractor.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-geocoding-queue.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-map.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-trip-finder.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-index-admin.php';
 
 /**
@@ -131,7 +132,8 @@ class AffiliateManagerAI {
     private $geo_index_admin;
     private $geo_auto_indexer;
     private $geo_map;
-    
+    private $trip_finder;
+
     public function __construct() {
         global $wpdb;
         $this->dashboard_stats = new ALMA_Dashboard_Stats($wpdb);
@@ -149,6 +151,8 @@ class AffiliateManagerAI {
         ALMA_Geo_Geocoding_Queue::init();
         $this->geo_map = new ALMA_Geo_Map($this->geo_index_store);
         $this->geo_map->init();
+        $this->trip_finder = new ALMA_Trip_Finder();
+        $this->trip_finder->init();
         add_action('init', array($this, 'init'));
         add_action('widgets_init', array('ALMA_Contextual_Affiliate_Widget', 'register_widget'));
         // Registrato qui (prima che `widgets_init` scatti) perché ALMA_Shortcodes::init()
@@ -1147,6 +1151,7 @@ class AffiliateManagerAI {
             ALMA_Contextual_Affiliate_Widget::MENU_SLUG,
             ALMA_Geo_Index_Admin::MENU_SLUG,
             ALMA_Geo_Map::MENU_SLUG,
+            ALMA_Trip_Finder::MENU_SLUG,
             'alma-affiliate-sources',
             self::AI_CONTENT_AGENT_MENU_SLUG,
             'affiliate-link-manager-settings',
@@ -1184,6 +1189,9 @@ class AffiliateManagerAI {
                             break;
                         case ALMA_Geo_Map::MENU_SLUG:
                             $item[0] = __('Mappa Geografica', 'affiliate-link-manager-ai');
+                            break;
+                        case ALMA_Trip_Finder::MENU_SLUG:
+                            $item[0] = __('Trova Viaggio', 'affiliate-link-manager-ai');
                             break;
                         case 'alma-affiliate-sources':
                             $item[0] = __('Affiliate Sources', 'affiliate-link-manager-ai');

--- a/assets/geo-map.js
+++ b/assets/geo-map.js
@@ -40,22 +40,26 @@
     }
 
     function popupContent(markerData, container, articles, recommendedLine) {
+        // Colore accento configurabile (impostazioni Mappa Geografica) per
+        // integrarsi con la palette del tema; classi CSS stabili così il tema
+        // (es. Custom CSS di BeTheme) può ridefinire ogni elemento.
+        var accent = cfg().accentColor || '#2271b1';
         // Larghezza FISSA: lo stato di caricamento e quello finale hanno le
         // stesse dimensioni, il popup non "salta" quando arrivano i contenuti.
         var html = '<div class="alma-geo-map-info" style="width:280px;font-size:13px;line-height:1.45;">';
-        html += '<strong style="font-size:16px;display:block;margin-bottom:1px;">📍 ' + escapeHtml(markerData.name) + '</strong>';
+        html += '<strong class="alma-geo-popup-title" style="font-size:16px;display:block;margin-bottom:1px;">📍 ' + escapeHtml(markerData.name) + '</strong>';
         if (recommendedLine) {
-            html += '<div style="margin-top:4px;font-weight:600;color:#2271b1;">🎯 ' + escapeHtml(recommendedLine) + '</div>';
+            html += '<div class="alma-geo-popup-recommended" style="margin-top:4px;font-weight:600;color:' + escapeHtml(accent) + ';">🎯 ' + escapeHtml(recommendedLine) + '</div>';
         }
         if (articles === null) {
-            html += '<p style="margin:10px 0 0;color:#666;">Caricamento articoli…</p>';
+            html += '<p class="alma-geo-popup-loading" style="margin:10px 0 0;color:#666;">Caricamento articoli…</p>';
         } else if (articles.length) {
-            html += '<div style="margin-top:10px;display:flex;flex-direction:column;gap:8px;">';
+            html += '<div class="alma-geo-popup-articles" style="margin-top:10px;display:flex;flex-direction:column;gap:8px;">';
             articles.slice(0, 5).forEach(function (article) {
                 var thumb = article.thumbnail
                     ? '<img src="' + escapeHtml(article.thumbnail) + '" alt="" loading="lazy" style="width:48px;height:48px;object-fit:cover;border-radius:6px;flex-shrink:0;" />'
                     : '<span style="width:48px;height:48px;border-radius:6px;background:#eef1f5;display:flex;align-items:center;justify-content:center;flex-shrink:0;font-size:18px;">📄</span>';
-                html += '<a href="' + escapeHtml(article.url) + '" style="display:flex;align-items:center;gap:10px;text-decoration:none;padding:4px;border-radius:6px;">' +
+                html += '<a class="alma-geo-popup-article" href="' + escapeHtml(article.url) + '" style="display:flex;align-items:center;gap:10px;text-decoration:none;padding:4px;border-radius:6px;">' +
                     thumb +
                     '<span style="font-weight:600;line-height:1.3;color:#1d2327;">' + escapeHtml(article.title) + '</span>' +
                     '</a>';
@@ -64,7 +68,7 @@
         }
         var pageUrl = listPageUrl(container, markerData.ids);
         if (pageUrl) {
-            html += '<p style="margin:12px 0 0;text-align:center;"><a href="' + escapeHtml(pageUrl) + '" style="display:inline-block;padding:7px 14px;background:#2271b1;color:#fff;border-radius:6px;font-weight:600;text-decoration:none;">Vedi tutti gli articoli →</a></p>';
+            html += '<p style="margin:12px 0 0;text-align:center;"><a class="alma-geo-popup-button" href="' + escapeHtml(pageUrl) + '" style="display:inline-block;padding:7px 14px;background:' + escapeHtml(accent) + ';color:#fff;border-radius:6px;font-weight:600;text-decoration:none;">Vedi tutti gli articoli →</a></p>';
         }
         html += '</div>';
         return html;

--- a/assets/trip-finder.js
+++ b/assets/trip-finder.js
@@ -1,0 +1,119 @@
+/**
+ * Affiliate Link Manager AI - Trova il tuo viaggio (ricerca a faccette)
+ *
+ * Progressive enhancement sul form GET renderizzato dal PHP: senza JS il
+ * form si invia normalmente; con JS le select aggiornano risultati e
+ * contatori via AJAX, la paginazione non ricarica la pagina e l'URL resta
+ * condivisibile (history.replaceState).
+ */
+(function () {
+    'use strict';
+
+    function initFinder(container) {
+        var ajaxUrl = container.getAttribute('data-ajax-url');
+        var baseUrl = container.getAttribute('data-base-url') || window.location.href.split('?')[0];
+        var perPage = container.getAttribute('data-per-page') || '';
+        var taxonomies = container.getAttribute('data-taxonomies') || '';
+        var facets = container.querySelector('.alma-trip-finder__facets');
+        var results = container.querySelector('.alma-trip-finder__results');
+        if (!ajaxUrl || !facets || !results) { return; }
+
+        container.classList.add('alma-trip-finder--js');
+
+        function currentSelection() {
+            var selection = {};
+            Array.prototype.forEach.call(container.querySelectorAll('.alma-trip-finder__select'), function (select) {
+                var match = /alma_f\[([^\]]+)\]/.exec(select.getAttribute('name') || '');
+                if (match && select.value !== '') {
+                    selection[match[1]] = select.value;
+                }
+            });
+            return selection;
+        }
+
+        function buildParams(selection, page) {
+            var params = new URLSearchParams();
+            Object.keys(selection).forEach(function (tax) {
+                params.set('alma_f[' + tax + ']', selection[tax]);
+            });
+            if (page > 1) { params.set('alma_tf_page', String(page)); }
+            return params;
+        }
+
+        var requestId = 0;
+        function update(page, selectionOverride) {
+            var selection = selectionOverride || currentSelection();
+            var params = buildParams(selection, page);
+
+            // URL condivisibile senza ricaricare la pagina.
+            var query = params.toString();
+            try {
+                window.history.replaceState(null, '', query ? baseUrl + '?' + query : baseUrl);
+            } catch (e) { /* browser restrittivi: l'URL resta quello corrente */ }
+
+            params.set('action', 'alma_trip_finder_render');
+            if (perPage) { params.set('per_page', perPage); }
+            if (taxonomies) { params.set('taxonomies', taxonomies); }
+
+            container.classList.add('is-loading');
+            var thisRequest = ++requestId;
+            fetch(ajaxUrl + '?' + params.toString(), { credentials: 'same-origin' })
+                .then(function (r) { return r.json(); })
+                .then(function (response) {
+                    if (thisRequest !== requestId) { return; } // risposta superata da una selezione più recente
+                    if (response && response.success && response.data) {
+                        facets.innerHTML = response.data.facets_html || '';
+                        results.innerHTML = response.data.results_html || '';
+                    }
+                })
+                .catch(function () { /* endpoint non raggiungibile: il form resta utilizzabile via submit */ })
+                .then(function () {
+                    if (thisRequest === requestId) { container.classList.remove('is-loading'); }
+                });
+        }
+
+        // Delegation: i nodi vengono sostituiti a ogni refresh AJAX.
+        container.addEventListener('change', function (event) {
+            if (event.target && event.target.classList.contains('alma-trip-finder__select')) {
+                update(1);
+            }
+        });
+
+        container.addEventListener('click', function (event) {
+            var pageLink = event.target.closest ? event.target.closest('a[data-tf-page]') : null;
+            if (pageLink && container.contains(pageLink)) {
+                event.preventDefault();
+                update(parseInt(pageLink.getAttribute('data-tf-page'), 10) || 1);
+                var top = container.getBoundingClientRect().top + window.pageYOffset - 80;
+                window.scrollTo({ top: top > 0 ? top : 0, behavior: 'smooth' });
+                return;
+            }
+            var chip = event.target.closest ? event.target.closest('a[data-tf-remove]') : null;
+            if (chip && container.contains(chip)) {
+                event.preventDefault();
+                var selection = currentSelection();
+                delete selection[chip.getAttribute('data-tf-remove')];
+                // Riallinea anche la select corrispondente prima del refresh.
+                var select = container.querySelector('select[name="alma_f[' + chip.getAttribute('data-tf-remove') + ']"]');
+                if (select) { select.value = ''; }
+                update(1, selection);
+            }
+        });
+    }
+
+    function boot() {
+        var containers = document.querySelectorAll('.alma-trip-finder');
+        Array.prototype.forEach.call(containers, function (container) {
+            if (!container.getAttribute('data-alma-initialized')) {
+                container.setAttribute('data-alma-initialized', '1');
+                initFinder(container);
+            }
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', boot);
+    } else {
+        boot();
+    }
+})();

--- a/includes/class-geo-map.php
+++ b/includes/class-geo-map.php
@@ -24,6 +24,8 @@ class ALMA_Geo_Map {
     const OPTION_LIST_PAGE = 'alma_geo_map_list_page_id';
     const OPTION_DEFAULT_WIDTH = 'alma_geo_map_default_width';
     const OPTION_DEFAULT_HEIGHT = 'alma_geo_map_default_height';
+    const OPTION_ACCENT = 'alma_geo_map_accent_color';
+    const DEFAULT_ACCENT = '#2271b1';
     const MARKERS_CACHE_KEY = 'alma_geo_map_markers_v1';
     const MARKERS_CACHE_TTL = 900; // 15 minuti
     const MAX_MARKERS = 2000;
@@ -47,6 +49,16 @@ class ALMA_Geo_Map {
 
     public function invalidate_markers_cache() {
         delete_transient(self::MARKERS_CACHE_KEY);
+    }
+
+    /**
+     * Colore accento dei componenti frontend (popup mappa, pagina elenco,
+     * Trova il tuo viaggio): configurabile dalle impostazioni per integrarsi
+     * con la palette del tema attivo (es. BeTheme). Default retrocompatibile.
+     */
+    public static function get_accent_color() {
+        $color = sanitize_hex_color((string) get_option(self::OPTION_ACCENT, self::DEFAULT_ACCENT));
+        return $color ? $color : self::DEFAULT_ACCENT;
     }
 
     /* ---------------------------------------------------------------------
@@ -167,6 +179,7 @@ class ALMA_Geo_Map {
                  */
                 'tileUrl' => $this->sanitize_tile_url(apply_filters('alma_geo_map_tile_url', 'https://tile.openstreetmap.org/{z}/{x}/{y}.png')),
                 'tileAttribution' => wp_kses_post(apply_filters('alma_geo_map_tile_attribution', '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors')),
+                'accentColor' => self::get_accent_color(),
             ));
         }
     }
@@ -390,6 +403,7 @@ class ALMA_Geo_Map {
         $paged = max(1, absint($_GET['alma_page'] ?? 1));
         $per_page = max(1, min(50, absint($atts['per_page'])));
         $data = $this->get_articles_for_locations($ids, $per_page, $paged);
+        $accent = self::get_accent_color();
 
         ob_start();
         ?>
@@ -398,7 +412,7 @@ class ALMA_Geo_Map {
                 <h2 class="alma-geo-location-articles__title">📍 <?php echo esc_html($data['location_name']); ?></h2>
                 <p class="alma-geo-location-articles__count" style="margin:0 0 4px;color:#555;"><?php echo esc_html(sprintf(_n('%d articolo', '%d articoli', $data['total'], 'affiliate-link-manager-ai'), $data['total'])); ?></p>
                 <?php if ($data['recommended_line'] !== '') : ?>
-                    <p class="alma-geo-location-articles__recommended" style="margin:0 0 18px;font-weight:600;color:#2271b1;">🎯 <?php echo esc_html($data['recommended_line']); ?></p>
+                    <p class="alma-geo-location-articles__recommended" style="margin:0 0 18px;font-weight:600;color:<?php echo esc_attr($accent); ?>;">🎯 <?php echo esc_html($data['recommended_line']); ?></p>
                 <?php endif; ?>
             <?php endif; ?>
             <?php if (empty($data['items'])) : ?>
@@ -425,7 +439,7 @@ class ALMA_Geo_Map {
                     for ($i = 1; $i <= $total_pages; $i++) {
                         $url = add_query_arg(array('alma_location' => implode(',', $ids), 'alma_page' => $i));
                         if ($i === $paged) {
-                            echo '<span style="padding:6px 12px;background:#2271b1;color:#fff;border-radius:4px;">' . esc_html((string) $i) . '</span>';
+                            echo '<span style="padding:6px 12px;background:' . esc_attr($accent) . ';color:#fff;border-radius:4px;">' . esc_html((string) $i) . '</span>';
                         } else {
                             echo '<a href="' . esc_url($url) . '" style="padding:6px 12px;border:1px solid #d0d5dd;border-radius:4px;">' . esc_html((string) $i) . '</a>';
                         }
@@ -464,6 +478,8 @@ class ALMA_Geo_Map {
             update_option(self::OPTION_LIST_PAGE, absint($_POST[self::OPTION_LIST_PAGE] ?? 0), false);
             update_option(self::OPTION_DEFAULT_WIDTH, $this->sanitize_css_dimension($_POST[self::OPTION_DEFAULT_WIDTH] ?? '100%', '100%'), false);
             update_option(self::OPTION_DEFAULT_HEIGHT, $this->sanitize_css_dimension($_POST[self::OPTION_DEFAULT_HEIGHT] ?? '600px', '600px'), false);
+            $accent = sanitize_hex_color((string) ($_POST[self::OPTION_ACCENT] ?? ''));
+            update_option(self::OPTION_ACCENT, $accent ? $accent : self::DEFAULT_ACCENT, false);
             $this->invalidate_markers_cache();
             echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__('Impostazioni Mappa Geografica salvate.', 'affiliate-link-manager-ai') . '</p></div>';
         }
@@ -480,6 +496,12 @@ class ALMA_Geo_Map {
                 <h2><?php esc_html_e('Shortcode', 'affiliate-link-manager-ai'); ?></h2>
                 <p><code>[alma_geo_map width="100%" height="600px"]</code></p>
                 <p class="description"><?php esc_html_e('Attributi: width e height accettano px, %, vh, vw, em, rem (es. width="80%" height="70vh"); zoom="2" (1-12) per lo zoom iniziale; search="no" per nascondere la ricerca. Per la pagina elenco usa lo shortcode:', 'affiliate-link-manager-ai'); ?> <code>[alma_geo_location_articles per_page="20"]</code></p>
+            </div>
+
+            <div class="card" style="max-width:860px;">
+                <h2><?php esc_html_e('Integrazione con il tema (BeTheme / Muffin Builder)', 'affiliate-link-manager-ai'); ?></h2>
+                <p><?php esc_html_e('Per una pagina "Esplora la mappa": crea una pagina con il Muffin Builder, aggiungi una sezione full width con padding 0 e inserisci lo shortcode in un elemento Column/Shortcode. La mappa si adatta alla larghezza della sezione.', 'affiliate-link-manager-ai'); ?></p>
+                <p><?php esc_html_e('Tutti gli elementi frontend usano classi CSS stabili (alma-geo-map, alma-geo-popup-*, alma-geo-location-articles__*, alma-trip-finder__*) personalizzabili dal Custom CSS del tema. Il colore accento qui sotto permette di allineare popup e pulsanti alla palette del tema senza CSS.', 'affiliate-link-manager-ai'); ?></p>
             </div>
 
             <div class="card" style="max-width:860px;">
@@ -519,6 +541,13 @@ class ALMA_Geo_Map {
                                 'option_none_value' => '0',
                             )); ?>
                             <p class="description"><?php esc_html_e('La pagina che si apre al click su una località: deve contenere lo shortcode [alma_geo_location_articles]. Senza pagina, il popup sulla mappa mostra comunque gli articoli.', 'affiliate-link-manager-ai'); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="<?php echo esc_attr(self::OPTION_ACCENT); ?>"><?php esc_html_e('Colore accento', 'affiliate-link-manager-ai'); ?></label></th>
+                        <td>
+                            <input type="color" name="<?php echo esc_attr(self::OPTION_ACCENT); ?>" id="<?php echo esc_attr(self::OPTION_ACCENT); ?>" value="<?php echo esc_attr(self::get_accent_color()); ?>" />
+                            <p class="description"><?php esc_html_e('Colore di pulsanti ed evidenziazioni nei componenti frontend (popup mappa, pagina elenco, Trova il tuo viaggio). Impostalo sul colore del tema, es. #2E8CCB per BeTheme di sothra.it. Default: #2271b1.', 'affiliate-link-manager-ai'); ?></p>
                         </td>
                     </tr>
                     <tr>

--- a/includes/class-trip-finder.php
+++ b/includes/class-trip-finder.php
@@ -1,0 +1,655 @@
+<?php
+/**
+ * "Trova il tuo viaggio": ricerca a faccette combinate sulle tassonomie
+ * degli articoli (Dove, Quando, Durata, Perché… su sothra.it).
+ *
+ * - Shortcode [alma_trip_finder]: una select per ogni tassonomia configurata,
+ *   con contatori aggiornati alla selezione corrente e opzioni impossibili
+ *   disabilitate; risultati aggiornati via AJAX con fallback GET senza JS
+ *   (il form si invia normalmente e la pagina si ricarica filtrata).
+ * - Chip faccette negli articoli (opzionale, default disattivo): le tassonomie
+ *   dell'articolo come link cliccabili verso la pagina Trova Viaggio
+ *   pre-filtrata (fallback: archivio del termine).
+ * - Pensato per il Muffin Builder di BeTheme: shortcode inseribile in una
+ *   sezione, classi CSS stabili (alma-trip-finder__*) personalizzabili dal
+ *   Custom CSS del tema, colore accento condiviso con la Mappa Geografica.
+ *
+ * Le tassonomie esistenti restano intatte (gli archivi continuano a lavorare
+ * per la SEO): questo è solo un layer UX sopra i dati già presenti.
+ */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALMA_Trip_Finder {
+    const MENU_SLUG = 'alma-trip-finder';
+    const OPTION_TAXONOMIES = 'alma_trip_finder_taxonomies';
+    const OPTION_PAGE = 'alma_trip_finder_page_id';
+    const OPTION_EXCLUDED_CATS = 'alma_trip_finder_excluded_categories';
+    const OPTION_PER_PAGE = 'alma_trip_finder_per_page';
+    const OPTION_CHIPS = 'alma_trip_finder_chips';
+    const OPTION_CACHE_VER = 'alma_trip_finder_cache_ver';
+    const CACHE_TTL = 600; // 10 minuti
+    const MAX_PER_PAGE = 48;
+    const MAX_CHIPS_PER_TAXONOMY = 3;
+
+    public function init() {
+        add_shortcode('alma_trip_finder', array($this, 'render_shortcode'));
+        add_action('admin_menu', array($this, 'add_menu'), 12);
+        add_action('wp_ajax_alma_trip_finder_render', array($this, 'ajax_render'));
+        add_action('wp_ajax_nopriv_alma_trip_finder_render', array($this, 'ajax_render'));
+        // Le chip sono opt-in: comportamento invariato finché non vengono
+        // attivate dalle impostazioni (retrocompatibilità).
+        add_filter('the_content', array($this, 'append_facet_chips'), 12);
+        // I contatori in cache dipendono dai termini assegnati agli articoli.
+        add_action('save_post_post', array($this, 'bump_cache_version'));
+        add_action('trashed_post', array($this, 'bump_cache_version'));
+        add_action('deleted_post', array($this, 'bump_cache_version'));
+    }
+
+    public function bump_cache_version() {
+        update_option(self::OPTION_CACHE_VER, absint(get_option(self::OPTION_CACHE_VER, 1)) + 1, false);
+    }
+
+    /* ---------------------------------------------------------------------
+     * Configurazione
+     * ------------------------------------------------------------------ */
+
+    /**
+     * Tassonomie faccetta valide: pubbliche e collegate ai post. L'override
+     * (attributo shortcode o parametro AJAX) è comunque validato contro le
+     * tassonomie reali dei post, mai usato così com'è.
+     */
+    public function get_facet_taxonomies($override = '') {
+        $available = get_object_taxonomies('post', 'objects');
+        $slugs = array();
+        if ($override !== '') {
+            $slugs = array_filter(array_map('sanitize_key', explode(',', (string) $override)));
+        }
+        if (empty($slugs)) {
+            $slugs = array_filter(array_map('sanitize_key', (array) get_option(self::OPTION_TAXONOMIES, array('category'))));
+        }
+        $taxonomies = array();
+        foreach ($slugs as $slug) {
+            if (isset($available[$slug]) && $available[$slug]->public && $slug !== 'post_format') {
+                $taxonomies[$slug] = $available[$slug];
+            }
+        }
+        return $taxonomies;
+    }
+
+    /**
+     * Selezione corrente dal parametro alma_f[tassonomia] = term_id,
+     * mantenendo solo termini esistenti nelle tassonomie configurate.
+     */
+    public function read_selection($raw, $taxonomies) {
+        $selection = array();
+        foreach ((array) $raw as $tax => $term_id) {
+            $tax = sanitize_key($tax);
+            $term_id = absint($term_id);
+            if ($term_id > 0 && isset($taxonomies[$tax])) {
+                $term = get_term($term_id, $tax);
+                if ($term instanceof WP_Term) {
+                    $selection[$tax] = $term_id;
+                }
+            }
+        }
+        return $selection;
+    }
+
+    private function get_excluded_category_ids() {
+        return array_values(array_filter(array_map('absint', (array) get_option(self::OPTION_EXCLUDED_CATS, array()))));
+    }
+
+    private function get_finder_page_url() {
+        $page_id = absint(get_option(self::OPTION_PAGE, 0));
+        return $page_id > 0 ? get_permalink($page_id) : '';
+    }
+
+    /* ---------------------------------------------------------------------
+     * Query e contatori faccette
+     * ------------------------------------------------------------------ */
+
+    private function build_query_args($selection, $extra = array()) {
+        $args = array_merge(array(
+            'post_type' => 'post',
+            'post_status' => 'publish',
+            'orderby' => 'date',
+            'order' => 'DESC',
+        ), $extra);
+        $tax_query = array();
+        foreach ($selection as $tax => $term_id) {
+            $tax_query[] = array(
+                'taxonomy' => $tax,
+                'field' => 'term_id',
+                'terms' => array($term_id),
+                // I termini gerarchici (es. Dove: Italia → Puglia) includono i figli.
+                'include_children' => true,
+            );
+        }
+        if (!empty($tax_query)) {
+            $tax_query['relation'] = 'AND';
+            $args['tax_query'] = $tax_query;
+        }
+        $excluded = $this->get_excluded_category_ids();
+        if (!empty($excluded)) {
+            $args['category__not_in'] = $excluded;
+        }
+        return $args;
+    }
+
+    /**
+     * ID dei post che soddisfano la selezione (tutte le faccette in AND),
+     * in transient: alimenta i contatori, non i risultati paginati.
+     */
+    private function get_matching_ids($selection) {
+        $key = 'alma_tf_ids_' . md5(wp_json_encode(array($selection, $this->get_excluded_category_ids(), get_option(self::OPTION_CACHE_VER, 1))));
+        $ids = get_transient($key);
+        if (is_array($ids)) {
+            return $ids;
+        }
+        $query = new WP_Query($this->build_query_args($selection, array(
+            'fields' => 'ids',
+            'posts_per_page' => -1,
+            'no_found_rows' => true,
+            'update_post_meta_cache' => false,
+            'update_post_term_cache' => false,
+        )));
+        $ids = array_map('absint', (array) $query->posts);
+        set_transient($key, $ids, self::CACHE_TTL);
+        return $ids;
+    }
+
+    /**
+     * Contatori per ogni tassonomia: quanti articoli restano scegliendo quel
+     * termine, data la selezione corrente sulle ALTRE faccette (conteggio a
+     * faccette standard: la propria selezione non limita le proprie opzioni).
+     */
+    public function get_facet_counts($taxonomies, $selection) {
+        $cache_key = 'alma_tf_counts_' . md5(wp_json_encode(array(array_keys($taxonomies), $selection, $this->get_excluded_category_ids(), get_option(self::OPTION_CACHE_VER, 1))));
+        $counts = get_transient($cache_key);
+        if (is_array($counts)) {
+            return $counts;
+        }
+        $counts = array();
+        foreach (array_keys($taxonomies) as $tax) {
+            $others = $selection;
+            unset($others[$tax]);
+            $post_ids = empty($others) && empty($this->get_excluded_category_ids())
+                ? null // nessun filtro: il SQL lavora direttamente su tutti i post pubblicati
+                : $this->get_matching_ids($others);
+            $pairs = $this->get_term_post_pairs($tax, $post_ids);
+            $parents = $this->get_term_parents($tax);
+            $counts[$tax] = self::aggregate_hierarchical_counts($pairs, $parents);
+        }
+        set_transient($cache_key, $counts, self::CACHE_TTL);
+        return $counts;
+    }
+
+    /**
+     * Coppie (term_id, post_id) della tassonomia sui post pubblicati,
+     * eventualmente ristrette a un elenco di ID (a blocchi, per non superare
+     * i limiti delle clausole IN su dataset di migliaia di articoli).
+     */
+    private function get_term_post_pairs($taxonomy, $post_ids = null) {
+        global $wpdb;
+        if (is_array($post_ids) && empty($post_ids)) {
+            return array();
+        }
+        $pairs = array();
+        $chunks = is_array($post_ids) ? array_chunk(array_map('absint', $post_ids), 2000) : array(null);
+        foreach ($chunks as $chunk) {
+            $in_sql = '';
+            $params = array($taxonomy);
+            if (is_array($chunk)) {
+                $in_sql = ' AND tr.object_id IN (' . implode(',', array_fill(0, count($chunk), '%d')) . ')';
+                $params = array_merge($params, $chunk);
+            }
+            $rows = $wpdb->get_results($wpdb->prepare(
+                "SELECT tt.term_id, tr.object_id
+                 FROM {$wpdb->term_relationships} tr
+                 INNER JOIN {$wpdb->term_taxonomy} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id AND tt.taxonomy = %s
+                 INNER JOIN {$wpdb->posts} p ON p.ID = tr.object_id AND p.post_type = 'post' AND p.post_status = 'publish'
+                 WHERE 1=1{$in_sql}",
+                $params
+            ), ARRAY_N);
+            foreach ((array) $rows as $row) {
+                $pairs[] = array((int) $row[0], (int) $row[1]);
+            }
+        }
+        return $pairs;
+    }
+
+    private function get_term_parents($taxonomy) {
+        $parents = array();
+        $terms = get_terms(array('taxonomy' => $taxonomy, 'hide_empty' => false, 'fields' => 'id=>parent'));
+        if (is_array($terms)) {
+            foreach ($terms as $term_id => $parent) {
+                $parents[(int) $term_id] = (int) $parent;
+            }
+        }
+        return $parents;
+    }
+
+    /**
+     * Conteggio DISTINTO dei post per termine includendo i discendenti: un
+     * articolo taggato "Puglia" conta anche per "Italia". Logica pura (senza
+     * WordPress) per essere testabile standalone; protetta dai cicli.
+     */
+    public static function aggregate_hierarchical_counts(array $pairs, array $parents) {
+        $sets = array();
+        foreach ($pairs as $pair) {
+            $term_id = (int) $pair[0];
+            $object_id = (int) $pair[1];
+            $visited = array();
+            while ($term_id > 0 && !isset($visited[$term_id])) {
+                $visited[$term_id] = true;
+                if (!isset($sets[$term_id])) {
+                    $sets[$term_id] = array();
+                }
+                $sets[$term_id][$object_id] = true;
+                $term_id = isset($parents[$term_id]) ? (int) $parents[$term_id] : 0;
+            }
+        }
+        $counts = array();
+        foreach ($sets as $term_id => $objects) {
+            $counts[$term_id] = count($objects);
+        }
+        return $counts;
+    }
+
+    /* ---------------------------------------------------------------------
+     * Shortcode
+     * ------------------------------------------------------------------ */
+
+    public function render_shortcode($atts) {
+        $atts = shortcode_atts(array(
+            'per_page' => get_option(self::OPTION_PER_PAGE, 12),
+            'taxonomies' => '',
+        ), $atts, 'alma_trip_finder');
+
+        $taxonomies = $this->get_facet_taxonomies($atts['taxonomies']);
+        if (empty($taxonomies)) {
+            return current_user_can('manage_options')
+                ? '<p>' . esc_html__('Trova il tuo viaggio: nessuna tassonomia configurata. Selezionale in Affiliate Link AI → Trova Viaggio.', 'affiliate-link-manager-ai') . '</p>'
+                : '';
+        }
+
+        $per_page = max(1, min(self::MAX_PER_PAGE, absint($atts['per_page'])));
+        $selection = $this->read_selection($_GET['alma_f'] ?? array(), $taxonomies);
+        $paged = max(1, absint($_GET['alma_tf_page'] ?? 1));
+        $base_url = get_permalink() ?: '';
+
+        $this->enqueue_assets();
+
+        static $instance = 0;
+        $instance++;
+        $finder_id = 'alma-trip-finder-' . $instance;
+
+        ob_start();
+        ?>
+        <div id="<?php echo esc_attr($finder_id); ?>"
+             class="alma-trip-finder"
+             data-ajax-url="<?php echo esc_url(admin_url('admin-ajax.php')); ?>"
+             data-base-url="<?php echo esc_url($base_url); ?>"
+             data-per-page="<?php echo esc_attr((string) $per_page); ?>"
+             data-taxonomies="<?php echo esc_attr(implode(',', array_keys($taxonomies))); ?>">
+            <form class="alma-trip-finder__form" method="get" action="<?php echo esc_url($base_url); ?>">
+                <div class="alma-trip-finder__facets">
+                    <?php echo $this->render_facets_html($taxonomies, $selection, $base_url); // phpcs:ignore WordPress.Security.EscapeOutput ?>
+                </div>
+                <button type="submit" class="alma-trip-finder__submit"><?php esc_html_e('Filtra', 'affiliate-link-manager-ai'); ?></button>
+            </form>
+            <div class="alma-trip-finder__results">
+                <?php echo $this->render_results_html($selection, $paged, $per_page, $base_url); // phpcs:ignore WordPress.Security.EscapeOutput ?>
+            </div>
+        </div>
+        <?php
+        return (string) ob_get_clean();
+    }
+
+    /**
+     * Select delle faccette + chip dei filtri attivi. Con $base_url vuoto
+     * (rendering AJAX) i link di rimozione usano solo i data-attribute: il JS
+     * è comunque attivo, il fallback senza JS serve solo al primo render.
+     */
+    public function render_facets_html($taxonomies, $selection, $base_url = '') {
+        $counts = $this->get_facet_counts($taxonomies, $selection);
+        $accent = class_exists('ALMA_Geo_Map') ? ALMA_Geo_Map::get_accent_color() : '#2271b1';
+
+        ob_start();
+        echo '<div class="alma-trip-finder__selects" style="display:flex;flex-wrap:wrap;gap:10px;">';
+        foreach ($taxonomies as $slug => $taxonomy) {
+            $tax_counts = isset($counts[$slug]) ? $counts[$slug] : array();
+            $selected = isset($selection[$slug]) ? $selection[$slug] : 0;
+            echo '<label class="alma-trip-finder__facet" style="flex:1 1 180px;min-width:150px;">';
+            echo '<span class="alma-trip-finder__facet-label" style="display:block;font-weight:600;margin-bottom:4px;font-size:14px;">' . esc_html($taxonomy->labels->singular_name ?: $taxonomy->label) . '</span>';
+            echo '<select name="alma_f[' . esc_attr($slug) . ']" class="alma-trip-finder__select" style="width:100%;padding:9px 10px;border:2px solid #d0d5dd;border-radius:6px;font-size:14px;background:#fff;">';
+            echo '<option value="">' . esc_html__('Tutti', 'affiliate-link-manager-ai') . '</option>';
+            echo $this->render_term_options($slug, $tax_counts, $selected); // phpcs:ignore WordPress.Security.EscapeOutput
+            echo '</select>';
+            echo '</label>';
+        }
+        echo '</div>';
+
+        if (!empty($selection)) {
+            echo '<div class="alma-trip-finder__active" style="margin-top:10px;display:flex;flex-wrap:wrap;gap:8px;align-items:center;">';
+            foreach ($selection as $slug => $term_id) {
+                $term = get_term($term_id, $slug);
+                if (!$term instanceof WP_Term) {
+                    continue;
+                }
+                $remove_url = $base_url !== '' ? remove_query_arg('alma_tf_page', add_query_arg($this->selection_query_args(array_diff_key($selection, array($slug => 0))), $base_url)) : '#';
+                echo '<a class="alma-trip-finder__chip" data-tf-remove="' . esc_attr($slug) . '" href="' . esc_url($remove_url) . '" style="display:inline-flex;align-items:center;gap:6px;padding:5px 12px;border:1px solid ' . esc_attr($accent) . ';color:' . esc_attr($accent) . ';border-radius:16px;font-size:13px;font-weight:600;text-decoration:none;">'
+                    . esc_html(html_entity_decode($term->name, ENT_QUOTES, 'UTF-8')) . ' <span aria-hidden="true">✕</span></a>';
+            }
+            echo '</div>';
+        }
+        return (string) ob_get_clean();
+    }
+
+    /**
+     * Opzioni della select in ordine gerarchico (indentate con "—"); le
+     * combinazioni impossibili (0 risultati) restano visibili ma disabilitate.
+     */
+    private function render_term_options($taxonomy, $tax_counts, $selected) {
+        $terms = get_terms(array('taxonomy' => $taxonomy, 'hide_empty' => true));
+        if (!is_array($terms) || empty($terms)) {
+            return '';
+        }
+        $children = array();
+        foreach ($terms as $term) {
+            $children[(int) $term->parent][] = $term;
+        }
+        return $this->walk_term_options($children, 0, 0, $tax_counts, $selected);
+    }
+
+    private function walk_term_options($children, $parent, $depth, $tax_counts, $selected) {
+        if (!isset($children[$parent]) || $depth > 10) {
+            return '';
+        }
+        $html = '';
+        foreach ($children[$parent] as $term) {
+            $count = isset($tax_counts[$term->term_id]) ? (int) $tax_counts[$term->term_id] : 0;
+            $is_selected = (int) $term->term_id === (int) $selected;
+            $label = str_repeat('— ', $depth) . html_entity_decode($term->name, ENT_QUOTES, 'UTF-8') . ' (' . $count . ')';
+            $html .= '<option value="' . esc_attr((string) $term->term_id) . '"'
+                . selected($is_selected, true, false)
+                . disabled($count === 0 && !$is_selected, true, false)
+                . '>' . esc_html($label) . '</option>';
+            $html .= $this->walk_term_options($children, (int) $term->term_id, $depth + 1, $tax_counts, $selected);
+        }
+        return $html;
+    }
+
+    private function selection_query_args($selection) {
+        $args = array();
+        foreach ($selection as $tax => $term_id) {
+            $args['alma_f[' . $tax . ']'] = absint($term_id);
+        }
+        return $args;
+    }
+
+    /**
+     * Griglia risultati + conteggio + paginazione (stesse card della pagina
+     * elenco della Mappa Geografica: stile coerente, personalizzabile dal tema).
+     */
+    public function render_results_html($selection, $paged, $per_page, $base_url = '') {
+        $accent = class_exists('ALMA_Geo_Map') ? ALMA_Geo_Map::get_accent_color() : '#2271b1';
+        $query = new WP_Query($this->build_query_args($selection, array(
+            'posts_per_page' => $per_page,
+            'paged' => $paged,
+        )));
+
+        ob_start();
+        echo '<p class="alma-trip-finder__count" style="margin:16px 0 12px;font-weight:600;color:#555;">'
+            . esc_html(sprintf(_n('%d articolo trovato', '%d articoli trovati', (int) $query->found_posts, 'affiliate-link-manager-ai'), (int) $query->found_posts))
+            . '</p>';
+
+        if (empty($query->posts)) {
+            echo '<p class="alma-trip-finder__empty">' . esc_html__('Nessun articolo corrisponde ai filtri scelti: prova a rimuoverne uno.', 'affiliate-link-manager-ai') . '</p>';
+        } else {
+            echo '<div class="alma-trip-finder__grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:20px;">';
+            foreach ($query->posts as $post) {
+                $title = html_entity_decode(get_the_title($post), ENT_QUOTES, 'UTF-8');
+                $url = get_permalink($post);
+                $thumbnail = get_the_post_thumbnail_url($post, 'medium') ?: '';
+                $excerpt = html_entity_decode(wp_trim_words(wp_strip_all_tags(get_the_excerpt($post)), 22, '…'), ENT_QUOTES, 'UTF-8');
+                echo '<article class="alma-trip-finder__item" style="border:1px solid #e0e0e0;border-radius:8px;overflow:hidden;background:#fff;">';
+                if ($thumbnail !== '') {
+                    echo '<a href="' . esc_url($url) . '"><img src="' . esc_url($thumbnail) . '" alt="' . esc_attr($title) . '" style="width:100%;height:160px;object-fit:cover;display:block;" loading="lazy" /></a>';
+                }
+                echo '<div style="padding:14px 16px;">';
+                echo '<h3 style="margin:0 0 6px;font-size:16px;"><a href="' . esc_url($url) . '">' . esc_html($title) . '</a></h3>';
+                echo '<p style="margin:0 0 6px;font-size:13px;color:#666;">' . esc_html(get_the_date('', $post)) . '</p>';
+                echo '<p style="margin:0;font-size:14px;color:#444;">' . esc_html($excerpt) . '</p>';
+                echo '</div></article>';
+            }
+            echo '</div>';
+
+            $total_pages = (int) ceil($query->found_posts / $per_page);
+            if ($total_pages > 1) {
+                echo '<nav class="alma-trip-finder__pagination" style="margin-top:20px;display:flex;gap:8px;flex-wrap:wrap;">';
+                $window_start = max(1, $paged - 4);
+                $window_end = min($total_pages, $paged + 4);
+                for ($i = $window_start; $i <= $window_end; $i++) {
+                    if ($i === $paged) {
+                        echo '<span style="padding:6px 12px;background:' . esc_attr($accent) . ';color:#fff;border-radius:4px;">' . esc_html((string) $i) . '</span>';
+                    } else {
+                        $url = $base_url !== '' ? add_query_arg(array_merge($this->selection_query_args($selection), array('alma_tf_page' => $i)), $base_url) : '#';
+                        echo '<a data-tf-page="' . esc_attr((string) $i) . '" href="' . esc_url($url) . '" style="padding:6px 12px;border:1px solid #d0d5dd;border-radius:4px;text-decoration:none;">' . esc_html((string) $i) . '</a>';
+                    }
+                }
+                echo '</nav>';
+            }
+        }
+        return (string) ob_get_clean();
+    }
+
+    private function enqueue_assets() {
+        if (file_exists(ALMA_PLUGIN_DIR . 'assets/trip-finder.js')) {
+            wp_enqueue_script('alma-trip-finder', ALMA_PLUGIN_URL . 'assets/trip-finder.js', array(), ALMA_VERSION, true);
+        }
+        // Micro-CSS di comportamento (il resto è inline con classi stabili):
+        // quando il JS è attivo il pulsante "Filtra" sparisce e i refresh AJAX
+        // attenuano i risultati durante il caricamento.
+        wp_register_style('alma-trip-finder', false, array(), ALMA_VERSION);
+        wp_enqueue_style('alma-trip-finder');
+        wp_add_inline_style('alma-trip-finder', '
+            .alma-trip-finder--js .alma-trip-finder__submit { display: none; }
+            .alma-trip-finder.is-loading .alma-trip-finder__results { opacity: .5; pointer-events: none; }
+            .alma-trip-finder__submit { margin-top: 10px; padding: 9px 22px; border-radius: 6px; border: 1px solid #d0d5dd; cursor: pointer; }
+            .alma-trip-finder__chip:hover span { color: #d63638; }
+        ');
+    }
+
+    /* ---------------------------------------------------------------------
+     * Endpoint AJAX (pubblico, sola lettura su contenuti pubblicati)
+     * ------------------------------------------------------------------ */
+
+    public function ajax_render() {
+        $taxonomies = $this->get_facet_taxonomies(sanitize_text_field(wp_unslash($_GET['taxonomies'] ?? '')));
+        if (empty($taxonomies)) {
+            wp_send_json_error(array('message' => __('Nessuna tassonomia configurata.', 'affiliate-link-manager-ai')), 400);
+        }
+        $selection = $this->read_selection($_GET['alma_f'] ?? array(), $taxonomies);
+        $paged = max(1, absint($_GET['alma_tf_page'] ?? 1));
+        $per_page = max(1, min(self::MAX_PER_PAGE, absint($_GET['per_page'] ?? get_option(self::OPTION_PER_PAGE, 12))));
+
+        wp_send_json_success(array(
+            'facets_html' => $this->render_facets_html($taxonomies, $selection),
+            'results_html' => $this->render_results_html($selection, $paged, $per_page),
+        ));
+    }
+
+    /* ---------------------------------------------------------------------
+     * Chip faccette negli articoli (opt-in)
+     * ------------------------------------------------------------------ */
+
+    public function append_facet_chips($content) {
+        if (get_option(self::OPTION_CHIPS, '0') !== '1') {
+            return $content;
+        }
+        if (!is_singular('post') || !in_the_loop() || !is_main_query()) {
+            return $content;
+        }
+        $taxonomies = $this->get_facet_taxonomies();
+        if (empty($taxonomies)) {
+            return $content;
+        }
+        $finder_url = $this->get_finder_page_url();
+        $accent = class_exists('ALMA_Geo_Map') ? ALMA_Geo_Map::get_accent_color() : '#2271b1';
+        $post_id = get_the_ID();
+
+        $chips = array();
+        foreach ($taxonomies as $slug => $taxonomy) {
+            $terms = get_the_terms($post_id, $slug);
+            if (!is_array($terms)) {
+                continue;
+            }
+            foreach (array_slice($terms, 0, self::MAX_CHIPS_PER_TAXONOMY) as $term) {
+                // La chip porta alla pagina Trova Viaggio pre-filtrata; senza
+                // pagina configurata, fallback all'archivio del termine (SEO).
+                $url = $finder_url !== ''
+                    ? add_query_arg(array('alma_f[' . $slug . ']' => (int) $term->term_id), $finder_url)
+                    : get_term_link($term);
+                if (is_wp_error($url)) {
+                    continue;
+                }
+                $chips[] = '<a class="alma-facet-chip" href="' . esc_url($url) . '" style="display:inline-flex;align-items:center;gap:5px;padding:4px 12px;border:1px solid ' . esc_attr($accent) . ';color:' . esc_attr($accent) . ';border-radius:16px;font-size:13px;font-weight:600;text-decoration:none;">'
+                    . esc_html($taxonomy->labels->singular_name ?: $taxonomy->label) . ': '
+                    . esc_html(html_entity_decode($term->name, ENT_QUOTES, 'UTF-8')) . '</a>';
+            }
+        }
+        if (empty($chips)) {
+            return $content;
+        }
+        $bar = '<div class="alma-facet-chips" style="display:flex;flex-wrap:wrap;gap:8px;margin:0 0 18px;">' . implode('', $chips) . '</div>';
+        return $bar . $content;
+    }
+
+    /* ---------------------------------------------------------------------
+     * Pagina impostazioni
+     * ------------------------------------------------------------------ */
+
+    public function add_menu() {
+        add_submenu_page(
+            'edit.php?post_type=affiliate_link',
+            __('Trova Viaggio', 'affiliate-link-manager-ai'),
+            __('Trova Viaggio', 'affiliate-link-manager-ai'),
+            'manage_options',
+            self::MENU_SLUG,
+            array($this, 'render_settings_page')
+        );
+    }
+
+    public function render_settings_page() {
+        if (!current_user_can('manage_options')) {
+            wp_die(esc_html__('Permessi insufficienti.', 'affiliate-link-manager-ai'));
+        }
+
+        if (!empty($_POST['alma_trip_finder_save']) && check_admin_referer('alma_trip_finder_settings')) {
+            $available = $this->get_all_post_taxonomies();
+            $chosen = array_values(array_intersect(array_map('sanitize_key', (array) ($_POST['alma_trip_finder_taxonomies'] ?? array())), array_keys($available)));
+            update_option(self::OPTION_TAXONOMIES, $chosen, false);
+            update_option(self::OPTION_PAGE, absint($_POST[self::OPTION_PAGE] ?? 0), false);
+            update_option(self::OPTION_EXCLUDED_CATS, array_values(array_filter(array_map('absint', (array) ($_POST['alma_trip_finder_excluded'] ?? array())))), false);
+            update_option(self::OPTION_PER_PAGE, max(1, min(self::MAX_PER_PAGE, absint($_POST[self::OPTION_PER_PAGE] ?? 12))), false);
+            update_option(self::OPTION_CHIPS, empty($_POST[self::OPTION_CHIPS]) ? '0' : '1', false);
+            $this->bump_cache_version();
+            echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__('Impostazioni Trova Viaggio salvate.', 'affiliate-link-manager-ai') . '</p></div>';
+        }
+
+        $available = $this->get_all_post_taxonomies();
+        $chosen = array_filter(array_map('sanitize_key', (array) get_option(self::OPTION_TAXONOMIES, array('category'))));
+        $excluded = $this->get_excluded_category_ids();
+        $categories = get_categories(array('hide_empty' => false));
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('Trova il tuo viaggio', 'affiliate-link-manager-ai'); ?></h1>
+            <p><?php esc_html_e('Ricerca a faccette combinate: il visitatore incrocia le tassonomie degli articoli (es. Dove + Quando + Durata + Perché) e vede solo gli articoli che le soddisfano tutte, con contatori aggiornati e combinazioni impossibili disabilitate.', 'affiliate-link-manager-ai'); ?></p>
+
+            <div class="card" style="max-width:860px;">
+                <h2><?php esc_html_e('Shortcode', 'affiliate-link-manager-ai'); ?></h2>
+                <p><code>[alma_trip_finder]</code></p>
+                <p class="description"><?php esc_html_e('Attributi opzionali: per_page="12" (max 48); taxonomies="slug1,slug2" per usare tassonomie diverse da quelle configurate qui. Con BeTheme: inserisci lo shortcode in un elemento del Muffin Builder; funziona anche senza JavaScript (il form si invia normalmente).', 'affiliate-link-manager-ai'); ?></p>
+            </div>
+
+            <form method="post">
+                <?php wp_nonce_field('alma_trip_finder_settings'); ?>
+                <table class="form-table" role="presentation">
+                    <tr>
+                        <th scope="row"><?php esc_html_e('Tassonomie faccetta', 'affiliate-link-manager-ai'); ?></th>
+                        <td>
+                            <div style="max-height:220px;overflow:auto;border:1px solid #d0d5dd;border-radius:4px;padding:10px 12px;max-width:420px;">
+                                <?php foreach ($available as $slug => $taxonomy) : ?>
+                                    <label style="display:block;margin-bottom:4px;">
+                                        <input type="checkbox" name="alma_trip_finder_taxonomies[]" value="<?php echo esc_attr($slug); ?>" <?php checked(in_array($slug, $chosen, true)); ?> />
+                                        <?php echo esc_html($taxonomy->label); ?> <code><?php echo esc_html($slug); ?></code>
+                                    </label>
+                                <?php endforeach; ?>
+                            </div>
+                            <p class="description"><?php esc_html_e('Le dimensioni di ricerca mostrate come filtri combinabili (su sothra.it: Dove, Come, Cosa, Perché, Quando, Durata). Gli archivi delle tassonomie restano invariati: questo è solo un layer di navigazione in più.', 'affiliate-link-manager-ai'); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="<?php echo esc_attr(self::OPTION_PAGE); ?>"><?php esc_html_e('Pagina Trova Viaggio', 'affiliate-link-manager-ai'); ?></label></th>
+                        <td>
+                            <?php wp_dropdown_pages(array(
+                                'name' => self::OPTION_PAGE,
+                                'id' => self::OPTION_PAGE,
+                                'selected' => absint(get_option(self::OPTION_PAGE, 0)),
+                                'show_option_none' => __('— Nessuna —', 'affiliate-link-manager-ai'),
+                                'option_none_value' => '0',
+                            )); ?>
+                            <p class="description"><?php esc_html_e('La pagina che contiene lo shortcode [alma_trip_finder]: è la destinazione delle chip faccetta negli articoli. Senza pagina, le chip puntano agli archivi delle tassonomie.', 'affiliate-link-manager-ai'); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php esc_html_e('Chip faccette negli articoli', 'affiliate-link-manager-ai'); ?></th>
+                        <td>
+                            <label>
+                                <input type="checkbox" name="<?php echo esc_attr(self::OPTION_CHIPS); ?>" value="1" <?php checked(get_option(self::OPTION_CHIPS, '0'), '1'); ?> />
+                                <?php esc_html_e('Mostra in cima a ogni articolo le sue faccette come chip cliccabili (es. Dove: Algeria · Quando: Primavera)', 'affiliate-link-manager-ai'); ?>
+                            </label>
+                            <p class="description"><?php esc_html_e('Disattivo di default: nessun cambiamento agli articoli finché non lo abiliti.', 'affiliate-link-manager-ai'); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php esc_html_e('Categorie da escludere', 'affiliate-link-manager-ai'); ?></th>
+                        <td>
+                            <div style="max-height:220px;overflow:auto;border:1px solid #d0d5dd;border-radius:4px;padding:10px 12px;max-width:420px;">
+                                <?php foreach ($categories as $category) : ?>
+                                    <label style="display:block;margin-bottom:4px;">
+                                        <input type="checkbox" name="alma_trip_finder_excluded[]" value="<?php echo esc_attr((string) $category->term_id); ?>" <?php checked(in_array((int) $category->term_id, $excluded, true)); ?> />
+                                        <?php echo esc_html($category->name); ?> <span style="color:#888;">(<?php echo esc_html((string) $category->count); ?>)</span>
+                                    </label>
+                                <?php endforeach; ?>
+                            </div>
+                            <p class="description"><?php esc_html_e('Gli articoli in queste categorie non compaiono nei risultati né nei contatori.', 'affiliate-link-manager-ai'); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="<?php echo esc_attr(self::OPTION_PER_PAGE); ?>"><?php esc_html_e('Articoli per pagina', 'affiliate-link-manager-ai'); ?></label></th>
+                        <td>
+                            <input type="number" min="1" max="<?php echo esc_attr((string) self::MAX_PER_PAGE); ?>" name="<?php echo esc_attr(self::OPTION_PER_PAGE); ?>" id="<?php echo esc_attr(self::OPTION_PER_PAGE); ?>" value="<?php echo esc_attr((string) absint(get_option(self::OPTION_PER_PAGE, 12))); ?>" class="small-text" />
+                            <p class="description"><?php esc_html_e('Default dello shortcode (sovrascrivibile con per_page). Il colore accento dei componenti si imposta in Mappa Geografica → Colore accento.', 'affiliate-link-manager-ai'); ?></p>
+                        </td>
+                    </tr>
+                </table>
+                <?php submit_button(__('Salva impostazioni', 'affiliate-link-manager-ai'), 'primary', 'alma_trip_finder_save'); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    private function get_all_post_taxonomies() {
+        $taxonomies = array();
+        foreach (get_object_taxonomies('post', 'objects') as $slug => $taxonomy) {
+            if ($taxonomy->public && $slug !== 'post_format') {
+                $taxonomies[$slug] = $taxonomy;
+            }
+        }
+        return $taxonomies;
+    }
+}


### PR DESCRIPTION
## Blocco 1 — Integrazione con il tema (BeTheme)

- **Colore accento configurabile** (Mappa Geografica → Colore accento, default `#2271b1` retrocompatibile): pulsanti ed evidenziazioni di popup mappa, pagina elenco articoli e Trova Viaggio si allineano alla palette del tema (es. `#2E8CCB` per sothra.it).
- **Classi CSS stabili** su tutti gli elementi del popup mappa (`alma-geo-popup-title/recommended/articles/article/button`) personalizzabili dal Custom CSS di BeTheme, come già avviene per gli altri componenti ALMA.
- Card con **istruzioni Muffin Builder** nelle impostazioni della mappa (sezione full-width + shortcode).

## Blocco 2 — Trova il tuo viaggio (ricerca a faccette combinate)

- **Nuovo shortcode `[alma_trip_finder per_page="12" taxonomies="slug1,slug2"]`**: una select per ogni tassonomia configurata (su sothra.it: Dove, Come, Cosa, Perché, Quando, Durata) combinabili in AND — l'utente incrocia più dimensioni insieme invece di navigarne una alla volta.
- **Contatori a faccette**: ogni opzione mostra quanti articoli restano scegliendola, calcolati sulla selezione corrente delle altre faccette; opzioni a 0 risultati disabilitate. Tassonomie gerarchiche indentate; un articolo taggato sulla foglia (Salento) conta anche per gli antenati (Puglia, Italia) senza doppi conteggi. Cache 10 minuti invalidata al salvataggio degli articoli.
- **AJAX con fallback no-JS**: risultati e contatori si aggiornano senza ricaricare la pagina, URL condivisibile (`?alma_f[dove]=…`); senza JavaScript il form GET si invia normalmente. Griglia con miniature, chip filtri attivi rimovibili, paginazione.
- **Pagina impostazioni "Trova Viaggio"**: tassonomie faccetta (tutte le tassonomie pubbliche dei post, incluse le custom), pagina che ospita lo shortcode, categorie escluse, articoli per pagina.
- **Chip faccette negli articoli (opt-in, default disattivo)**: in cima all'articolo le sue faccette come chip verso la pagina Trova Viaggio pre-filtrata (fallback: archivio del termine). Gli archivi tassonomia restano invariati (SEO intatta).

## Retrocompatibilità

- Nessuna opzione/API rimossa; accento default invariato; chip disattive finché non abilitate; endpoint AJAX pubblici in sola lettura su contenuti pubblicati.

## Test

- `php -l` e `node --check` su tutti i file modificati.
- Test standalone della logica pura `aggregate_hierarchical_counts` (12/12 PASS): propagazione agli antenati, niente doppi conteggi padre+figlio, somma su rami diversi, cicli nei parent gestiti, parent mancanti, input vuoto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_