### PR TITLE
Idee sul modello "Post" + geolocalizzazione idee (Fase 2) + import CSV programmato (Fase 3) — v2.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.56.0 - 2026-07-04
+
+### Idee sul modello "Post" + geolocalizzazione idee (Fase 2) + importazione massiva CSV programmata (Fase 3)
+- **Menu ristrutturato sul modello dei Post**: dopo la Dashboard ora ci sono **"Tutte le idee"** (elenco) e **"Aggiungi idea"** (workspace); la voce "AI Content Agent" è stata rinominata **"Impostazioni AI Content"** e spostata prima di Impostazioni. La tab "Idee contenuto" è stata eliminata (redirect alla Dashboard per i vecchi link).
+- **"Aggiungi idea"**: aprendo la pagina dal menu si parte con una nuova idea (l'ultima "Nuova idea" mai toccata viene riusata, per non accumulare bozze vuote); con `idea_id` si modifica un'idea esistente — è la destinazione di "Apri nel workspace" da Tutte le idee. I redirect delle azioni mantengono sempre l'idea corrente nell'URL.
+- **Geolocalizzazione delle idee (Fase 2)**: nuovo campo **Località** nel workspace con autocomplete sull'indice geografico. Con una località impostata: i link affiliati della sua area (stessa località, omonimi, paese per località-nazione) ricevono un **boost dominante (+40)** nella ricerca e vengono **inclusi anche senza match testuale**; il payload OpenAI riceve un blocco `geo_context` che impone coerenza geografica alla bozza. Colonna Località in Tutte le idee.
+- **Importazione massiva CSV con programmazione (Fase 3)**: pulsante "Importazione massiva (CSV)" in Tutte le idee → pagina dedicata con **download del CSV di esempio** (Titolo, Localita, Tema, Keyword principale, Keyword secondarie, Profilo istruzioni, Data programmata, Note AI; separatore , o ; autorilevato, max 500 righe). Ogni riga crea un'idea con località risolta sull'indice geografico (le non risolte vengono segnalate), keywords, profilo (per nome o ID) e data programmata; report di import con errori riga per riga.
+- **Generazione automatica in background**: runner WP-Cron giornaliero (con partenza immediata dopo ogni import) che per le idee programmate in scadenza seleziona automaticamente i migliori link affiliati (geo-first + keyword), li salva come selezione dell'idea e genera la bozza con la pipeline esistente — entro un **limite di bozze/giorno configurabile (default 3)** per controllare i costi OpenAI. Lock anti-concorrenza via `add_option` atomica, esiti registrati nella tabella jobs e contatore giornaliero visibile nella pagina di import. Cron rimosso alla disattivazione.
+- Retrocompatibilità: CPT e meta esistenti invariati (solo nuove meta), azioni admin esistenti riusate, vecchi URL della tab reindirizzati.
+- Versione plugin aggiornata a `2.56.0`.
+
 ## 2.55.0 - 2026-07-04
 
 ### AI Content Agent — Fase 1: riorganizzazione (menu + pagina Elenco Idee)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## 2.56.0 - 2026-07-04
+
+### Idee sul modello "Post" + geolocalizzazione idee + importazione massiva CSV programmata
+- Menu ristrutturato: "Tutte le idee" e "Aggiungi idea" dopo la Dashboard; "Impostazioni AI Content" (ex AI Content Agent) prima di Impostazioni; tab "Idee contenuto" eliminata.
+- Campo Località nell'idea con autocomplete sull'indice geografico: boost geo-first nella ricerca dei link affiliati e blocco geo_context nel payload OpenAI per bozze geograficamente coerenti.
+- Importazione massiva idee da CSV (con CSV di esempio scaricabile) e programmazione: runner giornaliero in background che seleziona i link della località e genera le bozze automaticamente, con limite bozze/giorno configurabile e log nei job.
+- Versione plugin aggiornata a `2.56.0`.
+
 ## 2.55.0 - 2026-07-04
 
 ### AI Content Agent — Fase 1: riorganizzazione (menu + pagina Elenco Idee)

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.55.0
+ * Version: 2.56.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.55.0');
+define('ALMA_VERSION', '2.56.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -54,6 +54,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-draft-quality-ch
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-draft-builder.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-result-usage.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-instructions-manager.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-idea-importer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-url-validator.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-interface.php';
 require_once ALMA_PLUGIN_DIR . 'includes/providers/class-affiliate-source-provider-manual.php';
@@ -155,6 +156,7 @@ class AffiliateManagerAI {
         $this->trip_finder = new ALMA_Trip_Finder();
         $this->trip_finder->init();
         ALMA_Dashboard_Insights::init();
+        ALMA_AI_Content_Agent_Idea_Importer::init();
         add_action('init', array($this, 'init'));
         add_action('widgets_init', array('ALMA_Contextual_Affiliate_Widget', 'register_widget'));
         // Registrato qui (prima che `widgets_init` scatti) perché ALMA_Shortcodes::init()
@@ -1117,14 +1119,34 @@ class AffiliateManagerAI {
             array('ALMA_AI_Content_Agent_Admin', 'render_page')
         );
 
-        // Elenco Idee (pagina dedicata, fuori dal workspace)
+        // Tutte le idee (elenco, modello "Post")
         add_submenu_page(
             self::AFFILIATE_LINK_PARENT_MENU,
-            __('Elenco Idee', 'affiliate-link-manager-ai'),
-            __('Elenco Idee', 'affiliate-link-manager-ai'),
+            __('Tutte le idee', 'affiliate-link-manager-ai'),
+            __('Tutte le idee', 'affiliate-link-manager-ai'),
             self::AI_CONTENT_AGENT_CAPABILITY,
             ALMA_AI_Content_Agent_Admin::IDEAS_LIST_MENU_SLUG,
             array('ALMA_AI_Content_Agent_Admin', 'render_ideas_list_page')
+        );
+
+        // Aggiungi idea (workspace)
+        add_submenu_page(
+            self::AFFILIATE_LINK_PARENT_MENU,
+            __('Aggiungi idea', 'affiliate-link-manager-ai'),
+            __('Aggiungi idea', 'affiliate-link-manager-ai'),
+            self::AI_CONTENT_AGENT_CAPABILITY,
+            ALMA_AI_Content_Agent_Admin::ADD_IDEA_MENU_SLUG,
+            array('ALMA_AI_Content_Agent_Admin', 'render_add_idea_page')
+        );
+
+        // Importazione massiva idee (pagina dedicata, raggiunta da Tutte le idee)
+        add_submenu_page(
+            null,
+            __('Importazione massiva idee', 'affiliate-link-manager-ai'),
+            __('Importazione massiva idee', 'affiliate-link-manager-ai'),
+            self::AI_CONTENT_AGENT_CAPABILITY,
+            ALMA_AI_Content_Agent_Idea_Importer::PAGE_SLUG,
+            array('ALMA_AI_Content_Agent_Idea_Importer', 'render_page')
         );
 
         // Pagina nascosta per modifica widget
@@ -1162,9 +1184,9 @@ class AffiliateManagerAI {
         $items = $submenu[$parent];
         $order = array(
             'affiliate-link-manager-dashboard',
-            // AI Content Agent subito dopo la Dashboard, con la pagina Elenco Idee.
-            self::AI_CONTENT_AGENT_MENU_SLUG,
+            // Idee sul modello "Post": elenco + aggiungi, subito dopo la Dashboard.
             ALMA_AI_Content_Agent_Admin::IDEAS_LIST_MENU_SLUG,
+            ALMA_AI_Content_Agent_Admin::ADD_IDEA_MENU_SLUG,
             'edit.php?post_type=affiliate_link',
             'post-new.php?post_type=affiliate_link',
             'edit-tags.php?taxonomy=link_type&post_type=affiliate_link',
@@ -1175,6 +1197,8 @@ class AffiliateManagerAI {
             ALMA_Geo_Map::MENU_SLUG,
             ALMA_Trip_Finder::MENU_SLUG,
             'alma-affiliate-sources',
+            // Impostazioni AI Content prima delle Impostazioni generali.
+            self::AI_CONTENT_AGENT_MENU_SLUG,
             'affiliate-link-manager-settings',
             'alma-css-editor',
         );
@@ -1215,7 +1239,13 @@ class AffiliateManagerAI {
                             $item[0] = __('Trova Viaggio', 'affiliate-link-manager-ai');
                             break;
                         case ALMA_AI_Content_Agent_Admin::IDEAS_LIST_MENU_SLUG:
-                            $item[0] = __('Elenco Idee', 'affiliate-link-manager-ai');
+                            $item[0] = __('Tutte le idee', 'affiliate-link-manager-ai');
+                            break;
+                        case ALMA_AI_Content_Agent_Admin::ADD_IDEA_MENU_SLUG:
+                            $item[0] = __('Aggiungi idea', 'affiliate-link-manager-ai');
+                            break;
+                        case self::AI_CONTENT_AGENT_MENU_SLUG:
+                            $item[0] = __('Impostazioni AI Content', 'affiliate-link-manager-ai');
                             break;
                         case 'alma-affiliate-sources':
                             $item[0] = __('Affiliate Sources', 'affiliate-link-manager-ai');
@@ -4363,6 +4393,7 @@ class AffiliateManagerAI {
         wp_clear_scheduled_hook('alma_daily_optimization');
         ALMA_Geo_Geocoding_Queue::unschedule();
         ALMA_Dashboard_Insights::unschedule();
+        ALMA_AI_Content_Agent_Idea_Importer::unschedule();
         $this->clear_deprecated_trend_cron_events();
         flush_rewrite_rules();
     }

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -4,7 +4,45 @@ class ALMA_AI_Content_Agent_Admin {
     const NOTICE_TRANSIENT_KEY = 'alma_ai_agent_admin_notice_';
     const RESULT_TRANSIENT_KEY = 'alma_ai_agent_admin_result_';
 
-    public static function init() { add_action('admin_post_alma_ai_agent_action', array(__CLASS__, 'handle_action')); }
+    public static function init() {
+        add_action('admin_post_alma_ai_agent_action', array(__CLASS__, 'handle_action'));
+        add_action('wp_ajax_alma_ai_idea_location_search', array(__CLASS__, 'ajax_idea_location_search'));
+    }
+
+    /**
+     * Autocomplete località per il workspace idea: cerca nell'indice
+     * geografico per nome (sola lettura, admin).
+     */
+    public static function ajax_idea_location_search() {
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(array('message' => 'forbidden'), 403);
+        }
+        check_ajax_referer('alma_ai_idea_location', 'nonce');
+        global $wpdb;
+        $term = sanitize_text_field(wp_unslash($_GET['term'] ?? ''));
+        if (mb_strlen($term) < 2 || !class_exists('ALMA_Geo_Index_Store')) {
+            wp_send_json_success(array());
+        }
+        $store = new ALMA_Geo_Index_Store();
+        if (!$store->tables_exist()) {
+            wp_send_json_success(array());
+        }
+        $like = $wpdb->esc_like($term) . '%';
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT id, canonical_name, country, type FROM {$store->table_locations()}
+             WHERE canonical_name LIKE %s OR canonical_name LIKE %s
+             ORDER BY CHAR_LENGTH(canonical_name) ASC LIMIT 20",
+            $like, '% ' . $like
+        ), ARRAY_A);
+        $out = array();
+        foreach ((array)$rows as $row) {
+            $label = html_entity_decode(sanitize_text_field($row['canonical_name']), ENT_QUOTES, 'UTF-8');
+            $country = sanitize_text_field((string)$row['country']);
+            if ($country !== '' && strcasecmp($country, $label) !== 0) { $label .= ' (' . $country . ')'; }
+            $out[] = array('id' => (int)$row['id'], 'label' => $label);
+        }
+        wp_send_json_success($out);
+    }
 
     public static function handle_action() {
         if (!current_user_can('manage_options')) { wp_die('forbidden'); }
@@ -121,7 +159,15 @@ class ALMA_AI_Content_Agent_Admin {
             $profile = $profile_id ? ALMA_AI_Content_Agent_Instructions_Manager::get_profile($profile_id) : array();
             $temporary_instructions = ALMA_AI_Content_Agent_Instructions_Manager::sanitize_profile_textarea(wp_unslash($_POST['temporary_instructions'] ?? ''));
             $instruction_snapshot = !empty($profile) ? ALMA_AI_Content_Agent_Instructions_Manager::build_compact_instruction_block($profile, $temporary_instructions) : '';
-            $payload = array('max_ideas'=>absint($_POST['max_ideas'] ?? 1),'content_search_query'=>sanitize_text_field($_POST['content_search_query'] ?? ($_POST['search_terms'] ?? '')),'search_terms'=>sanitize_text_field($_POST['search_terms'] ?? ($_POST['content_search_query'] ?? '')),'theme'=>sanitize_text_field($_POST['theme'] ?? ''),'destination'=>sanitize_text_field($_POST['destination'] ?? ''),'temporary_instructions'=>$temporary_instructions,'openai_prompt'=>ALMA_AI_Content_Agent_Instructions_Manager::sanitize_profile_textarea(wp_unslash($_POST['openai_prompt'] ?? $_POST['temporary_instructions'] ?? '')),'instruction_profile_id'=>$profile_id,'instruction_profile_name'=>sanitize_text_field($profile['profile_name'] ?? ''),'instruction_snapshot_hash'=>sanitize_text_field($instruction_snapshot !== '' ? ALMA_AI_Content_Agent_Instructions_Manager::snapshot_hash($instruction_snapshot) : ''),'instruction_snapshot'=>$instruction_snapshot,'search_scope'=>'affiliate_links_only');
+            // Fase 2: località dell'idea → boost geografico nella ricerca.
+            $geo_location_id = absint($_POST['idea_location_id'] ?? 0);
+            $geo_location_label = sanitize_text_field(wp_unslash($_POST['idea_location_label'] ?? ''));
+            $geo_link_ids = array();
+            if ($geo_location_id > 0 && class_exists('ALMA_Geo_Index_Store')) {
+                $geo_store = new ALMA_Geo_Index_Store();
+                $geo_link_ids = $geo_store->get_affiliate_link_ids_for_area($geo_location_id);
+            }
+            $payload = array('max_ideas'=>absint($_POST['max_ideas'] ?? 1),'content_search_query'=>sanitize_text_field($_POST['content_search_query'] ?? ($_POST['search_terms'] ?? '')),'search_terms'=>sanitize_text_field($_POST['search_terms'] ?? ($_POST['content_search_query'] ?? '')),'theme'=>sanitize_text_field($_POST['theme'] ?? ''),'destination'=>sanitize_text_field($_POST['destination'] ?? ''),'temporary_instructions'=>$temporary_instructions,'openai_prompt'=>ALMA_AI_Content_Agent_Instructions_Manager::sanitize_profile_textarea(wp_unslash($_POST['openai_prompt'] ?? $_POST['temporary_instructions'] ?? '')),'instruction_profile_id'=>$profile_id,'instruction_profile_name'=>sanitize_text_field($profile['profile_name'] ?? ''),'instruction_snapshot_hash'=>sanitize_text_field($instruction_snapshot !== '' ? ALMA_AI_Content_Agent_Instructions_Manager::snapshot_hash($instruction_snapshot) : ''),'instruction_snapshot'=>$instruction_snapshot,'search_scope'=>'affiliate_links_only','geo_location_id'=>$geo_location_id,'geo_location_label'=>$geo_location_label,'geo_link_ids'=>$geo_link_ids);
             $search = ALMA_AI_Content_Agent_Knowledge_Search::search($payload);
             $stats = ALMA_AI_Content_Agent_Selection_Session::add_search_results($payload, $search);
             $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true));
@@ -131,7 +177,7 @@ class ALMA_AI_Content_Agent_Admin {
                 if ($active_idea_id > 0) { update_user_meta(get_current_user_id(), '_alma_active_idea_id', $active_idea_id); }
             }
             if ($active_idea_id > 0) {
-                ALMA_AI_Content_Agent_Ideas::save_from_request($active_idea_id, array('idea_status'=>'bozza','instruction_profile_id'=>$profile_id,'openai_prompt'=>$payload['openai_prompt']));
+                ALMA_AI_Content_Agent_Ideas::save_from_request($active_idea_id, array('idea_status'=>'bozza','instruction_profile_id'=>$profile_id,'openai_prompt'=>$payload['openai_prompt'],'idea_location_id'=>$geo_location_id,'idea_location_label'=>$geo_location_label));
                 update_post_meta($active_idea_id, ALMA_AI_Content_Agent_Ideas::META_LAST_QUERY, array('content_search_query'=>$payload['content_search_query']));
                 ALMA_AI_Content_Agent_Selection_Session::persist_to_idea($active_idea_id);
             }
@@ -242,10 +288,18 @@ class ALMA_AI_Content_Agent_Admin {
 
         self::set_notice($result);
         $redirect_url = wp_get_referer();
-        // Creare o aprire un'idea porta sempre al workspace, anche partendo
-        // dalla pagina Elenco Idee.
+        $workspace_url = admin_url('edit.php?post_type=affiliate_link&page=' . self::ADD_IDEA_MENU_SLUG);
+        // Creare o aprire un'idea porta sempre al workspace (Aggiungi idea).
         if (($do === 'new_content_idea' || $do === 'load_content_idea') && !empty($result['success'])) {
-            $redirect_url = admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=idee');
+            $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true));
+            $redirect_url = $active_idea_id > 0 ? add_query_arg('idea_id', $active_idea_id, $workspace_url) : $workspace_url;
+        } elseif ($do === 'delete_content_idea' && !empty($result['success'])) {
+            $redirect_url = admin_url('edit.php?post_type=affiliate_link&page=' . self::IDEAS_LIST_MENU_SLUG);
+        } elseif (strpos((string)$redirect_url, 'page=' . self::ADD_IDEA_MENU_SLUG) !== false && strpos((string)$redirect_url, 'idea_id=') === false) {
+            // Il workspace è "Aggiungi idea": senza idea_id nell'URL un reload
+            // creerebbe una nuova idea, perdendo quella su cui si sta lavorando.
+            $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true));
+            if ($active_idea_id > 0) { $redirect_url = add_query_arg('idea_id', $active_idea_id, $redirect_url); }
         }
         wp_safe_redirect($redirect_url); exit;
     }
