### PR TITLE
Regia AI: camera di regia dell'agente di ideazione + Telegram con tema e bozze (v2.70.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.70.0 - 2026-07-05
+
+### Regia AI: camera di regia dell'agente di ideazione + Telegram potenziato
+- **Nuova pagina "Regia AI"** nel menu, subito dopo la Dashboard (`ALMA_AI_Agent_Control_Room`):
+  - **Piano editoriale**: comunichi all'agente quanti articoli creare (1-10), in quanti giorni distribuirli (1-60), un obiettivo opzionale, e se creare subito anche le bozze (**spuntato di default**); le idee oltre la quota bozze giornaliera vengono generate automaticamente nei giorni programmati dal job notturno.
+  - **Consiglio AI del piano**: un pulsante chiede all'AI di proporre quanti articoli, in quanti giorni e con quale focus, sulla base dei dati reali (click, gap geografici, opportunità Search Console, ritmo attuale); «Applica al piano» precompila il form.
+  - **Grafico attività** (Chart.js): idee create e bozze AI generate per giorno negli ultimi 30 giorni.
+  - **Storico esecuzioni** (ultime 30: data, idee, bozze, obiettivo, costo, esito, lancio manuale ✋) + report dettagliato dell'ultima esecuzione.
+  - **Limiti di guardia** (idee per esecuzione, esecuzioni automatiche/giorno) spostati qui.
+- **I lanci manuali partono sempre**: dalla Regia e da Telegram l'agente viene eseguito anche oltre il limite giornaliero di esecuzioni (con nota informativa); il limite continua a proteggere le esecuzioni non presidiate. Il piano richiesto (numero idee, giorni) guida i prompt dell'agente ("crea ESATTAMENTE N idee distribuite in X giorni").
+- **Telegram**: `/agente <argomento>` ora crea idee **e relative bozze** sul tema indicato (prima non generava bozze), parte anche oltre il limite giornaliero e lo segnala in chat; guida comandi aggiornata.
+- Il pannello "🤖 Agente ideazione AI" in Tutte le idee diventa una card compatta con lo stato e il pulsante «Apri la Regia AI» (la gestione completa vive nella nuova pagina).
+- Versione plugin aggiornata a `2.70.0`.
+
 ## 2.69.0 - 2026-07-05
 
 ### Fase 7.2 (PR C): tendenze Google Trends nelle schede località + tool tendenze_google

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## 2.70.0 - 2026-07-05
+
+### Regia AI: camera di regia dell'agente di ideazione + Telegram potenziato
+- Nuova pagina "Regia AI" dopo la Dashboard: piano editoriale (quanti articoli, in quanti giorni, obiettivo, bozze immediate di default), consiglio AI del piano basato sui dati, grafico attività 30 giorni, storico esecuzioni e limiti di guardia.
+- I lanci manuali (Regia e Telegram) partono anche oltre il limite giornaliero; `/agente <argomento>` su Telegram crea idee e bozze sul tema indicato.
+- Versione plugin aggiornata a `2.70.0`.
+
 ## 2.69.0 - 2026-07-05
 
 ### Fase 7.2 (PR C): tendenze Google Trends nelle schede località + tool tendenze_google

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.69.0
+ * Version: 2.70.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.69.0');
+define('ALMA_VERSION', '2.70.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -56,6 +56,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-result-usage.php
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-instructions-manager.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-content-agent-idea-importer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-idea-agent.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-ai-agent-control-room.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-insertion-rules.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-post-optimizer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-seo-bridge.php';
@@ -167,6 +168,7 @@ class AffiliateManagerAI {
         ALMA_Dashboard_Insights::init();
         ALMA_AI_Content_Agent_Idea_Importer::init();
         ALMA_AI_Idea_Agent::init();
+        ALMA_AI_Agent_Control_Room::init();
         ALMA_AI_Post_Optimizer::init();
         ALMA_Telegram_Bot::init();
         ALMA_AI_Post_Enricher::init();
@@ -1135,6 +1137,16 @@ class AffiliateManagerAI {
             array('ALMA_AI_Content_Agent_Admin', 'render_page')
         );
 
+        // Regia AI (camera di regia dell'agente di ideazione)
+        add_submenu_page(
+            self::AFFILIATE_LINK_PARENT_MENU,
+            __('Regia AI', 'affiliate-link-manager-ai'),
+            __('Regia AI', 'affiliate-link-manager-ai'),
+            self::AI_CONTENT_AGENT_CAPABILITY,
+            ALMA_AI_Agent_Control_Room::MENU_SLUG,
+            array('ALMA_AI_Agent_Control_Room', 'render_page')
+        );
+
         // Tutte le idee (elenco, modello "Post")
         add_submenu_page(
             self::AFFILIATE_LINK_PARENT_MENU,
@@ -1200,7 +1212,9 @@ class AffiliateManagerAI {
         $items = $submenu[$parent];
         $order = array(
             'affiliate-link-manager-dashboard',
-            // Idee sul modello "Post": elenco + aggiungi, subito dopo la Dashboard.
+            // Regia AI subito dopo la Dashboard: la camera di regia dell'agente.
+            ALMA_AI_Agent_Control_Room::MENU_SLUG,
+            // Idee sul modello "Post": elenco + aggiungi.
             ALMA_AI_Content_Agent_Admin::IDEAS_LIST_MENU_SLUG,
             ALMA_AI_Content_Agent_Admin::ADD_IDEA_MENU_SLUG,
             'edit.php?post_type=affiliate_link',

--- a/includes/class-ai-agent-control-room.php
+++ b/includes/class-ai-agent-control-room.php
@@ -1,0 +1,315 @@
+<?php
+/**
+ * Regia AI — camera di regia dell'agente di ideazione contenuti.
+ *
+ * Pagina dedicata (subito dopo la Dashboard) da cui:
+ * - lanciare un PIANO EDITORIALE: quanti articoli, in quanti giorni,
+ *   obiettivo opzionale, con creazione immediata delle bozze (default sì);
+ *   i lanci manuali partono anche oltre il limite giornaliero (force);
+ * - farsi CONSIGLIARE il piano dall'AI sulla base dei dati reali
+ *   (click, gap geografici, opportunità Search Console, ritmo attuale);
+ * - vedere COSA HA FATTO l'agente: grafico idee/bozze per giorno
+ *   (Chart.js), storico esecuzioni, report dettagliato dell'ultima;
+ * - regolare i limiti di guardia (idee per esecuzione, esecuzioni/giorno).
+ *
+ * La stessa regia risponde su Telegram: /agente <argomento> lancia un
+ * piano sul tema indicato, con bozze immediate, anche oltre i limiti.
+ */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALMA_AI_Agent_Control_Room {
+    const MENU_SLUG = 'alma-ai-regia';
+    const OPTION_ADVICE = 'alma_ai_regia_advice';
+
+    public static function init() {
+        add_action('admin_post_alma_ai_regia_advice', array(__CLASS__, 'handle_advice'));
+    }
+
+    /* ---------------------------------------------------------------------
+     * Consiglio AI del piano editoriale
+     * ------------------------------------------------------------------ */
+
+    public static function handle_advice() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_ai_regia_advice');
+        $notice = array('type' => 'success', 'message' => __('Consiglio del piano generato.', 'affiliate-link-manager-ai'));
+        $advice = self::generate_advice();
+        if (is_wp_error($advice)) {
+            $notice = array('type' => 'error', 'message' => sprintf(__('Consiglio non generato: %s', 'affiliate-link-manager-ai'), $advice->get_error_message()));
+        } else {
+            update_option(self::OPTION_ADVICE, array('time' => current_time('mysql'), 'data' => $advice), false);
+        }
+        set_transient('alma_ai_agent_admin_notice_' . get_current_user_id(), $notice, 120);
+        wp_safe_redirect(wp_get_referer() ?: admin_url('edit.php?post_type=affiliate_link&page=' . self::MENU_SLUG));
+        exit;
+    }
+
+    private static function generate_advice() {
+        if (empty(get_option('alma_openai_api_key', ''))) {
+            return new WP_Error('alma_regia', __('OpenAI non è configurata.', 'affiliate-link-manager-ai'));
+        }
+        $context = self::advice_context();
+        $result = ALMA_OpenAI_Service::request(array(
+            'system_prompt' => 'Sei il direttore editoriale di un blog di viaggi italiano monetizzato con link affiliati. '
+                . 'Sulla base dei dati ricevi devi consigliare un piano editoriale sostenibile per l\'agente AI di ideazione. '
+                . 'Rispondi SOLO con un oggetto JSON: {"articoli": <1-10>, "giorni": <3-30>, "obiettivo": "<obiettivo editoriale suggerito, 1 frase>", "motivazione": "<perché questo ritmo e questo focus, 2-3 frasi in italiano>"}.',
+            'user_prompt' => 'Dati del sito: ' . wp_json_encode($context, JSON_UNESCAPED_UNICODE),
+            'max_output_tokens' => 400,
+            'temperature' => 0.3,
+            'timeout' => 60,
+        ));
+        if (empty($result['success'])) {
+            return new WP_Error('alma_regia', sanitize_text_field((string)($result['error'] ?? 'Errore AI')));
+        }
+        $raw = (string) $result['response'];
+        $start = strpos($raw, '{');
+        $end = strrpos($raw, '}');
+        $data = ($start !== false && $end !== false) ? json_decode(substr($raw, $start, $end - $start + 1), true) : null;
+        if (!is_array($data) || empty($data['articoli'])) {
+            return new WP_Error('alma_regia', __('Risposta AI non interpretabile.', 'affiliate-link-manager-ai'));
+        }
+        return array(
+            'articoli' => max(1, min(10, absint($data['articoli']))),
+            'giorni' => max(3, min(30, absint($data['giorni'] ?? 14))),
+            'obiettivo' => sanitize_text_field((string)($data['obiettivo'] ?? '')),
+            'motivazione' => sanitize_textarea_field((string)($data['motivazione'] ?? '')),
+        );
+    }
+
+    /**
+     * Contesto compatto per il consiglio: numeri, non prose.
+     */
+    private static function advice_context() {
+        global $wpdb;
+        $context = array();
+        if (class_exists('ALMA_Dashboard_Insights')) {
+            $snapshot = ALMA_Dashboard_Insights::get_snapshot();
+            if (is_array($snapshot)) {
+                $context['click_periodi'] = $snapshot['periods'] ?? array();
+                $context['localita_con_link_senza_click'] = count((array)($snapshot['geo_unused'] ?? array()));
+                $context['localita_con_articoli_senza_link'] = count((array)($snapshot['geo_no_links'] ?? array()));
+            }
+        }
+        if (class_exists('ALMA_GSC_Connector') && ALMA_GSC_Connector::is_configured()) {
+            $gsc = get_option('alma_gsc_snapshot', null);
+            if (is_array($gsc)) {
+                $context['opportunita_search_console'] = array_slice((array)($gsc['opportunities'] ?? array()), 0, 5);
+            }
+        }
+        $context['idee_in_archivio'] = (int) $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = %s AND post_status NOT IN ('trash','auto-draft')",
+            'alma_content_idea'
+        ));
+        $series = self::activity_series(30);
+        $context['idee_create_ultimi_30gg'] = array_sum($series['ideas']);
+        $context['bozze_ai_ultimi_30gg'] = array_sum($series['drafts']);
+        if (class_exists('ALMA_AI_Content_Agent_Idea_Importer')) {
+            $context['limite_bozze_automatiche_al_giorno'] = (int) get_option('alma_ai_ideas_daily_draft_limit', 3);
+        }
+        return $context;
+    }
+
+    /* ---------------------------------------------------------------------
+     * Dati attività per il grafico
+     * ------------------------------------------------------------------ */
+
+    /**
+     * Idee create e bozze AI generate per giorno (ultimi N giorni).
+     */
+    public static function activity_series($days = 30) {
+        global $wpdb;
+        $days = max(7, min(90, absint($days)));
+        $from = gmdate('Y-m-d 00:00:00', current_time('timestamp') - ($days - 1) * DAY_IN_SECONDS);
+        $labels = array();
+        $ideas = array();
+        $drafts = array();
+        for ($i = $days - 1; $i >= 0; $i--) {
+            $key = gmdate('Y-m-d', current_time('timestamp') - $i * DAY_IN_SECONDS);
+            $labels[] = gmdate('d/m', strtotime($key));
+            $ideas[$key] = 0;
+            $drafts[$key] = 0;
+        }
+        $idea_rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT DATE(post_date) AS giorno, COUNT(*) AS n FROM {$wpdb->posts}
+             WHERE post_type = %s AND post_status NOT IN ('trash','auto-draft') AND post_date >= %s
+             GROUP BY DATE(post_date)",
+            'alma_content_idea', $from
+        ), ARRAY_A);
+        foreach ((array) $idea_rows as $row) {
+            if (isset($ideas[$row['giorno']])) { $ideas[$row['giorno']] = (int) $row['n']; }
+        }
+        $draft_rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT DATE(p.post_date) AS giorno, COUNT(*) AS n FROM {$wpdb->posts} p
+             INNER JOIN {$wpdb->postmeta} m ON m.post_id = p.ID AND m.meta_key = '_alma_ai_agent_generated' AND m.meta_value = '1'
+             WHERE p.post_type = 'post' AND p.post_status NOT IN ('trash','auto-draft') AND p.post_date >= %s
+             GROUP BY DATE(p.post_date)",
+            $from
+        ), ARRAY_A);
+        foreach ((array) $draft_rows as $row) {
+            if (isset($drafts[$row['giorno']])) { $drafts[$row['giorno']] = (int) $row['n']; }
+        }
+        return array('labels' => $labels, 'ideas' => array_values($ideas), 'drafts' => array_values($drafts));
+    }
+
+    /* ---------------------------------------------------------------------
+     * Pagina
+     * ------------------------------------------------------------------ */
+
+    private static function render_notice() {
+        $notice = get_transient('alma_ai_agent_admin_notice_' . get_current_user_id());
+        if (is_array($notice) && !empty($notice['message'])) {
+            delete_transient('alma_ai_agent_admin_notice_' . get_current_user_id());
+            echo '<div class="notice notice-' . esc_attr($notice['type'] === 'error' ? 'error' : 'success') . ' is-dismissible"><p>' . esc_html($notice['message']) . '</p></div>';
+        }
+    }
+
+    public static function render_page() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        $running = (bool) get_option(ALMA_AI_Idea_Agent::LOCK_OPTION);
+        $runs_today = ALMA_AI_Idea_Agent::runs_today();
+        $runs_limit = ALMA_AI_Idea_Agent::get_daily_runs_limit();
+        $draft_limit = (int) get_option('alma_ai_ideas_daily_draft_limit', 3);
+        $draft_counter = get_option('alma_ai_ideas_draft_counter', array());
+        $drafts_today = (is_array($draft_counter) && ($draft_counter['date'] ?? '') === current_time('Y-m-d')) ? (int) $draft_counter['count'] : 0;
+        $advice = get_option(self::OPTION_ADVICE, null);
+        $history = ALMA_AI_Idea_Agent::get_run_history();
+        $series = self::activity_series(30);
+        $card = 'border:1px solid #c3c4c7;border-radius:6px;background:#fff;padding:14px 16px;margin:0 0 14px;';
+
+        echo '<div class="wrap">';
+        echo '<h1>🎬 Regia AI</h1>';
+        self::render_notice();
+        echo '<p class="description" style="max-width:900px;">La camera di regia dell\'agente di ideazione: da qui gli comunichi il piano editoriale (quanti articoli, in quanti giorni, con quale obiettivo), ti fai consigliare il piano dai dati reali, e vedi cosa ha fatto. La stessa regia risponde su Telegram con <code>/agente &lt;argomento&gt;</code>.</p>';
+
+        // ---- Stato ----
+        echo '<div style="' . esc_attr($card) . 'display:flex;gap:22px;flex-wrap:wrap;align-items:center;">';
+        echo '<span><strong>' . esc_html__('Stato', 'affiliate-link-manager-ai') . ':</strong> ' . ($running ? '<span style="color:#996800;">⏳ ' . esc_html__('esecuzione in corso…', 'affiliate-link-manager-ai') . '</span>' : '<span style="color:#00753d;">✅ ' . esc_html__('pronto', 'affiliate-link-manager-ai') . '</span>') . '</span>';
+        echo '<span><strong>' . esc_html__('Esecuzioni oggi', 'affiliate-link-manager-ai') . ':</strong> ' . esc_html($runs_today . ' / ' . $runs_limit) . ' <span class="description">(' . esc_html__('i lanci manuali partono comunque', 'affiliate-link-manager-ai') . ')</span></span>';
+        echo '<span><strong>' . esc_html__('Bozze automatiche oggi', 'affiliate-link-manager-ai') . ':</strong> ' . esc_html($drafts_today . ' / ' . $draft_limit) . '</span>';
+        echo '</div>';
+
+        // ---- Piano editoriale ----
+        echo '<div style="' . esc_attr($card) . '">';
+        echo '<h2 style="margin-top:0;">📋 ' . esc_html__('Piano editoriale', 'affiliate-link-manager-ai') . '</h2>';
+        echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
+        wp_nonce_field('alma_ai_idea_agent_start');
+        echo '<input type="hidden" name="action" value="alma_ai_idea_agent_start">';
+        echo '<div style="display:flex;gap:16px;flex-wrap:wrap;align-items:flex-end;">';
+        echo '<p style="margin:0;"><label><strong>' . esc_html__('Quanti articoli', 'affiliate-link-manager-ai') . '</strong><br><input type="number" id="alma-regia-num" name="agent_num_ideas" min="1" max="10" value="' . esc_attr((string) ALMA_AI_Idea_Agent::get_max_ideas()) . '" class="small-text"></label></p>';
+        echo '<p style="margin:0;"><label><strong>' . esc_html__('In quanti giorni', 'affiliate-link-manager-ai') . '</strong><br><input type="number" id="alma-regia-giorni" name="agent_days" min="1" max="60" value="14" class="small-text"></label></p>';
+        echo '<p style="margin:0;flex:1 1 340px;"><label><strong>' . esc_html__('Obiettivo (opzionale)', 'affiliate-link-manager-ai') . '</strong><br><input type="text" id="alma-regia-obiettivo" name="agent_objective" class="widefat" placeholder="' . esc_attr__('Es. destinazioni per l\'autunno, focus Sicilia, cammini…', 'affiliate-link-manager-ai') . '"></label></p>';
+        echo '<p style="margin:0;"><label title="' . esc_attr__('Le bozze immediate rispettano il limite giornaliero: le idee oltre quota vengono generate automaticamente nei giorni programmati.', 'affiliate-link-manager-ai') . '"><input type="checkbox" name="agent_create_drafts" value="1" checked> ' . esc_html__('Crea subito anche le bozze', 'affiliate-link-manager-ai') . '</label></p>';
+        echo '<p style="margin:0;"><button class="button button-primary button-hero" ' . disabled($running, true, false) . '>' . esc_html($running ? __('Esecuzione in corso…', 'affiliate-link-manager-ai') : __('Avvia l\'agente', 'affiliate-link-manager-ai')) . '</button></p>';
+        echo '</div>';
+        echo '<p class="description" style="margin:8px 0 0;">' . esc_html__('L\'agente crea le idee con date di pubblicazione distribuite nel periodo indicato; le bozze non immediate vengono generate automaticamente nei giorni programmati (job notturno), nel rispetto del limite giornaliero.', 'affiliate-link-manager-ai') . '</p>';
+        echo '</form>';
+        echo '</div>';
+
+        // ---- Consiglio AI ----
+        echo '<div style="' . esc_attr($card) . '">';
+        echo '<h2 style="margin-top:0;">💡 ' . esc_html__('Fatti consigliare il piano', 'affiliate-link-manager-ai') . '</h2>';
+        echo '<div style="display:flex;gap:16px;flex-wrap:wrap;align-items:center;">';
+        echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '" style="margin:0;">';
+        wp_nonce_field('alma_ai_regia_advice');
+        echo '<input type="hidden" name="action" value="alma_ai_regia_advice"><button class="button">' . esc_html__('Chiedi un consiglio ai dati', 'affiliate-link-manager-ai') . '</button></form>';
+        echo '<span class="description">' . esc_html__('L\'AI analizza click, gap geografici, opportunità Search Console e il tuo ritmo attuale, e propone quanti articoli creare, in quanti giorni e con quale focus.', 'affiliate-link-manager-ai') . '</span>';
+        echo '</div>';
+        if (is_array($advice) && !empty($advice['data'])) {
+            $d = $advice['data'];
+            echo '<div style="margin-top:10px;padding:10px 12px;background:#f0f6fc;border:1px solid #c5d9ed;border-radius:6px;">';
+            echo '<p style="margin:0 0 6px;"><strong>' . esc_html(sprintf(__('Consiglio del %s', 'affiliate-link-manager-ai'), (string) $advice['time'])) . ':</strong> ';
+            echo esc_html(sprintf(__('%1$d articoli in %2$d giorni', 'affiliate-link-manager-ai'), (int) $d['articoli'], (int) $d['giorni']));
+            if (!empty($d['obiettivo'])) { echo ' — <em>' . esc_html($d['obiettivo']) . '</em>'; }
+            echo '</p>';
+            if (!empty($d['motivazione'])) { echo '<p style="margin:0 0 8px;" class="description">' . esc_html($d['motivazione']) . '</p>'; }
+            echo '<button type="button" class="button button-secondary" id="alma-regia-applica" data-articoli="' . esc_attr((string)(int) $d['articoli']) . '" data-giorni="' . esc_attr((string)(int) $d['giorni']) . '" data-obiettivo="' . esc_attr((string) $d['obiettivo']) . '">' . esc_html__('Applica al piano', 'affiliate-link-manager-ai') . '</button>';
+            echo '</div>';
+        }
+        echo '</div>';
+
+        // ---- Grafico attività ----
+        echo '<div style="' . esc_attr($card) . '">';
+        echo '<h2 style="margin-top:0;">📈 ' . esc_html__('Attività ultimi 30 giorni', 'affiliate-link-manager-ai') . '</h2>';
+        echo '<div style="height:280px;"><canvas id="alma-regia-chart"></canvas></div>';
+        echo '<p class="description">' . esc_html(sprintf(__('Totali: %1$d idee create, %2$d bozze AI generate.', 'affiliate-link-manager-ai'), array_sum($series['ideas']), array_sum($series['drafts']))) . '</p>';
+        echo '</div>';
+
+        // ---- Ultima esecuzione ----
+        echo '<div style="' . esc_attr($card) . '">';
+        echo '<h2 style="margin-top:0;">📄 ' . esc_html__('Ultima esecuzione', 'affiliate-link-manager-ai') . '</h2>';
+        ALMA_AI_Idea_Agent::render_last_run_details();
+        echo '</div>';
+
+        // ---- Storico ----
+        echo '<div style="' . esc_attr($card) . '">';
+        echo '<h2 style="margin-top:0;">🗂️ ' . esc_html__('Storico esecuzioni', 'affiliate-link-manager-ai') . '</h2>';
+        if (empty($history)) {
+            echo '<p class="description">' . esc_html__('Ancora nessuna esecuzione in archivio.', 'affiliate-link-manager-ai') . '</p>';
+        } else {
+            echo '<table class="widefat striped" style="max-width:1000px;"><thead><tr><th>' . esc_html__('Avvio', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Idee', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Bozze', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Obiettivo', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Costo ~$', 'affiliate-link-manager-ai') . '</th><th>' . esc_html__('Esito', 'affiliate-link-manager-ai') . '</th></tr></thead><tbody>';
+            foreach ($history as $run) {
+                echo '<tr>';
+                echo '<td>' . esc_html((string)($run['started_at'] ?? '')) . ($run['forced'] ? ' <span class="description" title="' . esc_attr__('Lancio manuale (Regia o Telegram)', 'affiliate-link-manager-ai') . '">✋</span>' : '') . '</td>';
+                echo '<td>' . esc_html((string)(int)($run['ideas'] ?? 0)) . '</td>';
+                echo '<td>' . esc_html((string)(int)($run['drafts'] ?? 0)) . '</td>';
+                $objective_label = (string)($run['objective'] ?? '');
+                echo '<td>' . esc_html($objective_label !== '' ? $objective_label : '—') . '</td>';
+                echo '<td>' . esc_html(number_format((float)($run['cost'] ?? 0), 4)) . '</td>';
+                echo '<td>' . (empty($run['error']) ? '✅' : '<span style="color:#d63638;" title="' . esc_attr((string)$run['error']) . '">⚠️ ' . esc_html((string)$run['error']) . '</span>') . '</td>';
+                echo '</tr>';
+            }
+            echo '</tbody></table>';
+        }
+        echo '</div>';
+
+        // ---- Limiti di guardia ----
+        echo '<div style="' . esc_attr($card) . '">';
+        echo '<h2 style="margin-top:0;">🛡️ ' . esc_html__('Limiti di guardia', 'affiliate-link-manager-ai') . '</h2>';
+        echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '" style="display:flex;gap:14px;align-items:center;flex-wrap:wrap;">';
+        wp_nonce_field('alma_ai_idea_agent_settings');
+        echo '<input type="hidden" name="action" value="alma_ai_idea_agent_settings">';
+        echo '<label>' . esc_html__('Idee per esecuzione (default)', 'affiliate-link-manager-ai') . ' <input type="number" min="1" max="10" class="small-text" name="' . esc_attr(ALMA_AI_Idea_Agent::OPTION_MAX_IDEAS) . '" value="' . esc_attr((string) ALMA_AI_Idea_Agent::get_max_ideas()) . '"></label>';
+        echo '<label>' . esc_html__('Esecuzioni automatiche al giorno', 'affiliate-link-manager-ai') . ' <input type="number" min="1" max="20" class="small-text" name="' . esc_attr(ALMA_AI_Idea_Agent::OPTION_DAILY_RUNS) . '" value="' . esc_attr((string) $runs_limit) . '"></label>';
+        echo '<button class="button">' . esc_html__('Salva limiti', 'affiliate-link-manager-ai') . '</button>';
+        echo '<span class="description">' . esc_html(sprintf(__('Il limite bozze automatiche (%d/giorno) si regola in Importazione massiva.', 'affiliate-link-manager-ai'), $draft_limit)) . '</span>';
+        echo '</form>';
+        echo '</div>';
+
+        // ---- JS: grafico + applica consiglio ----
+        $chart_payload = wp_json_encode(array('labels' => $series['labels'], 'ideas' => $series['ideas'], 'drafts' => $series['drafts']));
+        echo '<script>
+        (function(){
+            var data = ' . $chart_payload . ';
+            function initChart(){
+                var canvas = document.getElementById("alma-regia-chart");
+                if (!canvas || typeof window.Chart === "undefined") { return; }
+                new window.Chart(canvas, {
+                    type: "bar",
+                    data: { labels: data.labels, datasets: [
+                        { label: "' . esc_js(__('Idee create', 'affiliate-link-manager-ai')) . '", data: data.ideas, backgroundColor: "rgba(34,113,177,0.6)" },
+                        { label: "' . esc_js(__('Bozze AI', 'affiliate-link-manager-ai')) . '", data: data.drafts, backgroundColor: "rgba(0,163,42,0.6)" }
+                    ]},
+                    options: { responsive: true, maintainAspectRatio: false,
+                        scales: { x: { stacked: false }, y: { beginAtZero: true, ticks: { precision: 0 } } } }
+                });
+            }
+            var applyBtn = document.getElementById("alma-regia-applica");
+            if (applyBtn) {
+                applyBtn.addEventListener("click", function(){
+                    var num = document.getElementById("alma-regia-num");
+                    var giorni = document.getElementById("alma-regia-giorni");
+                    var obiettivo = document.getElementById("alma-regia-obiettivo");
+                    if (num) { num.value = this.getAttribute("data-articoli"); }
+                    if (giorni) { giorni.value = this.getAttribute("data-giorni"); }
+                    if (obiettivo) { obiettivo.value = this.getAttribute("data-obiettivo"); }
+                    window.scrollTo({ top: 0, behavior: "smooth" });
+                });
+            }
+            if (document.readyState === "loading") { document.addEventListener("DOMContentLoaded", initChart); } else { initChart(); }
+        })();
+        </script>';
+        echo '</div>';
+    }
+}

