### PR TITLE
Search Console: ricostruzione marker PEM mancanti nella chiave privata (v2.65.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.65.3 - 2026-07-05
+
+### Search Console: ricostruzione marker PEM mancanti
+- La normalizzazione della chiave privata ripara anche il caso in cui i marker `-----BEGIN/END PRIVATE KEY-----` siano stati rimossi per errore durante l'inserimento in wp-config (errore OpenSSL "DECODER routines::unsupported"): se il valore è il solo corpo base64, il PEM PKCS#8 viene ricostruito. Verificato con chiave RSA reale (4/4 formati firmano).
+- Versione plugin aggiornata a `2.65.3`.
+
 ## 2.65.2 - 2026-07-05
 
 ### Fix "Firma JWT fallita" con la costante JSON di Search Console

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.65.3 - 2026-07-05
+
+### Search Console: ricostruzione marker PEM mancanti
+- La chiave privata viene riparata anche quando i marker BEGIN/END sono stati rimossi per errore (ricostruzione PEM dal corpo base64).
+- Versione plugin aggiornata a `2.65.3`.
+
 ## 2.65.2 - 2026-07-05
 
 ### Fix "Firma JWT fallita" con la costante JSON di Search Console

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.65.2
+ * Version: 2.65.3
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.65.2');
+define('ALMA_VERSION', '2.65.3');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-gsc-connector.php
+++ b/includes/class-gsc-connector.php
@@ -125,6 +125,10 @@ class ALMA_GSC_Connector {
         if (strpos($key, "\n") === false && preg_match('/^(-----BEGIN [A-Z ]+-----)(.+)(-----END [A-Z ]+-----)$/s', $key, $m)) {
             // PEM finito su una riga sola: ricostruisce le righe da 64 caratteri.
             $key = $m[1] . "\n" . chunk_split(preg_replace('/\s+/', '', $m[2]), 64, "\n") . $m[3] . "\n";
+        } elseif (strpos($key, '-----BEGIN') === false && preg_match('/^[A-Za-z0-9+\/\s=]+$/', $key)) {
+            // Marker BEGIN/END rimossi per errore: la chiave Google è PKCS#8,
+            // ricostruisce il PEM attorno al corpo base64.
+            $key = "-----BEGIN PRIVATE KEY-----\n" . chunk_split(preg_replace('/\s+/', '', $key), 64, "\n") . "-----END PRIVATE KEY-----\n";
         }
         return $key;
     }


### PR DESCRIPTION
Follow-up del fix firma JWT, per l'errore segnalato `error:1E08010C:DECODER routines::unsupported`.

## Causa

Quel codice OpenSSL indica un PEM non decodificabile: succede quando, modificando a mano il JSON in wp-config, i marker `-----BEGIN PRIVATE KEY-----` / `-----END PRIVATE KEY-----` vengono rimossi o sostituiti (sono parte integrante della chiave, non segnaposto).

## Fix

- `normalize_private_key()` ora gestisce anche questo caso: se il valore non contiene alcun marker BEGIN ed è composto solo da base64, il **PEM PKCS#8 viene ricostruito** (marker + corpo a righe da 64 caratteri) — le chiavi Google sono sempre PKCS#8.
- Verifica funzionale con chiave RSA reale: firmano tutti e 4 i formati (originale, backslash-n, una riga, solo corpo base64).

## Test

- `php -l` + test `openssl_sign` (4/4 PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_