### PR TITLE
Fase 4 (PR 1): regole inserimento shortcode, widget creati dall'AI, bozze dirette dall'agente (v2.60.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.60.0 - 2026-07-05
+
+### Fase 4 (PR 1) — Regole inserimento shortcode, widget creati dall'AI, bozze dirette dall'agente
+- **Nuova tab "Regole inserimento"** in Impostazioni AI Content: pattern abilitati (anchor nel testo, bottone CTA, card con immagine, widget di raccolta), densità massima (default 1 inserimento ogni 300 parole), paragrafi iniziali protetti (default 2), link massimi nel widget, testo bottone di default, regole per le anchor. Un'unica fonte di verità per bozze manuali, runner programmato e agente.
+- **Vocabolario dei pattern nel payload OpenAI**: l'AI ora conosce tutte le leve degli shortcode — `text=` per anchor naturali nella frase, `button="yes"` per CTA a fine sezione, `img+fields` per card prodotto — con le regole d'uso orientate alla conversione senza rompere l'eleganza della lettura.
+- **QA deterministico post-generazione** (`ALMA_AI_Insertion_Rules::enforce`): densità applicata dal codice (le anchor in eccesso tornano testo semplice, gli altri pattern vengono rimossi), nessun inserimento nei paragrafi protetti, mai due shortcode consecutivi, massimo un widget per articolo. Testato standalone (12/12).
+- **Widget creati dall'AI**: la bozza può includere il segnaposto `[[ALMA_WIDGET]]` e una `widget_request` (titolo, 2-N link candidati, testo bottone, titoli/descrizioni riscritti per-link nel tono dell'articolo); il plugin crea l'istanza reale nell'option standard dei widget (visibile e modificabile in Elenco Widget Link, con layout automatico in base al numero di link) e sostituisce il segnaposto con `[affiliate_links_widget id="X"]`. Solo link candidati del payload: ID inventati scartati.
+- **Bozze dirette dall'agente di ideazione**: nuova casella "Crea subito anche le bozze" nel pannello agente — dopo la creazione delle idee genera immediatamente le bozze nel rispetto del **limite giornaliero di bozze automatiche** (stesso contatore del runner programmato); il report mostra le bozze generate con link di modifica e segnala quando il limite è raggiunto (le idee restanti restano in coda).
+- Versione plugin aggiornata a `2.60.0`.
+
 ## 2.59.0 - 2026-07-05
 
 ### Storage OpenAI e Media Library per l'agente + pulizia impostazioni

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## 2.60.0 - 2026-07-05
+
+### Fase 4 (PR 1) — Regole inserimento shortcode, widget creati dall'AI, bozze dirette dall'agente
+- Tab "Regole inserimento" in Impostazioni AI Content: pattern (anchor/bottone/card/widget), densità, paragrafi protetti, widget e anchor rules — inviate al modello e applicate comunque dal QA deterministico dopo la generazione (anchor in eccesso degradate a testo, max un widget).
+- L'AI può creare il widget di raccolta: segnaposto `[[ALMA_WIDGET]]` + `widget_request` con titoli/descrizioni riscritti → istanza reale in Elenco Widget Link e shortcode `[affiliate_links_widget id="X"]` nella bozza.
+- Agente di ideazione: opzione "Crea subito anche le bozze" (entro il limite giornaliero di bozze automatiche), con report delle bozze generate.
+- Versione plugin aggiornata a `2.60.0`.
+
 ## 2.59.0 - 2026-07-05
 
 ### Storage OpenAI e Media Library per l'agente + pulizia impostazioni

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.59.0
+ * Version: 2.60.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.59.0');
+define('ALMA_VERSION', '2.60.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -56,6 +56,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-result-usage.php
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-instructions-manager.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-idea-importer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-idea-agent.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-ai-insertion-rules.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-url-validator.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-interface.php';
 require_once ALMA_PLUGIN_DIR . 'includes/providers/class-affiliate-source-provider-manual.php';

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -280,6 +280,9 @@ class ALMA_AI_Content_Agent_Admin {
             $wpdb->delete(ALMA_AI_Content_Agent_Store::table('content_chunks'), array('knowledge_item_id'=>$id));
             $ok = $wpdb->delete(ALMA_AI_Content_Agent_Store::table('knowledge_items'), array('id'=>$id,'source_type'=>'document_txt'));
             $result = array('success'=>(bool)$ok,'message'=>$ok?'Documento TXT eliminato dal Knowledge Base.':'Errore eliminazione documento TXT.');
+        } elseif ($do === 'save_insertion_rules') {
+            ALMA_AI_Insertion_Rules::save_from_request($_POST);
+            $result = array('success' => true, 'message' => 'Regole inserimento salvate.');
         } elseif ($do === 'save_source') {
             $result = ALMA_AI_Content_Agent_Source_Manager::save_source($_POST);
         } elseif ($do === 'toggle_source') {
@@ -364,6 +367,47 @@ class ALMA_AI_Content_Agent_Admin {
      * workspace dell'idea attiva.
      */
     const IDEAS_LIST_MENU_SLUG = 'alma-ai-content-ideas';
+
+    /**
+     * Tab "Regole inserimento" (Fase 4): come l'AI inserisce gli shortcode
+     * affiliati nelle bozze — pattern abilitati, densità, posizioni, widget.
+     */
+    private static function render_insertion_rules_tab() {
+        $rules = ALMA_AI_Insertion_Rules::get_rules();
+        echo '<h2>Regole inserimento affiliati</h2>';
+        echo '<p class="description">Definiscono COME le bozze AI inseriscono gli shortcode: il vocabolario dei pattern viene inviato al modello e le regole di densità/posizione vengono comunque applicate dal sistema dopo la generazione (QA deterministico).</p>';
+        echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">';
+        wp_nonce_field('alma_ai_agent_action');
+        echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_insertion_rules">';
+        echo '<table class="form-table" role="presentation">';
+
+        echo '<tr><th scope="row">Pattern abilitati</th><td>';
+        foreach (ALMA_AI_Insertion_Rules::all_patterns() as $key => $label) {
+            echo '<label style="display:block;margin-bottom:4px;"><input type="checkbox" name="alma_ai_insert_patterns[]" value="'.esc_attr($key).'" '.checked(in_array($key, $rules['patterns'], true), true, false).'> '.esc_html($label).'</label>';
+        }
+        echo '<p class="description">Anchor: link testuale nella frase. Bottone: CTA a fine sezione. Card: box con immagine e descrizione. Widget: raccolta finale "Esperienze consigliate" con titoli/descrizioni riscritti dall\'AI (creato automaticamente e visibile in Elenco Widget Link).</p></td></tr>';
+
+        echo '<tr><th scope="row"><label for="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_DENSITY).'">Densità massima</label></th><td>';
+        echo '1 inserimento ogni <input type="number" min="100" max="2000" step="50" class="small-text" name="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_DENSITY).'" id="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_DENSITY).'" value="'.esc_attr((string)$rules['density_words']).'"> parole';
+        echo '<p class="description">Gli inserimenti oltre soglia vengono degradati: le anchor tornano testo semplice, gli altri pattern vengono rimossi.</p></td></tr>';
+
+        echo '<tr><th scope="row"><label for="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_MIN_PARAGRAPHS).'">Paragrafi iniziali protetti</label></th><td>';
+        echo '<input type="number" min="0" max="10" class="small-text" name="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_MIN_PARAGRAPHS).'" id="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_MIN_PARAGRAPHS).'" value="'.esc_attr((string)$rules['min_paragraphs_before']).'">';
+        echo '<p class="description">Nessun inserimento nei primi N paragrafi: l\'introduzione crea fiducia, non vende.</p></td></tr>';
+
+        echo '<tr><th scope="row"><label for="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_WIDGET_MAX_LINKS).'">Link massimi nel widget</label></th><td>';
+        echo '<input type="number" min="2" max="8" class="small-text" name="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_WIDGET_MAX_LINKS).'" id="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_WIDGET_MAX_LINKS).'" value="'.esc_attr((string)$rules['widget_max_links']).'">';
+        echo '<p class="description">Il widget di raccolta finale contiene da 2 a N link; massimo un widget per articolo (applicato dal QA).</p></td></tr>';
+
+        echo '<tr><th scope="row"><label for="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_BUTTON_TEXT).'">Testo bottone di default</label></th><td>';
+        echo '<input type="text" class="regular-text" name="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_BUTTON_TEXT).'" id="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_BUTTON_TEXT).'" value="'.esc_attr($rules['button_text']).'"></td></tr>';
+
+        echo '<tr><th scope="row"><label for="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_ANCHOR_RULES).'">Regole per le anchor</label></th><td>';
+        echo '<textarea class="large-text" rows="3" name="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_ANCHOR_RULES).'" id="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_ANCHOR_RULES).'">'.esc_textarea($rules['anchor_rules']).'</textarea>';
+        echo '<p class="description">Inviate al modello insieme al pattern anchor.</p></td></tr>';
+
+        echo '</table><p><button class="button button-primary">Salva regole</button></p></form>';
+    }
 
     public static function render_ideas_list_page() {
         if (!current_user_can('manage_options')) { return; }
@@ -482,7 +526,7 @@ class ALMA_AI_Content_Agent_Admin {
         if (!current_user_can('manage_options')) { return; }
         // La tab "Idee contenuto" non esiste più: il workspace vive nella
         // pagina "Aggiungi idea", l'elenco nella pagina "Tutte le idee".
-        $tabs = array('dashboard'=>'Dashboard','istruzioni-ai'=>'Istruzioni AI','documenti'=>'Documenti TXT','fonti'=>'Fonti online AI','reindex'=>'Reindicizza','log'=>'Stato/log');
+        $tabs = array('dashboard'=>'Dashboard','istruzioni-ai'=>'Istruzioni AI','inserimento'=>'Regole inserimento','documenti'=>'Documenti TXT','fonti'=>'Fonti online AI','reindex'=>'Reindicizza','log'=>'Stato/log');
         $legacy_map = array('overview'=>'dashboard','idee'=>'dashboard','reindirizza'=>'reindex','knowledge'=>'dashboard','media'=>'dashboard','bozze'=>'log','programmazione'=>'log',);
         $tab = sanitize_key($_GET['tab'] ?? 'dashboard');
         if (isset($legacy_map[$tab])) { $tab = $legacy_map[$tab]; }
@@ -490,6 +534,7 @@ class ALMA_AI_Content_Agent_Admin {
         echo '<div class="wrap alma-ai-agent-admin"><h1>Impostazioni AI Content</h1>'; self::render_notice();
         echo '<h2 class="nav-tab-wrapper">'; foreach ($tabs as $tk=>$tl) { echo '<a class="nav-tab '.($tk===$tab?'nav-tab-active':'').'" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab='.$tk)).'">'.esc_html($tl).'</a>'; } echo '</h2>';
         if ($tab === 'istruzioni-ai') { self::render_instructions_tab(); }
+        elseif ($tab === 'inserimento') { self::render_insertion_rules_tab(); }
         elseif ($tab === 'documenti') { self::render_documents_tab(); }
         elseif ($tab === 'fonti') { self::render_sources_tab(); }
         elseif ($tab === 'reindex') { self::render_reindex_tab(); }

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -952,6 +952,11 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'Non usare link non presenti nel payload.',
         );
         if (!empty($profile_payload['instruction_profile_rules']['affiliate_rules'])) { $affiliate_rules[] = $profile_payload['instruction_profile_rules']['affiliate_rules']; }