@@ -307,10 +361,10 @@ class ALMA_AI_Content_Agent_Admin {
 
     public static function render_ideas_list_page() {
         if (!current_user_can('manage_options')) { return; }
-        echo '<div class="wrap alma-ai-agent-admin"><h1>Elenco Idee</h1>';
+        echo '<div class="wrap alma-ai-agent-admin"><h1>Tutte le idee</h1>';
         self::render_notice();
 
-        $workspace_url = admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=idee');
+        $workspace_url = admin_url('edit.php?post_type=affiliate_link&page=' . self::ADD_IDEA_MENU_SLUG);
         $list_url = admin_url('edit.php?post_type=affiliate_link&page=' . self::IDEAS_LIST_MENU_SLUG);
         $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true));
 
@@ -350,8 +404,9 @@ class ALMA_AI_Content_Agent_Admin {
             $profile_names[(int)($profile_row['id'] ?? 0)] = sanitize_text_field($profile_row['profile_name'] ?? '');
         }
 
-        echo '<p>';
-        self::action_form('new_content_idea', 'Crea nuova idea', '', 'button button-primary');
+        echo '<p style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">';
+        echo '<a class="button button-primary" href="'.esc_url($workspace_url).'">Aggiungi idea</a>';
+        echo '<a class="button" href="'.esc_url(admin_url('admin.php?page=' . ALMA_AI_Content_Agent_Idea_Importer::PAGE_SLUG)).'">📥 Importazione massiva (CSV)</a>';
         echo '</p>';
 
         echo '<form method="get" action="'.esc_url(admin_url('edit.php')).'" class="alma-ideas-list-filters" style="display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end;margin:12px 0;">';
