### PR TITLE
Fix metabox AI Affiliati: "Contenuto troppo breve" su contenuti classic editor (CRLF) + conteggio parole (v2.61.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.61.1 - 2026-07-05
+
+### Fix "Contenuto troppo breve" nel metabox AI Affiliati (contenuti classic editor / CRLF)
+- **Fix rilevamento paragrafi**: il contenuto salvato dal classic editor (e da WPBakery, come su sothra.it) non contiene `</p>` e usa newline Windows `\r\n`; lo splitter cercava solo `\n\n` e vedeva l'intero articolo come UN paragrafo → "Contenuto troppo breve per proporre inserimenti" anche su articoli lunghi. Ora i paragrafi sono delimitati da `</p>` (HTML/Gutenberg) **oppure** da riga vuota con qualunque newline (`\r\n` incluso, anche con spazi), e viene scelta automaticamente la modalità che rileva più paragrafi. Riprodotto e verificato: contenuto CRLF passa da 1 a N paragrafi.
+- **Stesso fix nel QA `enforce()`** (Regole inserimento): con contenuto senza `</p>` la protezione dei primi paragrafi degradava TUTTI gli shortcode dell'articolo; ora usa la stessa delimitazione doppia.
+- **Fix conteggio parole per la densità**: `str_word_count` spezza le parole accentate italiane ("città" contata come due); nuovo conteggio Unicode-safe usato sia dal budget del metabox sia dal QA — la densità configurata (es. ogni 100 parole) ora è calcolata correttamente sui testi italiani.
+- Test standalone estesi: CRLF, WPBakery, righe vuote con spazi, inserimenti inline/blocco su contenuto classic (9 nuovi casi, tutte le suite verdi).
+- Versione plugin aggiornata a `2.61.1`.
+
 ## 2.61.0 - 2026-07-05
 
 ### Fase 4 (PR 2) — Metabox "AI Affiliati" nell'editor del post

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## 2.61.1 - 2026-07-05
+
+### Fix "Contenuto troppo breve" nel metabox AI Affiliati
+- Fix rilevamento paragrafi per contenuti classic editor/WPBakery con newline Windows (`\r\n`): l'articolo veniva visto come un solo paragrafo e le proposte AI non partivano mai. Stesso fix nella protezione dei primi paragrafi del QA.
+- Conteggio parole Unicode-safe per la densità (le parole accentate italiane venivano contate male).
+- Versione plugin aggiornata a `2.61.1`.
+
 ## 2.61.0 - 2026-07-05
 
 ### Fase 4 (PR 2) — Metabox "AI Affiliati" nell'editor del post

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.61.0
+ * Version: 2.61.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.61.0');
+define('ALMA_VERSION', '2.61.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-insertion-rules.php
+++ b/includes/class-ai-insertion-rules.php
@@ -120,12 +120,14 @@ class ALMA_AI_Insertion_Rules {
         }
 
         // 2. Nessuno shortcode nei primi N paragrafi: le anchor diventano
-        //    testo semplice, gli altri pattern vengono rimossi.
+        //    testo semplice, gli altri pattern vengono rimossi. I paragrafi
+        //    sono delimitati da </p> (HTML/Gutenberg) O da riga vuota (classic
+        //    editor, anche con newline Windows \r\n).
         if ($min_paragraphs > 0) {
-            $parts = preg_split('/(<\/p>)/i', $content, -1, PREG_SPLIT_DELIM_CAPTURE);
+            $parts = preg_split('/(<\/p>|\r?\n[ \t]*\r?\n)/i', $content, -1, PREG_SPLIT_DELIM_CAPTURE);
             $paragraph_index = 0;
             foreach ($parts as $i => $part) {
-                if (strcasecmp($part, '</p>') === 0) { $paragraph_index++; continue; }
+                if (strcasecmp($part, '</p>') === 0 || preg_match('/^\r?\n[ \t]*\r?\n$/', $part)) { $paragraph_index++; continue; }
                 if ($paragraph_index < $min_paragraphs && preg_match('/\[affiliate_link(?:s_widget)?[\s\]]/', $part)) {
                     $stripped = self::strip_shortcodes_to_text($part);
                     if ($stripped !== $part) {
@@ -138,7 +140,7 @@ class ALMA_AI_Insertion_Rules {
         }
 
         // 3. Densità: massimo floor(parole/densità) inserimenti (minimo 1).
-        $word_count = str_word_count(wp_strip_all_tags($content));
+        $word_count = self::count_words(wp_strip_all_tags($content));
         $max_insertions = max(1, (int) floor($word_count / $density));
         $found = preg_match_all('/\[affiliate_link(?:s_widget)?[^\]]*\]/', $content, $matches, PREG_OFFSET_CAPTURE);
         if ($found > $max_insertions) {
@@ -163,6 +165,14 @@ class ALMA_AI_Insertion_Rules {
         );
 
         return array('content' => $content, 'warnings' => array_values(array_unique($warnings)));
+    }
+
+    /**
+     * Conteggio parole Unicode-safe: str_word_count spezza le parole
+     * accentate italiane ("città" → 2), falsando la densità.
+     */
+    public static function count_words($text) {
+        return (int) preg_match_all('/\p{L}[\p{L}\p{N}\'\x{2019}]*/u', (string) $text, $m);
     }
 
     /**

--- a/includes/class-ai-post-optimizer.php
+++ b/includes/class-ai-post-optimizer.php
@@ -250,19 +250,50 @@ class ALMA_AI_Post_Optimizer {
      * Paragrafi: split/join compatibile con Gutenberg e classic
      * ------------------------------------------------------------------ */
 
-    public static function split_paragraphs($content) {
-        if (stripos($content, '</p>') !== false) {
-            $parts = preg_split('/(<\/p>)/i', $content, -1, PREG_SPLIT_DELIM_CAPTURE);
-            return array('parts' => $parts, 'mode' => 'html');
+    /**
+     * Un "delimitatore" è la chiusura di paragrafo HTML oppure una riga
+     * vuota (anche con newline Windows \r\n, come salva il classic editor).
+     */
+    public static function is_delimiter($part, $mode) {
+        if ($mode === 'html') {
+            return strcasecmp((string)$part, '</p>') === 0;
         }
-        return array('parts' => preg_split("/(\n\n)/", (string)$content, -1, PREG_SPLIT_DELIM_CAPTURE), 'mode' => 'text');
+        return (bool) preg_match('/^\r?\n[ \t]*\r?\n$/', (string)$part);
+    }
+
+    /**
+     * Sceglie lo split più ricco tra HTML (</p>, Gutenberg) e testo (riga
+     * vuota, classic editor / WPBakery): il contenuto classic con \r\n non
+     * contiene </p> e prima veniva visto come UN solo paragrafo.
+     */
+    public static function split_paragraphs($content) {
+        $content = (string) $content;
+        $text_parts = preg_split("/(\r?\n[ \t]*\r?\n)/", $content, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $text_count = self::count_paragraph_parts($text_parts, 'text');
+        if (stripos($content, '</p>') !== false) {
+            $html_parts = preg_split('/(<\/p>)/i', $content, -1, PREG_SPLIT_DELIM_CAPTURE);
+            $html_count = self::count_paragraph_parts($html_parts, 'html');
+            if ($html_count >= $text_count) {
+                return array('parts' => $html_parts, 'mode' => 'html');
+            }
+        }
+        return array('parts' => $text_parts, 'mode' => 'text');
+    }
+
+    private static function count_paragraph_parts($parts, $mode) {
+        $count = 0;
+        foreach ((array)$parts as $part) {
+            if (self::is_delimiter($part, $mode)) { continue; }
+            if (trim(wp_strip_all_tags($part)) !== '') { $count++; }
+        }
+        return $count;
     }
 
     public static function paragraph_texts($content) {
         $split = self::split_paragraphs($content);
         $texts = array();
         foreach ($split['parts'] as $part) {
-            if ($part === '</p>' || $part === "\n\n" || trim($part) === '') { continue; }
+            if (self::is_delimiter($part, $split['mode'])) { continue; }
             $text = trim(wp_strip_all_tags($part));
             if ($text !== '') { $texts[] = $text; }
         }
@@ -278,15 +309,14 @@ class ALMA_AI_Post_Optimizer {
         $parts = $split['parts'];
         $current = -1;
         foreach ($parts as $i => $part) {
-            if ($part === '</p>' || $part === "\n\n") { continue; }
+            if (self::is_delimiter($part, $split['mode'])) { continue; }
             if (trim(wp_strip_all_tags($part)) === '') { continue; }
             $current++;
             if ($current === (int)$paragraph_index) {
                 if ($inline) {
                     $parts[$i] = rtrim($part) . ' ' . $insertion;
                 } else {
-                    $closer = ($split['mode'] === 'html') ? '</p>' : "\n\n";
-                    $has_delimiter = isset($parts[$i + 1]) && $parts[$i + 1] === $closer;
+                    $has_delimiter = isset($parts[$i + 1]) && self::is_delimiter($parts[$i + 1], $split['mode']);
                     if ($split['mode'] === 'html') {
                         array_splice($parts, $i + 1 + ($has_delimiter ? 1 : 0), 0, array("\n" . $insertion . "\n"));
                     } elseif ($has_delimiter) {
@@ -333,7 +363,7 @@ class ALMA_AI_Post_Optimizer {
         }
 
         // Budget inserimenti: densità meno gli shortcode già presenti.
-        $word_count = str_word_count(wp_strip_all_tags($post->post_content));
+        $word_count = ALMA_AI_Insertion_Rules::count_words(wp_strip_all_tags($post->post_content));
         $existing = preg_match_all('/\[affiliate_link(?:s_widget)?[^\]]*\]/', $post->post_content, $m);
         $budget = max(0, (int)floor($word_count / $rules['density_words']) - (int)$existing);
         if ($budget < 1) {


### PR DESCRIPTION
Fix del bug segnalato ("Contenuto troppo breve per proporre inserimenti" su articoli lunghi, es. *i-5-migliori-strumenti-per-organizzare-il-viaggio-in-europa*) dopo rianalisi dell'intero flusso.

## Causa (riprodotta con test)

Il contenuto salvato dal **classic editor / WPBakery** (come su sothra.it) non contiene `</p>` e usa **newline Windows `\r\n`**. Lo splitter dei paragrafi cercava solo `\n\n`, quindi l'intero articolo risultava **UN solo paragrafo** → il controllo "minimo 3 paragrafi" falliva sempre.

Riproduzione prima del fix: contenuto CRLF di 4 blocchi → `paragraph_texts()` = 1. Dopo il fix → 4.

## Correzioni

1. **`split_paragraphs()`**: delimitatori `</p>` (HTML/Gutenberg) **oppure** riga vuota con qualunque newline (`\r?\n[ \t]*\r?\n`), con scelta automatica della modalità che rileva più paragrafi. Inserimenti inline/blocco allineati alla nuova delimitazione (`is_delimiter()`).
2. **Stesso difetto latente nel QA `enforce()`** delle Regole inserimento: su contenuto senza `</p>` la "protezione primi paragrafi" avrebbe degradato **tutti** gli shortcode dell'articolo. Corretto con la stessa delimitazione doppia.
3. **Conteggio parole Unicode-safe** (`count_words()`): `str_word_count` spezza le parole accentate italiane ("città" → 2 parole), falsando il budget di densità. Ora la densità (es. "ogni 100 parole") è calcolata correttamente; usato sia dal metabox sia dal QA.

## Verifica del flusso completo

- Metabox → diagnostica: ok (regex sugli shortcode, indipendente dai paragrafi).
- Proposte: gate lunghezza, budget densità (ora corretto), candidati geo+titolo, validazione proposte: ok.
- Applica: split/inserimento ora coerenti su HTML, CRLF e WPBakery; revision invariata.

## Test

- **9 nuovi casi standalone**: CRLF (4 paragrafi), WPBakery+CRLF, righe vuote con spazi, scelta modalità HTML, inserimento blocco/inline su CRLF, enforce() su CRLF. Tutte le suite verdi (31 casi totali) + `php -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_