+        // Fase 4: vocabolario dei pattern di inserimento e regole di densità
+        // dalla tab "Regole inserimento" (poi applicate anche dal QA).
+        if (class_exists('ALMA_AI_Insertion_Rules')) {
+            $affiliate_rules = array_merge($affiliate_rules, ALMA_AI_Insertion_Rules::payload_rules());
+        }
         $seo_rules = array(
             'Il titolo dell\'articolo deve ispirarsi a idea_context.idea_title (e al prompt); content_search_query è servita SOLO a selezionare i link affiliati, non usarla come argomento del pezzo.',
             'Produrre seo_title coerente con titolo idea e prompt.',
@@ -1018,6 +1023,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'seo_rules'=>$seo_rules,
             'media_rules'=>array_filter(array('Usa massimo '.$max_editorial_media_used.' immagini editoriali dalla Media Library nel corpo dell’articolo.','Usare immagini affiliate solo se pertinenti alla sezione.','Non inventare URL immagini.','Usare solo immagini presenti nei link affiliati selezionati.','Non duplicare troppe volte la stessa immagine.','Non scaricare immagini durante la generazione bozza.', $profile_payload['instruction_profile_rules']['image_rules'] ?? '')),
             'output_contract'=>array('title','slug','excerpt','content','seo_title','seo_description','featured_image_id','affiliate_shortcodes_used','affiliate_urls_used','internal_urls_used','media_used','category_ids','tag_ids','new_tags','warnings'),
+            'widget_request_contract'=>'Campo OPZIONALE widget_request nell\'output JSON: {"title":string,"link_ids":[int],"button_text":string,"rewritten":[{"id":int,"title":string,"description":string}]}. Compilalo SOLO se hai inserito il segnaposto [[ALMA_WIDGET]] nel content; il sistema creerà il widget reale e sostituirà il segnaposto.',
             'warnings'=>array_values(array_unique($warnings)),
             'agent_behavior'=>$agent_behavior,
         ), $profile_payload);
