### PR TITLE
Dashboard strategica: snapshot in background, trend click, gap geografici, consigli AI (v2.54.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.54.0 - 2026-07-04
+
+### Dashboard strategica — snapshot in background, trend, gap geografici, consigli AI
+- **Nessuna query pesante al rendering**: tutte le elaborazioni (trend, top, gap geografici) girano **una volta al giorno via WP-Cron** (~03:30, con lock anti-concorrenza) e il risultato è salvato in uno snapshot; la Dashboard legge solo lo snapshot. Pulsante "Aggiorna ora" per ricostruirlo su richiesta; data/durata dell'ultima elaborazione sempre visibili.
+- **Andamento click con grafici** (Chart.js): per giorno (30 giorni, barre), per settimana (26) e per mese (12, linea), con selettore del periodo. KPI 7/30/180 giorni con **confronto sul periodo precedente** (variazione % verde/rossa).
+- **Top Link migliorato**: classifica per click negli **ultimi 30 giorni** (non più solo lo storico cumulato) con tipologia link e click storici a confronto.
+- **Nuovo Top Articoli**: gli articoli che generano più click sui link affiliati che contengono. Il tracking ora registra il **post di provenienza** del click (nuova colonna `post_id` in `alma_analytics`, migrazione automatica; il frontend invia l'URL della pagina corrente — il solo referrer indicava la pagina precedente). I click storici restano validi ma senza attribuzione articolo.
+- **Copertura geografica strategica**: località più cliccate (90 giorni); località **con link affiliati ma senza click** (offerta che non produce, con conteggio link e articoli); località **con articoli ma senza link affiliati** (contenuto non monetizzato). KPI "link senza click negli ultimi 90 giorni".
+- **Consigli strategici AI su richiesta**: il riepilogo aggregato dello snapshot (nessun dato personale: IP e user agent non lasciano il sito) viene inviato al modello OpenAI configurato che restituisce 5 raccomandazioni prioritizzate con motivazione sui numeri; risultato salvato con data, modello e costo stimato. Mai chiamate automatiche.
+- Retrocompatibilità: gli endpoint AJAX esistenti della dashboard restano invariati; il cron viene rimosso alla disattivazione del plugin.
+- Versione plugin aggiornata a `2.54.0`.
+
 ## 2.53.0 - 2026-07-03
 
 ### Trova il tuo viaggio (ricerca a faccette) e integrazione con il tema (BeTheme)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## 2.54.0 - 2026-07-04
+
+### Dashboard strategica — snapshot in background, trend, gap geografici, consigli AI
+- Le query pesanti girano una volta al giorno via WP-Cron (snapshot con lock); la Dashboard legge solo lo snapshot — zero impatto sul rendering. Pulsante "Aggiorna ora".
+- Grafici andamento click per giorno (30gg), settimana (26) e mese (12); KPI 7/30/180 giorni con variazione % sul periodo precedente.
+- Top Link sugli ultimi 30 giorni (con tipologia e storico) e nuovo Top Articoli per click affiliati: il tracking registra ora il post di provenienza del click (colonna `post_id`, migrazione automatica).
+- Copertura geografica: località più cliccate, località con link ma senza click (90gg), località con articoli ma senza link affiliati.
+- Consigli strategici AI su richiesta dal riepilogo aggregato dello snapshot (5 raccomandazioni prioritizzate, costo stimato visibile, mai in automatico).
+- Versione plugin aggiornata a `2.54.0`.
+
 ## 2.53.0 - 2026-07-03
 
 ### Trova il tuo viaggio (ricerca a faccette) e integrazione con il tema (BeTheme)

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.53.0
+ * Version: 2.54.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.53.0');
+define('ALMA_VERSION', '2.54.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -25,6 +25,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-logger.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-utils.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-content-analysis-ai.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-dashboard-stats.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-dashboard-insights.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-openai-service.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-usage-logger.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-widget-ai-rewriter.php';
@@ -153,6 +154,7 @@ class AffiliateManagerAI {
         $this->geo_map->init();
         $this->trip_finder = new ALMA_Trip_Finder();
         $this->trip_finder->init();
+        ALMA_Dashboard_Insights::init();
         add_action('init', array($this, 'init'));
         add_action('widgets_init', array('ALMA_Contextual_Affiliate_Widget', 'register_widget'));
         // Registrato qui (prima che `widgets_init` scatti) perché ALMA_Shortcodes::init()
@@ -337,8 +339,15 @@ class AffiliateManagerAI {
             }
         }
 
+        // Post di provenienza del click: il frontend invia l'URL della pagina
+        // corrente (page_url); il referrer da solo indica la pagina PRECEDENTE
+        // e non permette di attribuire il click all'articolo giusto.
+        $page_url = isset($_POST['page_url']) ? esc_url_raw(wp_unslash($_POST['page_url'])) : '';
+        $source_post_id = $page_url !== '' ? absint(url_to_postid($page_url)) : 0;
+
         $inserted = $wpdb->insert($table_name, array(
             'link_id' => $link_id,
+            'post_id' => $source_post_id,
             'click_time' => current_time('mysql'),
             'user_ip' => $user_ip,
             'user_agent' => $user_agent,
@@ -1231,37 +1240,198 @@ class AffiliateManagerAI {
     /**
      * Render Dashboard Page
      */
+    /**
+     * Dashboard snapshot-driven: legge SOLO lo snapshot precalcolato dal cron
+     * giornaliero (ALMA_Dashboard_Insights) — nessuna query pesante durante
+     * il rendering della pagina.
+     */
     public function render_dashboard_page() {
         if (!current_user_can('manage_options')) {
             wp_die(__('Non hai i permessi per accedere a questa pagina.'));
         }
+        $snapshot = ALMA_Dashboard_Insights::get_snapshot();
+        $advice = ALMA_Dashboard_Insights::get_advice();
         ?>
         <div class="wrap">
             <h1><?php _e('Dashboard Link - Affiliate Link Manager', 'affiliate-link-manager-ai'); ?></h1>
-            <p style="font-size:14px;color:#666;">Versione <?php echo esc_html(ALMA_VERSION); ?></p>
-            <div id="alma-dashboard-root"><p><?php _e('Caricamento statistiche dashboard…', 'affiliate-link-manager-ai'); ?></p></div>
+            <p style="font-size:13px;color:#666;margin-top:2px;">
+                <?php printf(esc_html__('Versione %s', 'affiliate-link-manager-ai'), esc_html(ALMA_VERSION)); ?>
+                <?php if ($snapshot) : ?>
+                    · <?php printf(esc_html__('Dati aggiornati al %s (elaborazione %d ms, ricostruiti ogni notte)', 'affiliate-link-manager-ai'), esc_html($snapshot['generated_at']), (int) $snapshot['duration_ms']); ?>
+                <?php endif; ?>
+                · <button type="button" class="button button-small" id="alma-insights-rebuild"><?php esc_html_e('Aggiorna ora', 'affiliate-link-manager-ai'); ?></button>
+                <span id="alma-insights-rebuild-feedback" style="color:#2271b1;"></span>
+            </p>
+
+            <?php if (!$snapshot) : ?>
+                <div class="notice notice-info"><p><?php esc_html_e('Nessuno snapshot ancora disponibile: premi "Aggiorna ora" per generare i dati (poi verranno ricostruiti automaticamente ogni notte).', 'affiliate-link-manager-ai'); ?></p></div>
+            <?php else : ?>
+
+                <?php
+                $kpis = array(
+                    '7' => __('Click ultimi 7 giorni', 'affiliate-link-manager-ai'),
+                    '30' => __('Click ultimi 30 giorni', 'affiliate-link-manager-ai'),
+                    '180' => __('Click ultimi 180 giorni', 'affiliate-link-manager-ai'),
+                );
+                ?>
+                <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:16px;margin:16px 0;">
+                    <?php foreach ($kpis as $key => $label) :
+                        $period = $snapshot['periods'][$key] ?? array('clicks' => 0, 'previous' => 0, 'delta_pct' => null);
+                        $delta = $period['delta_pct'];
+                        $delta_color = $delta === null ? '#666' : ($delta >= 0 ? '#1a7f37' : '#d63638');
+                        $delta_text = $delta === null ? __('n/d', 'affiliate-link-manager-ai') : (($delta >= 0 ? '▲ +' : '▼ ') . $delta . '%');
+                        ?>
+                        <div class="postbox" style="margin:0;"><div class="inside">
+                            <h3 style="margin:4px 0 8px;"><?php echo esc_html($label); ?></h3>
+                            <div style="font-size:28px;font-weight:700;line-height:1;"><?php echo esc_html(number_format_i18n((int) $period['clicks'])); ?></div>
+                            <p style="margin:8px 0 0;color:<?php echo esc_attr($delta_color); ?>;font-weight:600;">
+                                <?php echo esc_html($delta_text); ?>
+                                <span style="color:#888;font-weight:400;"><?php printf(esc_html__('vs %s precedenti', 'affiliate-link-manager-ai'), esc_html(number_format_i18n((int) $period['previous']))); ?></span>
+                            </p>
+                        </div></div>
+                    <?php endforeach; ?>
+                    <div class="postbox" style="margin:0;"><div class="inside">
+                        <h3 style="margin:4px 0 8px;"><?php esc_html_e('Link senza click (90 giorni)', 'affiliate-link-manager-ai'); ?></h3>
+                        <div style="font-size:28px;font-weight:700;line-height:1;"><?php echo esc_html(number_format_i18n((int) ($snapshot['links_no_clicks_90d'] ?? 0))); ?></div>
+                        <p style="margin:8px 0 0;color:#888;"><?php printf(esc_html__('su %s link pubblicati', 'affiliate-link-manager-ai'), esc_html(number_format_i18n((int) ($snapshot['links_total'] ?? 0)))); ?></p>
+                    </div></div>
+                </div>
+
+                <div class="postbox"><div class="inside">
+                    <h3 style="display:flex;align-items:center;gap:14px;flex-wrap:wrap;">📈 <?php esc_html_e('Andamento click', 'affiliate-link-manager-ai'); ?>
+                        <span>
+                            <button type="button" class="button button-small alma-insights-range" data-range="daily"><?php esc_html_e('Giorno (30gg)', 'affiliate-link-manager-ai'); ?></button>
+                            <button type="button" class="button button-small alma-insights-range" data-range="weekly"><?php esc_html_e('Settimana (26)', 'affiliate-link-manager-ai'); ?></button>
+                            <button type="button" class="button button-small alma-insights-range" data-range="monthly"><?php esc_html_e('Mese (12)', 'affiliate-link-manager-ai'); ?></button>
+                        </span>
+                    </h3>
+                    <div style="height:320px;"><canvas id="alma-insights-chart"></canvas></div>
+                </div></div>
+
+                <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px;margin-top:16px;">
+                    <div class="postbox" style="margin:0;"><div class="inside">
+                        <h3>🏆 <?php esc_html_e('Top Link (ultimi 30 giorni)', 'affiliate-link-manager-ai'); ?></h3>
+                        <?php if (empty($snapshot['top_links'])) : ?>
+                            <p><?php esc_html_e('Nessun click registrato negli ultimi 30 giorni.', 'affiliate-link-manager-ai'); ?></p>
+                        <?php else : ?>
+                            <table class="widefat striped">
+                                <thead><tr>
+                                    <th><?php esc_html_e('Link', 'affiliate-link-manager-ai'); ?></th>
+                                    <th><?php esc_html_e('Tipologia', 'affiliate-link-manager-ai'); ?></th>
+                                    <th style="text-align:right;"><?php esc_html_e('Click 30gg', 'affiliate-link-manager-ai'); ?></th>
+                                    <th style="text-align:right;"><?php esc_html_e('Storico', 'affiliate-link-manager-ai'); ?></th>
+                                </tr></thead>
+                                <tbody>
+                                <?php foreach ($snapshot['top_links'] as $link) : ?>
+                                    <tr>
+                                        <td><a href="<?php echo esc_url($link['edit_url']); ?>"><?php echo esc_html($link['title']); ?></a></td>
+                                        <td><?php echo esc_html($link['types']); ?></td>
+                                        <td style="text-align:right;font-weight:600;"><?php echo esc_html(number_format_i18n($link['clicks_period'])); ?></td>
+                                        <td style="text-align:right;color:#666;"><?php echo esc_html(number_format_i18n($link['clicks_total'])); ?></td>
+                                    </tr>
+                                <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                        <?php endif; ?>
+                    </div></div>
+
+                    <div class="postbox" style="margin:0;"><div class="inside">
+                        <h3>📰 <?php esc_html_e('Top Articoli per click affiliati', 'affiliate-link-manager-ai'); ?></h3>
+                        <?php
+                        $top_articles = !empty($snapshot['top_articles_30d']) ? $snapshot['top_articles_30d'] : ($snapshot['top_articles_all'] ?? array());
+                        $articles_label = !empty($snapshot['top_articles_30d']) ? __('ultimi 30 giorni', 'affiliate-link-manager-ai') : __('da inizio tracciamento', 'affiliate-link-manager-ai');
+                        ?>
+                        <?php if (empty($top_articles)) : ?>
+                            <p><?php esc_html_e('Ancora nessun dato: l\'articolo di provenienza viene registrato per i click ricevuti a partire da questa versione. I dati compariranno con i prossimi click.', 'affiliate-link-manager-ai'); ?></p>
+                        <?php else : ?>
+                            <p class="description" style="margin-top:0;"><?php echo esc_html($articles_label); ?></p>
+                            <table class="widefat striped">
+                                <thead><tr>
+                                    <th><?php esc_html_e('Articolo', 'affiliate-link-manager-ai'); ?></th>
+                                    <th style="text-align:right;"><?php esc_html_e('Click affiliati', 'affiliate-link-manager-ai'); ?></th>
+                                    <th></th>
+                                </tr></thead>
+                                <tbody>
+                                <?php foreach ($top_articles as $article) : ?>
+                                    <tr>
+                                        <td><a href="<?php echo esc_url($article['edit_url']); ?>"><?php echo esc_html($article['title']); ?></a></td>
+                                        <td style="text-align:right;font-weight:600;"><?php echo esc_html(number_format_i18n($article['clicks'])); ?></td>
+                                        <td><a href="<?php echo esc_url($article['url']); ?>" target="_blank" rel="noopener"><?php esc_html_e('Vedi', 'affiliate-link-manager-ai'); ?></a></td>
+                                    </tr>
+                                <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                        <?php endif; ?>
+                    </div></div>
+                </div>
+
+                <h2 style="margin-top:24px;">🌍 <?php esc_html_e('Copertura geografica', 'affiliate-link-manager-ai'); ?></h2>
+                <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px;">
+                    <div class="postbox" style="margin:0;"><div class="inside">
+                        <h3>🔥 <?php esc_html_e('Località più cliccate (90gg)', 'affiliate-link-manager-ai'); ?></h3>
+                        <?php if (empty($snapshot['geo_top'])) : ?>
+                            <p><?php esc_html_e('Nessun click su link geolocalizzati nel periodo.', 'affiliate-link-manager-ai'); ?></p>
+                        <?php else : ?>
+                            <ul style="margin:0;">
+                                <?php foreach ($snapshot['geo_top'] as $geo) : ?>
+                                    <li>📍 <?php echo esc_html($geo['name']); ?><?php echo $geo['country'] !== '' ? esc_html(' (' . $geo['country'] . ')') : ''; ?> — <strong><?php echo esc_html(number_format_i18n($geo['clicks'])); ?></strong> <?php esc_html_e('click', 'affiliate-link-manager-ai'); ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                    </div></div>
+
+                    <div class="postbox" style="margin:0;"><div class="inside">
+                        <h3>🧊 <?php esc_html_e('Con link ma SENZA click (90gg)', 'affiliate-link-manager-ai'); ?></h3>
+                        <p class="description" style="margin-top:0;"><?php esc_html_e('L\'offerta esiste ma non produce: rivedi il posizionamento dei link o rafforza gli articoli di queste aree.', 'affiliate-link-manager-ai'); ?></p>
+                        <?php if (empty($snapshot['geo_unused'])) : ?>
+                            <p><?php esc_html_e('Nessuna: tutte le località con link hanno ricevuto click. 🎉', 'affiliate-link-manager-ai'); ?></p>
+                        <?php else : ?>
+                            <ul style="margin:0;">
+                                <?php foreach ($snapshot['geo_unused'] as $geo) : ?>
+                                    <li>📍 <?php echo esc_html($geo['name']); ?><?php echo $geo['country'] !== '' ? esc_html(' (' . $geo['country'] . ')') : ''; ?> — <?php printf(esc_html__('%1$s link, %2$s articoli', 'affiliate-link-manager-ai'), esc_html(number_format_i18n($geo['links'])), esc_html(number_format_i18n((int) ($geo['posts'] ?? 0)))); ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                    </div></div>
+
+                    <div class="postbox" style="margin:0;"><div class="inside">
+                        <h3>💡 <?php esc_html_e('Articoli SENZA link affiliati', 'affiliate-link-manager-ai'); ?></h3>
+                        <p class="description" style="margin-top:0;"><?php esc_html_e('Contenuto senza monetizzazione: importa o associa link affiliati per queste località.', 'affiliate-link-manager-ai'); ?></p>
+                        <?php if (empty($snapshot['geo_no_links'])) : ?>
+                            <p><?php esc_html_e('Nessuna: tutte le località con articoli hanno link affiliati. 🎉', 'affiliate-link-manager-ai'); ?></p>
+                        <?php else : ?>
+                            <ul style="margin:0;">
+                                <?php foreach ($snapshot['geo_no_links'] as $geo) : ?>
+                                    <li>📍 <?php echo esc_html($geo['name']); ?><?php echo $geo['country'] !== '' ? esc_html(' (' . $geo['country'] . ')') : ''; ?> — <?php printf(esc_html__('%s articoli', 'affiliate-link-manager-ai'), esc_html(number_format_i18n($geo['posts']))); ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                    </div></div>
+                </div>
+
+                <h2 style="margin-top:24px;">🤖 <?php esc_html_e('Consigli strategici AI', 'affiliate-link-manager-ai'); ?></h2>
+                <div class="postbox"><div class="inside">
+                    <p>
+                        <button type="button" class="button button-primary" id="alma-insights-ai"><?php esc_html_e('Genera consigli AI', 'affiliate-link-manager-ai'); ?></button>
+                        <span id="alma-insights-ai-feedback" style="margin-left:8px;color:#2271b1;"></span>
+                    </p>
+                    <p class="description"><?php esc_html_e('Invia il riepilogo aggregato dello snapshot (nessun dato personale) al modello OpenAI configurato e restituisce 5 raccomandazioni prioritizzate. Solo su richiesta, mai in automatico.', 'affiliate-link-manager-ai'); ?></p>
+                    <pre id="alma-insights-ai-text" style="white-space:pre-wrap;font-family:inherit;font-size:14px;background:#f6f7f7;border:1px solid #dcdcde;border-radius:6px;padding:14px;<?php echo $advice ? '' : 'display:none;'; ?>"><?php echo $advice ? esc_html($advice['text']) : ''; ?></pre>
+                    <p class="description" id="alma-insights-ai-meta"><?php
+                        if ($advice) {
+                            $meta_parts = array($advice['generated_at']);
+                            if (!empty($advice['model'])) { $meta_parts[] = $advice['model']; }
+                            if (!empty($advice['estimated_cost'])) { $meta_parts[] = '~$' . number_format((float) $advice['estimated_cost'], 4); }
+                            echo esc_html(implode(' · ', $meta_parts));
+                        }
+                    ?></p>
+                </div></div>
+
+            <?php endif; ?>
         </div>
-        <script>
-        jQuery(function($){
-            var nonce = '<?php echo esc_js(wp_create_nonce('alma_admin_nonce')); ?>';
-            $.post(ajaxurl,{action:'alma_get_dashboard_data',nonce:nonce}, function(resp){
-                if(!resp || !resp.success){ $('#alma-dashboard-root').html('<div class="notice notice-error"><p>Errore caricamento dashboard.</p></div>'); return; }
-                var d=resp.data;
-                $('#alma-dashboard-root').html('<div style="display:grid;grid-template-columns:repeat(3,1fr);gap:20px;"><div class="postbox"><div class="inside"><h3>🔗 Link Attivi</h3><strong>'+d.total_links+'</strong></div></div><div class="postbox"><div class="inside"><h3>📊 Click Totali</h3><strong>'+d.total_clicks+'</strong></div></div><div class="postbox"><div class="inside"><h3>🎯 CTR Medio</h3><strong>'+d.avg_ctr+'%</strong></div></div></div><div class="postbox"><div class="inside"><h3>🏆 Top Link</h3><ul id="alma-top"></ul></div></div><div class="postbox"><div class="inside"><h3>📈 Click mensili</h3><canvas id="alma-clicks-monthly"></canvas></div></div>');
-                // Titolo e URL inseriti come testo/attributo, mai come HTML: il titolo
-                // del link è modificabile da qualunque utente con edit_posts.
-                (d.top_links||[]).forEach(function(l){
-                    var $a = $('<a></a>').attr('href', l.edit_url).text(l.title);
-                    $('#alma-top').append($('<li></li>').append($a).append(document.createTextNode(' ('+parseInt(l.click_count,10)+')')));
-                });
-                $.post(ajaxurl,{action:'alma_get_chart_data',nonce:nonce,metric:'clicks',range:'monthly'}, function(c){
-                    if(c && c.success && window.Chart){new Chart(document.getElementById('alma-clicks-monthly'),{type:'line',data:{labels:c.data.labels,datasets:[{label:'Click Mensili',data:c.data.data,borderColor:'#2271b1'}]}});}
-                });
-            });
-        });
-        </script>
         <?php
-    }    
+    }
+
     /**
      * Ricorda per pochi secondi qualunque salvataggio editor standard di un Link Affiliato.
      *
@@ -4177,6 +4347,7 @@ class AffiliateManagerAI {
         // Rimuovi cron jobs
         wp_clear_scheduled_hook('alma_daily_optimization');
         ALMA_Geo_Geocoding_Queue::unschedule();
+        ALMA_Dashboard_Insights::unschedule();
         $this->clear_deprecated_trend_cron_events();
         flush_rewrite_rules();
     }
@@ -4250,6 +4421,7 @@ class AffiliateManagerAI {
         $sql = "CREATE TABLE $table_name (
             id mediumint(9) NOT NULL AUTO_INCREMENT,
             link_id mediumint(9) NOT NULL,
+            post_id bigint(20) unsigned DEFAULT 0 NOT NULL,
             click_time datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
             user_ip varchar(45) DEFAULT '' NOT NULL,
             user_agent text DEFAULT '' NOT NULL,
@@ -4259,7 +4431,8 @@ class AffiliateManagerAI {
             KEY link_id (link_id),
             KEY click_time (click_time),
             KEY link_time (link_id, click_time),
-            KEY source_time (source, click_time)
+            KEY source_time (source, click_time),
+            KEY post_time (post_id, click_time)
         ) $charset_collate;";
         
         require_once(ABSPATH . 'wp-admin/includes/upgrade.php');

--- a/assets/dashboard-insights.js
+++ b/assets/dashboard-insights.js
@@ -1,0 +1,130 @@
+/**
+ * Affiliate Link Manager AI - Insight strategici della Dashboard
+ *
+ * Grafico trend click (giorno/settimana/mese) con Chart.js sui dati dello
+ * snapshot precalcolato (nessuna query al caricamento); pulsanti
+ * "Aggiorna ora" (ricostruzione snapshot) e "Genera consigli AI".
+ */
+(function () {
+    'use strict';
+
+    function cfg() {
+        return window.almaInsights || {};
+    }
+
+    var chart = null;
+
+    function renderChart(range) {
+        var canvas = document.getElementById('alma-insights-chart');
+        if (!canvas || typeof window.Chart === 'undefined') { return; }
+        var series = (cfg().series || {})[range] || { labels: [], data: [] };
+        if (chart) { chart.destroy(); }
+        chart = new window.Chart(canvas, {
+            type: range === 'daily' ? 'bar' : 'line',
+            data: {
+                labels: series.labels,
+                datasets: [{
+                    label: (cfg().strings || {}).clicks || 'Click',
+                    data: series.data,
+                    borderColor: '#2271b1',
+                    backgroundColor: range === 'daily' ? 'rgba(34,113,177,0.55)' : 'rgba(34,113,177,0.12)',
+                    fill: range !== 'daily',
+                    tension: 0.25,
+                    pointRadius: 2
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { display: false } },
+                scales: { y: { beginAtZero: true, ticks: { precision: 0 } } }
+            }
+        });
+    }
+
+    function setActiveButton(range) {
+        var buttons = document.querySelectorAll('.alma-insights-range');
+        Array.prototype.forEach.call(buttons, function (button) {
+            button.classList.toggle('button-primary', button.getAttribute('data-range') === range);
+        });
+    }
+
+    function post(action, feedbackEl, onSuccess) {
+        var params = new URLSearchParams();
+        params.set('action', action);
+        params.set('nonce', cfg().nonce || '');
+        return fetch(cfg().ajaxUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: params.toString()
+        }).then(function (r) { return r.json(); }).then(function (response) {
+            if (response && response.success) {
+                onSuccess(response.data || {});
+            } else {
+                var message = response && response.data && response.data.message ? response.data.message : (cfg().strings || {}).error;
+                if (feedbackEl) { feedbackEl.textContent = message; }
+            }
+        }).catch(function () {
+            if (feedbackEl) { feedbackEl.textContent = (cfg().strings || {}).error; }
+        });
+    }
+
+    function boot() {
+        renderChart('daily');
+        setActiveButton('daily');
+
+        document.addEventListener('click', function (event) {
+            var target = event.target;
+
+            if (target.classList && target.classList.contains('alma-insights-range')) {
+                event.preventDefault();
+                var range = target.getAttribute('data-range');
+                renderChart(range);
+                setActiveButton(range);
+                return;
+            }
+
+            if (target.id === 'alma-insights-rebuild') {
+                event.preventDefault();
+                var feedback = document.getElementById('alma-insights-rebuild-feedback');
+                if (feedback) { feedback.textContent = (cfg().strings || {}).rebuilding; }
+                target.disabled = true;
+                post('alma_insights_rebuild', feedback, function () {
+                    if (feedback) { feedback.textContent = (cfg().strings || {}).rebuilt; }
+                    window.location.reload();
+                }).then(function () { target.disabled = false; });
+                return;
+            }
+
+            if (target.id === 'alma-insights-ai') {
+                event.preventDefault();
+                var aiFeedback = document.getElementById('alma-insights-ai-feedback');
+                var aiBox = document.getElementById('alma-insights-ai-text');
+                if (aiFeedback) { aiFeedback.textContent = (cfg().strings || {}).aiWorking; }
+                target.disabled = true;
+                post('alma_insights_ai_advice', aiFeedback, function (data) {
+                    if (aiFeedback) { aiFeedback.textContent = ''; }
+                    if (aiBox) {
+                        aiBox.textContent = data.text || '';
+                        aiBox.style.display = 'block';
+                    }
+                    var meta = document.getElementById('alma-insights-ai-meta');
+                    if (meta) {
+                        var parts = [];
+                        if (data.generated_at) { parts.push(data.generated_at); }
+                        if (data.model) { parts.push(data.model); }
+                        if (data.estimated_cost) { parts.push('~$' + Number(data.estimated_cost).toFixed(4)); }
+                        meta.textContent = parts.join(' · ');
+                    }
+                }).then(function () { target.disabled = false; });
+            }
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', boot);
+    } else {
+        boot();
+    }
+})();

--- a/assets/tracking.js
+++ b/assets/tracking.js
@@ -105,6 +105,9 @@
             nonce: alma_tracking.nonce,
             link_id: linkId,
             referrer: document.referrer || window.location.href,
+            // Pagina corrente: permette di attribuire il click all'articolo
+            // di provenienza (il referrer indica solo la pagina precedente).
+            page_url: window.location.href,
             click_type: clickType,
             source: source,
             timestamp: Date.now()

--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -130,6 +130,16 @@ class ALMA_Assets {
                     '4.4.0',
                     true
                 );
+                if (file_exists(ALMA_PLUGIN_DIR . 'assets/dashboard-insights.js') && class_exists('ALMA_Dashboard_Insights')) {
+                    wp_enqueue_script(
+                        'alma-dashboard-insights',
+                        ALMA_PLUGIN_URL . 'assets/dashboard-insights.js',
+                        array('chart.js'),
+                        ALMA_VERSION,
+                        true
+                    );
+                    wp_localize_script('alma-dashboard-insights', 'almaInsights', ALMA_Dashboard_Insights::get_chart_payload());
+                }
             }
         }
 

--- a/includes/class-dashboard-insights.php
+++ b/includes/class-dashboard-insights.php
@@ -1,0 +1,524 @@
+<?php
+/**
+ * Insight strategici della Dashboard: snapshot precalcolato in background.
+ *
+ * Le query pesanti (trend click, top link/articoli, gap geografici) girano
+ * UNA volta al giorno via WP-Cron (o su richiesta con "Aggiorna ora") e il
+ * risultato viene salvato in un'option: il rendering della Dashboard legge
+ * solo lo snapshot, zero query pesanti a ogni apertura della pagina.
+ *
+ * Contenuto dello snapshot:
+ * - Trend click: per giorno (30gg), per settimana (26), per mese (12).
+ * - Periodi 7/30/180 giorni con confronto sul periodo precedente (delta %).
+ * - Top link per click negli ultimi 30 giorni (+ click totali storici).
+ * - Top articoli per click sui link affiliati che contengono (post_id
+ *   registrato dal tracking a partire dalla v2.54.0).
+ * - Gap geografici: località con link affiliati MA senza click (90gg),
+ *   località con articoli MA senza link affiliati, top località per click.
+ *
+ * "Consigli AI": su richiesta lo snapshot viene riassunto e inviato al
+ * servizio OpenAI già configurato per ottenere raccomandazioni strategiche;
+ * il risultato è salvato con data e costo stimato (mai chiamate automatiche).
+ */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALMA_Dashboard_Insights {
+    const CRON_HOOK = 'alma_dashboard_insights_rebuild';
+    const OPTION_SNAPSHOT = 'alma_dashboard_insights_snapshot';
+    const OPTION_ADVICE = 'alma_dashboard_insights_ai_advice';
+    const LOCK_OPTION = 'alma_dashboard_insights_lock';
+    const LOCK_TTL = 300; // 5 minuti: oltre, il lock è considerato orfano
+    const GEO_CLICK_WINDOW_DAYS = 90;
+
+    public static function init() {
+        add_action('init', array(__CLASS__, 'maybe_schedule_cron'));
+        add_action(self::CRON_HOOK, array(__CLASS__, 'rebuild'));
+        add_action('wp_ajax_alma_insights_rebuild', array(__CLASS__, 'ajax_rebuild'));
+        add_action('wp_ajax_alma_insights_ai_advice', array(__CLASS__, 'ajax_ai_advice'));
+    }
+
+    public static function maybe_schedule_cron() {
+        if (!wp_next_scheduled(self::CRON_HOOK)) {
+            // Prima esecuzione nella notte successiva (~03:30 ora del sito),
+            // poi ogni giorno: i dati sono pronti al mattino.
+            $first = strtotime('tomorrow 03:30', current_time('timestamp'));
+            $first = $first - (current_time('timestamp') - time()); // riporta a UTC
+            wp_schedule_event($first, 'daily', self::CRON_HOOK);
+        }
+    }
+
+    public static function unschedule() {
+        wp_clear_scheduled_hook(self::CRON_HOOK);
+    }
+
+    public static function get_snapshot() {
+        $snapshot = get_option(self::OPTION_SNAPSHOT, null);
+        return is_array($snapshot) ? $snapshot : null;
+    }
+
+    public static function get_advice() {
+        $advice = get_option(self::OPTION_ADVICE, null);
+        return is_array($advice) ? $advice : null;
+    }
+
+    /* ---------------------------------------------------------------------
+     * Ricostruzione snapshot (cron o manuale)
+     * ------------------------------------------------------------------ */
+
+    /**
+     * Lock via add_option atomica con TTL (pattern del geocoding/auto-indexer):
+     * evita ricostruzioni concorrenti cron + "Aggiorna ora".
+     */
+    private static function acquire_lock() {
+        if (add_option(self::LOCK_OPTION, (string) time(), '', 'no')) {
+            return true;
+        }
+        $started = absint(get_option(self::LOCK_OPTION, 0));
+        if ($started > 0 && (time() - $started) > self::LOCK_TTL) {
+            update_option(self::LOCK_OPTION, (string) time(), false);
+            return true;
+        }
+        return false;
+    }
+
+    private static function release_lock() {
+        delete_option(self::LOCK_OPTION);
+    }
+
+    public static function rebuild() {
+        if (!self::acquire_lock()) {
+            return false;
+        }
+        $start = microtime(true);
+        try {
+            $snapshot = array(
+                'clicks_daily' => self::clicks_series_daily(30),
+                'clicks_weekly' => self::clicks_series_weekly(26),
+                'clicks_monthly' => self::clicks_series_monthly(12),
+                'periods' => array(
+                    '7' => self::period_comparison(7),
+                    '30' => self::period_comparison(30),
+                    '180' => self::period_comparison(180),
+                ),
+                'top_links' => self::top_links(10, 30),
+                'top_articles_30d' => self::top_articles(10, 30),
+                'top_articles_all' => self::top_articles(10, 0),
+                'geo_top' => self::geo_top_locations(10, self::GEO_CLICK_WINDOW_DAYS),
+                'geo_unused' => self::geo_unused_locations(15, self::GEO_CLICK_WINDOW_DAYS),
+                'geo_no_links' => self::geo_locations_without_links(15),
+                'links_total' => (int) wp_count_posts('affiliate_link')->publish,
+                'links_no_clicks_90d' => self::links_without_clicks_count(self::GEO_CLICK_WINDOW_DAYS),
+                'generated_at' => current_time('mysql'),
+                'duration_ms' => 0,
+            );
+            $snapshot['duration_ms'] = (int) round((microtime(true) - $start) * 1000);
+            update_option(self::OPTION_SNAPSHOT, $snapshot, false);
+            return true;
+        } finally {
+            self::release_lock();
+        }
+    }
+
+    private static function analytics_table() {
+        global $wpdb;
+        return $wpdb->prefix . 'alma_analytics';
+    }
+
+    /**
+     * Confine temporale in ora del sito (click_time è salvato con
+     * current_time('mysql')).
+     */
+    private static function since($days) {
+        return gmdate('Y-m-d 00:00:00', current_time('timestamp') - $days * DAY_IN_SECONDS);
+    }
+
+    private static function clicks_series_daily($days) {
+        global $wpdb;
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT DATE(click_time) AS bucket, COUNT(*) AS c FROM " . self::analytics_table() . " WHERE click_time >= %s GROUP BY bucket",
+            self::since($days - 1)
+        ), ARRAY_A);
+        $map = array();
+        foreach ((array) $rows as $row) {
+            $map[$row['bucket']] = (int) $row['c'];
+        }
+        $labels = array();
+        $data = array();
+        $now = current_time('timestamp');
+        for ($i = $days - 1; $i >= 0; $i--) {
+            $day = gmdate('Y-m-d', $now - $i * DAY_IN_SECONDS);
+            $labels[] = wp_date('d/m', strtotime($day . ' 12:00:00'));
+            $data[] = isset($map[$day]) ? $map[$day] : 0;
+        }
+        return array('labels' => $labels, 'data' => $data);
+    }
+
+    private static function clicks_series_weekly($weeks) {
+        global $wpdb;
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT YEARWEEK(click_time, 1) AS bucket, COUNT(*) AS c FROM " . self::analytics_table() . " WHERE click_time >= %s GROUP BY bucket",
+            self::since($weeks * 7)
+        ), ARRAY_A);
+        $map = array();
+        foreach ((array) $rows as $row) {
+            $map[(string) $row['bucket']] = (int) $row['c'];
+        }
+        $labels = array();
+        $data = array();
+        $now = current_time('timestamp');
+        for ($i = $weeks - 1; $i >= 0; $i--) {
+            $ts = $now - $i * WEEK_IN_SECONDS;
+            $key = gmdate('oW', $ts); // formato YEARWEEK mode 1 (ISO)
+            $labels[] = wp_date('d/m', strtotime(gmdate('Y-m-d', $ts) . ' 12:00:00'));
+            $data[] = isset($map[$key]) ? $map[$key] : 0;
+        }
+        return array('labels' => $labels, 'data' => $data);
+    }
+
+    private static function clicks_series_monthly($months) {
+        global $wpdb;
+        $now = current_time('timestamp');
+        $start = gmdate('Y-m-01 00:00:00', strtotime('-' . ($months - 1) . ' months', $now));
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT DATE_FORMAT(click_time, '%%Y-%%m') AS bucket, COUNT(*) AS c FROM " . self::analytics_table() . " WHERE click_time >= %s GROUP BY bucket",
+            $start
+        ), ARRAY_A);
+        $map = array();
+        foreach ((array) $rows as $row) {
+            $map[$row['bucket']] = (int) $row['c'];
+        }
+        $labels = array();
+        $data = array();
+        for ($i = $months - 1; $i >= 0; $i--) {
+            $ym = gmdate('Y-m', strtotime("-$i months", $now));
+            $labels[] = wp_date('M y', strtotime($ym . '-01 12:00:00'));
+            $data[] = isset($map[$ym]) ? $map[$ym] : 0;
+        }
+        return array('labels' => $labels, 'data' => $data);
+    }
+
+    /**
+     * Click del periodo vs periodo precedente di pari durata, con delta %.
+     */
+    private static function period_comparison($days) {
+        global $wpdb;
+        $table = self::analytics_table();
+        $current_start = self::since($days);
+        $previous_start = self::since($days * 2);
+        $current = (int) $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM {$table} WHERE click_time >= %s", $current_start
+        ));
+        $previous = (int) $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM {$table} WHERE click_time >= %s AND click_time < %s", $previous_start, $current_start
+        ));
+        $delta = null;
+        if ($previous > 0) {
+            $delta = round((($current - $previous) / $previous) * 100, 1);
+        } elseif ($current > 0) {
+            $delta = 100.0;
+        }
+        return array('clicks' => $current, 'previous' => $previous, 'delta_pct' => $delta);
+    }
+
+    /**
+     * Top link per click nel periodo, con tipologia e click totali storici.
+     */
+    private static function top_links($limit, $days) {
+        global $wpdb;
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT a.link_id, COUNT(*) AS clicks
+             FROM " . self::analytics_table() . " a
+             INNER JOIN {$wpdb->posts} p ON p.ID = a.link_id AND p.post_type = 'affiliate_link' AND p.post_status = 'publish'
+             WHERE a.click_time >= %s
+             GROUP BY a.link_id ORDER BY clicks DESC LIMIT %d",
+            self::since($days), absint($limit)
+        ), ARRAY_A);
+        $links = array();
+        foreach ((array) $rows as $row) {
+            $link_id = (int) $row['link_id'];
+            $types = get_the_terms($link_id, 'link_type');
+            $type_names = array();
+            if (is_array($types)) {
+                foreach ($types as $type) {
+                    $type_names[] = html_entity_decode($type->name, ENT_QUOTES, 'UTF-8');
+                }
+            }
+            $links[] = array(
+                'id' => $link_id,
+                'title' => html_entity_decode(get_the_title($link_id), ENT_QUOTES, 'UTF-8'),
+                'clicks_period' => (int) $row['clicks'],
+                'clicks_total' => (int) (get_post_meta($link_id, '_click_count', true) ?: 0),
+                'types' => implode(', ', $type_names),
+                'edit_url' => get_edit_post_link($link_id, 'raw'),
+            );
+        }
+        return $links;
+    }
+
+    /**
+     * Top articoli per click sui link affiliati che contengono. Usa la colonna
+     * post_id valorizzata dal tracking dalla v2.54.0: i click precedenti non
+     * hanno il dato (post_id = 0) e vengono esclusi.
+     */
+    private static function top_articles($limit, $days) {
+        global $wpdb;
+        $where_time = $days > 0 ? $wpdb->prepare(' AND a.click_time >= %s', self::since($days)) : '';
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT a.post_id, COUNT(*) AS clicks
+             FROM " . self::analytics_table() . " a
+             INNER JOIN {$wpdb->posts} p ON p.ID = a.post_id AND p.post_type IN ('post', 'page') AND p.post_status = 'publish'
+             WHERE a.post_id > 0{$where_time}
+             GROUP BY a.post_id ORDER BY clicks DESC LIMIT %d",
+            absint($limit)
+        ), ARRAY_A);
+        $articles = array();
+        foreach ((array) $rows as $row) {
+            $post_id = (int) $row['post_id'];
+            $articles[] = array(
+                'id' => $post_id,
+                'title' => html_entity_decode(get_the_title($post_id), ENT_QUOTES, 'UTF-8'),
+                'clicks' => (int) $row['clicks'],
+                'url' => get_permalink($post_id),
+                'edit_url' => get_edit_post_link($post_id, 'raw'),
+            );
+        }
+        return $articles;
+    }
+
+    private static function geo_store() {
+        return class_exists('ALMA_Geo_Index_Store') ? new ALMA_Geo_Index_Store() : null;
+    }
+
+    /**
+     * Località più cliccate: click sui link affiliati associati a ciascuna
+     * località nel periodo (un click conta per ogni località del link).
+     */
+    private static function geo_top_locations($limit, $days) {
+        global $wpdb;
+        $store = self::geo_store();
+        if (!$store || !$store->tables_exist()) {
+            return array();
+        }
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT l.canonical_name AS name, l.country, COUNT(*) AS clicks
+             FROM " . self::analytics_table() . " a
+             INNER JOIN {$store->table_content_index()} ci ON ci.object_type = %s AND ci.object_id = a.link_id
+             INNER JOIN {$store->table_locations()} l ON l.id = ci.location_id
+             WHERE a.click_time >= %s
+             GROUP BY l.id ORDER BY clicks DESC LIMIT %d",
+            ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK, self::since($days), absint($limit)
+        ), ARRAY_A);
+        return self::format_geo_rows($rows, 'clicks');
+    }
+
+    /**
+     * Aree geografiche NON utilizzate: località che HANNO link affiliati ma
+     * nessun click nel periodo — dove l'offerta esiste ma non produce.
+     */
+    private static function geo_unused_locations($limit, $days) {
+        global $wpdb;
+        $store = self::geo_store();
+        if (!$store || !$store->tables_exist()) {
+            return array();
+        }
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT l.canonical_name AS name, l.country,
+                    COUNT(DISTINCT ci.object_id) AS links,
+                    (SELECT COUNT(DISTINCT ci3.object_id) FROM {$store->table_content_index()} ci3
+                     INNER JOIN {$wpdb->posts} p3 ON p3.ID = ci3.object_id AND p3.post_type = 'post' AND p3.post_status = 'publish'
+                     WHERE ci3.location_id = l.id AND ci3.object_type = %s) AS posts
+             FROM {$store->table_locations()} l
+             INNER JOIN {$store->table_content_index()} ci ON ci.location_id = l.id AND ci.object_type = %s
+             INNER JOIN {$wpdb->posts} p ON p.ID = ci.object_id AND p.post_type = 'affiliate_link' AND p.post_status = 'publish'
+             WHERE NOT EXISTS (
+                 SELECT 1 FROM " . self::analytics_table() . " a
+                 INNER JOIN {$store->table_content_index()} ci2 ON ci2.object_type = %s AND ci2.object_id = a.link_id
+                 WHERE ci2.location_id = l.id AND a.click_time >= %s
+             )
+             GROUP BY l.id ORDER BY links DESC, posts DESC LIMIT %d",
+            ALMA_Geo_Index_Store::OBJECT_TYPE_POST,
+            ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK,
+            ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK,
+            self::since($days), absint($limit)
+        ), ARRAY_A);
+        return self::format_geo_rows($rows, 'links', 'posts');
+    }
+
+    /**
+     * Opportunità: località con articoli pubblicati ma NESSUN link affiliato
+     * associato — contenuto senza monetizzazione.
+     */
+    private static function geo_locations_without_links($limit) {
+        global $wpdb;
+        $store = self::geo_store();
+        if (!$store || !$store->tables_exist()) {
+            return array();
+        }
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT l.canonical_name AS name, l.country, COUNT(DISTINCT ci.object_id) AS posts
+             FROM {$store->table_locations()} l
+             INNER JOIN {$store->table_content_index()} ci ON ci.location_id = l.id AND ci.object_type = %s
+             INNER JOIN {$wpdb->posts} p ON p.ID = ci.object_id AND p.post_type = 'post' AND p.post_status = 'publish'
+             WHERE NOT EXISTS (
+                 SELECT 1 FROM {$store->table_content_index()} ci2
+                 WHERE ci2.location_id = l.id AND ci2.object_type = %s
+             )
+             GROUP BY l.id ORDER BY posts DESC LIMIT %d",
+            ALMA_Geo_Index_Store::OBJECT_TYPE_POST,
+            ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK,
+            absint($limit)
+        ), ARRAY_A);
+        return self::format_geo_rows($rows, 'posts');
+    }
+
+    private static function format_geo_rows($rows, $metric_key, $secondary_key = null) {
+        $out = array();
+        foreach ((array) $rows as $row) {
+            $entry = array(
+                'name' => html_entity_decode(sanitize_text_field($row['name']), ENT_QUOTES, 'UTF-8'),
+                'country' => sanitize_text_field((string) ($row['country'] ?? '')),
+                $metric_key => (int) $row[$metric_key],
+            );
+            if ($secondary_key !== null && isset($row[$secondary_key])) {
+                $entry[$secondary_key] = (int) $row[$secondary_key];
+            }
+            $out[] = $entry;
+        }
+        return $out;
+    }
+
+    private static function links_without_clicks_count($days) {
+        global $wpdb;
+        return (int) $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM {$wpdb->posts} p
+             WHERE p.post_type = 'affiliate_link' AND p.post_status = 'publish'
+             AND NOT EXISTS (SELECT 1 FROM " . self::analytics_table() . " a WHERE a.link_id = p.ID AND a.click_time >= %s)",
+            self::since($days)
+        ));
+    }
+
+    /* ---------------------------------------------------------------------
+     * AJAX admin
+     * ------------------------------------------------------------------ */
+
+    private static function verify_ajax_request() {
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(array('message' => __('Permessi insufficienti.', 'affiliate-link-manager-ai')), 403);
+        }
+        if (!check_ajax_referer('alma_insights', 'nonce', false)) {
+            wp_send_json_error(array('message' => __('Nonce non valido.', 'affiliate-link-manager-ai')), 400);
+        }
+    }
+
+    public static function ajax_rebuild() {
+        self::verify_ajax_request();
+        if (!self::rebuild()) {
+            wp_send_json_error(array('message' => __('Ricostruzione già in corso, riprova tra qualche minuto.', 'affiliate-link-manager-ai')), 409);
+        }
+        $snapshot = self::get_snapshot();
+        wp_send_json_success(array(
+            'generated_at' => $snapshot['generated_at'] ?? '',
+            'duration_ms' => $snapshot['duration_ms'] ?? 0,
+        ));
+    }
+
+    public static function ajax_ai_advice() {
+        self::verify_ajax_request();
+        $snapshot = self::get_snapshot();
+        if (!$snapshot) {
+            wp_send_json_error(array('message' => __('Genera prima lo snapshot dei dati (Aggiorna ora).', 'affiliate-link-manager-ai')), 400);
+        }
+
+        $result = ALMA_OpenAI_Service::request(array(
+            'system_prompt' => 'Sei un consulente strategico di affiliate marketing per un blog di viaggi italiano. '
+                . 'Ricevi le statistiche aggregate dei click sui link affiliati e i gap geografici. '
+                . 'Rispondi in italiano, conciso e operativo.',
+            'user_prompt' => self::build_advice_prompt($snapshot),
+            'max_output_tokens' => 900,
+            'temperature' => 0.4,
+            'timeout' => 60,
+        ));
+
+        if (empty($result['success'])) {
+            wp_send_json_error(array('message' => sanitize_text_field($result['error'] ?? __('Errore AI', 'affiliate-link-manager-ai'))), 500);
+        }
+
+        $advice = array(
+            'text' => sanitize_textarea_field((string) $result['response']),
+            'generated_at' => current_time('mysql'),
+            'model' => sanitize_text_field((string) ($result['model'] ?? '')),
+            'estimated_cost' => isset($result['estimated_cost']) && $result['estimated_cost'] !== null ? (float) $result['estimated_cost'] : null,
+        );
+        update_option(self::OPTION_ADVICE, $advice, false);
+        wp_send_json_success($advice);
+    }
+
+    /**
+     * Riassunto compatto dello snapshot per il prompt AI (solo aggregati,
+     * nessun dato personale: IP e user agent non lasciano mai il sito).
+     */
+    public static function build_advice_prompt($snapshot) {
+        $lines = array();
+        $lines[] = 'DATI AGGREGATI (generati il ' . ($snapshot['generated_at'] ?? '?') . '):';
+        foreach (array('7' => '7 giorni', '30' => '30 giorni', '180' => '180 giorni') as $key => $label) {
+            $period = $snapshot['periods'][$key] ?? null;
+            if ($period) {
+                $delta = $period['delta_pct'] === null ? 'n/d' : ($period['delta_pct'] >= 0 ? '+' : '') . $period['delta_pct'] . '%';
+                $lines[] = "- Click ultimi {$label}: {$period['clicks']} (periodo precedente: {$period['previous']}, variazione: {$delta})";
+            }
+        }
+        $lines[] = '- Link affiliati pubblicati: ' . ($snapshot['links_total'] ?? 0) . '; senza click negli ultimi 90 giorni: ' . ($snapshot['links_no_clicks_90d'] ?? 0);
+
+        $lines[] = 'TOP LINK (30 giorni):';
+        foreach (array_slice((array) ($snapshot['top_links'] ?? array()), 0, 5) as $link) {
+            $lines[] = "- {$link['title']} [{$link['types']}]: {$link['clicks_period']} click (storico {$link['clicks_total']})";
+        }
+        $lines[] = 'TOP ARTICOLI per click affiliati (30 giorni):';
+        foreach (array_slice((array) ($snapshot['top_articles_30d'] ?? array()), 0, 5) as $article) {
+            $lines[] = "- {$article['title']}: {$article['clicks']} click";
+        }
+        $lines[] = 'LOCALITÀ PIÙ CLICCATE (90 giorni):';
+        foreach (array_slice((array) ($snapshot['geo_top'] ?? array()), 0, 5) as $geo) {
+            $lines[] = "- {$geo['name']} ({$geo['country']}): {$geo['clicks']} click";
+        }
+        $lines[] = 'LOCALITÀ CON LINK AFFILIATI MA SENZA CLICK (90 giorni):';
+        foreach (array_slice((array) ($snapshot['geo_unused'] ?? array()), 0, 10) as $geo) {
+            $lines[] = "- {$geo['name']} ({$geo['country']}): {$geo['links']} link, " . ($geo['posts'] ?? 0) . ' articoli';
+        }
+        $lines[] = 'LOCALITÀ CON ARTICOLI MA SENZA LINK AFFILIATI:';
+        foreach (array_slice((array) ($snapshot['geo_no_links'] ?? array()), 0, 10) as $geo) {
+            $lines[] = "- {$geo['name']} ({$geo['country']}): {$geo['posts']} articoli";
+        }
+        $lines[] = '';
+        $lines[] = 'Sulla base di questi dati fornisci 5 consigli strategici concreti e prioritizzati '
+            . '(1 = più importante) per aumentare i click affiliati e coprire i gap geografici. '
+            . 'Per ogni consiglio: azione specifica, motivazione basata sui numeri, risultato atteso.';
+        return implode("\n", $lines);
+    }
+
+    /* ---------------------------------------------------------------------
+     * Payload per il JS della dashboard (grafici)
+     * ------------------------------------------------------------------ */
+
+    public static function get_chart_payload() {
+        $snapshot = self::get_snapshot();
+        return array(
+            'ajaxUrl' => admin_url('admin-ajax.php'),
+            'nonce' => wp_create_nonce('alma_insights'),
+            'series' => array(
+                'daily' => $snapshot['clicks_daily'] ?? array('labels' => array(), 'data' => array()),
+                'weekly' => $snapshot['clicks_weekly'] ?? array('labels' => array(), 'data' => array()),
+                'monthly' => $snapshot['clicks_monthly'] ?? array('labels' => array(), 'data' => array()),
+            ),
+            'strings' => array(
+                'clicks' => __('Click', 'affiliate-link-manager-ai'),
+                'rebuilding' => __('Ricostruzione in corso…', 'affiliate-link-manager-ai'),
+                'rebuilt' => __('Dati aggiornati, ricarico la pagina…', 'affiliate-link-manager-ai'),
+                'aiWorking' => __('L\'AI sta analizzando i dati…', 'affiliate-link-manager-ai'),
+                'error' => __('Errore, riprova.', 'affiliate-link-manager-ai'),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
## Query in background, mai al rendering

- Nuova classe `ALMA_Dashboard_Insights`: tutte le elaborazioni girano **una volta al giorno via WP-Cron** (~03:30, lock via `add_option` atomica con TTL) e producono uno **snapshot** salvato in option; la Dashboard legge solo lo snapshot — zero query pesanti all'apertura della pagina.
- Pulsante **"Aggiorna ora"** per ricostruire su richiesta; data e durata dell'ultima elaborazione sempre visibili; cron rimosso alla disattivazione.

## Trend e KPI con grafici

- **Andamento click** con Chart.js: per giorno (30gg, barre), settimana (26) e mese (12, linea) con selettore periodo.
- **KPI 7/30/180 giorni** con confronto sul periodo precedente (variazione % verde/rossa) + KPI "link senza click negli ultimi 90 giorni".

## Top Link migliorato + nuovo Top Articoli

- Top Link ora classificato per click negli **ultimi 30 giorni** (con tipologia e storico a confronto), non più solo per cumulato storico.
- **Top Articoli** per click sui link affiliati contenuti: il tracking registra il **post di provenienza** — nuova colonna `post_id` su `alma_analytics` (migrazione automatica via dbDelta al bump di versione) e `page_url` inviato dal frontend (il solo `referrer` indicava la pagina precedente, non quella del click).

## Copertura geografica strategica

- Località **più cliccate** (90 giorni).
- Località **con link affiliati ma senza click** (offerta che non produce, con conteggio link e articoli).
- Località **con articoli ma senza link affiliati** (contenuto non monetizzato).

## Consigli strategici AI (on-demand)

- Pulsante "Genera consigli AI": il riepilogo aggregato dello snapshot (nessun dato personale — IP e user agent non lasciano il sito) viene inviato al modello OpenAI configurato → 5 raccomandazioni prioritizzate con motivazioni sui numeri; salvate con data, modello e costo stimato. Mai chiamate automatiche.

## Retrocompatibilità

- Endpoint AJAX esistenti (`alma_get_dashboard_data`, `alma_get_chart_data`) invariati; nessuna opzione rimossa; i click storici restano validi (senza attribuzione articolo, indicato in UI).

## Test

- `php -l` su tutti i PHP modificati, `node --check` sui JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_