--- a/includes/class-ai-idea-agent.php
+++ b/includes/class-ai-idea-agent.php
@@ -27,9 +27,11 @@ class ALMA_AI_Idea_Agent {
     const LOCK_OPTION = 'alma_ai_idea_agent_lock';
     const LOCK_TTL = 600;
     const MAX_ROUNDS = 12;
+    const OPTION_RUN_HISTORY = 'alma_ai_idea_agent_history';
+    const HISTORY_MAX = 30;
 
     public static function init() {
-        add_action(self::CRON_HOOK, array(__CLASS__, 'run'), 10, 3);
+        add_action(self::CRON_HOOK, array(__CLASS__, 'run'), 10, 6);
         add_action('admin_post_alma_ai_idea_agent_start', array(__CLASS__, 'handle_start'));
         add_action('admin_post_alma_ai_idea_agent_settings', array(__CLASS__, 'handle_settings'));
     }
@@ -56,6 +58,11 @@ class ALMA_AI_Idea_Agent {
         return (is_array($counter) && ($counter['date'] ?? '') === current_time('Y-m-d')) ? (int)$counter['count'] : 0;
     }
 
+    public static function get_run_history() {
+        $history = get_option(self::OPTION_RUN_HISTORY, array());
+        return is_array($history) ? $history : array();
+    }
+
     /* ---------------------------------------------------------------------
      * Avvio (admin) → esecuzione in background
      * ------------------------------------------------------------------ */
@@ -63,22 +70,27 @@ class ALMA_AI_Idea_Agent {
     public static function handle_start() {
         if (!current_user_can('manage_options')) { wp_die('forbidden'); }
         check_admin_referer('alma_ai_idea_agent_start');
-        $notice = array('type' => 'success', 'message' => __('Agente ideazione avviato in background: i risultati compariranno qui e in Tutte le idee entro qualche minuto.', 'affiliate-link-manager-ai'));
+        $notice = array('type' => 'success', 'message' => __('Agente ideazione avviato in background: il report comparirà nella Regia AI entro qualche minuto.', 'affiliate-link-manager-ai'));
 
         if (empty(get_option('alma_openai_api_key', ''))) {
             $notice = array('type' => 'error', 'message' => __('OpenAI non è configurata.', 'affiliate-link-manager-ai'));
-        } elseif (self::runs_today() >= self::get_daily_runs_limit()) {
-            $notice = array('type' => 'error', 'message' => __('Limite di esecuzioni giornaliere dell\'agente raggiunto.', 'affiliate-link-manager-ai'));
         } elseif (get_option(self::LOCK_OPTION)) {
             $notice = array('type' => 'error', 'message' => __('Un\'esecuzione dell\'agente è già in corso.', 'affiliate-link-manager-ai'));
         } else {
             $objective = sanitize_textarea_field(wp_unslash($_POST['agent_objective'] ?? ''));
             $create_drafts = empty($_POST['agent_create_drafts']) ? 0 : 1;
-            wp_schedule_single_event(time() + 5, self::CRON_HOOK, array(get_current_user_id(), $objective, $create_drafts));
+            $num_ideas = max(0, min(10, absint($_POST['agent_num_ideas'] ?? 0)));
+            $days_span = max(0, min(60, absint($_POST['agent_days'] ?? 0)));
+            // I lanci manuali dalla Regia partono sempre (force=1): il limite
+            // giornaliero protegge solo le esecuzioni non presidiate.
+            if (self::runs_today() >= self::get_daily_runs_limit()) {
+                $notice['message'] .= ' ' . __('Nota: limite giornaliero già raggiunto, il lancio manuale viene eseguito comunque.', 'affiliate-link-manager-ai');
+            }
+            wp_schedule_single_event(time() + 5, self::CRON_HOOK, array(get_current_user_id(), $objective, $create_drafts, 1, $num_ideas, $days_span));
             if (function_exists('spawn_cron')) { spawn_cron(); }
         }
         set_transient('alma_ai_agent_admin_notice_' . get_current_user_id(), $notice, 120);
-        wp_safe_redirect(wp_get_referer() ?: admin_url('edit.php?post_type=affiliate_link&page=alma-ai-content-ideas'));
+        wp_safe_redirect(wp_get_referer() ?: admin_url('edit.php?post_type=affiliate_link&page=alma-ai-regia'));
         exit;
     }
 
@@ -105,16 +117,19 @@ class ALMA_AI_Idea_Agent {
         return false;
     }
 
-    public static function run($user_id = 0, $objective = '', $create_drafts = 0) {
+    public static function run($user_id = 0, $objective = '', $create_drafts = 0, $force = 0, $num_ideas = 0, $days_span = 0) {
         if (!self::acquire_lock()) { return; }
         $started_at = current_time('mysql');
         $report = array(
             'started_at' => $started_at, 'finished_at' => '', 'rounds' => 0,
             'tool_calls' => array(), 'ideas_created' => array(), 'drafts_created' => array(),
             'cost_total' => 0.0, 'model' => '', 'summary' => '', 'error' => '',
+            'objective' => sanitize_textarea_field((string) $objective), 'forced' => (int) (bool) $force,
         );
         try {
-            if (self::runs_today() >= self::get_daily_runs_limit()) {
+            // I lanci manuali (Regia, Telegram) hanno force=1 e partono sempre;
+            // il limite giornaliero ferma solo le esecuzioni non presidiate.
+            if (empty($force) && self::runs_today() >= self::get_daily_runs_limit()) {
                 $report['error'] = 'Limite esecuzioni giornaliere raggiunto.';
                 return;
             }
@@ -123,12 +138,13 @@ class ALMA_AI_Idea_Agent {
             $user_id = absint($user_id) ?: 1;
             wp_set_current_user($user_id);
 
-            $max_ideas = self::get_max_ideas();
+            $max_ideas = $num_ideas > 0 ? max(1, min(10, absint($num_ideas))) : self::get_max_ideas();
+            $days_span = $days_span > 0 ? max(1, min(60, absint($days_span))) : 14;
             $ideas_created = array();
 
             $input_items = array(
-                array('role' => 'system', 'content' => array(array('type' => 'input_text', 'text' => self::system_prompt($max_ideas)))),
-                array('role' => 'user', 'content' => array(array('type' => 'input_text', 'text' => self::user_prompt($objective)))),
+                array('role' => 'system', 'content' => array(array('type' => 'input_text', 'text' => self::system_prompt($max_ideas, $days_span)))),
+                array('role' => 'user', 'content' => array(array('type' => 'input_text', 'text' => self::user_prompt($objective, $num_ideas, $days_span)))),
             );
 
             for ($round = 1; $round <= self::MAX_ROUNDS; $round++) {
@@ -193,6 +209,22 @@ class ALMA_AI_Idea_Agent {
         } finally {
             $report['finished_at'] = current_time('mysql');
             update_option(self::OPTION_LAST_RUN, $report, false);
+            // Storico compatto per la Regia AI (ultime 30 esecuzioni).
+            $drafts_ok = 0;
+            foreach ((array) $report['drafts_created'] as $draft) {
+                if (!empty($draft['post_id'])) { $drafts_ok++; }
+            }
+            $history = self::get_run_history();
+            array_unshift($history, array(
+                'started_at' => $report['started_at'],
+                'ideas' => count((array) $report['ideas_created']),
+                'drafts' => $drafts_ok,
+                'objective' => mb_substr((string) $report['objective'], 0, 120),
+                'cost' => round((float) $report['cost_total'], 4),
+                'error' => mb_substr((string) $report['error'], 0, 160),
+                'forced' => (int) $report['forced'],
+            ));
+            update_option(self::OPTION_RUN_HISTORY, array_slice($history, 0, self::HISTORY_MAX), false);
             delete_option(self::LOCK_OPTION);
             // Regia Telegram: report di fine esecuzione alle chat autorizzate.
             if (class_exists('ALMA_Telegram_Bot')) {
@@ -201,10 +233,10 @@ class ALMA_AI_Idea_Agent {
         }
     }
 
-    private static function system_prompt($max_ideas) {
+    private static function system_prompt($max_ideas, $days_span = 14) {
         $prompt = 'Sei l\'agente strategico di ideazione contenuti di un blog di viaggi italiano monetizzato con link affiliati. '
             . 'Il tuo compito: analizzare i DATI REALI del sito tramite gli strumenti disponibili e creare fino a ' . (int)$max_ideas . ' nuove idee di articolo ad alto potenziale. '
-            . 'Metodo obbligatorio: 1) analizza le performance, i gap geografici e — se disponibile — le ricerche reali con analizza_ricerche_google (le "opportunità" con impression alte e posizione debole sono il segnale più prezioso: domanda dimostrata senza contenuto adeguato); 2) per ogni opportunità verifica con cerca_link_affiliati che esistano link da monetizzare, con elenca_articoli_esistenti che il tema non sia già coperto (evita duplicati) e con cerca_media se la Media Library ha già immagini utilizzabili sul tema (se sì, segnalalo nel prompt dell\'idea); per le idee legate a una destinazione consulta scheda_localita e usa il clima reale per il taglio stagionale (es. proponi "quando andare" o contenuti per i mesi migliori in arrivo, citando i mesi consigliati nel prompt dell\'idea) e i fatti Wikidata (patrimonio UNESCO, attrazioni notevoli) per angoli accurati e non ancora coperti; per validare un tema usa tendenze_google (Italia, 5 anni): domanda in crescita e mesi di picco delle ricerche indicano COSA proporre e QUANDO pubblicare (prima del picco); 3) crea le idee con crea_idea, includendo località (se pertinente), un prompt editoriale ricco che citi le query target, e una data programmata distribuita nei prossimi 14 giorni. '
+            . 'Metodo obbligatorio: 1) analizza le performance, i gap geografici e — se disponibile — le ricerche reali con analizza_ricerche_google (le "opportunità" con impression alte e posizione debole sono il segnale più prezioso: domanda dimostrata senza contenuto adeguato); 2) per ogni opportunità verifica con cerca_link_affiliati che esistano link da monetizzare, con elenca_articoli_esistenti che il tema non sia già coperto (evita duplicati) e con cerca_media se la Media Library ha già immagini utilizzabili sul tema (se sì, segnalalo nel prompt dell\'idea); per le idee legate a una destinazione consulta scheda_localita e usa il clima reale per il taglio stagionale (es. proponi "quando andare" o contenuti per i mesi migliori in arrivo, citando i mesi consigliati nel prompt dell\'idea) e i fatti Wikidata (patrimonio UNESCO, attrazioni notevoli) per angoli accurati e non ancora coperti; per validare un tema usa tendenze_google (Italia, 5 anni): domanda in crescita e mesi di picco delle ricerche indicano COSA proporre e QUANDO pubblicare (prima del picco); 3) crea le idee con crea_idea, includendo località (se pertinente), un prompt editoriale ricco che citi le query target, e una data programmata distribuita nei prossimi ' . (int)$days_span . ' giorni. '
             . 'Privilegia: località con link affiliati ma senza click (offerta inutilizzata), località con molti articoli ma senza copertura pratica/commerciale, trend di click in crescita. '
             . 'Non inventare dati: basa ogni decisione sugli output degli strumenti. Non superare il numero massimo di idee. '
             . 'Alla fine rispondi in italiano con un riepilogo: per ogni idea creata, titolo e motivazione basata sui numeri.';
@@ -219,9 +251,12 @@ class ALMA_AI_Idea_Agent {
         return preg_match('/^[A-Za-z0-9_\-]{1,120}$/', $id) ? $id : '';
     }
 
-    private static function user_prompt($objective) {
+    private static function user_prompt($objective, $num_ideas = 0, $days_span = 0) {
         $objective = trim((string)$objective);
         $base = 'Analizza i dati del sito e crea le idee di contenuto più promettenti.';
+        if ($num_ideas > 0) {
+            $base = 'Piano editoriale richiesto dall\'editore: crea ESATTAMENTE ' . (int)$num_ideas . ' idee di contenuto, con date programmate distribuite in modo sensato nei prossimi ' . max(1, (int)$days_span) . ' giorni (mai più di una al giorno se possibile).';
+        }
         return $objective !== '' ? $base . ' Obiettivo specifico indicato dall\'editore: ' . $objective : $base;
     }
 
@@ -429,34 +464,33 @@ class ALMA_AI_Idea_Agent {
     }
 
     /* ---------------------------------------------------------------------
-     * UI (card nella pagina Tutte le idee)
+     * UI
      * ------------------------------------------------------------------ */
 
+    /**
+     * Card compatta in Tutte le idee: la gestione completa dell'agente
+     * vive nella pagina Regia AI (v2.70.0).
+     */
     public static function render_panel() {
         if (!current_user_can('manage_options')) { return; }
-        $last = self::get_last_run();
         $running = (bool) get_option(self::LOCK_OPTION);
-        echo '<div class="alma-ideas-card" style="border:1px solid #c3c4c7;border-radius:6px;background:#fff;padding:14px 16px;margin:12px 0;">';
-        echo '<h2 style="margin:0 0 6px;">🤖 Agente ideazione AI</h2>';
-        echo '<p class="description" style="margin-top:0;">Analizza i dati reali (click, gap geografici, link disponibili, articoli esistenti) e crea nuove idee motivate dai numeri. Non genera bozze e non pubblica nulla.</p>';
+        $last = self::get_last_run();
+        echo '<div class="alma-ideas-card" style="border:1px solid #c3c4c7;border-radius:6px;background:#fff;padding:12px 16px;margin:12px 0;display:flex;gap:14px;align-items:center;flex-wrap:wrap;">';
+        echo '<span style="font-size:1.05em;"><strong>🤖 Agente ideazione AI</strong></span>';
+        if ($running) {
+            echo '<span class="description">' . esc_html__('Esecuzione in corso…', 'affiliate-link-manager-ai') . '</span>';
+        } elseif ($last) {
+            echo '<span class="description">' . esc_html(sprintf(__('Ultima esecuzione: %1$s — %2$d idee create.', 'affiliate-link-manager-ai'), (string)($last['started_at'] ?? ''), count((array)($last['ideas_created'] ?? array())))) . '</span>';
+        }
+        echo '<a class="button button-primary" href="' . esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-regia')) . '">' . esc_html__('Apri la Regia AI', 'affiliate-link-manager-ai') . '</a>';
+        echo '</div>';
+    }
 
-        echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'" style="display:flex;gap:10px;align-items:flex-end;flex-wrap:wrap;">';
-        wp_nonce_field('alma_ai_idea_agent_start');
-        echo '<input type="hidden" name="action" value="alma_ai_idea_agent_start">';
-        echo '<p style="margin:0;flex:1 1 320px;"><label><strong>'.esc_html__('Obiettivo (opzionale)', 'affiliate-link-manager-ai').'</strong><br><input type="text" name="agent_objective" class="widefat" placeholder="'.esc_attr__('Es. concentrati sull\'Italia, oppure su idee per l\'estate…', 'affiliate-link-manager-ai').'"></label></p>';
-        echo '<p style="margin:0;"><label title="'.esc_attr__('Le bozze contano nel limite giornaliero di bozze automatiche (impostazioni Importazione massiva).', 'affiliate-link-manager-ai').'"><input type="checkbox" name="agent_create_drafts" value="1"> '.esc_html__('Crea subito anche le bozze', 'affiliate-link-manager-ai').'</label></p>';
-        echo '<p style="margin:0;"><button class="button button-primary" '.disabled($running, true, false).'>'.esc_html($running ? __('Esecuzione in corso…', 'affiliate-link-manager-ai') : __('Esegui agente', 'affiliate-link-manager-ai')).'</button></p>';
-        echo '</form>';
-
-        echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'" style="display:flex;gap:14px;align-items:center;flex-wrap:wrap;margin-top:8px;">';
-        wp_nonce_field('alma_ai_idea_agent_settings');
-        echo '<input type="hidden" name="action" value="alma_ai_idea_agent_settings">';
-        echo '<label>'.esc_html__('Max idee per esecuzione', 'affiliate-link-manager-ai').' <input type="number" min="1" max="10" class="small-text" name="'.esc_attr(self::OPTION_MAX_IDEAS).'" value="'.esc_attr((string)self::get_max_ideas()).'"></label>';
-        echo '<label>'.esc_html__('Max esecuzioni al giorno', 'affiliate-link-manager-ai').' <input type="number" min="1" max="20" class="small-text" name="'.esc_attr(self::OPTION_DAILY_RUNS).'" value="'.esc_attr((string)self::get_daily_runs_limit()).'"></label>';
-        echo '<span class="description">'.esc_html(sprintf(__('Esecuzioni oggi: %1$d / %2$d', 'affiliate-link-manager-ai'), self::runs_today(), self::get_daily_runs_limit())).'</span>';
-        echo '<button class="button">'.esc_html__('Salva limiti', 'affiliate-link-manager-ai').'</button>';
-        echo '</form>';
-
+    /**
+     * Report dettagliato dell'ultima esecuzione (usato dalla Regia AI).
+     */
+    public static function render_last_run_details() {
+        $last = self::get_last_run();
         if ($last) {
             $ideas = (array)($last['ideas_created'] ?? array());
             echo '<details style="margin-top:10px;"'.(empty($last['error']) ? '' : ' open').'><summary><strong>'.esc_html__('Ultima esecuzione', 'affiliate-link-manager-ai').'</strong> · '.esc_html($last['started_at'] ?? '').' · '.esc_html(sprintf(__('%1$d idee create, %2$d chiamate strumento, costo stimato ~$%3$s', 'affiliate-link-manager-ai'), count($ideas), count((array)($last['tool_calls'] ?? array())), number_format((float)($last['cost_total'] ?? 0), 4))).($last['model'] !== '' ? ' · '.esc_html($last['model']) : '').'</summary>';
@@ -483,7 +517,8 @@ class ALMA_AI_Idea_Agent {
             }
             if (!empty($last['summary'])) { echo '<pre style="white-space:pre-wrap;font-family:inherit;background:#f6f7f7;border:1px solid #dcdcde;border-radius:6px;padding:10px;margin-top:8px;">'.esc_html($last['summary']).'</pre>'; }
             echo '</details>';
+        } else {
+            echo '<p class="description">' . esc_html__('Nessuna esecuzione registrata: avvia il primo piano qui sopra.', 'affiliate-link-manager-ai') . '</p>';
         }
-        echo '</div>';
     }
 }

--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -122,7 +122,7 @@ class ALMA_Assets {
                 }
             }
 
-            if ($hook === 'affiliate_link_page_affiliate-link-manager-dashboard') {
+            if (in_array($hook, array('affiliate_link_page_affiliate-link-manager-dashboard', 'affiliate_link_page_alma-ai-regia'), true)) {
                 wp_enqueue_script(
                     'chart.js',
                     'https://cdn.jsdelivr.net/npm/chart.js',

--- a/includes/class-telegram-bot.php
+++ b/includes/class-telegram-bot.php
@@ -200,7 +200,7 @@ class ALMA_Telegram_Bot {
 
     public static function instructions_text() {
         return "<b>Comandi disponibili</b>\n"
-            . "/agente &lt;obiettivo&gt; — avvia l'agente di ideazione (obiettivo opzionale)\n"
+            . "/agente &lt;argomento&gt; — avvia l'agente: crea idee E bozze sul tema indicato (opzionale); parte anche oltre il limite giornaliero\n"
             . "/report — esito dell'ultima esecuzione dell'agente\n"
             . "/bozze — ultime bozze AI con pulsanti Pubblica/Cestina\n"
             . "/top — report sintetico: click e gap geografici\n"
@@ -222,20 +222,22 @@ class ALMA_Telegram_Bot {
             self::send_message($chat_id, '❌ OpenAI non è configurata nel plugin.');
             return;
         }
-        if (ALMA_AI_Idea_Agent::runs_today() >= ALMA_AI_Idea_Agent::get_daily_runs_limit()) {
-            self::send_message($chat_id, '❌ Limite di esecuzioni giornaliere dell\'agente raggiunto (' . (int) ALMA_AI_Idea_Agent::runs_today() . '/' . (int) ALMA_AI_Idea_Agent::get_daily_runs_limit() . ').');
-            return;
-        }
         if (get_option(ALMA_AI_Idea_Agent::LOCK_OPTION)) {
             self::send_message($chat_id, '⏳ Un\'esecuzione dell\'agente è già in corso: riceverai il report al termine.');
             return;
         }
+        // Lancio dalla regia Telegram: force=1 (parte anche oltre il limite
+        // giornaliero) e bozze immediate attive, come dalla pagina Regia AI.
+        $over_limit = ALMA_AI_Idea_Agent::runs_today() >= ALMA_AI_Idea_Agent::get_daily_runs_limit();
         // Autore delle idee: il primo amministratore.
         $admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 'ID'));
         $user_id = !empty($admins) ? (int) $admins[0] : 1;
-        wp_schedule_single_event(time() + 5, ALMA_AI_Idea_Agent::CRON_HOOK, array($user_id, sanitize_textarea_field($objective), 0));
+        wp_schedule_single_event(time() + 5, ALMA_AI_Idea_Agent::CRON_HOOK, array($user_id, sanitize_textarea_field($objective), 1, 1, 0, 0));
         if (function_exists('spawn_cron')) { spawn_cron(); }
-        self::send_message($chat_id, '🤖 Agente di ideazione avviato' . ($objective !== '' ? ' con obiettivo: <i>' . self::esc($objective) . '</i>' : '') . ".\nRiceverai qui il report al termine (2-5 minuti).");
+        self::send_message($chat_id, '🤖 Agente di ideazione avviato' . ($objective !== '' ? ' sul tema: <i>' . self::esc($objective) . '</i>' : '')
+            . "\nCreerà idee e le relative bozze (nel rispetto del limite giornaliero bozze)."
+            . ($over_limit ? "\n✋ Limite esecuzioni giornaliere già raggiunto: il lancio manuale viene eseguito comunque." : '')
+            . "\nRiceverai qui il report al termine (2-5 minuti).");
     }
 
     private static function command_report($chat_id) {


### PR DESCRIPTION
## Cosa cambia (v2.70.0)

### Nuova pagina "Regia AI" (subito dopo la Dashboard)
Nuova classe `ALMA_AI_Agent_Control_Room`, voce di menu tra Dashboard e Tutte le idee:
- **Piano editoriale**: quanti articoli creare (1-10), in quanti giorni distribuirli (1-60), obiettivo opzionale, «Crea subito anche le bozze» **spuntato di default**. Le idee oltre la quota bozze giornaliera vengono generate automaticamente nei giorni programmati dal job notturno.
- **Consiglio AI del piano**: un pulsante chiede all'AI quanti articoli, in quanti giorni e con quale focus, sulla base di click, gap geografici, opportunità Search Console e ritmo attuale; «Applica al piano» precompila il form.
- **Grafico attività** (Chart.js, stesso caricamento della Dashboard): idee create e bozze AI generate per giorno negli ultimi 30 giorni.
- **Storico esecuzioni** (ultime 30: data, idee, bozze, obiettivo, costo, esito, ✋ per i lanci manuali) + report dettagliato dell'ultima esecuzione.
- **Limiti di guardia** (idee per esecuzione, esecuzioni automatiche/giorno) spostati qui.

### Lanci manuali sempre eseguiti
- `run()` accetta `force`, `num_ideas`, `days_span`: i lanci manuali (Regia, Telegram) partono anche oltre il limite giornaliero di esecuzioni, con nota informativa; il limite continua a proteggere i run non presidiati. Il piano guida i prompt («crea ESATTAMENTE N idee distribuite nei prossimi X giorni»). Il report registra obiettivo e flag `forced`; nuovo storico compatto in option (30 voci).

### Telegram
- `/agente <argomento>` ora crea idee **e relative bozze** sul tema indicato (prima non generava bozze), parte anche oltre il limite giornaliero segnalandolo in chat; guida comandi aggiornata.

### Tutte le idee
- Il pannello "🤖 Agente ideazione AI" diventa una card compatta con stato e pulsante «Apri la Regia AI» (`render_panel()` conservato per compatibilità; il dettaglio ultima esecuzione è ora `render_last_run_details()`, usato dalla Regia).

## Verifiche
- `php -l` OK su tutti i file modificati.
- Sanity test dei prompt di piano (ESATTAMENTE N idee / X giorni / obiettivo, e fallback senza piano) su estrazione standalone: OK.
- Retrocompatibilità: nessuna option rimossa; cron hook invariato (nuovi argomenti opzionali con default); `render_panel()` mantiene la stessa firma.
- Bump versione `2.70.0` (feature → minor), CHANGELOG.md e README.md aggiornati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_