@@ -1218,8 +1224,21 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         $taxonomy_clean = self::validate_taxonomies($parsed, (array)($payload['category_candidates'] ?? array()), (array)($payload['tag_candidates'] ?? array()));
         $clean['warnings'] = array_values(array_unique(array_merge((array)$clean['warnings'], (array)$taxonomy_clean['warnings'])));
         if ($clean['title'] === '' || trim(wp_strip_all_tags($clean['content'])) === '') { return self::fail('Titolo o contenuto non validi dopo QA.', $res['model'] ?? '', 'session:user:'.$user_id); }
+
+        // Fase 4: widget richiesto dall'AI (creazione istanza reale + shortcode)
+        // e enforcement deterministico delle regole di inserimento.
+        $ai_widget_id = 0;
+        if (class_exists('ALMA_AI_Insertion_Rules')) {
+            $widget_request = is_array($parsed['widget_request'] ?? null) ? $parsed['widget_request'] : array();
+            $widget_result = ALMA_AI_Insertion_Rules::apply_widget_request($clean['content'], $widget_request, $candidate_affiliate_ids);
+            $ai_widget_id = (int) $widget_result['widget_id'];
+            $enforced = ALMA_AI_Insertion_Rules::enforce($widget_result['content'], ALMA_AI_Insertion_Rules::get_rules());
+            $clean['content'] = $enforced['content'];
+            $clean['warnings'] = array_values(array_unique(array_merge((array)$clean['warnings'], (array)$widget_result['warnings'], (array)$enforced['warnings'])));
+        }
         $post_id = wp_insert_post(array('post_type'=>'post','post_status'=>'draft','post_author'=>$user_id,'post_title'=>$clean['title'],'post_name'=>$clean['slug'],'post_excerpt'=>$clean['excerpt'],'post_content'=>$clean['content']), true);
         if (is_wp_error($post_id) || !$post_id) { return self::fail('Errore creazione bozza.', $res['model'] ?? '', 'session:user:'.$user_id); }
+        if (!empty($ai_widget_id)) { update_post_meta($post_id, '_alma_ai_agent_widget_id', (int) $ai_widget_id); }
         $taxonomy_applied = self::apply_taxonomies_to_post($post_id, $taxonomy_clean);
         $taxonomy_warnings = array_values(array_unique(array_merge((array)$taxonomy_clean['warnings'], (array)$taxonomy_applied['warnings'])));
 