@@ -365,9 +420,9 @@ class ALMA_AI_Content_Agent_Admin {
         echo '<label><strong>Autore</strong><br><select name="idea_author"><option value="all" '.selected($author_filter, 'all', false).'>Tutti</option><option value="mine" '.selected($author_filter, 'mine', false).'>Solo le mie</option></select></label>';
         echo '<button class="button">Filtra</button> <a class="button" href="'.esc_url($list_url).'">Reset</a></form>';
 
-        echo '<table class="widefat striped"><thead><tr><th>Titolo</th><th>Autore</th><th>Profilo istruzioni</th><th>Contenuti</th><th>Stato</th><th>Bozza</th><th>Ultima modifica</th><th>Azioni</th></tr></thead><tbody>';
+        echo '<table class="widefat striped"><thead><tr><th>Titolo</th><th>Località</th><th>Autore</th><th>Profilo istruzioni</th><th>Contenuti</th><th>Programmata</th><th>Stato</th><th>Bozza</th><th>Ultima modifica</th><th>Azioni</th></tr></thead><tbody>';
         if (empty($query->posts)) {
-            echo '<tr><td colspan="8"><em>Nessuna idea trovata'.($search !== '' || $status_filter !== 'all' || $author_filter !== 'all' ? ' con i filtri correnti' : '').'.</em></td></tr>';
+            echo '<tr><td colspan="10"><em>Nessuna idea trovata'.($search !== '' || $status_filter !== 'all' || $author_filter !== 'all' ? ' con i filtri correnti' : '').'.</em></td></tr>';
         }
         foreach ($query->posts as $idea_post) {
             $idea = ALMA_AI_Content_Agent_Ideas::get($idea_post->ID);
@@ -382,14 +437,16 @@ class ALMA_AI_Content_Agent_Admin {
 
             echo '<tr>';
             echo '<td><strong>'.esc_html($idea_post->post_title).'</strong>'.($is_active ? ' <span class="alma-active-idea-badge">Attiva</span>' : '').'</td>';
+            echo '<td>'.($idea['location_label'] !== '' ? '📍 '.esc_html($idea['location_label']) : '—').'</td>';
             echo '<td>'.esc_html($author ? $author->display_name : '—').'</td>';
             echo '<td>'.esc_html($profile_label).'</td>';
             echo '<td>'.(int)$selection_count.'</td>';
+            echo '<td>'.($idea['scheduled_at'] !== '' ? esc_html($idea['scheduled_at']) : '—').'</td>';
             echo '<td>'.($executed ? '<span class="alma-badge is-success">Eseguita</span><br><span class="description">'.esc_html($idea['executed_at']).'</span>' : '<span class="alma-badge is-warning">Non eseguita</span>').'</td>';
             echo '<td>'.($draft_post ? '<a href="'.esc_url(get_edit_post_link($draft_id, 'raw')).'">'.esc_html(get_post_status_object($draft_post->post_status)->label ?? $draft_post->post_status).'</a>' : '—').'</td>';
             echo '<td>'.esc_html($idea_post->post_modified).'</td>';
             echo '<td><div class="alma-actions-inline" style="display:flex;gap:4px;flex-wrap:wrap;">';
-            echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="load_content_idea"><input type="hidden" name="idea_id" value="'.(int)$idea_post->ID.'"><button class="button button-small button-primary">Apri nel workspace</button></form>';
+            echo '<a class="button button-small button-primary" href="'.esc_url(add_query_arg('idea_id', (int)$idea_post->ID, $workspace_url)).'">Apri nel workspace</a>';
             if ($selection_count > 0 && !$draft_post) {
                 echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="generate_draft"><input type="hidden" name="idea_id" value="'.(int)$idea_post->ID.'"><button class="button button-small">Genera bozza</button></form>';
             }
@@ -408,26 +465,71 @@ class ALMA_AI_Content_Agent_Admin {
             }
             echo '</span></div></div>';
         }
-        echo '<p><a href="'.esc_url($workspace_url).'">← Vai al workspace Idee contenuto</a></p>';
         echo '</div>';
     }
 
+    const ADD_IDEA_MENU_SLUG = 'alma-ai-add-idea';
+
     public static function render_page() {
         if (!current_user_can('manage_options')) { return; }
-        $tabs = array('dashboard'=>'Dashboard','idee'=>'Idee contenuto','istruzioni-ai'=>'Istruzioni AI','documenti'=>'Documenti TXT','fonti'=>'Fonti online AI','reindex'=>'Reindicizza','log'=>'Stato/log');
-        $legacy_map = array('overview'=>'dashboard','reindirizza'=>'reindex','knowledge'=>'dashboard','media'=>'dashboard','bozze'=>'log','programmazione'=>'log',);
+        // La tab "Idee contenuto" non esiste più: il workspace vive nella
+        // pagina "Aggiungi idea", l'elenco nella pagina "Tutte le idee".
+        $tabs = array('dashboard'=>'Dashboard','istruzioni-ai'=>'Istruzioni AI','documenti'=>'Documenti TXT','fonti'=>'Fonti online AI','reindex'=>'Reindicizza','log'=>'Stato/log');
+        $legacy_map = array('overview'=>'dashboard','idee'=>'dashboard','reindirizza'=>'reindex','knowledge'=>'dashboard','media'=>'dashboard','bozze'=>'log','programmazione'=>'log',);
         $tab = sanitize_key($_GET['tab'] ?? 'dashboard');
         if (isset($legacy_map[$tab])) { $tab = $legacy_map[$tab]; }
         if (!isset($tabs[$tab])) { $tab = 'dashboard'; }
-        echo '<div class="wrap alma-ai-agent-admin"><h1>AI Content Agent</h1>'; self::render_notice();
+        echo '<div class="wrap alma-ai-agent-admin"><h1>Impostazioni AI Content</h1>'; self::render_notice();
         echo '<h2 class="nav-tab-wrapper">'; foreach ($tabs as $tk=>$tl) { echo '<a class="nav-tab '.($tk===$tab?'nav-tab-active':'').'" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab='.$tk)).'">'.esc_html($tl).'</a>'; } echo '</h2>';
-        if ($tab === 'dashboard') { self::render_overview_tab(); }
-        elseif ($tab === 'istruzioni-ai') { self::render_instructions_tab(); }
+        if ($tab === 'istruzioni-ai') { self::render_instructions_tab(); }
         elseif ($tab === 'documenti') { self::render_documents_tab(); }
         elseif ($tab === 'fonti') { self::render_sources_tab(); }
         elseif ($tab === 'reindex') { self::render_reindex_tab(); }
         elseif ($tab === 'log') { self::render_log_tab(); }
-        else { self::render_ideas_tab(); }
+        else { self::render_overview_tab(); }
+        echo '</div>';
+    }
+
+    /**
+     * Pagina "Aggiungi idea": il workspace, sul modello dei Post.
+     * - con ?idea_id=N apre quell'idea (modifica);
+     * - senza parametri crea una nuova idea (riusando l'eventuale ultima
+     *   "Nuova idea" mai toccata, per non accumulare righe vuote).
+     */
+    public static function render_add_idea_page() {
+        if (!current_user_can('manage_options')) { return; }
+        $requested_id = absint($_GET['idea_id'] ?? 0);
+        $idea_id = 0;
+        if ($requested_id > 0 && get_post_type($requested_id) === ALMA_AI_Content_Agent_Ideas::CPT) {
+            $idea_id = $requested_id;
+        } else {
+            $reusable = get_posts(array(
+                'post_type' => ALMA_AI_Content_Agent_Ideas::CPT,
+                'post_status' => 'publish',
+                'posts_per_page' => 1,
+                'fields' => 'ids',
+                'orderby' => 'date',
+                'order' => 'DESC',
+                'author' => get_current_user_id(),
+                'title' => 'Nuova idea',
+                'no_found_rows' => true,
+            ));
+            foreach ((array)$reusable as $candidate_id) {
+                $candidate = ALMA_AI_Content_Agent_Ideas::get((int)$candidate_id);
+                if (!empty($candidate) && empty($candidate['prompt']) && empty($candidate['selection']) && empty($candidate['executed_at'])) {
+                    $idea_id = (int)$candidate_id;
+                }
+            }
+            if ($idea_id < 1) {
+                $idea_id = ALMA_AI_Content_Agent_Ideas::create('Nuova idea');
+            }
+        }
+        if ($idea_id > 0) {
+            update_user_meta(get_current_user_id(), '_alma_active_idea_id', $idea_id);
+        }
+        echo '<div class="wrap alma-ai-agent-admin"><h1>Aggiungi idea</h1>';
+        self::render_notice();
+        self::render_workspace();
         echo '</div>';
     }
 
@@ -800,9 +902,9 @@ class ALMA_AI_Content_Agent_Admin {
         echo '<p class="alma-instructions-activate"><label><input type="checkbox" name="activate_profile" value="1" '.checked($is_current_active, true, false).'> Attiva questo profilo dopo il salvataggio</label></p><p><button class="button button-primary">Salva profilo</button></p></form>';
     }
 
