### PR TITLE
Search Console: diagnosi 403 con elenco proprietà visibili al service account (v2.65.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.65.5 - 2026-07-05
+
+### Search Console: diagnosi dei 403 con elenco proprietà visibili al service account
+- Quando l'API risponde **HTTP 403** ("User does not have sufficient permission for site …"), il plugin ora interroga `sites.list` e mostra **le proprietà che il service account vede davvero** con il relativo livello di permesso: se l'elenco non contiene la proprietà configurata, il messaggio suggerisce di copiarne una esattamente (caso tipico: l'email è stata aggiunta a una proprietà di tipo **Dominio** → `sc-domain:sothra.it`, mentre nel plugin era configurato il prefisso URL `https://www.sothra.it/`, o viceversa). Se il service account non vede alcuna proprietà, il messaggio indica dove aggiungere l'email e ricorda la latenza di propagazione.
+- Nuovo metodo pubblico `ALMA_GSC_Connector::list_sites()` (Webmasters API `sites.list`), riutilizzabile per future diagnostiche.
+- Versione plugin aggiornata a `2.65.5`.
+
 ## 2.65.4 - 2026-07-05
 
 ### Search Console: percorso relativo per hosting condivisi + diagnosi chiave privata

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.65.5 - 2026-07-05
+
+### Search Console: diagnosi dei 403 con elenco proprietà visibili
+- Sugli errori HTTP 403 il plugin elenca le proprietà realmente visibili al service account (via `sites.list`), evidenziando il mismatch tipico tra proprietà Dominio (`sc-domain:…`) e prefisso URL.
+- Versione plugin aggiornata a `2.65.5`.
+
 ## 2.65.4 - 2026-07-05
 
 ### Search Console: percorso relativo per hosting condivisi + diagnosi chiave privata

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.65.4
+ * Version: 2.65.5
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.65.4');
+define('ALMA_VERSION', '2.65.5');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-gsc-connector.php
+++ b/includes/class-gsc-connector.php
@@ -253,7 +253,7 @@ class ALMA_GSC_Connector {
         if ($code < 200 || $code >= 300) {
             $detail = is_array($data) ? sanitize_text_field((string)($data['error']['message'] ?? '')) : '';
             if ($code === 403) {
-                $detail .= ' ' . __('Verifica che l\'email del service account sia stata aggiunta come utente della proprietà in Search Console.', 'affiliate-link-manager-ai');
+                $detail .= ' ' . self::permission_hint($property, $token);
             }
             return new WP_Error('alma_gsc_api', sprintf(__('Errore Search Console (HTTP %d).', 'affiliate-link-manager-ai'), $code) . ' ' . $detail);
         }
@@ -268,6 +268,48 @@ class ALMA_GSC_Connector {
             );
         }
         return $rows;
+    }
+
+    /**
+     * Elenca le proprietà che il service account vede davvero (sites.list).
+     * Serve a diagnosticare i 403: spesso l'email è stata aggiunta a una
+     * proprietà di TIPO diverso (Dominio → sc-domain:… vs prefisso URL).
+     */
+    public static function list_sites($token = null) {
+        if ($token === null) {
+            $token = self::get_access_token();
+        }
+        if (is_wp_error($token)) { return $token; }
+        $response = wp_remote_get('https://searchconsole.googleapis.com/webmasters/v3/sites', array(
+            'timeout' => 20,
+            'headers' => array('Authorization' => 'Bearer ' . $token),
+        ));
+        if (is_wp_error($response)) { return $response; }
+        $data = json_decode(wp_remote_retrieve_body($response), true);
+        $sites = array();
+        foreach ((array) ($data['siteEntry'] ?? array()) as $entry) {
+            $sites[] = array(
+                'site_url' => sanitize_text_field((string) ($entry['siteUrl'] ?? '')),
+                'permission' => sanitize_text_field((string) ($entry['permissionLevel'] ?? '')),
+            );
+        }
+        return $sites;
+    }
+
+    /**
+     * Messaggio esplicativo per gli HTTP 403: confronta la proprietà
+     * configurata con quelle realmente visibili al service account.
+     */
+    private static function permission_hint($property, $token = null) {
+        $sites = self::list_sites($token);
+        if (is_wp_error($sites) || empty($sites)) {
+            return sprintf(__('Il service account NON vede alcuna proprietà: in Search Console apri la proprietà "%s" → Impostazioni → Utenti e autorizzazioni e aggiungi l\'email del service account (client_email del JSON); la propagazione può richiedere qualche minuto.', 'affiliate-link-manager-ai'), $property);
+        }
+        $labels = array();
+        foreach ($sites as $site) {
+            $labels[] = $site['site_url'] . ' (' . $site['permission'] . ')';
+        }
+        return sprintf(__('La proprietà configurata è "%1$s" ma il service account vede queste: %2$s — copia ESATTAMENTE una di queste nel campo Proprietà (es. "sc-domain:sothra.it" se è una proprietà di tipo Dominio).', 'affiliate-link-manager-ai'), $property, implode(', ', $labels));
     }
 
     /* ---------------------------------------------------------------------


### PR DESCRIPTION
## Cosa cambia (v2.65.5)

- Quando l'API Search Analytics risponde **HTTP 403** ("User does not have sufficient permission for site …"), il plugin ora interroga `sites.list` con lo stesso token e aggiunge al messaggio d'errore **le proprietà che il service account vede davvero** con il livello di permesso. Caso tipico diagnosticato: l'email del service account è stata aggiunta a una proprietà di tipo **Dominio** (`sc-domain:sothra.it`) mentre nel plugin è configurato il prefisso URL `https://www.sothra.it/`, o viceversa — il messaggio invita a copiare esattamente una delle proprietà elencate.
- Se il service account non vede **alcuna** proprietà, il messaggio indica dove aggiungere l'email (Impostazioni → Utenti e autorizzazioni della proprietà giusta) e ricorda la possibile latenza di propagazione.
- Nuovo metodo pubblico `ALMA_GSC_Connector::list_sites($token = null)` (Webmasters API `sites.list`), riutilizzabile per future diagnostiche.

## Verifiche
- `php -l` OK su `includes/class-gsc-connector.php` e `affiliate-link-manager-ai.php`.
- Bump versione `2.65.5`, CHANGELOG.md e README.md aggiornati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_