--- a/includes/class-ai-content-agent-idea-importer.php
+++ b/includes/class-ai-content-agent-idea-importer.php
@@ -400,6 +400,26 @@ class ALMA_AI_Content_Agent_Idea_Importer {
     }
 
     /**
+     * Genera SUBITO la bozza di un'idea rispettando il limite giornaliero di
+     * bozze automatiche (stesso contatore del runner programmato): usato
+     * dall'agente di ideazione quando l'editore chiede anche le bozze.
+     */
+    public static function generate_draft_now($idea_id) {
+        $limit = self::get_daily_limit();
+        $today = current_time('Y-m-d');
+        $counter = get_option(self::OPTION_COUNTER, array());
+        $done = (is_array($counter) && ($counter['date'] ?? '') === $today) ? (int)$counter['count'] : 0;
+        if ($limit < 1 || $done >= $limit) {
+            return array('success' => false, 'error' => 'Limite giornaliero di bozze automatiche raggiunto (' . $done . '/' . $limit . ').', 'quota_exhausted' => true);
+        }
+        $result = self::generate_draft_for_scheduled_idea(absint($idea_id));
+        if (!empty($result['success'])) {
+            update_option(self::OPTION_COUNTER, array('date' => $today, 'count' => $done + 1), false);
+        }
+        return is_array($result) ? $result : array('success' => false, 'error' => 'Risposta generazione non valida');
+    }
+
+    /**
      * Pipeline per una singola idea programmata:
      * 1. candidati affiliate via Knowledge Search (geo-first sulla località
      *    dell'idea + keyword del CSV), top N selezionati;

--- a/includes/class-ai-idea-agent.php
+++ b/includes/class-ai-idea-agent.php
@@ -29,7 +29,7 @@ class ALMA_AI_Idea_Agent {
     const MAX_ROUNDS = 12;
 
     public static function init() {
-        add_action(self::CRON_HOOK, array(__CLASS__, 'run'), 10, 2);
+        add_action(self::CRON_HOOK, array(__CLASS__, 'run'), 10, 3);
         add_action('admin_post_alma_ai_idea_agent_start', array(__CLASS__, 'handle_start'));
         add_action('admin_post_alma_ai_idea_agent_settings', array(__CLASS__, 'handle_settings'));
     }
@@ -73,7 +73,8 @@ class ALMA_AI_Idea_Agent {
             $notice = array('type' => 'error', 'message' => __('Un\'esecuzione dell\'agente è già in corso.', 'affiliate-link-manager-ai'));
         } else {
             $objective = sanitize_textarea_field(wp_unslash($_POST['agent_objective'] ?? ''));
-            wp_schedule_single_event(time() + 5, self::CRON_HOOK, array(get_current_user_id(), $objective));
+            $create_drafts = empty($_POST['agent_create_drafts']) ? 0 : 1;
+            wp_schedule_single_event(time() + 5, self::CRON_HOOK, array(get_current_user_id(), $objective, $create_drafts));
             if (function_exists('spawn_cron')) { spawn_cron(); }
         }
         set_transient('alma_ai_agent_admin_notice_' . get_current_user_id(), $notice, 120);
@@ -104,12 +105,12 @@ class ALMA_AI_Idea_Agent {
         return false;
     }
 
-    public static function run($user_id = 0, $objective = '') {
+    public static function run($user_id = 0, $objective = '', $create_drafts = 0) {
         if (!self::acquire_lock()) { return; }
         $started_at = current_time('mysql');
         $report = array(
             'started_at' => $started_at, 'finished_at' => '', 'rounds' => 0,
-            'tool_calls' => array(), 'ideas_created' => array(),
+            'tool_calls' => array(), 'ideas_created' => array(), 'drafts_created' => array(),
             'cost_total' => 0.0, 'model' => '', 'summary' => '', 'error' => '',
         );
         try {
@@ -168,6 +169,24 @@ class ALMA_AI_Idea_Agent {
                 }
             }
             $report['ideas_created'] = $ideas_created;
+
+            // Su richiesta: genera SUBITO le bozze delle idee create, nel
+            // rispetto del limite giornaliero di bozze automatiche (Fase 3).
+            if (!empty($create_drafts) && !empty($ideas_created) && class_exists('ALMA_AI_Content_Agent_Idea_Importer')) {
+                foreach ($ideas_created as $idea) {
+                    $draft = ALMA_AI_Content_Agent_Idea_Importer::generate_draft_now((int)$idea['id']);
+                    $report['drafts_created'][] = array(
+                        'idea_id' => (int)$idea['id'],
+                        'titolo' => $idea['titolo'],
+                        'post_id' => (int)($draft['post_id'] ?? 0),
+                        'error' => empty($draft['success']) ? sanitize_text_field((string)($draft['error'] ?? '')) : '',
+                    );
+                    if (!empty($draft['quota_exhausted'])) {
+                        $report['drafts_created'][] = array('idea_id' => 0, 'titolo' => '', 'post_id' => 0, 'error' => 'Limite giornaliero raggiunto: le idee rimanenti restano in coda (generale automaticamente domani o dal workspace).');
+                        break;
+                    }
+                }
+            }
         } catch (Throwable $e) {
             $report['error'] = sanitize_text_field($e->getMessage());
             ALMA_Logger::error('Idea agent run error', array('error' => $e->getMessage()));
@@ -412,6 +431,7 @@ class ALMA_AI_Idea_Agent {
         wp_nonce_field('alma_ai_idea_agent_start');
         echo '<input type="hidden" name="action" value="alma_ai_idea_agent_start">';
         echo '<p style="margin:0;flex:1 1 320px;"><label><strong>'.esc_html__('Obiettivo (opzionale)', 'affiliate-link-manager-ai').'</strong><br><input type="text" name="agent_objective" class="widefat" placeholder="'.esc_attr__('Es. concentrati sull\'Italia, oppure su idee per l\'estate…', 'affiliate-link-manager-ai').'"></label></p>';
+        echo '<p style="margin:0;"><label title="'.esc_attr__('Le bozze contano nel limite giornaliero di bozze automatiche (impostazioni Importazione massiva).', 'affiliate-link-manager-ai').'"><input type="checkbox" name="agent_create_drafts" value="1"> '.esc_html__('Crea subito anche le bozze', 'affiliate-link-manager-ai').'</label></p>';
         echo '<p style="margin:0;"><button class="button button-primary" '.disabled($running, true, false).'>'.esc_html($running ? __('Esecuzione in corso…', 'affiliate-link-manager-ai') : __('Esegui agente', 'affiliate-link-manager-ai')).'</button></p>';
         echo '</form>';
 
@@ -433,6 +453,18 @@ class ALMA_AI_Idea_Agent {
                 foreach ($ideas as $idea) {
                     $edit = admin_url('edit.php?post_type=affiliate_link&page=alma-ai-add-idea&idea_id=' . (int)$idea['id']);
                     echo '<li><a href="'.esc_url($edit).'">'.esc_html($idea['titolo']).'</a>'.(!empty($idea['localita']) ? ' — 📍 '.esc_html($idea['localita']) : '').'</li>';
+                }
+                echo '</ul>';
+            }
+            $drafts = (array)($last['drafts_created'] ?? array());
+            if (!empty($drafts)) {
+                echo '<p style="margin:10px 0 4px;"><strong>'.esc_html__('Bozze generate:', 'affiliate-link-manager-ai').'</strong></p><ul style="margin:0 0 0 18px;list-style:disc;">';
+                foreach ($drafts as $draft) {
+                    if (!empty($draft['post_id'])) {
+                        echo '<li><a href="'.esc_url(get_edit_post_link((int)$draft['post_id'], 'raw')).'">'.esc_html($draft['titolo']).'</a></li>';
+                    } elseif (!empty($draft['error'])) {
+                        echo '<li style="color:#996800;">'.esc_html(($draft['titolo'] !== '' ? $draft['titolo'].' — ' : '').$draft['error']).'</li>';
+                    }
                 }
                 echo '</ul>';
             }

--- a/includes/class-ai-insertion-rules.php
+++ b/includes/class-ai-insertion-rules.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * Fase 4 — Regole di inserimento degli shortcode affiliati nelle bozze AI.
+ *
+ * Due livelli:
+ * 1. PROMPT: vocabolario dei pattern di inserimento (anchor nel testo,
+ *    bottone CTA, card, widget di raccolta) con le regole d'uso, costruito
+ *    dalle impostazioni della tab "Regole inserimento".
+ * 2. QA DETERMINISTICO: dopo la generazione, enforce() garantisce nel codice
+ *    ciò che il prompt chiede — densità massima, niente inserimenti nei primi
+ *    paragrafi, mai due shortcode consecutivi, massimo un widget. Le anchor
+ *    in eccesso diventano testo semplice (la lettura non si rompe), gli
+ *    altri pattern in eccesso vengono rimossi.
+ *
+ * La creazione del widget dall'AI passa da create_widget_instance(): scrive
+ * una nuova istanza nell'option widget_affiliate_links_widget (la stessa
+ * usata da Crea Widget Link) e restituisce l'ID per [affiliate_links_widget].
+ */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALMA_AI_Insertion_Rules {
+    const OPTION_DENSITY = 'alma_ai_insert_density_words';
+    const OPTION_PATTERNS = 'alma_ai_insert_patterns';
+    const OPTION_MIN_PARAGRAPHS = 'alma_ai_insert_min_paragraphs';
+    const OPTION_WIDGET_MAX_LINKS = 'alma_ai_insert_widget_max_links';
+    const OPTION_BUTTON_TEXT = 'alma_ai_insert_button_text';
+    const OPTION_ANCHOR_RULES = 'alma_ai_insert_anchor_rules';
+    const WIDGET_PLACEHOLDER = '[[ALMA_WIDGET]]';
+
+    public static function all_patterns() {
+        return array(
+            'anchor' => 'Anchor nel testo',
+            'button' => 'Bottone CTA',
+            'card' => 'Card con immagine',
+            'widget' => 'Widget di raccolta finale',
+        );
+    }
+
+    public static function get_rules() {
+        $patterns = array_values(array_intersect(
+            array_filter(array_map('sanitize_key', (array) get_option(self::OPTION_PATTERNS, array_keys(self::all_patterns())))),
+            array_keys(self::all_patterns())
+        ));
+        if (empty($patterns)) { $patterns = array('anchor'); }
+        return array(
+            'density_words' => max(100, min(2000, absint(get_option(self::OPTION_DENSITY, 300)))),
+            'patterns' => $patterns,
+            'min_paragraphs_before' => max(0, min(10, absint(get_option(self::OPTION_MIN_PARAGRAPHS, 2)))),
+            'widget_max_links' => max(2, min(8, absint(get_option(self::OPTION_WIDGET_MAX_LINKS, 4)))),
+            'button_text' => sanitize_text_field(get_option(self::OPTION_BUTTON_TEXT, __('Scopri di più', 'affiliate-link-manager-ai'))) ?: __('Scopri di più', 'affiliate-link-manager-ai'),
+            'anchor_rules' => sanitize_textarea_field(get_option(self::OPTION_ANCHOR_RULES, 'Anchor descrittive e naturali nella frase; mai "clicca qui", mai il solo nome del provider.')),
+        );
+    }
+
+    public static function save_from_request($post) {
+        update_option(self::OPTION_DENSITY, max(100, min(2000, absint($post[self::OPTION_DENSITY] ?? 300))), false);
+        $patterns = array_values(array_intersect(array_map('sanitize_key', (array)($post['alma_ai_insert_patterns'] ?? array())), array_keys(self::all_patterns())));
+        update_option(self::OPTION_PATTERNS, !empty($patterns) ? $patterns : array('anchor'), false);
+        update_option(self::OPTION_MIN_PARAGRAPHS, max(0, min(10, absint($post[self::OPTION_MIN_PARAGRAPHS] ?? 2))), false);
+        update_option(self::OPTION_WIDGET_MAX_LINKS, max(2, min(8, absint($post[self::OPTION_WIDGET_MAX_LINKS] ?? 4))), false);
+        update_option(self::OPTION_BUTTON_TEXT, sanitize_text_field(wp_unslash($post[self::OPTION_BUTTON_TEXT] ?? '')), false);
+        update_option(self::OPTION_ANCHOR_RULES, sanitize_textarea_field(wp_unslash($post[self::OPTION_ANCHOR_RULES] ?? '')), false);
+    }
+
+    /**
+     * Vocabolario dei pattern per il payload OpenAI: descrive COME inserire
+     * gli shortcode in modo coerente col flusso di lettura e orientato alla
+     * conversione, secondo la configurazione.
+     */
+    public static function payload_rules() {
+        $rules = self::get_rules();
+        $lines = array(
+            'PATTERN DI INSERIMENTO AFFILIATI (usa SOLO questi, scegliendo il pattern in base al punto dell\'articolo):',
+        );
+        if (in_array('anchor', $rules['patterns'], true)) {
+            $lines[] = '- anchor nel testo: [affiliate_link id="ID" text="anchor naturale"] dentro un paragrafo, dove il prodotto/esperienza è citato nel discorso. ' . $rules['anchor_rules'];
+        }
+        if (in_array('button', $rules['patterns'], true)) {
+            $lines[] = '- bottone CTA: [affiliate_link id="ID" button="yes" button_text="testo azione"] da solo dopo la chiusura di una sezione che ha creato interesse (mai a metà frase). Default button_text: "' . $rules['button_text'] . '".';
+        }
+        if (in_array('card', $rules['patterns'], true)) {
+            $lines[] = '- card prodotto: [affiliate_link id="ID" img="yes" fields="title,content" button="yes"] quando dedichi un blocco a una singola esperienza importante (max 1-2 per articolo).';
+        }
+        if (in_array('widget', $rules['patterns'], true)) {
+            $lines[] = '- widget di raccolta: UNA sola volta, in chiusura dell\'articolo, inserisci il segnaposto ' . self::WIDGET_PLACEHOLDER . ' e compila il campo widget_request dell\'output con: title (es. "Le migliori esperienze a X"), link_ids (2-' . $rules['widget_max_links'] . ' ID dei link più pertinenti), button_text, e per ogni link rewritten[{id,title,description}] con titolo e descrizione riscritti nel tono dell\'articolo (descrizione 1-2 frasi orientate al beneficio).';
+        }
+        $lines[] = 'REGOLE DI DENSITÀ E POSIZIONE (verranno comunque applicate dal sistema):';
+        $lines[] = '- massimo 1 inserimento ogni ' . $rules['density_words'] . ' parole di contenuto;';
+        $lines[] = '- nessun inserimento nei primi ' . $rules['min_paragraphs_before'] . ' paragrafi (l\'introduzione crea fiducia, non vende);';
+        $lines[] = '- mai due shortcode consecutivi senza testo tra loro; distribuisci gli inserimenti lungo l\'articolo;';
+        $lines[] = '- l\'eleganza della lettura viene prima della conversione: se un inserimento non è naturale, non farlo.';
+        return $lines;
+    }
+
+    /* ---------------------------------------------------------------------
+     * QA deterministico post-generazione (logica pura, testabile standalone)
+     * ------------------------------------------------------------------ */
+
+    /**
+     * Applica le regole al contenuto HTML generato. Ritorna array con
+     * 'content' e 'warnings'. Pure: nessuna dipendenza WordPress.
+     */
+    public static function enforce($content, $rules) {
+        $warnings = array();
+        $content = (string) $content;
+        $density = max(100, (int) ($rules['density_words'] ?? 300));
+        $min_paragraphs = max(0, (int) ($rules['min_paragraphs_before'] ?? 2));
+
+        // 1. Massimo un widget per articolo.
+        $widget_count = preg_match_all('/\[affiliate_links_widget[^\]]*\]/', $content, $widget_matches);
+        if ($widget_count > 1) {
+            $first = true;
+            $content = preg_replace_callback('/\[affiliate_links_widget[^\]]*\]/', function ($m) use (&$first) {
+                if ($first) { $first = false; return $m[0]; }
+                return '';
+            }, $content);
+            $warnings[] = 'Widget in eccesso rimossi: massimo uno per articolo.';
+        }
+
+        // 2. Nessuno shortcode nei primi N paragrafi: le anchor diventano
+        //    testo semplice, gli altri pattern vengono rimossi.
+        if ($min_paragraphs > 0) {
+            $parts = preg_split('/(<\/p>)/i', $content, -1, PREG_SPLIT_DELIM_CAPTURE);
+            $paragraph_index = 0;
+            foreach ($parts as $i => $part) {
+                if (strcasecmp($part, '</p>') === 0) { $paragraph_index++; continue; }
+                if ($paragraph_index < $min_paragraphs && preg_match('/\[affiliate_link(?:s_widget)?[\s\]]/', $part)) {
+                    $stripped = self::strip_shortcodes_to_text($part);
+                    if ($stripped !== $part) {
+                        $parts[$i] = $stripped;
+                        $warnings[] = 'Inserimenti rimossi dai primi ' . $min_paragraphs . ' paragrafi.';
+                    }
+                }
+            }
+            $content = implode('', $parts);
+        }
+
+        // 3. Densità: massimo floor(parole/densità) inserimenti (minimo 1).
+        $word_count = str_word_count(wp_strip_all_tags($content));
+        $max_insertions = max(1, (int) floor($word_count / $density));
+        $found = preg_match_all('/\[affiliate_link(?:s_widget)?[^\]]*\]/', $content, $matches, PREG_OFFSET_CAPTURE);
+        if ($found > $max_insertions) {
+            // Conserva i primi max_insertions; gli eccessi: anchor → testo, altri → rimossi.
+            $keep = $max_insertions;
+            $content = preg_replace_callback('/\[affiliate_link(?:s_widget)?[^\]]*\]/', function ($m) use (&$keep) {
+                if ($keep > 0) { $keep--; return $m[0]; }
+                return self::shortcode_to_text($m[0]);
+            }, $content);
+            $warnings[] = sprintf('Densità applicata: %d inserimenti mantenuti su %d (1 ogni %d parole su %d).', $max_insertions, $found, $density, $word_count);
+        }
+
+        // 4. Mai due shortcode consecutivi senza testo tra loro: il secondo
+        //    viene degradato (anchor → testo, altri → rimossi).
+        $content = preg_replace_callback(
+            '/(\[affiliate_link(?:s_widget)?[^\]]*\])(\s*(?:<\/?p[^>]*>|<br[^>]*>|\s)*)(\[affiliate_link(?:s_widget)?[^\]]*\])/',
+            function ($m) use (&$warnings) {
+                $warnings[] = 'Shortcode consecutivi: il secondo è stato degradato a testo.';
+                return $m[1] . $m[2] . self::shortcode_to_text($m[3]);
+            },
+            $content
+        );
+
+        return array('content' => $content, 'warnings' => array_values(array_unique($warnings)));
+    }
+
+    /**
+     * Converte uno shortcode in testo leggibile: le anchor mantengono il
+     * loro testo (la frase resta di senso compiuto), gli altri spariscono.
+     */
+    public static function shortcode_to_text($shortcode) {
+        // \s prima di text=" evita il falso positivo su button_text=".
+        if (preg_match('/\[affiliate_link[^\]]*\stext="([^"]*)"/', $shortcode, $m)) {
+            return $m[1];
+        }
+        return '';
+    }
+
+    private static function strip_shortcodes_to_text($html) {
+        return preg_replace_callback('/\[affiliate_link(?:s_widget)?[^\]]*\]/', function ($m) {
+            return self::shortcode_to_text($m[0]);
+        }, $html);
+    }
+
+    /* ---------------------------------------------------------------------
+     * Creazione widget dall'AI
+     * ------------------------------------------------------------------ */
+
+    /**
+     * Valida la widget_request dell'AI e crea l'istanza widget nell'option
+     * standard (visibile e modificabile in Elenco Widget Link).
+     * Ritorna array('widget_id' => N, 'shortcode' => '[affiliate_links_widget id="N"]')
+     * oppure array('error' => ...).
+     */
+    public static function create_widget_from_request($request, $candidate_affiliate_ids) {
+        $rules = self::get_rules();
+        if (!in_array('widget', $rules['patterns'], true)) {
+            return array('error' => 'Pattern widget disabilitato nelle Regole inserimento.');
+        }
+        $request = is_array($request) ? $request : array();
+        $link_ids = array_values(array_unique(array_filter(array_map('absint', (array)($request['link_ids'] ?? array())))));
+        // Solo link candidati del payload: l'AI non può inventare ID.
+        $link_ids = array_values(array_intersect($link_ids, array_map('absint', (array)$candidate_affiliate_ids)));
+        $link_ids = array_slice($link_ids, 0, $rules['widget_max_links']);
+        if (count($link_ids) < 2) {
+            return array('error' => 'widget_request ignorata: servono almeno 2 link candidati validi.');
+        }
+
+        $rewritten = array();
+        foreach ((array)($request['rewritten'] ?? array()) as $row) {
+            if (!is_array($row)) { continue; }
+            $rid = absint($row['id'] ?? 0);
+            $rtitle = sanitize_text_field((string)($row['title'] ?? ''));
+            $rdesc = sanitize_textarea_field((string)($row['description'] ?? ''));
+            if ($rid > 0 && in_array($rid, $link_ids, true) && $rtitle !== '' && $rdesc !== '') {
+                $rewritten[(string)$rid] = array('title' => $rtitle, 'description' => $rdesc);
+            }
+        }
+
+        $columns = max(1, min(3, count($link_ids)));
+        $instance = array(
+            'title' => sanitize_text_field((string)($request['title'] ?? '')) ?: __('Esperienze consigliate', 'affiliate-link-manager-ai'),
+            'custom_content' => '',
+            'show_image' => 1,
+            'show_title' => 1,
+            'show_content' => 1,
+            'show_button' => 1,
+            'button_text' => sanitize_text_field((string)($request['button_text'] ?? '')) ?: $rules['button_text'],
+            'template_desktop_columns' => $columns,
+            'template_mobile_columns' => 1,
+            'layout_preset' => 'columns_' . $columns,
+            'links' => $link_ids,
+            'rewritten_links' => $rewritten,
+            'alma_created_by' => 'ai_agent',
+        );
+
+        $instances = get_option('widget_affiliate_links_widget', array());
+        if (!is_array($instances)) { $instances = array(); }
+        $multiwidget = $instances['_multiwidget'] ?? 1;
+        unset($instances['_multiwidget']);
+        $numeric_ids = array_filter(array_map('intval', array_keys($instances)));
+        $next_id = empty($numeric_ids) ? 2 : (max($numeric_ids) + 1);
+        $instances[$next_id] = $instance;
+        $instances['_multiwidget'] = $multiwidget;
+        update_option('widget_affiliate_links_widget', $instances);
+
+        return array(
+            'widget_id' => $next_id,
+            'shortcode' => '[affiliate_links_widget id="' . $next_id . '"]',
+        );
+    }
+
+    /**
+     * Applica la widget_request al contenuto: crea il widget e sostituisce il
+     * segnaposto (o accoda in fondo se il segnaposto manca). Ritorna
+     * array('content','warnings','widget_id').
+     */
+    public static function apply_widget_request($content, $request, $candidate_affiliate_ids) {
+        $warnings = array();
+        $widget_id = 0;
+        $has_placeholder = strpos($content, self::WIDGET_PLACEHOLDER) !== false;
+
+        if (empty($request) && !$has_placeholder) {
+            return array('content' => $content, 'warnings' => $warnings, 'widget_id' => 0);
+        }
+        if (empty($request)) {
+            // Segnaposto senza richiesta: va rimosso, non deve arrivare in pagina.
+            return array('content' => str_replace(self::WIDGET_PLACEHOLDER, '', $content), 'warnings' => array('Segnaposto widget senza widget_request: rimosso.'), 'widget_id' => 0);
+        }
+
+        $created = self::create_widget_from_request($request, $candidate_affiliate_ids);
+        if (!empty($created['error'])) {
+            $warnings[] = $created['error'];
+            $content = str_replace(self::WIDGET_PLACEHOLDER, '', $content);
+            return array('content' => $content, 'warnings' => $warnings, 'widget_id' => 0);
+        }
+        $widget_id = (int) $created['widget_id'];
+        if ($has_placeholder) {
+            $content = str_replace(self::WIDGET_PLACEHOLDER, $created['shortcode'], $content);
+        } else {
+            $content .= "\n\n" . $created['shortcode'];
+            $warnings[] = 'Segnaposto widget mancante: widget aggiunto in coda all\'articolo.';
+        }
+        return array('content' => $content, 'warnings' => $warnings, 'widget_id' => $widget_id);
+    }
+}