-    private static function render_ideas_tab() {
-        // Il tab è SOLO il workspace dell'idea attiva: l'elenco completo vive
-        // nella pagina dedicata "Elenco Idee".
+    private static function render_workspace() {
+        // Workspace dell'idea attiva (pagina "Aggiungi idea"): l'elenco
+        // completo vive nella pagina dedicata "Tutte le idee".
         $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true));
         if ($active_idea_id > 0) {
             $active_post = get_post($active_idea_id);
@@ -871,7 +973,7 @@ class ALMA_AI_Content_Agent_Admin {
         if (!empty($active_idea['draft_post_id']) && get_post((int)$active_idea['draft_post_id'])) { echo '<a class="button" href="'.esc_url(get_edit_post_link((int)$active_idea['draft_post_id'],'raw')).'">Apri bozza</a>'; }
         echo '<div class="alma-actions-inline alma-idea-main-actions">';
         self::action_form('new_content_idea','Crea nuova idea','', 'button alma-action-button alma-action-primary', 'dashicons-lightbulb');
-        if($active_idea_id){ echo '<form id="alma-save-idea-form" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_content_idea"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><input type="hidden" name="idea_status" value="bozza"><input type="hidden" id="alma-save-idea-openai-prompt" name="openai_prompt" value="'.esc_attr($active_idea['prompt']??'').'"><input type="hidden" id="alma-save-idea-instruction-profile-id" name="instruction_profile_id" value="'.(int)$selected_profile_id.'"><button class="button alma-action-button alma-action-success"><span class="dashicons dashicons-saved" aria-hidden="true"></span><span>Salva idea</span></button></form>'; }
+        if($active_idea_id){ echo '<form id="alma-save-idea-form" method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_content_idea"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><input type="hidden" name="idea_status" value="bozza"><input type="hidden" id="alma-save-idea-openai-prompt" name="openai_prompt" value="'.esc_attr($active_idea['prompt']??'').'"><input type="hidden" id="alma-save-idea-instruction-profile-id" name="instruction_profile_id" value="'.(int)$selected_profile_id.'"><input type="hidden" id="alma-save-idea-location-id" name="idea_location_id" value="'.(int)($active_idea['location_id'] ?? 0).'"><input type="hidden" id="alma-save-idea-location-label" name="idea_location_label" value="'.esc_attr($active_idea['location_label'] ?? '').'"><button class="button alma-action-button alma-action-success"><span class="dashicons dashicons-saved" aria-hidden="true"></span><span>Salva idea</span></button></form>'; }
         if($active_idea_id){ echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="delete_content_idea"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><button class="button alma-action-button alma-action-danger"><span class="dashicons dashicons-trash" aria-hidden="true"></span><span>Elimina</span></button></form>'; }
         self::action_form('create_draft_from_selection','Crea bozza','', 'button alma-action-button alma-action-primary', 'dashicons-edit-page');
         self::action_form('download_ai_payload_json','Scarica JSON payload OpenAI',$active_idea_id ? '<input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'">' : '', 'button alma-action-button alma-action-secondary', 'dashicons-media-code');
@@ -892,7 +994,7 @@ class ALMA_AI_Content_Agent_Admin {
 
         echo '<section class="alma-idea-section"><h4 class="alma-idea-section-title">Tutte le idee</h4>';
         echo '<p class="description">L\'elenco completo delle idee (con filtri, ricerca e azioni) è nella pagina dedicata.</p>';
-        echo '<p><a class="button" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=' . self::IDEAS_LIST_MENU_SLUG)).'">📋 Elenco Idee</a></p>';
+        echo '<p><a class="button" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=' . self::IDEAS_LIST_MENU_SLUG)).'">📋 Tutte le idee</a></p>';
         echo '</section>';
 
         echo '<section class="alma-idea-section alma-idea-details"><h4 class="alma-idea-section-title">Dettagli idea</h4><ul><li><strong>Contenuti aggiunti:</strong> '.(int)($summary['selected_total'] ?? 0).'</li><li><strong>Profilo istruzioni AI:</strong> '.(int)($active_idea['profile_id'] ?? 0).'</li><li><strong>Prompt OpenAI:</strong> '.(!empty($active_idea['prompt']) ? 'Presente' : 'Assente').'</li></ul></section></div></aside>';
@@ -905,6 +1007,42 @@ class ALMA_AI_Content_Agent_Admin {
             if (!empty($selected_inactive_profile['id'])) { echo '<option value="'.(int)$selected_inactive_profile['id'].'" selected>'.esc_html($selected_inactive_profile['profile_name']).' (non attivo, già scelto)</option>'; }
         }
         echo '</select></p>';
+        // Fase 2: località dell'idea con autocomplete sull'indice geografico.
+        $idea_location_id = absint($active_idea['location_id'] ?? 0);
+        $idea_location_label = sanitize_text_field($active_idea['location_label'] ?? '');
+        echo '<p><label for="alma-idea-location">Località (indice geografico)</label>';
+        echo '<input id="alma-idea-location" class="widefat" type="text" list="alma-idea-location-list" autocomplete="off" placeholder="Es. Algeria, Copenaghen, Maldive…" value="'.esc_attr($idea_location_label).'">';
+        echo '<datalist id="alma-idea-location-list"></datalist>';
+        echo '<input type="hidden" id="alma-idea-location-id" name="idea_location_id" value="'.(int)$idea_location_id.'">';
+        echo '<input type="hidden" id="alma-idea-location-label" name="idea_location_label" value="'.esc_attr($idea_location_label).'">';
+        echo '<span class="description">Con una località impostata, i link affiliati della sua area geografica vengono privilegiati nella ricerca e la bozza AI resta geograficamente coerente. Svuota il campo per rimuoverla.</span></p>';
+        echo '<script>(function(){
+            var input=document.getElementById("alma-idea-location"),list=document.getElementById("alma-idea-location-list");
+            var hidId=document.getElementById("alma-idea-location-id"),hidLabel=document.getElementById("alma-idea-location-label");
+            var saveId=document.getElementById("alma-save-idea-location-id"),saveLabel=document.getElementById("alma-save-idea-location-label");
+            if(!input||!list||!hidId||!hidLabel){return;}
+            var nonce="'.esc_js(wp_create_nonce('alma_ai_idea_location')).'",ajaxUrl="'.esc_js(admin_url('admin-ajax.php')).'",options={},timer=null;
+            function sync(id,label){hidId.value=id;hidLabel.value=label;if(saveId){saveId.value=id;}if(saveLabel){saveLabel.value=label;}}
+            input.addEventListener("input",function(){
+                var term=input.value.trim();
+                if(term===""){sync(0,"");return;}
+                if(options[term]){sync(options[term],term);return;}
+                sync(0,term);
+                if(timer){clearTimeout(timer);}
+                if(term.length<2){return;}
+                timer=setTimeout(function(){
+                    fetch(ajaxUrl+"?action=alma_ai_idea_location_search&nonce="+encodeURIComponent(nonce)+"&term="+encodeURIComponent(term),{credentials:"same-origin"})
+                        .then(function(r){return r.json();})
+                        .then(function(resp){
+                            if(!resp||!resp.success||!Array.isArray(resp.data)){return;}
+                            options={};list.innerHTML="";
+                            resp.data.forEach(function(row){options[row.label]=row.id;var o=document.createElement("option");o.value=row.label;list.appendChild(o);});
+                            if(options[input.value.trim()]){sync(options[input.value.trim()],input.value.trim());}
+                        }).catch(function(){});
+                },250);
+            });
+            input.addEventListener("change",function(){var term=input.value.trim();if(options[term]){sync(options[term],term);}else if(term===""){sync(0,"");}});
+        })();</script>';
         if (empty($profiles)) { echo '<p class="description"><strong>Nessun profilo istruzioni AI attivo.</strong> Attiva almeno un profilo nella tab Istruzioni AI oppure scegli esplicitamente Nessun profilo.</p>'; }
         echo '<p><label for="alma-openai-prompt">Prompt per OpenAI</label><textarea id="alma-openai-prompt" class="widefat" rows="4" name="openai_prompt">'.esc_textarea($active_idea['prompt'] ?? ($session['openai_prompt'] ?? '')).'</textarea><span class="description">Questo prompt verrà inviato a OpenAI insieme ai contenuti raccolti e guiderà cosa scrivere nella bozza.</span></p><p><button class="button button-primary">Cerca contenuti</button></p></form></div>';
 
