### PR TITLE
Diagnostica granulare credenziali Search Console (v2.65.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.65.1 - 2026-07-05
+
+### Diagnostica granulare credenziali Search Console
+- Lo stato credenziali nella tab Search Console ora distingue i casi invece del generico "costante non definita": **costante mancante** (con promemoria: il `define()` va PRIMA della riga `/* That's all, stop editing! */` di wp-config.php), **file inesistente per PHP** (percorso/open_basedir), **file non leggibile** (permessi), **JSON non valido**, **tipo sbagliato** (es. client OAuth invece di service account), **campi mancanti** — e in caso di successo mostra l'email del service account da aggiungere come utente della proprietà.
+- Versione plugin aggiornata a `2.65.1`.
+
 ## 2.65.0 - 2026-07-05
 
 ### Fase 7.1 — Google Search Console per l'agente AI + sospensione chip faccette

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.65.1 - 2026-07-05
+
+### Diagnostica granulare credenziali Search Console
+- Lo stato credenziali distingue: costante mancante (con nota sulla posizione in wp-config.php), file inesistente, file non leggibile, JSON non valido o di tipo sbagliato; in caso di successo mostra l'email del service account.
+- Versione plugin aggiornata a `2.65.1`.
+
 ## 2.65.0 - 2026-07-05
 
 ### Fase 7.1 — Google Search Console per l'agente AI + sospensione chip faccette

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.65.0
+ * Version: 2.65.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.65.0');
+define('ALMA_VERSION', '2.65.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-gsc-connector.php
+++ b/includes/class-gsc-connector.php
@@ -52,6 +52,43 @@ class ALMA_GSC_Connector {
         return '';
     }
 
+    /**
+     * Diagnostica granulare delle credenziali: distingue costante mancante,
+     * file inesistente, file non leggibile (permessi/open_basedir) e JSON
+     * non valido — "costante non definita" da sola non basta a capire dove
+     * intervenire.
+     */
+    public static function credentials_status() {
+        if (defined('ALMA_GSC_SERVICE_ACCOUNT_FILE')) {
+            $path = (string) ALMA_GSC_SERVICE_ACCOUNT_FILE;
+            if (!file_exists($path)) {
+                return array('state' => 'error', 'message' => sprintf(__('Costante definita ma il file NON esiste per PHP: %s — controlla il percorso assoluto (e eventuali restrizioni open_basedir).', 'affiliate-link-manager-ai'), $path));
+            }
+            if (!is_readable($path)) {
+                return array('state' => 'error', 'message' => sprintf(__('File presente ma NON leggibile dall\'utente del web server: %s — sistem i permessi (es. chmod 640 con owner corretto).', 'affiliate-link-manager-ai'), $path));
+            }
+            return self::validate_credentials_json((string) file_get_contents($path), sprintf(__('file %s', 'affiliate-link-manager-ai'), $path));
+        }
+        if (defined('ALMA_GSC_SERVICE_ACCOUNT_JSON')) {
+            return self::validate_credentials_json((string) ALMA_GSC_SERVICE_ACCOUNT_JSON, __('costante JSON', 'affiliate-link-manager-ai'));
+        }
+        return array('state' => 'warning', 'message' => __('Nessuna costante definita. Verifica che il define() sia nel wp-config.php del sito, PRIMA della riga "/* That\'s all, stop editing! */" (dopo quella riga le costanti non vengono caricate).', 'affiliate-link-manager-ai'));
+    }
+
+    private static function validate_credentials_json($json, $source_label) {
+        $data = json_decode($json, true);
+        if (!is_array($data)) {
+            return array('state' => 'error', 'message' => sprintf(__('%s: contenuto non è JSON valido.', 'affiliate-link-manager-ai'), $source_label));
+        }
+        if (($data['type'] ?? '') !== 'service_account') {
+            return array('state' => 'error', 'message' => sprintf(__('%s: non è una chiave service account (type="%s") — serve il JSON con "type":"service_account".', 'affiliate-link-manager-ai'), $source_label, (string)($data['type'] ?? '')));
+        }
+        if (empty($data['client_email']) || empty($data['private_key'])) {
+            return array('state' => 'error', 'message' => sprintf(__('%s: mancano client_email o private_key.', 'affiliate-link-manager-ai'), $source_label));
+        }
+        return array('state' => 'success', 'message' => sprintf(__('OK (%1$s) — service account: %2$s. Ricorda di aggiungere questa email come utente della proprietà in Search Console.', 'affiliate-link-manager-ai'), $source_label, sanitize_text_field((string) $data['client_email'])));
+    }
+
     public static function is_configured() {
         return self::credentials_json() !== '' && self::get_property() !== '';
     }
@@ -302,7 +339,7 @@ class ALMA_GSC_Connector {
      * ------------------------------------------------------------------ */
 
     public static function render_settings_tab() {
-        $configured_constants = self::credentials_json() !== '';
+        $credentials_status = self::credentials_status();
         $snapshot = get_option(self::OPTION_SNAPSHOT, null);
 
         echo '<h2>Google Search Console</h2>';
@@ -313,8 +350,9 @@ class ALMA_GSC_Connector {
         echo '<li>Indica la proprietà qui sotto, salva, poi <strong>Verifica connessione</strong> e <strong>Aggiorna dati ora</strong>.</li></ol>';
         echo '<p><strong>Cosa ci fa l\'agente:</strong> legge le query reali con cui gli utenti trovano il sito (top, in crescita, e soprattutto le <em>opportunità</em>: query con molte impression ma posizione debole) e le usa per proporre idee di contenuto con domanda già dimostrata.</p></div>';
 
+        $badge_class = $credentials_status['state'] === 'success' ? 'is-success' : 'is-warning';
         echo '<table class="form-table" role="presentation">';
-        echo '<tr><th scope="row">Stato credenziali</th><td><span class="alma-badge '.($configured_constants ? 'is-success' : 'is-warning').'">'.($configured_constants ? 'costante definita' : 'costante non definita').'</span><p class="description">Le credenziali vivono solo in wp-config.php / file, mai nel database.</p></td></tr>';
+        echo '<tr><th scope="row">Stato credenziali</th><td><span class="alma-badge '.esc_attr($badge_class).'">'.esc_html($credentials_status['state'] === 'success' ? 'OK' : ($credentials_status['state'] === 'error' ? 'errore' : 'non configurate')).'</span> '.esc_html($credentials_status['message']).'<p class="description">Le credenziali vivono solo in wp-config.php / file, mai nel database. La costante va inserita PRIMA della riga <code>/* That\'s all, stop editing! */</code>.</p></td></tr>';
         echo '</table>';
 
         echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">';


### PR DESCRIPTION
Fix UX per il problema segnalato ("costante non definita" nonostante file presente): lo stato credenziali non distingueva i casi di fallimento.

## Cosa cambia

Nuovo `credentials_status()` mostrato nella tab Search Console, che distingue:

- **costante mancante** — con promemoria che il `define()` va inserito PRIMA della riga `/* That's all, stop editing! */` di `wp-config.php` (dopo quella riga non viene caricato: è la causa più frequente);
- **costante definita ma file inesistente per PHP** — percorso errato o restrizione `open_basedir` (il messaggio mostra il percorso visto da PHP);
- **file presente ma non leggibile** — permessi/owner;
- **JSON non valido**;
- **tipo sbagliato** — es. chiave "web" di un client OAuth invece di `"type":"service_account"`;
- **campi mancanti** (client_email/private_key);
- **OK** — con l'email del service account da aggiungere come utente della proprietà in Search Console.

## Test

- `php -l` sul file modificato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_