### PR TITLE
Warmer schede località: report parziale, budget per fonte, run in catena (v2.71.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.71.0 - 2026-07-06
+
+### Warmer schede località: report affidabile, turni garantiti e run in catena
+- **Bug 1 — report azzerato**: quando il budget di 60 secondi si esauriva a metà run, un `break` usciva da entrambi i cicli prima del salvataggio dei contatori e il report mostrava "elaborate 0, ok 0, errori 0" per tutte le fonti nonostante le schede venissero realmente create. Ora i contatori di ogni fonte vengono salvati **anche se parziali**.
+- **Bug 2 — starvation delle fonti**: Open-Meteo (con più località in attesa) consumava l'intero budget a ogni run e Wikidata/Google Trends non arrivavano quasi mai al proprio turno (nella pratica: 56 schede clima vs 19 fatti vs 1 tendenze). Ora ogni fonte ha un **budget dedicato di 20 secondi per run**: il turno è garantito.
+- **Run in catena**: un solo run notturno non basta per smaltire migliaia di schede su hosting condiviso. Finché resta lavoro (e il run corrente ha prodotto qualcosa), il warmer **si auto-programma** un nuovo run dopo 90 secondi, fino a **30 run al giorno** — tanti run brevi invece di uno lungo, il pattern giusto per Aruba. A regime: centinaia di schede al giorno, backlog smaltito in pochi giorni. Contatore giornaliero con tetto anti-loop (si azzera al cambio data, tollera opzioni corrotte) e guardia sul cooldown di Google Trends (niente giri a vuoto).
+- La tab "Schede località" spiega il nuovo comportamento e mostra i run di recupero usati oggi (X/30).
+- Test standalone 6/6 sul contatore della catena (tetto giornaliero, reset al cambio data, opzione corrotta).
+- Versione plugin aggiornata a `2.71.0`.
+
 ## 2.70.1 - 2026-07-06
 
 ### Fix precisione widget contestuale: basta link di altre regioni sugli articoli localizzati

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.71.0 - 2026-07-06
+
+### Warmer schede località: report affidabile, turni garantiti e run in catena
+- Il report del run non si azzera più quando il budget interrompe il lavoro a metà; ogni fonte (clima/fatti/tendenze) ha un budget dedicato per run; finché c'è lavoro il warmer si auto-programma run brevi ogni 90 secondi (max 30/giorno) — backlog smaltito in giorni invece che mesi.
+- Versione plugin aggiornata a `2.71.0`.
+
 ## 2.70.1 - 2026-07-06
 
 ### Fix precisione widget contestuale

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.70.1
+ * Version: 2.71.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.70.1');
+define('ALMA_VERSION', '2.71.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-geo-facts.php
+++ b/includes/class-geo-facts.php
@@ -43,7 +43,11 @@ class ALMA_Geo_Facts {
     const TTL_DAYS_WIKIDATA = 180;  // fatti anagrafici: 6 mesi
     const TTL_DAYS_TRENDS = 30;     // tendenze di ricerca: 1 mese
     const TTL_DAYS_ERROR = 7;       // errore API: ritenta dopo una settimana
-    const TIME_BUDGET = 60;         // secondi per run del warmer
+    const TIME_BUDGET = 60;         // guardia totale per invocazione (hosting condiviso)
+    const SOURCE_TIME_BUDGET = 20;  // budget PER FONTE: ogni fonte ha il suo turno garantito
+    const CHAIN_DELAY = 90;         // secondi tra un run in catena e il successivo
+    const MAX_CHAINS_PER_DAY = 30;  // run di recupero auto-programmati al giorno
+    const OPTION_CHAIN_COUNTER = 'alma_geo_facts_chain_counter';
     const WIKIDATA_MATCH_KM = 100;  // distanza massima nome↔coordinate per accettare l'entità
 
     public static function init() {
@@ -555,28 +559,43 @@ class ALMA_Geo_Facts {
         return true;
     }
 
+    /**
+     * Un'invocazione del warmer: ogni fonte ha il SUO budget di tempo (niente
+     * starvation: prima Open-Meteo esauriva il budget totale e Wikidata/Trends
+     * non arrivavano mai al turno), e i contatori vengono salvati anche se
+     * il run si interrompe a metà (prima un "break" sul budget azzerava il
+     * report dell'intero run, mostrando "elaborate 0" nonostante il lavoro).
+     * Se resta lavoro, il run successivo si auto-programma tra CHAIN_DELAY
+     * secondi (max MAX_CHAINS_PER_DAY al giorno): tanti run brevi, il pattern
+     * giusto per gli hosting condivisi.
+     */
     public static function warm_batch() {
         if (!self::is_enabled() || !self::acquire_lock()) { return; }
         $started_at = time();
         $report_sources = array();
+        $total_processed = 0;
         try {
             foreach (self::sources() as $source => $ttl_days) {
-                if ($source === self::SOURCE_GOOGLE_TRENDS && get_transient(ALMA_Google_Trends::COOLDOWN_TRANSIENT)) { continue; }
-                $ok = 0;
-                $errors = 0;
-                $processed = 0;
-                $pending = self::pending_locations(self::get_batch_size(), $source);
-                foreach ($pending as $location) {
-                    if ((time() - $started_at) > self::TIME_BUDGET) { break 2; }
-                    if ($source === self::SOURCE_GOOGLE_TRENDS && get_transient(ALMA_Google_Trends::COOLDOWN_TRANSIENT)) { break; }
-                    $processed++;
-                    if (self::warm_one($location, $source, $ttl_days)) { $ok++; } else { $errors++; }
-                    // Cortesia verso le API gratuite: WDQS chiede ritmi moderati,
-                    // gli endpoint non ufficiali di Trends ancora di più.
-                    $pauses = array(self::SOURCE_WIKIDATA => 1000000, self::SOURCE_GOOGLE_TRENDS => 2000000);
-                    usleep($pauses[$source] ?? 500000);
+                $entry = array('processed' => 0, 'ok' => 0, 'errors' => 0, 'remaining' => 0);
+                $skip = ($source === self::SOURCE_GOOGLE_TRENDS && get_transient(ALMA_Google_Trends::COOLDOWN_TRANSIENT))
+                    || ((time() - $started_at) > self::TIME_BUDGET);
+                if (!$skip) {
+                    $source_started = time();
+                    $pending = self::pending_locations(self::get_batch_size(), $source);
+                    foreach ($pending as $location) {
+                        if ((time() - $source_started) > self::SOURCE_TIME_BUDGET) { break; }
+                        if ($source === self::SOURCE_GOOGLE_TRENDS && get_transient(ALMA_Google_Trends::COOLDOWN_TRANSIENT)) { break; }
+                        $entry['processed']++;
+                        if (self::warm_one($location, $source, $ttl_days)) { $entry['ok']++; } else { $entry['errors']++; }
+                        // Cortesia verso le API gratuite: WDQS chiede ritmi moderati,
+                        // gli endpoint non ufficiali di Trends ancora di più.
+                        $pauses = array(self::SOURCE_WIKIDATA => 1000000, self::SOURCE_GOOGLE_TRENDS => 2000000);
+                        usleep($pauses[$source] ?? 500000);
+                    }
                 }
-                $report_sources[$source] = array('processed' => $processed, 'ok' => $ok, 'errors' => $errors, 'remaining' => self::pending_count($source));
+                $entry['remaining'] = self::pending_count($source);
+                $report_sources[$source] = $entry;
+                $total_processed += $entry['processed'];
             }
         } finally {
             $totals = array('processed' => 0, 'ok' => 0, 'errors' => 0, 'remaining' => 0);
@@ -589,6 +608,31 @@ class ALMA_Geo_Facts {
             update_option(self::OPTION_LAST_REPORT, array_merge(array('time' => current_time('mysql'), 'sources' => $report_sources), $totals), false);
             delete_option(self::LOCK_OPTION);
         }
+        // Catena di recupero: solo se questo run ha prodotto qualcosa (evita
+        // giri a vuoto, es. Trends in cooldown come unica fonte con lavoro).
+        if ($total_processed > 0 && $totals['remaining'] > 0 && self::chain_allowed()) {
+            wp_schedule_single_event(time() + self::CHAIN_DELAY, self::CRON_HOOK);
+            if (function_exists('spawn_cron')) { spawn_cron(); }
+        }
+    }
+
+    /**
+     * Contatore giornaliero dei run in catena: consenso e incremento atomici
+     * rispetto alla giornata (si azzera al cambio data). Il tetto evita loop
+     * infiniti anche in caso di anomalie.
+     */
+    public static function chain_allowed() {
+        $counter = get_option(self::OPTION_CHAIN_COUNTER, array());
+        $today = current_time('Y-m-d');
+        if (!is_array($counter) || ($counter['date'] ?? '') !== $today) {
+            $counter = array('date' => $today, 'count' => 0);
+        }
+        if ((int) $counter['count'] >= self::MAX_CHAINS_PER_DAY) {
+            return false;
+        }
+        $counter['count'] = (int) $counter['count'] + 1;
+        update_option(self::OPTION_CHAIN_COUNTER, $counter, false);
+        return true;
     }
 
     /* ---------------------------------------------------------------------
@@ -751,7 +795,7 @@ class ALMA_Geo_Facts {
         echo '<h2>Schede località (fonti esterne)</h2>';
         echo '<div class="alma-agent-card" style="max-width:900px;"><h3>Come funziona</h3>';
         echo '<p>Per ogni località dell\'indice geografico con coordinate, il plugin costruisce una <strong>scheda</strong> con dati da fonti esterne: il <strong>clima</strong> da Open-Meteo (mesi migliori per visitare, mesi da evitare, temperature e piogge mensili), la <strong>carta d\'identità</strong> da Wikidata (descrizione, popolazione, patrimonio UNESCO, Wikipedia italiana e attrazioni notevoli entro 10 km, disambiguate per vicinanza alle coordinate) e le <strong>tendenze di ricerca</strong> da Google Trends (in quali mesi gli italiani cercano la destinazione, trend dell\'interesse, query correlate in crescita). Non si importano interi dataset: si salva solo la scheda compatta, già in italiano, riusata dall\'agente AI con lo strumento <code>scheda_localita</code>.</p>';
-        echo '<p>Le schede si riempiono da sole con un job notturno (poche località per volta, interrompibile) e restano valide 9 mesi (clima) / 6 mesi (fatti) / 1 mese (tendenze); se l\'agente chiede una località non ancora pronta, la scheda viene creata al volo.</p>';
+        echo '<p>Le schede si riempiono da sole: il job notturno lavora a run brevi (ogni fonte ha il suo turno garantito) e, finché c\'è lavoro, si <strong>auto-programma</strong> ogni ' . esc_html((string) self::CHAIN_DELAY) . ' secondi fino a ' . esc_html((string) self::MAX_CHAINS_PER_DAY) . ' run al giorno. Le schede restano valide 9 mesi (clima) / 6 mesi (fatti) / 1 mese (tendenze); se l\'agente chiede una località non ancora pronta, la scheda viene creata al volo.</p>';
         echo '<p class="description">⚠️ Google Trends non ha un\'API ufficiale: si usano gli endpoint interni del sito. Se Google limita le richieste (HTTP 429) la fonte si sospende da sola per 6 ore e riprende al run successivo; se l\'endpoint cambiasse, la fonte segnala l\'errore senza impattare il resto del plugin.</p></div>';
 
         echo '<table class="form-table" role="presentation">';
@@ -767,7 +811,9 @@ class ALMA_Geo_Facts {
             }
             echo '</td></tr>';
         }
-        echo '<tr><th scope="row">Ultimo run</th><td>' . (is_array($report) ? esc_html((string) $report['time']) : '—') . ($running ? ' — <strong>aggiornamento in corso…</strong>' : '') . '</td></tr>';
+        $chain_counter = get_option(self::OPTION_CHAIN_COUNTER, array());
+        $chains_today = (is_array($chain_counter) && ($chain_counter['date'] ?? '') === current_time('Y-m-d')) ? (int) $chain_counter['count'] : 0;
+        echo '<tr><th scope="row">Ultimo run</th><td>' . (is_array($report) ? esc_html((string) $report['time']) : '—') . ($running ? ' — <strong>aggiornamento in corso…</strong>' : '') . '<p class="description">Run di recupero auto-programmati oggi: ' . esc_html((string) $chains_today) . ' / ' . esc_html((string) self::MAX_CHAINS_PER_DAY) . '.</p></td></tr>';
         echo '</table>';
 
         echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';


### PR DESCRIPTION
## Contesto

Dopo una notte di warmer lo stato era: Clima 56 schede pronte / 1263 in attesa, Wikidata 19 / 1299, Trends 1 / 1318 — e il report dell'ultimo run mostrava «elaborate 0, ok 0, errori 0» per **tutte** le fonti nonostante le schede venissero create davvero.

## Diagnosi (confermata dal codice)

1. **Report azzerato**: in `warm_batch()` il `break 2` sul budget totale di 60s usciva da entrambi i cicli **prima** della riga che salvava i contatori della fonte in corso; il blocco `finally` riempiva quindi tutte le fonti con zeri. Il lavoro parziale c'era ma spariva dal report.
2. **Starvation**: Open-Meteo (la fonte con più località in attesa, elaborata per prima) consumava l'intero budget a ogni run; Wikidata e Google Trends non arrivavano quasi mai al proprio turno — da cui la distribuzione 56/19/1. Inoltre "50 località per run" non era onorabile in 60 secondi e un solo run a notte avrebbe richiesto mesi per ~1300 località × 3 fonti.

## Fix (v2.71.0)

- **Report per fonte sempre salvato, anche parziale**: i contatori vengono scritti in `$report_sources` alla fine del turno di ogni fonte, budget o no.
- **Budget dedicato per fonte** (`SOURCE_TIME_BUDGET` = 20s): ogni fonte ha il turno garantito a ogni invocazione; resta la guardia totale di 60s.
- **Run in catena**: se resta lavoro e il run corrente ha prodotto qualcosa, il warmer si auto-programma (`wp_schedule_single_event`, +90s) fino a **30 run al giorno** — tanti run brevi invece di uno lungo, il pattern giusto per hosting condivisi come Aruba. Contatore giornaliero anti-loop (`alma_geo_facts_chain_counter`: tetto, reset al cambio data, tolleranza a opzione corrotta) e guardia sul cooldown di Trends (il requisito `processed > 0` evita giri a vuoto).
- Tab "Schede località": spiega la catena e mostra i run di recupero usati oggi (X/30).

A regime: ~10-15 schede per fonte per run × fino a 30 run/giorno → centinaia di schede al giorno, backlog smaltito in pochi giorni.

## Verifiche
- `php -l` OK su `includes/class-geo-facts.php` e `affiliate-link-manager-ai.php`.
- Test standalone **6/6** sul contatore della catena (30 consensi, 31° negato, reset al cambio data, opzione corrotta tollerata).
- Bump versione `2.71.0`, CHANGELOG.md e README.md aggiornati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_