@@ -955,19 +1093,19 @@ class ALMA_AI_Content_Agent_Admin {
 
         echo '<div class="alma-ideas-card"><div class="alma-results-header"><h3>2. Risultati ricerca</h3></div><p class="description">In questa fase la ricerca mostra solo Link affiliati indicizzati.</p>';
         echo '<form class="alma-results-filters" method="get" action="'.esc_url(admin_url('edit.php')).'">';
-        echo '<input type="hidden" name="post_type" value="affiliate_link"><input type="hidden" name="page" value="alma-ai-content-agent"><input type="hidden" name="tab" value="idee"><input type="hidden" name="alma_results_page" value="1">';
+        echo '<input type="hidden" name="post_type" value="affiliate_link"><input type="hidden" name="page" value="'.esc_attr(self::ADD_IDEA_MENU_SLUG).'"><input type="hidden" name="idea_id" value="'.(int)$active_idea_id.'"><input type="hidden" name="alma_results_page" value="1">';
         echo '<div class="alma-results-filter-grid"><p><label for="alma-link-type-filter"><strong>Tipologie Link</strong></label><select id="alma-link-type-filter" name="alma_link_type_filter" class="widefat"><option value="all">Tutte le tipologie</option>';
         foreach ($link_type_options as $option_value => $option_label) { echo '<option value="'.esc_attr($option_value).'" '.selected($active_link_type_filter, $option_value, false).'>'.esc_html($option_label).'</option>'; }
         echo '</select></p><p><label for="alma-source-filter"><strong>Fonte / Source / Provider</strong></label><select id="alma-source-filter" name="alma_source_filter" class="widefat"><option value="all">Tutte le fonti</option>';
         foreach ($source_options as $option_value => $option_label) { echo '<option value="'.esc_attr($option_value).'" '.selected($active_source_filter, $option_value, false).'>'.esc_html($option_label).'</option>'; }
         echo '</select></p></div>';
-        $reset_url = add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-ai-content-agent','tab'=>'idee','alma_results_page'=>1), admin_url('edit.php'));
+        $reset_url = add_query_arg(array('post_type'=>'affiliate_link','page'=>self::ADD_IDEA_MENU_SLUG,'idea_id'=>(int)$active_idea_id,'alma_results_page'=>1), admin_url('edit.php'));
         echo '<p class="alma-results-filter-actions"><button class="button button-primary" type="submit">Applica filtri</button> <a class="button" href="'.esc_url($reset_url).'">Reset filtri</a></p></form>';
 
         echo '<div class="tablenav top"><div class="tablenav-pages">';
         echo '<span class="displaying-num">'.(int)$total_results.' elementi</span>';
         echo '<span class="pagination-links">';
-        $base = add_query_arg(array('post_type'=>'affiliate_link','page'=>'alma-ai-content-agent','tab'=>'idee','alma_link_type_filter'=>$active_link_type_filter,'alma_source_filter'=>$active_source_filter), admin_url('edit.php'));
+        $base = add_query_arg(array('post_type'=>'affiliate_link','page'=>self::ADD_IDEA_MENU_SLUG,'idea_id'=>(int)$active_idea_id,'alma_link_type_filter'=>$active_link_type_filter,'alma_source_filter'=>$active_source_filter), admin_url('edit.php'));
         $is_first = ($current_page <= 1);
         $is_last = ($current_page >= $total_pages);
         if ($is_first) { echo '<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&laquo;</span><span class="tablenav-pages-navspan button disabled" aria-hidden="true">&lsaquo;</span>'; }

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -1117,6 +1117,19 @@ class ALMA_AI_Content_Agent_Draft_Builder {
 
         $ctx = array('posts'=>array(),'pages'=>array(),'affiliate_links'=>array(),'documents'=>array(),'sources_online'=>array(),'media'=>array());
         $warnings = array();
+
+        // Fase 2: blocco geografico esplicito nel payload. Se l'idea attiva ha
+        // una località, l'AI deve restare geograficamente coerente.
+        $geo_idea_id = absint(get_user_meta($user_id, '_alma_active_idea_id', true));
+        if ($geo_idea_id > 0) {
+            $geo_label = sanitize_text_field((string) get_post_meta($geo_idea_id, ALMA_AI_Content_Agent_Ideas::META_LOCATION_LABEL, true));
+            if ($geo_label !== '') {
+                $ctx['geo_context'] = array(
+                    'location' => $geo_label,
+                    'rules' => 'L\'articolo riguarda la località "' . $geo_label . '". Usa SOLO link affiliati e link interni geograficamente coerenti con questa destinazione; non citare né linkare destinazioni diverse, se non per confronti esplicitamente richiesti dal prompt.',
+                );
+            }
+        }
         foreach ($selected as $row) {
             $group = sanitize_key($row['source_group'] ?? '');
             $sid = absint($row['source_id'] ?? 0);

--- a/includes/class-ai-content-agent-idea-importer.php
+++ b/includes/class-ai-content-agent-idea-importer.php
@@ -1,0 +1,451 @@
+<?php
+/**
+ * Importazione massiva delle Idee contenuto da CSV con programmazione.
+ *
+ * - Pagina dedicata (raggiunta dal pulsante in "Tutte le idee"): upload CSV,
+ *   download del CSV di esempio, limite bozze automatiche/giorno, report
+ *   dell'ultimo import.
+ * - Colonne CSV: Titolo (obbligatoria), Localita, Tema, Keyword principale,
+ *   Keyword secondarie, Profilo istruzioni (nome o ID), Data programmata
+ *   (YYYY-MM-DD o GG/MM/AAAA), Note AI. Separatore , o ; (autorilevato).
+ * - Ogni riga crea un'idea (CPT alma_content_idea) con località risolta
+ *   sull'indice geografico e data programmata.
+ * - Runner in background (WP-Cron giornaliero + kick immediato post-import):
+ *   per le idee programmate in scadenza seleziona automaticamente i link
+ *   affiliati candidati (geo-first + keyword) e genera la bozza via OpenAI,
+ *   rispettando un tetto di bozze/giorno per controllare i costi. Lock via
+ *   add_option atomica, esiti nella tabella jobs (mai job invisibili).
+ */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALMA_AI_Content_Agent_Idea_Importer {
+    const PAGE_SLUG = 'alma-ai-import-ideas';
+    const CRON_HOOK = 'alma_ai_ideas_scheduled_runner';
+    const OPTION_DAILY_LIMIT = 'alma_ai_ideas_daily_draft_limit';
+    const OPTION_COUNTER = 'alma_ai_ideas_draft_counter';
+    const LOCK_OPTION = 'alma_ai_ideas_runner_lock';
+    const LOCK_TTL = 600;
+    const REPORT_TRANSIENT = 'alma_ai_ideas_import_report_';
+    const MAX_ROWS = 500;
+    const MAX_AUTO_CANDIDATES = 8;
+
+    public static function init() {
+        add_action('init', array(__CLASS__, 'maybe_schedule_cron'));
+        add_action(self::CRON_HOOK, array(__CLASS__, 'run_scheduled'));
+        add_action('admin_post_alma_ai_ideas_import', array(__CLASS__, 'handle_import'));
+        add_action('admin_post_alma_ai_ideas_csv_template', array(__CLASS__, 'handle_template_download'));
+        add_action('admin_post_alma_ai_ideas_import_settings', array(__CLASS__, 'handle_settings'));
+    }
+
+    public static function maybe_schedule_cron() {
+        if (!wp_next_scheduled(self::CRON_HOOK)) {
+            $first = strtotime('tomorrow 04:30', current_time('timestamp'));
+            $first = $first - (current_time('timestamp') - time());
+            wp_schedule_event($first, 'daily', self::CRON_HOOK);
+        }
+    }
+
+    public static function unschedule() {
+        wp_clear_scheduled_hook(self::CRON_HOOK);
+    }
+
+    public static function get_daily_limit() {
+        return max(0, min(50, absint(get_option(self::OPTION_DAILY_LIMIT, 3))));
+    }
+
+    /* ---------------------------------------------------------------------
+     * Pagina admin
+     * ------------------------------------------------------------------ */
+
+    public static function render_page() {
+        if (!current_user_can('manage_options')) {
+            wp_die(esc_html__('Permessi insufficienti.', 'affiliate-link-manager-ai'));
+        }
+        $list_url = admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-ideas');
+        $report = get_transient(self::REPORT_TRANSIENT . get_current_user_id());
+        $template_url = wp_nonce_url(admin_url('admin-post.php?action=alma_ai_ideas_csv_template'), 'alma_ai_ideas_csv_template');
+        ?>
+        <div class="wrap alma-ai-agent-admin">
+            <h1><?php esc_html_e('Importazione massiva idee (CSV)', 'affiliate-link-manager-ai'); ?></h1>
+            <p><a href="<?php echo esc_url($list_url); ?>">← <?php esc_html_e('Torna a Tutte le idee', 'affiliate-link-manager-ai'); ?></a></p>
+
+            <?php if (is_array($report)) : delete_transient(self::REPORT_TRANSIENT . get_current_user_id()); ?>
+                <div class="notice notice-<?php echo esc_attr(empty($report['errors']) ? 'success' : 'warning'); ?>">
+                    <p><strong><?php printf(esc_html__('Import completato: %1$d idee create, %2$d righe scartate.', 'affiliate-link-manager-ai'), (int)$report['created'], count((array)$report['errors'])); ?></strong></p>
+                    <?php if (!empty($report['errors'])) : ?>
+                        <ul><?php foreach ((array)$report['errors'] as $error) : ?><li><?php echo esc_html($error); ?></li><?php endforeach; ?></ul>
+                    <?php endif; ?>
+                    <?php if (!empty($report['unresolved_locations'])) : ?>
+                        <p><?php esc_html_e('Località non trovate nell\'indice geografico (idea creata senza località):', 'affiliate-link-manager-ai'); ?> <?php echo esc_html(implode(', ', (array)$report['unresolved_locations'])); ?></p>
+                    <?php endif; ?>
+                </div>
+            <?php endif; ?>
+
+            <div class="card" style="max-width:860px;">
+                <h2><?php esc_html_e('Struttura del file', 'affiliate-link-manager-ai'); ?></h2>
+                <p><?php esc_html_e('Colonne (intestazione obbligatoria in prima riga; separatore virgola o punto e virgola):', 'affiliate-link-manager-ai'); ?></p>
+                <p><code>Titolo</code> (obbligatoria) · <code>Localita</code> · <code>Tema</code> · <code>Keyword principale</code> · <code>Keyword secondarie</code> (separate da |) · <code>Profilo istruzioni</code> (nome o ID) · <code>Data programmata</code> (AAAA-MM-GG o GG/MM/AAAA) · <code>Note AI</code></p>
+                <p><a class="button" href="<?php echo esc_url($template_url); ?>">⬇️ <?php esc_html_e('Scarica CSV di esempio', 'affiliate-link-manager-ai'); ?></a></p>
+                <p class="description"><?php printf(esc_html__('Massimo %d righe per file. Le idee con Data programmata vengono lavorate automaticamente in background: alla data indicata l\'AI seleziona i link affiliati della località (o coerenti con le keyword) e genera la bozza, entro il limite giornaliero configurato qui sotto.', 'affiliate-link-manager-ai'), (int)self::MAX_ROWS); ?></p>
+            </div>
+
+            <div class="card" style="max-width:860px;">
+                <h2><?php esc_html_e('Carica CSV', 'affiliate-link-manager-ai'); ?></h2>
+                <form method="post" enctype="multipart/form-data" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                    <?php wp_nonce_field('alma_ai_ideas_import'); ?>
+                    <input type="hidden" name="action" value="alma_ai_ideas_import">
+                    <p><input type="file" name="ideas_csv" accept=".csv,text/csv" required></p>
+                    <p><button class="button button-primary"><?php esc_html_e('Importa idee', 'affiliate-link-manager-ai'); ?></button></p>
+                </form>
+                <p class="description"><?php esc_html_e('L\'import crea subito le idee (visibili in Tutte le idee) e avvia automaticamente il runner in background per quelle già in scadenza.', 'affiliate-link-manager-ai'); ?></p>
+            </div>
+
+            <div class="card" style="max-width:860px;">
+                <h2><?php esc_html_e('Generazione automatica in background', 'affiliate-link-manager-ai'); ?></h2>
+                <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                    <?php wp_nonce_field('alma_ai_ideas_import_settings'); ?>
+                    <input type="hidden" name="action" value="alma_ai_ideas_import_settings">
+                    <p><label><?php esc_html_e('Massimo bozze generate automaticamente al giorno', 'affiliate-link-manager-ai'); ?>
+                        <input type="number" name="<?php echo esc_attr(self::OPTION_DAILY_LIMIT); ?>" min="0" max="50" value="<?php echo esc_attr((string)self::get_daily_limit()); ?>" class="small-text"></label></p>
+                    <p class="description"><?php esc_html_e('Tetto ai costi OpenAI: il runner giornaliero non supera questo numero di bozze. 0 = generazione automatica sospesa (le idee restano programmate).', 'affiliate-link-manager-ai'); ?></p>
+                    <p><button class="button"><?php esc_html_e('Salva', 'affiliate-link-manager-ai'); ?></button></p>
+                </form>
+                <?php
+                $counter = get_option(self::OPTION_COUNTER, array());
+                $today = current_time('Y-m-d');
+                $today_count = (is_array($counter) && ($counter['date'] ?? '') === $today) ? (int)$counter['count'] : 0;
+                $next_run = wp_next_scheduled(self::CRON_HOOK);
+                ?>
+                <p class="description"><?php printf(esc_html__('Bozze generate oggi: %1$d / %2$d · Prossima esecuzione automatica: %3$s', 'affiliate-link-manager-ai'), $today_count, self::get_daily_limit(), $next_run ? esc_html(get_date_from_gmt(gmdate('Y-m-d H:i:s', $next_run), 'Y-m-d H:i')) : '—'); ?></p>
+            </div>
+        </div>
+        <?php
+    }
+
+    public static function handle_template_download() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_ai_ideas_csv_template');
+        nocache_headers();
+        header('Content-Type: text/csv; charset=utf-8');
+        header('Content-Disposition: attachment; filename="idee-contenuto-esempio.csv"');
+        $out = fopen('php://output', 'w');
+        // BOM UTF-8 per Excel.
+        fwrite($out, "\xEF\xBB\xBF");
+        fputcsv($out, array('Titolo', 'Localita', 'Tema', 'Keyword principale', 'Keyword secondarie', 'Profilo istruzioni', 'Data programmata', 'Note AI'));
+        fputcsv($out, array('Cosa vedere ad Algeri in 3 giorni', 'Algeri', 'Città', 'algeri cosa vedere', 'algeria viaggio|casbah algeri', 'Default', current_time('Y-m-d'), 'Taglio pratico, itinerario giorno per giorno, budget indicativo.'));
+        fputcsv($out, array('Weekend enogastronomico in Salento', 'Salento', 'Enogastronomia', 'salento weekend enogastronomia', 'cantine salento|cucina salentina', '', gmdate('Y-m-d', current_time('timestamp') + 7 * DAY_IN_SECONDS), 'Tono caldo, consigli locali, esperienze prenotabili.'));
+        fclose($out);
+        exit;
+    }
+
+    public static function handle_settings() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_ai_ideas_import_settings');
+        update_option(self::OPTION_DAILY_LIMIT, max(0, min(50, absint($_POST[self::OPTION_DAILY_LIMIT] ?? 3))), false);
+        wp_safe_redirect(wp_get_referer() ?: admin_url('admin.php?page=' . self::PAGE_SLUG));
+        exit;
+    }
+
+    /* ---------------------------------------------------------------------
+     * Import CSV
+     * ------------------------------------------------------------------ */
+
+    public static function handle_import() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_ai_ideas_import');
+
+        $report = array('created' => 0, 'errors' => array(), 'unresolved_locations' => array());
+        $file = $_FILES['ideas_csv'] ?? array();
+        if (empty($file['tmp_name']) || !is_uploaded_file($file['tmp_name'])) {
+            $report['errors'][] = __('Nessun file ricevuto.', 'affiliate-link-manager-ai');
+        } elseif ((int)$file['size'] > 2 * 1024 * 1024) {
+            $report['errors'][] = __('File troppo grande (max 2 MB).', 'affiliate-link-manager-ai');
+        } else {
+            $report = self::import_file($file['tmp_name']);
+        }
+
+        set_transient(self::REPORT_TRANSIENT . get_current_user_id(), $report, 300);
+        // Avvio automatico: le idee già in scadenza vengono lavorate subito
+        // in background, senza aspettare il giro notturno.
+        if ($report['created'] > 0) {
+            wp_schedule_single_event(time() + 30, self::CRON_HOOK);
+            if (function_exists('spawn_cron')) { spawn_cron(); }
+        }
+        wp_safe_redirect(admin_url('admin.php?page=' . self::PAGE_SLUG));
+        exit;
+    }
+
+    private static function import_file($path) {
+        $report = array('created' => 0, 'errors' => array(), 'unresolved_locations' => array());
+        $handle = fopen($path, 'r');
+        if (!$handle) {
+            $report['errors'][] = __('Impossibile leggere il file.', 'affiliate-link-manager-ai');
+            return $report;
+        }
+        $first_line = (string) fgets($handle);
+        // Rimuove il BOM e autorileva il separatore.
+        $first_line = preg_replace('/^\xEF\xBB\xBF/', '', $first_line);
+        $delimiter = substr_count($first_line, ';') > substr_count($first_line, ',') ? ';' : ',';
+        $headers = array_map(array(__CLASS__, 'normalize_header'), (array) str_getcsv($first_line, $delimiter));
+
+        $column_map = array();
+        $aliases = array(
+            'titolo' => 'title', 'title' => 'title',
+            'localita' => 'location', 'località' => 'location', 'location' => 'location',
+            'tema' => 'theme', 'theme' => 'theme',
+            'keyword principale' => 'primary_keyword', 'keyword' => 'primary_keyword',
+            'keyword secondarie' => 'secondary_keywords',
+            'profilo istruzioni' => 'profile', 'profilo' => 'profile',
+            'data programmata' => 'scheduled', 'data' => 'scheduled',
+            'note ai' => 'notes', 'note' => 'notes', 'prompt' => 'notes',
+        );
+        foreach ($headers as $index => $header) {
+            if (isset($aliases[$header])) { $column_map[$aliases[$header]] = $index; }
+        }
+        if (!isset($column_map['title'])) {
+            fclose($handle);
+            $report['errors'][] = __('Colonna "Titolo" mancante nell\'intestazione.', 'affiliate-link-manager-ai');
+            return $report;
+        }
+
+        $profiles_by_name = array();
+        foreach ((array) ALMA_AI_Content_Agent_Instructions_Manager::get_profiles(100, 0) as $profile_row) {
+            $profiles_by_name[mb_strtolower(trim((string)($profile_row['profile_name'] ?? '')))] = (int)($profile_row['id'] ?? 0);
+        }
+
+        $row_number = 1;
+        while (($row = fgetcsv($handle, 0, $delimiter)) !== false) {
+            $row_number++;
+            if ($report['created'] >= self::MAX_ROWS) {
+                $report['errors'][] = sprintf(__('Limite di %d righe raggiunto: le righe successive sono state ignorate.', 'affiliate-link-manager-ai'), self::MAX_ROWS);
+                break;
+            }
+            $get = function ($key) use ($row, $column_map) {
+                return isset($column_map[$key], $row[$column_map[$key]]) ? trim((string) $row[$column_map[$key]]) : '';
+            };
+            $title = sanitize_text_field($get('title'));
+            if ($title === '') {
+                if (implode('', array_map('trim', (array)$row)) !== '') {
+                    $report['errors'][] = sprintf(__('Riga %d: titolo mancante.', 'affiliate-link-manager-ai'), $row_number);
+                }
+                continue;
+            }
+
+            $profile_id = 0;
+            $profile_raw = $get('profile');
+            if ($profile_raw !== '') {
+                $profile_id = ctype_digit($profile_raw) ? absint($profile_raw) : ($profiles_by_name[mb_strtolower($profile_raw)] ?? 0);
+                if ($profile_id === 0) {
+                    $report['errors'][] = sprintf(__('Riga %1$d: profilo istruzioni "%2$s" non trovato (idea creata senza profilo).', 'affiliate-link-manager-ai'), $row_number, $profile_raw);
+                }
+            }
+
+            $idea_id = ALMA_AI_Content_Agent_Ideas::create($title, $profile_id);
+            if ($idea_id < 1) {
+                $report['errors'][] = sprintf(__('Riga %d: errore creazione idea.', 'affiliate-link-manager-ai'), $row_number);
+                continue;
+            }
+
+            $location_raw = sanitize_text_field($get('location'));
+            if ($location_raw !== '') {
+                $location = self::resolve_location($location_raw);
+                if ($location) {
+                    update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_LOCATION_ID, (int)$location['id']);
+                    update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_LOCATION_LABEL, sanitize_text_field($location['label']));
+                } else {
+                    $report['unresolved_locations'][] = $location_raw;
+                }
+            }
+
+            $keywords = array_values(array_filter(array_map('sanitize_text_field', array_merge(
+                array($get('primary_keyword')),
+                array_map('trim', explode('|', $get('secondary_keywords')))
+            ))));
+            update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_KEYWORDS, $keywords);
+
+            $theme = sanitize_text_field($get('theme'));
+            $notes = sanitize_textarea_field($get('notes'));
+            $prompt_parts = array_filter(array($notes, $theme !== '' ? 'Tema: ' . $theme : ''));
+            if (!empty($prompt_parts)) {
+                update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_PROMPT, implode("\n", $prompt_parts));
+            }
+
+            $scheduled = self::normalize_date($get('scheduled'));
+            update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_SCHEDULED_AT, $scheduled);
+            update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_SOURCE, 'csv');
+
+            $report['created']++;
+        }
+        fclose($handle);
+        $report['unresolved_locations'] = array_values(array_unique($report['unresolved_locations']));
+        return $report;
+    }
+
+    private static function normalize_header($header) {
+        return mb_strtolower(trim((string) $header));
+    }
+
+    private static function normalize_date($raw) {
+        $raw = trim((string) $raw);
+        if ($raw === '') { return ''; }
+        if (preg_match('/^(\d{4})-(\d{2})-(\d{2})$/', $raw)) { return $raw; }
+        if (preg_match('#^(\d{1,2})/(\d{1,2})/(\d{4})$#', $raw, $m)) {
+            return sprintf('%04d-%02d-%02d', (int)$m[3], (int)$m[2], (int)$m[1]);
+        }
+        return '';
+    }
+
+    private static function resolve_location($name) {
+        global $wpdb;
+        if (!class_exists('ALMA_Geo_Index_Store')) { return null; }
+        $store = new ALMA_Geo_Index_Store();
+        if (!$store->tables_exist()) { return null; }
+        $row = $wpdb->get_row($wpdb->prepare(
+            "SELECT id, canonical_name, country FROM {$store->table_locations()} WHERE LOWER(canonical_name) = LOWER(%s) ORDER BY id ASC LIMIT 1",
+            $name
+        ), ARRAY_A);
+        if (!$row) {
+            $row = $wpdb->get_row($wpdb->prepare(
+                "SELECT id, canonical_name, country FROM {$store->table_locations()} WHERE canonical_name LIKE %s ORDER BY CHAR_LENGTH(canonical_name) ASC LIMIT 1",
+                $wpdb->esc_like($name) . '%'
+            ), ARRAY_A);
+        }
+        if (!$row) { return null; }
+        $label = html_entity_decode(sanitize_text_field($row['canonical_name']), ENT_QUOTES, 'UTF-8');
+        $country = sanitize_text_field((string)$row['country']);
+        if ($country !== '' && strcasecmp($country, $label) !== 0) { $label .= ' (' . $country . ')'; }
+        return array('id' => (int)$row['id'], 'label' => $label);
+    }
+
+    /* ---------------------------------------------------------------------
+     * Runner in background
+     * ------------------------------------------------------------------ */
+
+    private static function acquire_lock() {
+        if (add_option(self::LOCK_OPTION, (string) time(), '', 'no')) { return true; }
+        $started = absint(get_option(self::LOCK_OPTION, 0));
+        if ($started > 0 && (time() - $started) > self::LOCK_TTL) {
+            update_option(self::LOCK_OPTION, (string) time(), false);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Genera le bozze delle idee programmate in scadenza, entro il limite
+     * giornaliero. Riusa l'intera pipeline esistente: selezione candidati via
+     * Knowledge Search (geo-first), sessione contenuto, Draft Builder.
+     */
+    public static function run_scheduled() {
+        if (!self::acquire_lock()) { return; }
+        global $wpdb;
+        $job_id = 0;
+        try {
+            $limit = self::get_daily_limit();
+            $today = current_time('Y-m-d');
+            $counter = get_option(self::OPTION_COUNTER, array());
+            $done_today = (is_array($counter) && ($counter['date'] ?? '') === $today) ? (int)$counter['count'] : 0;
+            $quota = max(0, $limit - $done_today);
+            if ($quota < 1 || empty(get_option('alma_openai_api_key', ''))) { return; }
+
+            $idea_ids = get_posts(array(
+                'post_type' => ALMA_AI_Content_Agent_Ideas::CPT,
+                'post_status' => 'publish',
+                'posts_per_page' => $quota,
+                'fields' => 'ids',
+                'orderby' => 'meta_value',
+                'meta_key' => ALMA_AI_Content_Agent_Ideas::META_SCHEDULED_AT,
+                'order' => 'ASC',
+                'no_found_rows' => true,
+                'meta_query' => array(
+                    array('key' => ALMA_AI_Content_Agent_Ideas::META_SCHEDULED_AT, 'value' => '', 'compare' => '!='),
+                    array('key' => ALMA_AI_Content_Agent_Ideas::META_SCHEDULED_AT, 'value' => $today, 'compare' => '<='),
+                    array('key' => ALMA_AI_Content_Agent_Ideas::META_EXECUTED_AT, 'value' => '', 'compare' => '='),
+                    array('key' => ALMA_AI_Content_Agent_Ideas::META_DRAFT_POST_ID, 'value' => 0, 'compare' => '<=', 'type' => 'NUMERIC'),
+                ),
+            ));
+            if (empty($idea_ids)) { return; }
+
+            $jobs_table = ALMA_AI_Content_Agent_Store::table('jobs');
+            $wpdb->insert($jobs_table, array('job_type' => 'scheduled_ideas', 'status' => 'running', 'total_items' => count($idea_ids), 'started_at' => current_time('mysql'), 'updated_at' => current_time('mysql')));
+            $job_id = (int) $wpdb->insert_id;
+
+            $processed = 0;
+            $errors = 0;
+            $last_error = '';
+            $original_user = get_current_user_id();
+            foreach ($idea_ids as $idea_id) {
+                $result = self::generate_draft_for_scheduled_idea((int) $idea_id);
+                $processed++;
+                if (empty($result['success'])) {
+                    $errors++;
+                    $last_error = sanitize_text_field((string)($result['error'] ?? 'errore generazione'));
+                } else {
+                    $done_today++;
+                }
+                update_option(self::OPTION_COUNTER, array('date' => $today, 'count' => $done_today), false);
+                if ($job_id > 0) {
+                    $wpdb->update($jobs_table, array('processed_items' => $processed, 'errors_count' => $errors, 'last_error' => $last_error, 'updated_at' => current_time('mysql')), array('id' => $job_id));
+                }
+            }
+            wp_set_current_user($original_user);
+            if ($job_id > 0) {
+                $wpdb->update($jobs_table, array('status' => $errors > 0 ? 'completed_with_errors' : 'completed', 'finished_at' => current_time('mysql'), 'updated_at' => current_time('mysql')), array('id' => $job_id));
+            }
+        } finally {
+            delete_option(self::LOCK_OPTION);
+        }
+    }
+
+    /**
+     * Pipeline per una singola idea programmata:
+     * 1. candidati affiliate via Knowledge Search (geo-first sulla località
+     *    dell'idea + keyword del CSV), top N selezionati;
+     * 2. selezione persistita sull'idea e caricata in sessione (nel contesto
+     *    dell'autore dell'idea, come farebbe dall'admin);
+     * 3. bozza generata dal Draft Builder esistente; meta idea aggiornate.
+     */
+    private static function generate_draft_for_scheduled_idea($idea_id) {
+        $idea = ALMA_AI_Content_Agent_Ideas::get($idea_id);
+        if (empty($idea)) { return array('success' => false, 'error' => 'Idea non trovata'); }
+        $author_id = absint(get_post_field('post_author', $idea_id)) ?: 1;
+        wp_set_current_user($author_id);
+
+        $geo_link_ids = array();
+        if (!empty($idea['location_id']) && class_exists('ALMA_Geo_Index_Store')) {
+            $store = new ALMA_Geo_Index_Store();
+            $geo_link_ids = $store->get_affiliate_link_ids_for_area((int)$idea['location_id']);
+        }
+        $keywords = (array)($idea['keywords'] ?? array());
+        $query_text = trim(implode(' ', array_filter(array($idea['title'], implode(' ', array_slice($keywords, 0, 3))))));
+
+        $search = ALMA_AI_Content_Agent_Knowledge_Search::search(array(
+            'content_search_query' => $query_text,
+            'search_scope' => 'affiliate_links_only',
+            'geo_location_id' => (int)($idea['location_id'] ?? 0),
+            'geo_location_label' => (string)($idea['location_label'] ?? ''),
+            'geo_link_ids' => $geo_link_ids,
+        ));
+        $candidates = array_slice((array)($search['groups']['affiliate_link'] ?? array()), 0, self::MAX_AUTO_CANDIDATES);
+        if (empty($candidates)) {
+            update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_EXECUTED_AT, current_time('mysql'));
+            return array('success' => false, 'error' => 'Nessun link affiliato candidato per l\'idea #' . $idea_id);
+        }
+        foreach ($candidates as &$candidate) { $candidate['selected'] = true; }
+        unset($candidate);
+
+        update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_RESULTS, $candidates);
+        update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_SELECTION, $candidates);
+        update_user_meta($author_id, '_alma_active_idea_id', $idea_id);
+        ALMA_AI_Content_Agent_Selection_Session::load_from_idea(ALMA_AI_Content_Agent_Ideas::get($idea_id));
+
+        $result = ALMA_AI_Content_Agent_Draft_Builder::generate_from_selection_session($author_id);
+        update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_EXECUTED_AT, current_time('mysql'));
+        if (!empty($result['success']) && !empty($result['post_id'])) {
+            update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_DRAFT_POST_ID, absint($result['post_id']));
+        }
+        return is_array($result) ? $result : array('success' => false, 'error' => 'Risposta generazione non valida');
+    }
+}

