### PR TITLE
Fix "Firma JWT fallita" Search Console: normalizzazione chiave privata incollata (v2.65.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.65.2 - 2026-07-05
+
+### Fix "Firma JWT fallita" con la costante JSON di Search Console
+- **Normalizzazione automatica della chiave privata**: incollando il JSON del service account in wp-config.php gli `\n` del PEM possono arrivare a PHP come backslash letterali (o con `\r`, o la chiave su una riga sola) e OpenSSL rifiutava la firma. Ora la chiave viene riparata automaticamente (backslash-n → a-capo, ricostruzione righe da 64 caratteri) — verificato con chiave RSA reale nei tre formati rotti tipici.
+- Il messaggio d'errore di firma include ora il dettaglio OpenSSL e suggerisce l'alternativa `ALMA_GSC_SERVICE_ACCOUNT_FILE` (file originale non modificato, sempre preferibile).
+- Versione plugin aggiornata a `2.65.2`.
+
 ## 2.65.1 - 2026-07-05
 
 ### Diagnostica granulare credenziali Search Console

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.65.2 - 2026-07-05
+
+### Fix "Firma JWT fallita" con la costante JSON di Search Console
+- La chiave privata incollata in wp-config viene normalizzata automaticamente (backslash-n letterali, \r, PEM su una riga); errore di firma con dettaglio OpenSSL.
+- Versione plugin aggiornata a `2.65.2`.
+
 ## 2.65.1 - 2026-07-05
 
 ### Diagnostica granulare credenziali Search Console

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.65.1
+ * Version: 2.65.2
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.65.1');
+define('ALMA_VERSION', '2.65.2');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-gsc-connector.php
+++ b/includes/class-gsc-connector.php
@@ -114,6 +114,21 @@ class ALMA_GSC_Connector {
         return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
     }
 
+    /**
+     * Ripara i danni tipici del copia-incolla del PEM: "\n" letterali
+     * (backslash+n) al posto degli a-capo, \r residui, spazi attorno ai
+     * marker BEGIN/END. Una chiave già corretta resta invariata.
+     */
+    public static function normalize_private_key($key) {
+        $key = str_replace(array('\\n', "\r"), array("\n", ''), $key);
+        $key = trim($key);
+        if (strpos($key, "\n") === false && preg_match('/^(-----BEGIN [A-Z ]+-----)(.+)(-----END [A-Z ]+-----)$/s', $key, $m)) {
+            // PEM finito su una riga sola: ricostruisce le righe da 64 caratteri.
+            $key = $m[1] . "\n" . chunk_split(preg_replace('/\s+/', '', $m[2]), 64, "\n") . $m[3] . "\n";
+        }
+        return $key;
+    }
+
     private static function get_access_token() {
         $cached = get_transient(self::TOKEN_TRANSIENT);
         if (is_string($cached) && $cached !== '') { return $cached; }
@@ -134,9 +149,15 @@ class ALMA_GSC_Connector {
             'iat' => $now,
             'exp' => $now + 3600,
         )));
+        // Normalizza la chiave: incollando il JSON in wp-config gli "\n"
+        // possono arrivare come backslash letterali (o con \r) e il PEM
+        // risulta su una riga sola — OpenSSL lo rifiuta.
+        $private_key = self::normalize_private_key((string) $credentials['private_key']);
         $signature = '';
-        if (!openssl_sign($header . '.' . $claims, $signature, $credentials['private_key'], 'sha256WithRSAEncryption')) {
-            return new WP_Error('alma_gsc_sign', __('Firma JWT fallita: chiave privata non valida.', 'affiliate-link-manager-ai'));
+        if (!openssl_sign($header . '.' . $claims, $signature, $private_key, 'sha256WithRSAEncryption')) {
+            $openssl_detail = '';
+            while (($openssl_error = openssl_error_string()) !== false) { $openssl_detail = $openssl_error; }
+            return new WP_Error('alma_gsc_sign', __('Firma JWT fallita: chiave privata non valida.', 'affiliate-link-manager-ai') . ($openssl_detail !== '' ? ' [' . sanitize_text_field($openssl_detail) . ']' : '') . ' ' . __('Suggerimento: usa la costante ALMA_GSC_SERVICE_ACCOUNT_FILE con il file JSON originale non modificato.', 'affiliate-link-manager-ai'));
         }
         $jwt = $header . '.' . $claims . '.' . self::base64url($signature);
 


### PR DESCRIPTION
Fix del problema segnalato usando `ALMA_GSC_SERVICE_ACCOUNT_JSON` in wp-config.php.

## Causa

Incollando il JSON del service account in una stringa PHP, gli `\n` del PEM della chiave privata possono arrivare a `json_decode` come **backslash letterali** (oppure con `\r`, oppure la chiave finisce su **una riga sola**): il JSON risulta valido, `client_email`/`private_key` presenti, ma OpenSSL rifiuta il PEM → "Firma JWT fallita: chiave privata non valida".

## Fix

- Nuovo **`normalize_private_key()`**: converte i `\n` letterali in a-capo reali, rimuove i `\r`, e se il PEM è su una riga sola ricostruisce il corpo base64 in righe da 64 caratteri tra i marker BEGIN/END. Una chiave già corretta resta invariata.
- **Verificato con una chiave RSA reale** generata al volo: firma OK nei tre formati (originale, backslash-n, una-riga).
- Il messaggio d'errore di firma ora include il **dettaglio `openssl_error_string()`** e suggerisce l'alternativa `ALMA_GSC_SERVICE_ACCOUNT_FILE` (file originale non modificato, sempre preferibile).

## Test

- `php -l` + test funzionale della normalizzazione con `openssl_sign` su chiave reale (3/3 PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_