### PR DESCRIPTION
Prima PR della Fase 4 come da progetto approvato, con in più la **creazione diretta delle bozze dall'agente**.

## Tab "Regole inserimento" (Impostazioni AI Content)

- Pattern abilitati: **anchor nel testo** (`text=`), **bottone CTA** (`button="yes"`), **card con immagine** (`img+fields`), **widget di raccolta**.
- Densità massima (default 1 inserimento / 300 parole), paragrafi iniziali protetti (default 2), link massimi nel widget (default 4), testo bottone default, regole anchor.
- Unica fonte di verità per bozze manuali, runner programmato e agente.

## Vocabolario pattern nel payload + QA deterministico

- Il Draft Builder invia al modello il vocabolario completo delle leve degli shortcode con regole d'uso orientate alla conversione ("l'eleganza della lettura viene prima della conversione").
- Nuova classe **`ALMA_AI_Insertion_Rules`** con `enforce()` deterministico post-generazione: densità applicata dal codice (anchor in eccesso → testo semplice, altri pattern rimossi), nessun inserimento nei paragrafi protetti, mai due shortcode consecutivi, massimo un widget per articolo. **Test standalone 12/12 PASS** (falso positivo `button_text` vs `text` incluso).

## Widget creati dall'AI

- La bozza può includere il segnaposto `[[ALMA_WIDGET]]` + campo `widget_request` (titolo, 2-N link, testo bottone, `rewritten[{id,title,description}]` nel tono dell'articolo).
- Il plugin valida (solo link candidati del payload, ID inventati scartati), **crea l'istanza reale** nell'option standard `widget_affiliate_links_widget` (visibile/modificabile in Elenco Widget Link, layout automatico per numero di link, riuso del meccanismo `rewritten_links` esistente) e sostituisce il segnaposto con `[affiliate_links_widget id="X"]`; l'ID widget viene salvato come meta della bozza.
- Segnaposto orfano o richiesta non valida → rimozione pulita + warning nel report QA.

## Bozze dirette dall'agente di ideazione

- Checkbox **"Crea subito anche le bozze"** nel pannello agente: dopo il loop di ideazione genera le bozze delle idee create, **entro il limite giornaliero di bozze automatiche** (contatore condiviso con il runner programmato, nuovo metodo `generate_draft_now`).
- Il report dell'esecuzione mostra le bozze generate (link modifica) e segnala il raggiungimento del limite (le idee restanti restano programmabili).

## Test

- `php -l` su tutti i file; test standalone `enforce()`/`shortcode_to_text()` 12/12 PASS.

Prossima: PR 2 della Fase 4 (metabox "AI Affiliati" nell'editor del post con diagnostica shortcode e ottimizzazione a proposte selettive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_