--- a/includes/class-ai-content-agent-ideas.php
+++ b/includes/class-ai-content-agent-ideas.php
@@ -13,6 +13,12 @@ class ALMA_AI_Content_Agent_Ideas {
     const META_DRAFT_POST_ID = '_alma_idea_draft_post_id';
     const META_INSTRUCTION_SNAPSHOT_HASH = '_alma_idea_instruction_snapshot_hash';
     const META_INSTRUCTION_SNAPSHOT = '_alma_idea_instruction_snapshot';
+    // Fase 2/3: geolocalizzazione e programmazione.
+    const META_LOCATION_ID = '_alma_idea_location_id';
+    const META_LOCATION_LABEL = '_alma_idea_location_label';
+    const META_SCHEDULED_AT = '_alma_idea_scheduled_at';
+    const META_SOURCE = '_alma_idea_source';
+    const META_KEYWORDS = '_alma_idea_keywords';
 
     public static function init() {
         add_action('init', array(__CLASS__, 'register_cpt'));
@@ -48,6 +54,11 @@ class ALMA_AI_Content_Agent_Ideas {
         update_post_meta($id, self::META_DRAFT_POST_ID, 0);
         update_post_meta($id, self::META_INSTRUCTION_SNAPSHOT_HASH, '');
         update_post_meta($id, self::META_INSTRUCTION_SNAPSHOT, '');
+        update_post_meta($id, self::META_LOCATION_ID, 0);
+        update_post_meta($id, self::META_LOCATION_LABEL, '');
+        update_post_meta($id, self::META_SCHEDULED_AT, '');
+        update_post_meta($id, self::META_SOURCE, 'manual');
+        update_post_meta($id, self::META_KEYWORDS, array());
         return (int)$id;
     }
 
@@ -71,7 +82,8 @@ class ALMA_AI_Content_Agent_Ideas {
         $results = self::normalize_meta_rows(get_post_meta($p->ID, self::META_RESULTS, true));
         $selection = self::normalize_meta_rows(get_post_meta($p->ID, self::META_SELECTION, true));
         $stored_profile_id = absint(get_post_meta($p->ID, self::META_PROFILE_ID, true));
-        return array('ID'=>$p->ID,'title'=>$p->post_title,'profile_id'=>$stored_profile_id,'instruction_profile_id'=>$stored_profile_id,'has_instruction_profile_meta'=>metadata_exists('post', $p->ID, self::META_PROFILE_ID),'prompt'=>get_post_meta($p->ID,self::META_PROMPT,true),'last_query'=>$last_query,'results'=>$results,'selection'=>$selection,'instruction_snapshot_hash'=>sanitize_text_field((string)get_post_meta($p->ID,self::META_INSTRUCTION_SNAPSHOT_HASH,true)),'instruction_snapshot'=>ALMA_AI_Content_Agent_Instructions_Manager::sanitize_profile_textarea((string)get_post_meta($p->ID,self::META_INSTRUCTION_SNAPSHOT,true)),'executed_at'=>sanitize_text_field((string)get_post_meta($p->ID,self::META_EXECUTED_AT,true)),'draft_post_id'=>absint(get_post_meta($p->ID,self::META_DRAFT_POST_ID,true)),'modified'=>$p->post_modified);
+        $keywords = get_post_meta($p->ID, self::META_KEYWORDS, true);
+        return array('ID'=>$p->ID,'title'=>$p->post_title,'profile_id'=>$stored_profile_id,'instruction_profile_id'=>$stored_profile_id,'has_instruction_profile_meta'=>metadata_exists('post', $p->ID, self::META_PROFILE_ID),'prompt'=>get_post_meta($p->ID,self::META_PROMPT,true),'last_query'=>$last_query,'results'=>$results,'selection'=>$selection,'instruction_snapshot_hash'=>sanitize_text_field((string)get_post_meta($p->ID,self::META_INSTRUCTION_SNAPSHOT_HASH,true)),'instruction_snapshot'=>ALMA_AI_Content_Agent_Instructions_Manager::sanitize_profile_textarea((string)get_post_meta($p->ID,self::META_INSTRUCTION_SNAPSHOT,true)),'executed_at'=>sanitize_text_field((string)get_post_meta($p->ID,self::META_EXECUTED_AT,true)),'draft_post_id'=>absint(get_post_meta($p->ID,self::META_DRAFT_POST_ID,true)),'location_id'=>absint(get_post_meta($p->ID,self::META_LOCATION_ID,true)),'location_label'=>sanitize_text_field((string)get_post_meta($p->ID,self::META_LOCATION_LABEL,true)),'scheduled_at'=>sanitize_text_field((string)get_post_meta($p->ID,self::META_SCHEDULED_AT,true)),'source'=>sanitize_key((string)get_post_meta($p->ID,self::META_SOURCE,true) ?: 'manual'),'keywords'=>is_array($keywords) ? array_values(array_filter(array_map('sanitize_text_field', $keywords))) : array(),'modified'=>$p->post_modified);
     }
 
     public static function save_from_request($idea_id, $data) {
@@ -88,6 +100,16 @@ class ALMA_AI_Content_Agent_Ideas {
         }
         if (array_key_exists('openai_prompt', (array)$data)) {
             update_post_meta($idea_id, self::META_PROMPT, sanitize_textarea_field((string)$data['openai_prompt']));
+        }
+        if (array_key_exists('idea_location_id', (array)$data)) {
+            $location_id = absint($data['idea_location_id']);
+            update_post_meta($idea_id, self::META_LOCATION_ID, $location_id);
+            $label = sanitize_text_field((string)($data['idea_location_label'] ?? ''));
+            update_post_meta($idea_id, self::META_LOCATION_LABEL, $location_id > 0 ? $label : '');
+        }
+        if (array_key_exists('idea_scheduled_at', (array)$data)) {
+            $scheduled = sanitize_text_field((string)$data['idea_scheduled_at']);
+            update_post_meta($idea_id, self::META_SCHEDULED_AT, preg_match('/^\d{4}-\d{2}-\d{2}$/', $scheduled) ? $scheduled : '');
         }
         return true;
     }

--- a/includes/class-ai-content-agent-knowledge-search.php
+++ b/includes/class-ai-content-agent-knowledge-search.php
@@ -10,6 +10,12 @@ class ALMA_AI_Content_Agent_Knowledge_Search {
         $results = array();
         $search_scope = sanitize_key((string)($input['search_scope'] ?? ''));
 
+        // Fase 2: geolocalizzazione. Se l'idea ha una località, i link della
+        // sua area geografica ricevono un boost dominante e vengono inclusi
+        // anche quando il match testuale da solo non li troverebbe.
+        $geo_link_ids = array_values(array_filter(array_map('absint', (array)($input['geo_link_ids'] ?? array()))));
+        $geo_label = sanitize_text_field((string)($input['geo_location_label'] ?? ''));
+
         if ($search_scope === 'affiliate_links_only') {
             $results = array_merge($results, self::search_affiliate_links($query));
         } else {
@@ -22,10 +28,61 @@ class ALMA_AI_Content_Agent_Knowledge_Search {
             $results = array_merge($results, self::search_media($query));
         }
 
+        if (!empty($geo_link_ids)) {
+            $results = self::apply_geo_context($results, $geo_link_ids, $geo_label, $query);
+        }
+
         $results = self::dedupe($results);
         $grouped = self::group_and_rank($results);
 
         return array('query' => $query, 'groups' => $grouped, 'generated_at' => current_time('mysql'));
+    }
+
+    /**
+     * Boost dei risultati affiliate della località (+40) e iniezione dei link
+     * dell'area geografica assenti dal match testuale (score base 55).
+     */
+    private static function apply_geo_context($results, $geo_link_ids, $geo_label, $query) {
+        $geo_map = array_fill_keys($geo_link_ids, true);
+        $present = array();
+        foreach ($results as $i => $r) {
+            if (($r['source_group'] ?? $r['source_type'] ?? '') !== 'affiliate_link') { continue; }
+            $sid = (int)($r['source_id'] ?? 0);
+            if ($sid > 0 && isset($geo_map[$sid])) {
+                $results[$i]['score'] = min(100, (int)$r['score'] + 40);
+                $results[$i]['reason'] = trim('Località coerente' . ($geo_label !== '' ? ' (' . $geo_label . ')' : '') . ' · ' . (string)$r['reason'], ' ·');
+                $present[$sid] = true;
+            }
+        }
+        $missing = array_diff($geo_link_ids, array_keys($present));
+        foreach (array_slice($missing, 0, 60) as $link_id) {
+            $p = get_post($link_id);
+            if (!$p || $p->post_type !== 'affiliate_link' || $p->post_status !== 'publish') { continue; }
+            $affiliate = ALMA_AI_Content_Agent_Affiliate_Index::get_affiliate_url_data($link_id);
+            if (empty($affiliate['valid'])) { continue; }
+            $link_types = wp_get_object_terms($link_id, 'link_type', array('fields' => 'names'));
+            $provider = (string) get_post_meta($link_id, '_alma_source_provider', true);
+            if ($provider === '') { $provider = (string) get_post_meta($link_id, '_alma_provider', true); }
+            $image = ALMA_AI_Content_Agent_Affiliate_Index::get_image_data($link_id);
+            $results[] = self::result(array_merge(array(
+                'key' => 'affiliate_geo:' . $link_id,
+                'source_group' => 'affiliate_link',
+                'source_type' => 'affiliate_link',
+                'source_id' => $link_id,
+                'title' => get_the_title($p),
+                'excerpt' => wp_trim_words(wp_strip_all_tags((string)($p->post_excerpt ?: $p->post_content)), 18),
+                'score' => 55,
+                'reason' => 'Link affiliato della località' . ($geo_label !== '' ? ' ' . $geo_label : ''),
+                'edit_url' => get_edit_post_link($link_id, 'raw'),
+                'affiliate_url' => esc_url_raw((string)$affiliate['url']),
+                'link_types' => is_wp_error($link_types) ? array() : array_values(array_filter(array_map('sanitize_text_field', (array)$link_types))),
+                'provenance' => sanitize_text_field($provider),
+                'provider' => sanitize_text_field($provider),
+                'source' => sanitize_text_field($provider),
+                'dedupe_ref' => 'affiliate_link:' . $link_id,
+            ), $image));
+        }
+        return $results;
     }
 
     private static function normalize_input($input) {

--- a/includes/class-geo-index-store.php
+++ b/includes/class-geo-index-store.php
@@ -715,6 +715,47 @@ class ALMA_Geo_Index_Store {
         );
     }
 
+    /**
+     * ID dei link affiliati pubblicati collegati all'AREA della località:
+     * stessa riga, località omonime (import diversi) e — per le località di
+     * tipo paese — tutte le località del paese. Usato dall'AI Content Agent
+     * per la selezione geo-first dei candidati.
+     */
+    public function get_affiliate_link_ids_for_area($location_id) {
+        global $wpdb;
+        $location = $this->get_location($location_id);
+        if (!$location) {
+            return array();
+        }
+        $name = trim((string) $location['canonical_name']);
+        $city = trim((string) (($location['city'] ?? '') !== '' ? $location['city'] : $name));
+        $conditions = array('l.id = %d');
+        $params = array(absint($location_id));
+        if ($name !== '') {
+            $conditions[] = 'LOWER(l.canonical_name) = LOWER(%s)';
+            $params[] = $name;
+        }
+        if ($city !== '') {
+            $conditions[] = "(l.city <> '' AND LOWER(l.city) = LOWER(%s))";
+            $params[] = $city;
+        }
+        $country_code = trim((string) ($location['country_code'] ?? ''));
+        if (($location['type'] ?? '') === 'country' && $country_code !== '') {
+            $conditions[] = 'l.country_code = %s';
+            $params[] = $country_code;
+        }
+        $where = implode(' OR ', $conditions);
+        $ids = $wpdb->get_col($wpdb->prepare(
+            "SELECT DISTINCT ci.object_id
+             FROM {$this->table_locations()} l
+             INNER JOIN {$this->table_content_index()} ci ON ci.location_id = l.id AND ci.object_type = %s
+             INNER JOIN {$wpdb->posts} p ON p.ID = ci.object_id AND p.post_type = 'affiliate_link' AND p.post_status = 'publish'
+             WHERE ({$where})",
+            array_merge(array(self::OBJECT_TYPE_AFFILIATE_LINK), $params)
+        ));
+        return array_values(array_filter(array_map('absint', (array) $ids)));
+    }
+
     public function get_locations_by_geocoding_status($status = 'pending', $limit = 20) {
         global $wpdb;
         if (!$this->tables_exist()) {


### PR DESCRIPTION
Recepisce il feedback sulla Fase 1 e completa le Fasi 2 e 3 del piano.

## Ristrutturazione sul modello dei Post

- Dopo la Dashboard: **Tutte le idee** (elenco con filtri, ricerca, colonne Località e Programmata) e **Aggiungi idea** (workspace).
- **"AI Content Agent" → "Impostazioni AI Content"**, spostata prima di Impostazioni; **tab "Idee contenuto" eliminata** (i vecchi link ricadono sulla Dashboard).
- "Aggiungi idea" dal menu apre il workspace su una nuova idea (riusando l'eventuale ultima "Nuova idea" mai toccata per non accumulare bozze vuote); con `?idea_id=N` modifica un'idea esistente — è la destinazione di "Apri nel workspace". I redirect delle azioni mantengono sempre `idea_id` nell'URL, così un reload non perde il lavoro.
- In Tutte le idee: pulsante **"Importazione massiva (CSV)"** verso la pagina dedicata.

## Fase 2 — Geolocalizzazione delle idee

- Campo **Località** nel workspace con **autocomplete AJAX sull'indice geografico** (nuovo endpoint admin read-only con nonce).
- Con località impostata: i link affiliati della sua **area geografica** (stessa località + omonimi + intero paese per località-nazione, nuovo metodo `get_affiliate_link_ids_for_area` nello store geo) ricevono **+40 di score** nella ricerca e vengono **iniettati anche senza match testuale** (score base 55, motivazione esplicita).
- Il payload OpenAI della bozza include un blocco `geo_context` con la località e la regola di coerenza geografica (solo link della destinazione).

## Fase 3 — Importazione massiva CSV con programmazione

- Pagina dedicata con **download del CSV di esempio** (BOM UTF-8 per Excel). Colonne: Titolo (obbligatoria), Localita, Tema, Keyword principale, Keyword secondarie (separate da |), Profilo istruzioni (nome o ID), Data programmata (AAAA-MM-GG o GG/MM/AAAA), Note AI. Separatore `,` o `;` autorilevato, max 500 righe, file max 2 MB.
- Ogni riga crea un'idea con località risolta sull'indice geografico (le non risolte sono elencate nel report), keywords, profilo e data programmata; report post-import con errori riga per riga.
- **Runner in background** (WP-Cron giornaliero ~04:30 + partenza immediata dopo ogni import): per le idee programmate in scadenza seleziona automaticamente i migliori candidati (geo-first + keyword via Knowledge Search), li persiste come selezione dell'idea e genera la bozza con la pipeline esistente (Selection Session + Draft Builder, nel contesto dell'autore dell'idea). **Limite bozze/giorno configurabile (default 3)** per controllare i costi OpenAI; lock via `add_option` atomica con TTL; esiti nella tabella `jobs` con contatori aggiornati riga per riga; contatore giornaliero e prossima esecuzione visibili in pagina. Cron rimosso alla disattivazione.

## Retrocompatibilità

- CPT `alma_content_idea` invariato: solo nuove meta (località, programmazione, keywords, origine). Azioni admin esistenti riusate; nessuna opzione/API rimossa.

## Test

- `php -l` su tutti i file PHP modificati e sul nuovo importer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_