### PR TITLE
Fase 6: arricchimento automatico in background dei post pubblicati (v2.64.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.64.0 - 2026-07-05
+
+### Fase 6 — Arricchimento automatico in background dei post pubblicati
+- **Nuova tab "Arricchimento"** in Impostazioni AI Content: attivazione on/off, **articoli al giorno** da analizzare (default 5, 1 chiamata OpenAI per articolo, contatore odierno visibile), **cooldown ri-analisi** (default 60 giorni), pulsante "Esegui ora", coda stimata e **report attività** (ultimi 100 articoli: esito, link aggiunti/sostituiti, note/errori, link di modifica).
+- **Applicazione diretta senza revisione manuale**: il runner giornaliero analizza gli articoli e **aggiorna il post pubblicato aggiungendo i link** — il contenuto esistente non viene mai riscritto (le anchor si accodano al paragrafo scelto, bottoni/card come blocchi autonomi; inserimenti in ordine di paragrafo decrescente per non spostare gli indici). Ogni aggiornamento crea una **revisione WordPress** (rollback nativo).
+- **Ciclo di copertura con ri-analisi**: prima tutti gli articoli mai analizzati, poi il ciclo riparte automaticamente dai più vecchi di analisi — mai prima del cooldown. Nelle **ri-analisi** l'AI riceve gli shortcode esistenti con la loro coerenza geografica e può proporre **sostituzioni** (link incoerenti/non validi o candidati nettamente migliori), applicate preservando pattern e struttura dello shortcode (max 3 per articolo). Motore condiviso con il metabox "AI Affiliati" (stesse Regole inserimento, densità, paragrafi protetti, soli link candidati).
+- **Niente notifiche per articolo**: a fine esecuzione un solo **digest Telegram** (analizzati/aggiornati/link aggiunti/sostituiti), se il bot è abilitato.
+- Lock anti-concorrenza, budget tempo per esecuzione (150s), costi registrati nell'usage logger (task `post_enricher`), cron rimosso alla disattivazione. Test standalone per la logica di sostituzione.
+- Versione plugin aggiornata a `2.64.0`.
+
 ## 2.63.0 - 2026-07-05
 
 ### Fase 5 — Bot Telegram: regia, monitoraggio e strategia

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## 2.64.0 - 2026-07-05
+
+### Fase 6 — Arricchimento automatico in background dei post pubblicati
+- Tab "Arricchimento": attivazione, articoli/giorno, cooldown ri-analisi, Esegui ora, report attività con esiti per articolo.
+- Il runner aggiorna direttamente i post pubblicati aggiungendo link affiliati (mai riscrittura del contenuto), con revisione WordPress a ogni modifica.
+- Ciclo automatico: prima gli articoli mai analizzati, poi ri-analisi oltre il cooldown con possibili sostituzioni di link incoerenti.
+- Un solo digest Telegram per esecuzione (niente notifiche per articolo).
+- Versione plugin aggiornata a `2.64.0`.
+
 ## 2.63.0 - 2026-07-05
 
 ### Fase 5 — Bot Telegram: regia, monitoraggio e strategia

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.63.0
+ * Version: 2.64.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.63.0');
+define('ALMA_VERSION', '2.64.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -60,6 +60,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-ai-insertion-rules.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-post-optimizer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-seo-bridge.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-telegram-bot.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-ai-post-enricher.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-url-validator.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-interface.php';
 require_once ALMA_PLUGIN_DIR . 'includes/providers/class-affiliate-source-provider-manual.php';
@@ -165,6 +166,7 @@ class AffiliateManagerAI {
         ALMA_AI_Idea_Agent::init();
         ALMA_AI_Post_Optimizer::init();
         ALMA_Telegram_Bot::init();
+        ALMA_AI_Post_Enricher::init();
         add_action('init', array($this, 'init'));
         add_action('widgets_init', array('ALMA_Contextual_Affiliate_Widget', 'register_widget'));
         // Registrato qui (prima che `widgets_init` scatti) perché ALMA_Shortcodes::init()
@@ -4466,6 +4468,7 @@ class AffiliateManagerAI {
         ALMA_Dashboard_Insights::unschedule();
         ALMA_AI_Content_Agent_Idea_Importer::unschedule();
         ALMA_AI_Idea_Agent::unschedule();
+        ALMA_AI_Post_Enricher::unschedule();
         $this->clear_deprecated_trend_cron_events();
         flush_rewrite_rules();
     }

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -286,6 +286,9 @@ class ALMA_AI_Content_Agent_Admin {
         } elseif ($do === 'save_telegram_settings') {
             ALMA_Telegram_Bot::save_settings($_POST);
             $result = array('success' => true, 'message' => 'Impostazioni Telegram salvate.');
+        } elseif ($do === 'save_enricher_settings') {
+            ALMA_AI_Post_Enricher::save_settings($_POST);
+            $result = array('success' => true, 'message' => 'Impostazioni Arricchimento salvate.');
         } elseif ($do === 'save_source') {
             $result = ALMA_AI_Content_Agent_Source_Manager::save_source($_POST);
         } elseif ($do === 'toggle_source') {
@@ -530,7 +533,7 @@ class ALMA_AI_Content_Agent_Admin {
         if (!current_user_can('manage_options')) { return; }
         // La tab "Idee contenuto" non esiste più: il workspace vive nella
         // pagina "Aggiungi idea", l'elenco nella pagina "Tutte le idee".
-        $tabs = array('dashboard'=>'Dashboard','istruzioni-ai'=>'Istruzioni AI','inserimento'=>'Regole inserimento','telegram'=>'Telegram','documenti'=>'Documenti TXT','fonti'=>'Fonti online AI','reindex'=>'Reindicizza','log'=>'Stato/log');
+        $tabs = array('dashboard'=>'Dashboard','istruzioni-ai'=>'Istruzioni AI','inserimento'=>'Regole inserimento','arricchimento'=>'Arricchimento','telegram'=>'Telegram','documenti'=>'Documenti TXT','fonti'=>'Fonti online AI','reindex'=>'Reindicizza','log'=>'Stato/log');
         $legacy_map = array('overview'=>'dashboard','idee'=>'dashboard','reindirizza'=>'reindex','knowledge'=>'dashboard','media'=>'dashboard','bozze'=>'log','programmazione'=>'log',);
         $tab = sanitize_key($_GET['tab'] ?? 'dashboard');
         if (isset($legacy_map[$tab])) { $tab = $legacy_map[$tab]; }
@@ -539,6 +542,7 @@ class ALMA_AI_Content_Agent_Admin {
         echo '<h2 class="nav-tab-wrapper">'; foreach ($tabs as $tk=>$tl) { echo '<a class="nav-tab '.($tk===$tab?'nav-tab-active':'').'" href="'.esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab='.$tk)).'">'.esc_html($tl).'</a>'; } echo '</h2>';
         if ($tab === 'istruzioni-ai') { self::render_instructions_tab(); }
         elseif ($tab === 'inserimento') { self::render_insertion_rules_tab(); }
+        elseif ($tab === 'arricchimento') { ALMA_AI_Post_Enricher::render_settings_tab(); }
         elseif ($tab === 'telegram') { ALMA_Telegram_Bot::render_settings_tab(); }
         elseif ($tab === 'documenti') { self::render_documents_tab(); }
         elseif ($tab === 'fonti') { self::render_sources_tab(); }

--- a/includes/class-ai-post-enricher.php
+++ b/includes/class-ai-post-enricher.php
@@ -1,0 +1,298 @@
+<?php
+/**
+ * Fase 6 — Arricchimento automatico in background dei post pubblicati.
+ *
+ * Ogni giorno il runner analizza N articoli pubblicati e APPLICA direttamente
+ * gli inserimenti di link affiliati proposti dall'AI (motore condiviso con il
+ * metabox "AI Affiliati"): il contenuto esistente NON viene mai riscritto —
+ * vengono solo aggiunti shortcode nei punti proposti (o sostituiti link
+ * incoerenti nelle ri-analisi). Ogni aggiornamento passa da wp_update_post →
+ * revisione WordPress (rollback nativo).
+ *
+ * Ciclo di copertura:
+ * 1. prima gli articoli MAI analizzati (priorità a quelli senza shortcode);
+ * 2. finiti tutti, si riparte dai più "vecchi" di analisi — ma un articolo
+ *    non viene mai ri-analizzato prima del cooldown configurato (default 60
+ *    giorni), per controllare i costi ed evitare churn. Nelle ri-analisi
+ *    l'AI può anche sostituire link esistenti se incoerenti.
+ *
+ * Niente notifiche per singolo articolo: a fine esecuzione un solo digest
+ * Telegram (se abilitato) con il riepilogo, e il report completo nella tab
+ * "Arricchimento" di Impostazioni AI Content.
+ */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALMA_AI_Post_Enricher {
+    const CRON_HOOK = 'alma_ai_post_enricher_run';
+    const OPTION_ENABLED = 'alma_ai_enrich_enabled';
+    const OPTION_DAILY = 'alma_ai_enrich_daily_limit';
+    const OPTION_COOLDOWN = 'alma_ai_enrich_cooldown_days';
+    const OPTION_COUNTER = 'alma_ai_enrich_counter';
+    const OPTION_LOG = 'alma_ai_enrich_log';
+    const META_LAST_RUN = '_alma_ai_enrich_last_run';
+    const LOCK_OPTION = 'alma_ai_enrich_lock';
+    const LOCK_TTL = 900;
+    const MAX_LOG_ENTRIES = 100;
+    const TIME_BUDGET_SECONDS = 150;
+
+    public static function init() {
+        add_action('init', array(__CLASS__, 'maybe_schedule_cron'));
+        add_action(self::CRON_HOOK, array(__CLASS__, 'run'));
+        add_action('admin_post_alma_ai_enrich_run_now', array(__CLASS__, 'handle_run_now'));
+    }
+
+    public static function maybe_schedule_cron() {
+        if (!wp_next_scheduled(self::CRON_HOOK)) {
+            $first = strtotime('tomorrow 05:30', current_time('timestamp'));
+            $first = $first - (current_time('timestamp') - time());
+            wp_schedule_event($first, 'daily', self::CRON_HOOK);
+        }
+    }
+
+    public static function unschedule() {
+        wp_clear_scheduled_hook(self::CRON_HOOK);
+    }
+
+    public static function is_enabled() {
+        return get_option(self::OPTION_ENABLED, '0') === '1';
+    }
+
+    public static function get_daily_limit() {
+        return max(0, min(50, absint(get_option(self::OPTION_DAILY, 5))));
+    }
+
+    public static function get_cooldown_days() {
+        return max(7, min(365, absint(get_option(self::OPTION_COOLDOWN, 60))));
+    }
+
+    public static function processed_today() {
+        $counter = get_option(self::OPTION_COUNTER, array());
+        return (is_array($counter) && ($counter['date'] ?? '') === current_time('Y-m-d')) ? (int)$counter['count'] : 0;
+    }
+
+    public static function save_settings($post) {
+        update_option(self::OPTION_ENABLED, empty($post[self::OPTION_ENABLED]) ? '0' : '1', false);
+        update_option(self::OPTION_DAILY, max(0, min(50, absint($post[self::OPTION_DAILY] ?? 5))), false);
+        update_option(self::OPTION_COOLDOWN, max(7, min(365, absint($post[self::OPTION_COOLDOWN] ?? 60))), false);
+    }
+
+    public static function handle_run_now() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_ai_enrich_admin');
+        wp_schedule_single_event(time() + 5, self::CRON_HOOK);
+        if (function_exists('spawn_cron')) { spawn_cron(); }
+        set_transient('alma_ai_agent_admin_notice_' . get_current_user_id(), array('type' => 'success', 'message' => __('Arricchimento avviato in background: il report comparirà qui sotto tra qualche minuto.', 'affiliate-link-manager-ai')), 120);
+        wp_safe_redirect(wp_get_referer() ?: admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-agent&tab=arricchimento'));
+        exit;
+    }
+
+    /* ---------------------------------------------------------------------
+     * Runner
+     * ------------------------------------------------------------------ */
+
+    private static function acquire_lock() {
+        if (add_option(self::LOCK_OPTION, (string) time(), '', 'no')) { return true; }
+        $started = absint(get_option(self::LOCK_OPTION, 0));
+        if ($started > 0 && (time() - $started) > self::LOCK_TTL) {
+            update_option(self::LOCK_OPTION, (string) time(), false);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Coda di lavoro: prima i post mai analizzati (i senza-shortcode hanno
+     * priorità naturale perché più redditizi), poi i più vecchi di analisi
+     * oltre il cooldown — il ciclo riparte da solo dopo aver coperto tutto.
+     */
+    public static function next_posts($limit) {
+        $limit = max(1, absint($limit));
+        $ids = get_posts(array(
+            'post_type' => 'post',
+            'post_status' => 'publish',
+            'posts_per_page' => $limit,
+            'fields' => 'ids',
+            'orderby' => 'date',
+            'order' => 'DESC',
+            'no_found_rows' => true,
+            'meta_query' => array(array('key' => self::META_LAST_RUN, 'compare' => 'NOT EXISTS')),
+        ));
+        $ids = array_map('absint', (array) $ids);
+        if (count($ids) < $limit) {
+            $cutoff = gmdate('Y-m-d H:i:s', current_time('timestamp') - self::get_cooldown_days() * DAY_IN_SECONDS);
+            $more = get_posts(array(
+                'post_type' => 'post',
+                'post_status' => 'publish',
+                'posts_per_page' => $limit - count($ids),
+                'fields' => 'ids',
+                'orderby' => 'meta_value',
+                'meta_key' => self::META_LAST_RUN,
+                'order' => 'ASC',
+                'no_found_rows' => true,
+                'post__not_in' => $ids ?: array(0),
+                'meta_query' => array(array('key' => self::META_LAST_RUN, 'value' => $cutoff, 'compare' => '<')),
+            ));
+            $ids = array_merge($ids, array_map('absint', (array) $more));
+        }
+        return array_values(array_unique(array_filter($ids)));
+    }
+
+    public static function run() {
+        if (!self::is_enabled() || !self::acquire_lock()) { return; }
+        $started = time();
+        $summary = array('processed' => 0, 'updated' => 0, 'links_added' => 0, 'links_replaced' => 0, 'skipped' => 0, 'errors' => 0);
+        try {
+            $limit = self::get_daily_limit();
+            $today = current_time('Y-m-d');
+            $done_today = self::processed_today();
+            $quota = max(0, $limit - $done_today);
+            if ($quota < 1 || empty(get_option('alma_openai_api_key', ''))) { return; }
+
+            $post_ids = self::next_posts($quota);
+            foreach ($post_ids as $post_id) {
+                if ((time() - $started) > self::TIME_BUDGET_SECONDS) { break; }
+                $entry = self::enrich_post($post_id);
+                $summary['processed']++;
+                $done_today++;
+                update_option(self::OPTION_COUNTER, array('date' => $today, 'count' => $done_today), false);
+                if (!empty($entry['updated'])) {
+                    $summary['updated']++;
+                    $summary['links_added'] += (int) $entry['added'];
+                    $summary['links_replaced'] += (int) $entry['replaced'];
+                } elseif (!empty($entry['error'])) {
+                    $summary['errors']++;
+                } else {
+                    $summary['skipped']++;
+                }
+            }
+        } finally {
+            delete_option(self::LOCK_OPTION);
+            // Un solo digest Telegram per esecuzione (mai per singolo articolo).
+            if ($summary['processed'] > 0 && class_exists('ALMA_Telegram_Bot') && ALMA_Telegram_Bot::is_enabled()) {
+                ALMA_Telegram_Bot::send_message_to_all(sprintf(
+                    "🔗 <b>Arricchimento affiliati</b>\nArticoli analizzati: %d · aggiornati: %d\nLink aggiunti: %d · sostituiti: %d · saltati: %d · errori: %d",
+                    $summary['processed'], $summary['updated'], $summary['links_added'], $summary['links_replaced'], $summary['skipped'], $summary['errors']
+                ));
+            }
+        }
+    }
+
+    /**
+     * Analizza e aggiorna UN post: proposte dal motore condiviso, applicate
+     * tutte automaticamente (aggiunte in ordine di paragrafo decrescente per
+     * non spostare gli indici; sostituzioni sul contenuto risultante).
+     */
+    public static function enrich_post($post_id) {
+        $post = get_post($post_id);
+        $entry = array('post_id' => (int) $post_id, 'title' => $post ? html_entity_decode(get_the_title($post), ENT_QUOTES, 'UTF-8') : ('#' . $post_id), 'time' => current_time('mysql'), 'added' => 0, 'replaced' => 0, 'updated' => false, 'note' => '', 'error' => '');
+        if (!$post || $post->post_status !== 'publish') {
+            $entry['error'] = 'Post non disponibile';
+            self::log_entry($entry);
+            return $entry;
+        }
+        update_post_meta($post_id, self::META_LAST_RUN, current_time('mysql'));
+
+        $has_links = (bool) preg_match('/\[affiliate_link(?:s_widget)?[\s\]]/', $post->post_content);
+        $result = ALMA_AI_Post_Optimizer::generate_proposals($post, array(
+            'allow_replacements' => $has_links,
+            'task' => 'post_enricher',
+        ));
+        if (!empty($result['error'])) {
+            $entry['note'] = $result['error'];
+            self::log_entry($entry);
+            return $entry;
+        }
+
+        $content = $post->post_content;
+        $additions = array();
+        foreach ((array) $result['proposals'] as $proposal) {
+            if (($proposal['pattern'] ?? '') === 'replace') {
+                $replaced = ALMA_AI_Post_Optimizer::apply_replacement($content, (int)$proposal['old_link_id'], (int)$proposal['link_id'], (string)($proposal['anchor_text'] ?? ''));
+                if (!empty($replaced['replaced'])) {
+                    $content = $replaced['content'];
+                    $entry['replaced']++;
+                }
+            } else {
+                $additions[] = $proposal;
+            }
+        }
+        // Paragrafi decrescenti: gli inserimenti non spostano gli indici successivi.
+        usort($additions, function ($a, $b) { return (int)$b['paragraph'] <=> (int)$a['paragraph']; });
+        foreach ($additions as $proposal) {
+            $content = ALMA_AI_Post_Optimizer::insert_after_paragraph($content, (int)$proposal['paragraph'], (string)$proposal['insertion'], !empty($proposal['inline']));
+            $entry['added']++;
+        }
+
+        if ($content === $post->post_content) {
+            $entry['note'] = 'Nessuna modifica applicabile';
+            self::log_entry($entry);
+            return $entry;
+        }
+        // Solo aggiunte/sostituzioni di shortcode: il testo esistente resta
+        // intatto; wp_update_post crea la revisione per il rollback.
+        $updated = wp_update_post(array('ID' => $post_id, 'post_content' => $content), true);
+        if (is_wp_error($updated)) {
+            $entry['error'] = sanitize_text_field($updated->get_error_message());
+        } else {
+            $entry['updated'] = true;
+        }
+        self::log_entry($entry);
+        return $entry;
+    }
+
+    private static function log_entry($entry) {
+        $log = (array) get_option(self::OPTION_LOG, array());
+        array_unshift($log, $entry);
+        update_option(self::OPTION_LOG, array_slice($log, 0, self::MAX_LOG_ENTRIES), false);
+    }
+
+    /* ---------------------------------------------------------------------
+     * Tab amministrazione
+     * ------------------------------------------------------------------ */
+
+    public static function render_settings_tab() {
+        $enabled = self::is_enabled();
+        $pending_new = count(self::next_posts(200));
+        $log = (array) get_option(self::OPTION_LOG, array());
+        $next_run = wp_next_scheduled(self::CRON_HOOK);
+
+        echo '<h2>Arricchimento automatico dei post pubblicati</h2>';
+        echo '<p class="description" style="max-width:900px;">Ogni giorno l\'AI analizza gli articoli pubblicati e <strong>aggiunge</strong> (mai riscrive) link affiliati coerenti con contenuto e località, secondo le Regole inserimento, aggiornando il post direttamente. Ciclo: prima tutti gli articoli mai analizzati, poi ri-analisi dei più vecchi oltre il cooldown — nelle ri-analisi l\'AI può anche sostituire link incoerenti. Ogni modifica crea una revisione (rollback nativo). Nessuna notifica per articolo: un solo digest Telegram per esecuzione.</p>';
+
+        echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">';
+        wp_nonce_field('alma_ai_agent_action');
+        echo '<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="save_enricher_settings">';
+        echo '<table class="form-table" role="presentation">';
+        echo '<tr><th scope="row">Attiva arricchimento</th><td><label><input type="checkbox" name="'.esc_attr(self::OPTION_ENABLED).'" value="1" '.checked($enabled, true, false).'> Analizza e aggiorna gli articoli in background ogni giorno</label></td></tr>';
+        echo '<tr><th scope="row"><label for="'.esc_attr(self::OPTION_DAILY).'">Articoli al giorno</label></th><td><input type="number" min="0" max="50" class="small-text" name="'.esc_attr(self::OPTION_DAILY).'" id="'.esc_attr(self::OPTION_DAILY).'" value="'.esc_attr((string)self::get_daily_limit()).'"> <span class="description">Ogni articolo = 1 chiamata OpenAI. Oggi: '.(int)self::processed_today().' / '.(int)self::get_daily_limit().'</span></td></tr>';
+        echo '<tr><th scope="row"><label for="'.esc_attr(self::OPTION_COOLDOWN).'">Cooldown ri-analisi (giorni)</label></th><td><input type="number" min="7" max="365" class="small-text" name="'.esc_attr(self::OPTION_COOLDOWN).'" id="'.esc_attr(self::OPTION_COOLDOWN).'" value="'.esc_attr((string)self::get_cooldown_days()).'"> <span class="description">Un articolo già analizzato non viene rivisto prima di questo intervallo.</span></td></tr>';
+        echo '</table><p><button class="button button-primary">Salva impostazioni</button></p></form>';
+
+        echo '<div class="alma-actions-inline" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin:8px 0 16px;">';
+        echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">';
+        wp_nonce_field('alma_ai_enrich_admin');
+        echo '<input type="hidden" name="action" value="alma_ai_enrich_run_now"><button class="button" '.disabled(!$enabled, true, false).'>Esegui ora</button></form>';
+        echo '<span class="description">In coda: ~'.(int)$pending_new.' articoli · Prossima esecuzione automatica: '.esc_html($next_run ? get_date_from_gmt(gmdate('Y-m-d H:i:s', $next_run), 'Y-m-d H:i') : '—').'</span>';
+        echo '</div>';
+
+        echo '<h3>Report attività (ultimi '.(int)self::MAX_LOG_ENTRIES.')</h3>';
+        if (empty($log)) {
+            echo '<p class="description">Nessuna attività registrata.</p>';
+            return;
+        }
+        echo '<table class="widefat striped"><thead><tr><th>Data</th><th>Articolo</th><th>Esito</th><th>Link aggiunti</th><th>Sostituiti</th><th>Note</th></tr></thead><tbody>';
+        foreach ($log as $entry) {
+            if (!is_array($entry)) { continue; }
+            $edit_url = get_edit_post_link((int)($entry['post_id'] ?? 0), 'raw');
+            $status = !empty($entry['updated']) ? '<span class="alma-badge is-success">Aggiornato</span>' : (!empty($entry['error']) ? '<span class="alma-badge is-warning">Errore</span>' : '<span class="alma-badge">Nessuna modifica</span>');
+            echo '<tr><td>'.esc_html((string)($entry['time'] ?? '')).'</td>';
+            echo '<td>'.($edit_url ? '<a href="'.esc_url($edit_url).'">'.esc_html((string)($entry['title'] ?? '')).'</a>' : esc_html((string)($entry['title'] ?? ''))).'</td>';
+            echo '<td>'.$status.'</td>';
+            echo '<td>'.(int)($entry['added'] ?? 0).'</td><td>'.(int)($entry['replaced'] ?? 0).'</td>';
+            echo '<td>'.esc_html((string)($entry['error'] ?: ($entry['note'] ?? ''))).'</td></tr>';
+        }
+        echo '</tbody></table>';
+    }
+}

--- a/includes/class-ai-post-optimizer.php
+++ b/includes/class-ai-post-optimizer.php
@@ -352,29 +352,52 @@ class ALMA_AI_Post_Optimizer {
         $post_id = self::verify_request();
         $post = get_post($post_id);
         if (!$post) { wp_send_json_error(array('message' => __('Post non trovato.', 'affiliate-link-manager-ai')), 404); }
+        $result = self::generate_proposals($post);
+        if (!empty($result['error'])) {
+            wp_send_json_error(array('message' => $result['error']));
+        }
+        $proposals = (array) $result['proposals'];
+        update_post_meta($post_id, self::META_PROPOSALS, $proposals);
+
+        ob_start();
+        self::render_proposals_rows($proposals);
+        wp_send_json_success(array('html' => (string) ob_get_clean(), 'count' => count($proposals)));
+    }
+
+    /**
+     * Motore proposte, riusato dal metabox (AJAX) e dall'arricchimento in
+     * background (Fase 6). $args:
+     * - allow_replacements: consente proposte di SOSTITUZIONE di shortcode
+     *   esistenti (link geograficamente incoerenti o nettamente peggiori);
+     * - task: etichetta per l'usage logger.
+     * Ritorna array('proposals' => array, 'error' => string).
+     */
+    public static function generate_proposals($post, $args = array()) {
+        $allow_replacements = !empty($args['allow_replacements']);
+        $task = sanitize_key($args['task'] ?? 'post_optimizer');
         if (empty(get_option('alma_openai_api_key', ''))) {
-            wp_send_json_error(array('message' => __('OpenAI non è configurata.', 'affiliate-link-manager-ai')));
+            return array('proposals' => array(), 'error' => __('OpenAI non è configurata.', 'affiliate-link-manager-ai'));
         }
 
         $rules = ALMA_AI_Insertion_Rules::get_rules();
         $paragraphs = self::paragraph_texts($post->post_content);
         if (count($paragraphs) < max(3, $rules['min_paragraphs_before'] + 1)) {
-            wp_send_json_error(array('message' => __('Contenuto troppo breve per proporre inserimenti.', 'affiliate-link-manager-ai')));
+            return array('proposals' => array(), 'error' => __('Contenuto troppo breve per proporre inserimenti.', 'affiliate-link-manager-ai'));
         }
 
         // Budget inserimenti: densità meno gli shortcode già presenti.
         $word_count = ALMA_AI_Insertion_Rules::count_words(wp_strip_all_tags($post->post_content));
         $existing = preg_match_all('/\[affiliate_link(?:s_widget)?[^\]]*\]/', $post->post_content, $m);
         $budget = max(0, (int)floor($word_count / $rules['density_words']) - (int)$existing);
-        if ($budget < 1) {
-            wp_send_json_error(array('message' => __('Densità massima già raggiunta: nessun nuovo inserimento consigliabile.', 'affiliate-link-manager-ai')));
+        if ($budget < 1 && !$allow_replacements) {
+            return array('proposals' => array(), 'error' => __('Densità massima già raggiunta: nessun nuovo inserimento consigliabile.', 'affiliate-link-manager-ai'));
         }
         $budget = min($budget, self::MAX_PROPOSALS);
 
         // Candidati: link dell'area geografica del post + match testuale sul titolo.
         $candidates = self::collect_candidates($post);
         if (empty($candidates)) {
-            wp_send_json_error(array('message' => __('Nessun link affiliato candidato (né geografico né per keyword) per questo articolo.', 'affiliate-link-manager-ai')));
+            return array('proposals' => array(), 'error' => __('Nessun link affiliato candidato (né geografico né per keyword) per questo articolo.', 'affiliate-link-manager-ai'));
         }
 
         $allowed_patterns = array_values(array_intersect($rules['patterns'], array('anchor', 'button', 'card')));
@@ -388,8 +411,21 @@ class ALMA_AI_Post_Optimizer {
             'regole_anchor' => $rules['anchor_rules'],
         );
         $prompt = 'Analizza l\'articolo e proponi al massimo ' . $budget . ' inserimenti di link affiliati che aumentino la conversione SENZA rompere il flusso di lettura. '
-            . 'Rispondi SOLO JSON: {"proposte":[{"paragrafo":int (indice del paragrafo DOPO il quale inserire, >= primo_paragrafo_utilizzabile),"pattern":"anchor|button|card","link_id":int (solo da link_candidati),"frase":string (SOLO per anchor: una frase completa e naturale che prosegue il paragrafo e contiene lo shortcode [affiliate_link id="ID" text="anchor descrittiva"]),"button_text":string (per button/card),"motivo":string (perché qui, orientato alla conversione)}]}. '
-            . 'Meglio poche proposte eccellenti che tante mediocri. CONTEXT: ' . wp_json_encode($context);
+            . 'Rispondi SOLO JSON: {"proposte":[{"paragrafo":int (indice del paragrafo DOPO il quale inserire, >= primo_paragrafo_utilizzabile),"pattern":"anchor|button|card","link_id":int (solo da link_candidati),"frase":string (SOLO per anchor: una frase completa e naturale che prosegue il paragrafo e contiene lo shortcode [affiliate_link id="ID" text="anchor descrittiva"]),"button_text":string (per button/card),"motivo":string (perché qui, orientato alla conversione)}]}. ';
+        if ($allow_replacements) {
+            $existing_analysis = self::analyze_content($post->ID, $post->post_content);
+            $existing_links = array();
+            foreach ((array)$existing_analysis['rows'] as $row) {
+                if ($row['pattern'] === 'Widget') { continue; }
+                if (preg_match('/\bid="?(\d+)"?/', $row['shortcode'], $mm)) {
+                    $existing_links[] = array('link_id' => (int)$mm[1], 'titolo' => $row['title'], 'coerenza_geografica' => $row['geo'], 'valido' => $row['status'] === 'ok');
+                }
+            }
+            $context['shortcode_esistenti'] = $existing_links;
+            $prompt .= 'Puoi inoltre proporre la SOSTITUZIONE di uno shortcode esistente SOLO se il suo link è geograficamente incoerente, non valido, o esiste un candidato nettamente più pertinente: aggiungi alle proposte {"azione":"sostituisci","vecchio_link_id":int (da shortcode_esistenti),"nuovo_link_id":int (da link_candidati),"testo_anchor":string (nuova anchor descrittiva se il pattern è anchor),"motivo":string}. Non sostituire link già coerenti solo per variare. ';
+            if ($budget < 1) { $prompt .= 'La densità massima è già raggiunta: NON proporre nuovi inserimenti, valuta solo eventuali sostituzioni. '; }
+        }
+        $prompt .= 'Meglio poche proposte eccellenti che tante mediocri. CONTEXT: ' . wp_json_encode($context);
 
         $res = ALMA_OpenAI_Service::request(array(
             'system_prompt' => 'Sei un editor esperto di monetizzazione affiliate per blog di viaggi. Proponi inserimenti eleganti e pertinenti. Output solo JSON valido.',
@@ -399,23 +435,76 @@ class ALMA_AI_Post_Optimizer {
             'temperature' => 0.4,
             'timeout' => 60,
         ));
-        ALMA_AI_Usage_Logger::log(array('task' => 'post_optimizer', 'success' => !empty($res['success']), 'model' => $res['model'] ?? '', 'response_time' => $res['response_time'] ?? null, 'input_tokens' => $res['usage']['input_tokens'] ?? null, 'output_tokens' => $res['usage']['output_tokens'] ?? null, 'estimated_cost' => $res['estimated_cost'] ?? null, 'error' => $res['error'] ?? '', 'reference_id' => 'post:' . $post_id));
+        ALMA_AI_Usage_Logger::log(array('task' => $task, 'success' => !empty($res['success']), 'model' => $res['model'] ?? '', 'response_time' => $res['response_time'] ?? null, 'input_tokens' => $res['usage']['input_tokens'] ?? null, 'output_tokens' => $res['usage']['output_tokens'] ?? null, 'estimated_cost' => $res['estimated_cost'] ?? null, 'error' => $res['error'] ?? '', 'reference_id' => 'post:' . $post->ID));
         if (empty($res['success'])) {
-            wp_send_json_error(array('message' => sanitize_text_field((string)($res['error'] ?? __('Errore AI', 'affiliate-link-manager-ai')))));
+            return array('proposals' => array(), 'error' => sanitize_text_field((string)($res['error'] ?? __('Errore AI', 'affiliate-link-manager-ai'))));
         }
         $parsed = json_decode((string)$res['response'], true);
         if (!is_array($parsed)) { $parsed = json_decode(ALMA_AI_Content_Agent_Text_Utils::extract_first_json((string)$res['response']), true); }
         $raw_proposals = is_array($parsed['proposte'] ?? null) ? $parsed['proposte'] : array();
 
         $proposals = self::validate_proposals($raw_proposals, $candidates, $paragraphs, $rules, $budget, $allowed_patterns);
-        if (empty($proposals)) {
-            wp_send_json_error(array('message' => __('L\'AI non ha prodotto proposte valide per questo articolo.', 'affiliate-link-manager-ai')));
+        if ($allow_replacements) {
+            $proposals = array_merge($proposals, self::validate_replacements($raw_proposals, $candidates, $post->post_content));
         }
-        update_post_meta($post_id, self::META_PROPOSALS, $proposals);
+        if (empty($proposals)) {
+            return array('proposals' => array(), 'error' => __('L\'AI non ha prodotto proposte valide per questo articolo.', 'affiliate-link-manager-ai'));
+        }
+        return array('proposals' => $proposals, 'error' => '');
+    }
 
-        ob_start();
-        self::render_proposals_rows($proposals);
-        wp_send_json_success(array('html' => (string) ob_get_clean(), 'count' => count($proposals)));
+    /**
+     * Valida le proposte di sostituzione: il vecchio ID deve essere in uno
+     * shortcode del contenuto, il nuovo tra i candidati, e diversi tra loro.
+     */
+    private static function validate_replacements($raw, $candidates, $content) {
+        $candidate_map = array();
+        foreach ($candidates as $candidate) { $candidate_map[(int)$candidate['id']] = $candidate['titolo']; }
+        $proposals = array();
+        foreach ((array)$raw as $row) {
+            if (!is_array($row) || sanitize_key((string)($row['azione'] ?? '')) !== 'sostituisci') { continue; }
+            $old_id = absint($row['vecchio_link_id'] ?? 0);
+            $new_id = absint($row['nuovo_link_id'] ?? 0);
+            if ($old_id < 1 || $new_id < 1 || $old_id === $new_id) { continue; }
+            if (!isset($candidate_map[$new_id])) { continue; }
+            if (!preg_match('/\[affiliate_link[^\]]*\bid="?' . $old_id . '"?[\s"\]]/', $content)) { continue; }
+            $proposal = array(
+                'pattern' => 'replace',
+                'link_id' => $new_id,
+                'link_title' => $candidate_map[$new_id],
+                'old_link_id' => $old_id,
+                'paragraph' => 0,
+                'insertion' => sprintf('Sostituzione link #%d → #%d (%s)', $old_id, $new_id, $candidate_map[$new_id]),
+                'inline' => false,
+                'anchor_text' => str_replace('"', '', sanitize_text_field((string)($row['testo_anchor'] ?? ''))),
+                'reason' => sanitize_text_field((string)($row['motivo'] ?? '')),
+                'created_at' => current_time('mysql'),
+            );
+            $proposals[md5(wp_json_encode(array('replace', $old_id, $new_id)))] = $proposal;
+            if (count($proposals) >= 3) { break; }
+        }
+        return $proposals;
+    }
+
+    /**
+     * Sostituisce il primo shortcode del vecchio link con il nuovo ID
+     * (stessa struttura/pattern); per le anchor aggiorna anche text=.
+     */
+    public static function apply_replacement($content, $old_link_id, $new_link_id, $anchor_text = '') {
+        $done = false;
+        return array('content' => preg_replace_callback(
+            '/\[affiliate_link([^\]]*)\]/',
+            function ($m) use (&$done, $old_link_id, $new_link_id, $anchor_text) {
+                if ($done || !preg_match('/\bid="?' . (int)$old_link_id . '"?(\s|$)/', $m[1] . ' ')) { return $m[0]; }
+                $done = true;
+                $inner = preg_replace('/\bid="?' . (int)$old_link_id . '"?/', 'id="' . (int)$new_link_id . '"', $m[1]);
+                if ($anchor_text !== '' && preg_match('/\stext="[^"]*"/', $inner)) {
+                    $inner = preg_replace('/(\s)text="[^"]*"/', '$1text="' . $anchor_text . '"', $inner);
+                }
+                return '[affiliate_link' . $inner . ']';
+            },
+            $content
+        ), 'replaced' => $done);
     }
 
     private static function collect_candidates($post) {

--- a/includes/class-telegram-bot.php
+++ b/includes/class-telegram-bot.php
@@ -91,6 +91,12 @@ class ALMA_Telegram_Bot {
         }
     }
 
+    /** Digest e messaggi di servizio verso tutte le chat autorizzate. */
+    public static function send_message_to_all($text, $keyboard = null) {
+        if (!self::is_enabled()) { return; }
+        self::broadcast($text, $keyboard);
+    }
+
     private static function esc($text) {
         return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8');
     }


### PR DESCRIPTION
Ultima fase del piano, con le modifiche richieste: applicazione diretta (niente coda di revisione né notifiche per articolo), pagina di amministrazione dedicata, ri-analisi ciclica.

## Tab "Arricchimento" (Impostazioni AI Content)

- **Attivazione** on/off (default off), **articoli al giorno** (default 5, contatore odierno visibile — 1 chiamata OpenAI per articolo), **cooldown ri-analisi** (default 60 giorni), pulsante **Esegui ora**, coda stimata e prossima esecuzione.
- **Report attività**: ultimi 100 articoli lavorati con esito (Aggiornato / Nessuna modifica / Errore), link aggiunti/sostituiti, note e link di modifica.

## Applicazione diretta, contenuto mai riscritto

- Il runner giornaliero (`ALMA_AI_Post_Enricher`, cron ~05:30 + kick da "Esegui ora") analizza gli articoli col **motore condiviso del metabox** (`generate_proposals`, rifattorizzato per il riuso) e **aggiorna il post pubblicato applicando tutte le proposte valide**: solo aggiunte di shortcode (anchor in coda al paragrafo, bottoni/card come blocchi), applicate in ordine di paragrafo **decrescente** per non spostare gli indici. Il testo esistente resta intatto.
- Ogni aggiornamento passa da `wp_update_post` → **revisione WordPress** (rollback nativo).
- Stesse garanzie della Fase 4: Regole inserimento (densità residua, paragrafi protetti), soli link candidati geo+titolo, ID inventati scartati.

## Ciclo di copertura e ri-analisi (come consigliato)

- **Passata 1**: tutti gli articoli mai analizzati (meta `_alma_ai_enrich_last_run` assente), i più recenti prima.
- **Poi il ciclo riparte da solo** dai più vecchi di analisi — ma mai prima del **cooldown** configurato: costi sotto controllo e niente churn.
- Nelle **ri-analisi** (post con shortcode esistenti) l'AI riceve i link presenti con la loro coerenza geografica e può proporre **sostituzioni** (`apply_replacement`: stesso pattern, nuovo ID e nuova anchor; solo per link incoerenti/non validi o candidati nettamente migliori, max 3 per articolo, testata standalone). A densità già raggiunta valuta solo sostituzioni.

## Telegram: solo digest

- Nessuna notifica per articolo: a fine esecuzione **un solo messaggio** riepilogativo (analizzati, aggiornati, link aggiunti/sostituiti, saltati, errori) se il bot è abilitato (nuovo `send_message_to_all`).

## Robustezza

- Lock via `add_option` atomica con TTL, budget tempo 150s per esecuzione, contatore giornaliero, costi nell'usage logger (task `post_enricher`), cron rimosso alla disattivazione.

## Test

- `php -l` su tutti i file; regressione suite optimizer (10/10 + 9/9 CRLF) e nuovo test `apply_replacement` (3/3: sostituzione con anchor, solo prima occorrenza, ID assente invariato).

Nota: la **Fase 7** (nuove fonti dati per l'agente: Google Trends, Search Console, Open-Meteo, OurAirports, Wikidata, OSM/Overture, UNWTO/Eurostat) è pianificata separatamente, non in questa PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_