### PR TITLE
Verifica link affiliati: audit degli URL salvati + bonifica tpx.li (v2.73.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.73.0 - 2026-07-06
+
+### Verifica link affiliati: audit degli URL salvati + bonifica tpx.li
+- **Diagnosi del caso "0 visite su GetYourGuide"**: alcuni Link Affiliati erano salvati nel database come short link Travelpayouts (`getyourguide.tpx.li/…`) invece del deep link ufficiale con `partner_id` — i click finivano tracciati da Travelpayouts e il programma partner GetYourGuide non li vedeva. Verificato che **il plugin non altera mai gli URL in uscita** (pubblica esattamente il valore di `_affiliate_url`; nel codice non esiste alcun riferimento a tpx.li/Travelpayouts) e che l'import CSV corrente produce URL corretti (`getyourguide.com` + `partner_id`): il problema è nei dati storici di quei link.
+- **Nuova pagina "Verifica link"** (menu Affiliate Link AI): riepilogo dei domini realmente in uso nei link pubblicati (con ⚠️ sui tpx.li), conteggio dei link getyourguide.* senza partner_id, elenco dei link da bonificare.
+- **Bonifica guidata**: batch da 15 link per click (interrompibile, lock atomico, budget 25s) — per ogni link il server segue i redirect fino al prodotto getyourguide.*, elimina i parametri di tracciamento Travelpayouts e riapplica `partner_id`/`utm_medium` ufficiali riusando il builder dell'import CSV. **L'URL originale viene salvato nel meta di backup `_alma_url_pre_bonifica`** prima di ogni modifica (mai sovrascritto se già presente); i link irrisolvibili vengono marcati e esclusi dai giri successivi (con pulsante "Ritenta i falliti"); il Partner ID viene precompilato da un link GYG già corretto. Report dell'ultimo giro con esito per link. La cache del widget contestuale viene invalidata a fine giro.
+- Test standalone 13/13 (pulizia URL attività con parametri Travelpayouts, domini .it/.com, rifiuto tpx.li/pagine città/domini estranei, risoluzione Location assoluti/relativi/scheme-relative, estrazione partner_id, flusso completo fino all'URL ufficiale).
+- Versione plugin aggiornata a `2.73.0`.
+
 ## 2.72.0 - 2026-07-06
 
 ### Fase 7.2 (PR D): territorio OpenStreetMap + aeroporto più vicino nelle schede località

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.73.0 - 2026-07-06
+
+### Verifica link affiliati: audit + bonifica tpx.li
+- Nuova pagina "Verifica link": mostra i domini realmente salvati nei link affiliati e bonifica gli short link Travelpayouts (tpx.li) trasformandoli nel deep link GetYourGuide ufficiale con partner_id (redirect risolti dal server, backup dell'URL originale, batch interrompibili).
+- Versione plugin aggiornata a `2.73.0`.
+
 ## 2.72.0 - 2026-07-06
 
 ### Fase 7.2 (PR D): territorio OpenStreetMap + aeroporto più vicino

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.72.0
+ * Version: 2.73.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.72.0');
+define('ALMA_VERSION', '2.73.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -63,6 +63,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-ai-seo-bridge.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-telegram-bot.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-post-enricher.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-gsc-connector.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-link-auditor.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-google-trends.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-facts.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-url-validator.php';
@@ -173,6 +174,7 @@ class AffiliateManagerAI {
         ALMA_Telegram_Bot::init();
         ALMA_AI_Post_Enricher::init();
         ALMA_GSC_Connector::init();
+        ALMA_Affiliate_Link_Auditor::init();
         ALMA_Geo_Facts::init();
         add_action('init', array($this, 'init'));
         add_action('widgets_init', array('ALMA_Contextual_Affiliate_Widget', 'register_widget'));
@@ -1175,6 +1177,16 @@ class AffiliateManagerAI {
             self::AI_CONTENT_AGENT_CAPABILITY,
             ALMA_AI_Content_Agent_Idea_Importer::PAGE_SLUG,
             array('ALMA_AI_Content_Agent_Idea_Importer', 'render_page')
+        );
+
+        // Verifica link affiliati (audit URL + bonifica tpx.li)
+        add_submenu_page(
+            'edit.php?post_type=affiliate_link',
+            __('Verifica link affiliati', 'affiliate-link-manager-ai'),
+            __('Verifica link', 'affiliate-link-manager-ai'),
+            'manage_options',
+            ALMA_Affiliate_Link_Auditor::MENU_SLUG,
+            array('ALMA_Affiliate_Link_Auditor', 'render_page')
         );
 
         // Pagina nascosta per modifica widget

--- a/includes/class-affiliate-link-auditor.php
+++ b/includes/class-affiliate-link-auditor.php
@@ -1,0 +1,372 @@
+<?php
+/**
+ * Verifica link affiliati — audit degli URL salvati + bonifica tpx.li.
+ *
+ * Caso reale che ha originato lo strumento: alcuni link GetYourGuide erano
+ * salvati nel database come short link Travelpayouts (getyourguide.tpx.li/…)
+ * invece del deep link ufficiale con partner_id → il programma partner
+ * GetYourGuide mostrava 0 visite. Il plugin NON altera mai gli URL in
+ * uscita: emette esattamente ciò che è salvato in _affiliate_url; questa
+ * pagina serve a vedere COSA è salvato e a correggerlo.
+ *
+ * Bonifica: per ogni link tpx.li il server segue i redirect fino al
+ * prodotto getyourguide.*, elimina i parametri di tracciamento
+ * Travelpayouts e riapplica partner_id/utm_medium ufficiali (riusando il
+ * builder dell'import CSV). L'URL originale viene salvato in un meta di
+ * backup prima di ogni modifica: nulla va perso. Batch da 15 link per
+ * click, interrompibile, con lock atomico e marcatura dei falliti (per
+ * non rielaborarli all'infinito).
+ */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALMA_Affiliate_Link_Auditor {
+    const MENU_SLUG = 'alma-link-audit';
+    const LOCK_OPTION = 'alma_link_audit_lock';
+    const LOCK_TTL = 120;
+    const OPTION_LAST_REPORT = 'alma_link_audit_last_report';
+    const META_BACKUP = '_alma_url_pre_bonifica';
+    const META_FAILED = '_alma_url_bonifica_failed';
+    const BATCH_SIZE = 15;
+    const TIME_BUDGET = 25;
+    const MAX_REDIRECTS = 6;
+
+    public static function init() {
+        add_action('admin_post_alma_link_audit_fix', array(__CLASS__, 'handle_fix'));
+        add_action('admin_post_alma_link_audit_retry', array(__CLASS__, 'handle_retry'));
+    }
+
+    /* ---------------------------------------------------------------------
+     * Audit (sola lettura)
+     * ------------------------------------------------------------------ */
+
+    /**
+     * Riepilogo dei domini presenti in _affiliate_url.
+     */
+    public static function domain_summary() {
+        global $wpdb;
+        $rows = $wpdb->get_results(
+            "SELECT LOWER(SUBSTRING_INDEX(SUBSTRING_INDEX(SUBSTRING_INDEX(pm.meta_value, '://', -1), '/', 1), '?', 1)) AS dominio, COUNT(*) AS n
+             FROM {$wpdb->postmeta} pm INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+             WHERE pm.meta_key = '_affiliate_url' AND pm.meta_value <> '' AND p.post_type = 'affiliate_link' AND p.post_status = 'publish'
+             GROUP BY dominio ORDER BY n DESC LIMIT 30",
+            ARRAY_A
+        );
+        return (array) $rows;
+    }
+
+    /**
+     * Link con URL tpx.li (Travelpayouts) ancora da bonificare.
+     */
+    public static function tpx_links($limit = 50, $exclude_failed = true) {
+        global $wpdb;
+        $failed_join = $exclude_failed ? "LEFT JOIN {$wpdb->postmeta} f ON f.post_id = pm.post_id AND f.meta_key = '" . self::META_FAILED . "'" : '';
+        $failed_where = $exclude_failed ? 'AND f.meta_id IS NULL' : '';
+        return (array) $wpdb->get_results($wpdb->prepare(
+            "SELECT pm.post_id, pm.meta_value AS url, p.post_title
+             FROM {$wpdb->postmeta} pm
+             INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+             {$failed_join}
+             WHERE pm.meta_key = '_affiliate_url' AND pm.meta_value LIKE %s
+               AND p.post_type = 'affiliate_link' AND p.post_status = 'publish' {$failed_where}
+             ORDER BY pm.post_id ASC LIMIT %d",
+            '%' . $wpdb->esc_like('.tpx.li/') . '%', max(1, absint($limit))
+        ), ARRAY_A);
+    }
+
+    public static function tpx_count($exclude_failed = true) {
+        global $wpdb;
+        $failed_join = $exclude_failed ? "LEFT JOIN {$wpdb->postmeta} f ON f.post_id = pm.post_id AND f.meta_key = '" . self::META_FAILED . "'" : '';
+        $failed_where = $exclude_failed ? 'AND f.meta_id IS NULL' : '';
+        return (int) $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM {$wpdb->postmeta} pm
+             INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+             {$failed_join}
+             WHERE pm.meta_key = '_affiliate_url' AND pm.meta_value LIKE %s
+               AND p.post_type = 'affiliate_link' AND p.post_status = 'publish' {$failed_where}",
+            '%' . $wpdb->esc_like('.tpx.li/') . '%'
+        ));
+    }
+
+    public static function failed_count() {
+        global $wpdb;
+        return (int) $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE meta_key = %s",
+            self::META_FAILED
+        ));
+    }
+
+    /**
+     * Link getyourguide.* SENZA partner_id: si monetizzano ma non tracciano.
+     */
+    public static function gyg_missing_partner_count() {
+        global $wpdb;
+        return (int) $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM {$wpdb->postmeta} pm
+             INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+             WHERE pm.meta_key = '_affiliate_url' AND pm.meta_value LIKE %s AND pm.meta_value NOT LIKE %s
+               AND p.post_type = 'affiliate_link' AND p.post_status = 'publish'",
+            '%' . $wpdb->esc_like('getyourguide.') . '%', '%' . $wpdb->esc_like('partner_id=') . '%'
+        ));
+    }
+
+    /**
+     * Partner ID già in uso nei link GYG corretti: precompila la bonifica.
+     */
+    public static function detect_partner_id() {
+        global $wpdb;
+        $url = (string) $wpdb->get_var($wpdb->prepare(
+            "SELECT pm.meta_value FROM {$wpdb->postmeta} pm
+             INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+             WHERE pm.meta_key = '_affiliate_url' AND pm.meta_value LIKE %s AND pm.meta_value LIKE %s
+               AND p.post_type = 'affiliate_link' AND p.post_status = 'publish' LIMIT 1",
+            '%' . $wpdb->esc_like('getyourguide.') . '%', '%' . $wpdb->esc_like('partner_id=') . '%'
+        ));
+        return self::extract_partner_id($url);
+    }
+
+    /**
+     * partner_id da un URL. Pura, testabile.
+     */
+    public static function extract_partner_id($url) {
+        $query = (string) (wp_parse_url((string) $url, PHP_URL_QUERY) ?: '');
+        if ($query === '') { return ''; }
+        wp_parse_str($query, $params);
+        return sanitize_text_field((string) ($params['partner_id'] ?? ''));
+    }
+
+    /* ---------------------------------------------------------------------
+     * Bonifica
+     * ------------------------------------------------------------------ */
+
+    /**
+     * URL GetYourGuide "pulito": host getyourguide.*, niente query/fragment
+     * (via i parametri di tracciamento Travelpayouts), path di un'attività
+     * (…-t123456/). Ritorna '' se l'URL non è un prodotto GYG. Pura, testabile.
+     */
+    public static function clean_gyg_url($url) {
+        $parts = wp_parse_url(trim((string) $url));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+        $path = (string) ($parts['path'] ?? '');
+        if ($host === '' || strpos($host, 'getyourguide.') === false || strpos($host, 'tpx.li') !== false) {
+            return '';
+        }
+        if (!preg_match('#-t\d+/?$#', $path)) {
+            return '';
+        }
+        return 'https://' . $host . rtrim($path, '/') . '/';
+    }
+
+    /**
+     * Risolve un header Location eventualmente relativo. Pura, testabile.
+     */
+    public static function resolve_location_url($current_url, $location) {
+        $location = trim((string) $location);
+        if ($location === '') { return ''; }
+        if (preg_match('#^https?://#i', $location)) { return $location; }
+        $parts = wp_parse_url((string) $current_url);
+        $scheme = (string) ($parts['scheme'] ?? 'https');
+        $host = (string) ($parts['host'] ?? '');
+        if ($host === '') { return ''; }
+        if (strpos($location, '//') === 0) { return $scheme . ':' . $location; }
+        if (strpos($location, '/') === 0) { return $scheme . '://' . $host . $location; }
+        $base_path = (string) ($parts['path'] ?? '/');
+        $base_dir = substr($base_path, 0, (int) strrpos($base_path, '/') + 1);
+        return $scheme . '://' . $host . $base_dir . $location;
+    }
+
+    /**
+     * Segue i redirect (max MAX_REDIRECTS) fino a un URL getyourguide.*.
+     */
+    public static function resolve_redirect_chain($url) {
+        $current = (string) $url;
+        for ($hop = 0; $hop < self::MAX_REDIRECTS; $hop++) {
+            $host = strtolower((string) (wp_parse_url($current, PHP_URL_HOST) ?: ''));
+            if ($host !== '' && strpos($host, 'getyourguide.') !== false && strpos($host, 'tpx.li') === false) {
+                return $current;
+            }
+            $response = wp_remote_get($current, array(
+                'timeout' => 15,
+                'redirection' => 0,
+                'user-agent' => 'Mozilla/5.0 (compatible; AffiliateLinkManagerAI/' . ALMA_VERSION . '; +' . home_url('/') . ')',
+            ));
+            if (is_wp_error($response)) {
+                return new WP_Error('alma_audit_http', $response->get_error_message());
+            }
+            $code = wp_remote_retrieve_response_code($response);
+            $location = wp_remote_retrieve_header($response, 'location');
+            if (is_array($location)) { $location = end($location); }
+            if ($code < 300 || $code >= 400 || (string) $location === '') {
+                return new WP_Error('alma_audit_noredirect', sprintf(__('La catena di redirect si è fermata su %1$s (HTTP %2$d) senza raggiungere getyourguide.', 'affiliate-link-manager-ai'), $current, $code));
+            }
+            $next = self::resolve_location_url($current, (string) $location);
+            if ($next === '') {
+                return new WP_Error('alma_audit_location', __('Header Location non interpretabile.', 'affiliate-link-manager-ai'));
+            }
+            $current = $next;
+        }
+        return new WP_Error('alma_audit_loop', __('Troppi redirect senza raggiungere getyourguide.', 'affiliate-link-manager-ai'));
+    }
+
+    private static function acquire_lock() {
+        if (add_option(self::LOCK_OPTION, (string) time(), '', 'no')) { return true; }
+        $started = absint(get_option(self::LOCK_OPTION, 0));
+        if ($started > 0 && (time() - $started) > self::LOCK_TTL) {
+            update_option(self::LOCK_OPTION, (string) time(), false);
+            return true;
+        }
+        return false;
+    }
+
+    private static function redirect_back($type, $message) {
+        set_transient('alma_link_audit_notice_' . get_current_user_id(), array('type' => $type, 'message' => $message), 120);
+        wp_safe_redirect(wp_get_referer() ?: admin_url('edit.php?post_type=affiliate_link&page=' . self::MENU_SLUG));
+        exit;
+    }
+
+    public static function handle_fix() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_link_audit');
+        $partner_id = sanitize_text_field(wp_unslash($_POST['partner_id'] ?? ''));
+        if ($partner_id === '') {
+            self::redirect_back('error', 'Inserisci il Partner ID GetYourGuide prima di avviare la bonifica.');
+        }
+        if (!self::acquire_lock()) {
+            self::redirect_back('error', 'Una bonifica è già in corso: riprova tra qualche istante.');
+        }
+        $started_at = time();
+        $details = array();
+        $fixed = 0;
+        $errors = 0;
+        try {
+            $links = self::tpx_links(self::BATCH_SIZE);
+            foreach ($links as $link) {
+                if ((time() - $started_at) > self::TIME_BUDGET) { break; }
+                $post_id = (int) $link['post_id'];
+                $old_url = (string) $link['url'];
+                $resolved = self::resolve_redirect_chain($old_url);
+                $clean = is_wp_error($resolved) ? '' : self::clean_gyg_url($resolved);
+                if (is_wp_error($resolved) || $clean === '') {
+                    $reason = is_wp_error($resolved) ? $resolved->get_error_message() : __('Destinazione non riconosciuta come attività GetYourGuide.', 'affiliate-link-manager-ai');
+                    update_post_meta($post_id, self::META_FAILED, sanitize_text_field($reason));
+                    $details[] = array('post_id' => $post_id, 'titolo' => (string) $link['post_title'], 'esito' => 'errore', 'nota' => sanitize_text_field($reason));
+                    $errors++;
+                } else {
+                    $new_url = ALMA_Affiliate_Source_GYG_CSV_Importer::build_affiliate_url($clean, $partner_id);
+                    // Backup una-tantum: se esiste già non viene sovrascritto,
+                    // così l'URL originario pre-bonifica resta sempre recuperabile.
+                    add_post_meta($post_id, self::META_BACKUP, $old_url, true);
+                    update_post_meta($post_id, '_affiliate_url', esc_url_raw($new_url));
+                    $details[] = array('post_id' => $post_id, 'titolo' => (string) $link['post_title'], 'esito' => 'corretto', 'nota' => $new_url);
+                    $fixed++;
+                }
+                usleep(300000); // cortesia verso il servizio di redirect
+            }
+            update_option(self::OPTION_LAST_REPORT, array(
+                'time' => current_time('mysql'),
+                'fixed' => $fixed,
+                'errors' => $errors,
+                'remaining' => self::tpx_count(),
+                'details' => $details,
+            ), false);
+            // Gli URL sono cambiati: il widget contestuale deve rigenerare la cache.
+            if (class_exists('ALMA_Contextual_Affiliate_Widget') && method_exists('ALMA_Contextual_Affiliate_Widget', 'bump_cache_version')) {
+                ALMA_Contextual_Affiliate_Widget::bump_cache_version();
+            }
+        } finally {
+            delete_option(self::LOCK_OPTION);
+        }
+        $remaining = self::tpx_count();
+        self::redirect_back($errors > 0 && $fixed === 0 ? 'error' : 'success', sprintf('Bonifica: %1$d corretti, %2$d falliti in questo giro; %3$d ancora da bonificare.', $fixed, $errors, $remaining) . ($remaining > 0 ? ' Premi di nuovo il pulsante per continuare.' : ' Completata!'));
+    }
+
+    public static function handle_retry() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_link_audit');
+        delete_post_meta_by_key(self::META_FAILED);
+        self::redirect_back('success', 'Marcature di errore azzerate: i link falliti verranno ritentati alla prossima bonifica.');
+    }
+
+    /* ---------------------------------------------------------------------
+     * Pagina
+     * ------------------------------------------------------------------ */
+
+    public static function render_page() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        $notice = get_transient('alma_link_audit_notice_' . get_current_user_id());
+        $card = 'border:1px solid #c3c4c7;border-radius:6px;background:#fff;padding:14px 16px;margin:0 0 14px;';
+        echo '<div class="wrap"><h1>🔍 Verifica link affiliati</h1>';
+        if (is_array($notice) && !empty($notice['message'])) {
+            delete_transient('alma_link_audit_notice_' . get_current_user_id());
+            echo '<div class="notice notice-' . esc_attr($notice['type'] === 'error' ? 'error' : 'success') . ' is-dismissible"><p>' . esc_html($notice['message']) . '</p></div>';
+        }
+        echo '<p class="description" style="max-width:900px;">Il plugin pubblica esattamente l\'URL salvato in ogni Link Affiliato, senza alterarlo. Questa pagina mostra <strong>cosa è salvato davvero</strong> e corregge i link salvati come short link Travelpayouts (<code>tpx.li</code>) — che non vengono tracciati dal programma partner ufficiale GetYourGuide — trasformandoli nel deep link ufficiale con il tuo <code>partner_id</code>.</p>';
+
+        // ---- Riepilogo domini ----
+        echo '<div style="' . esc_attr($card) . '"><h2 style="margin-top:0;">Domini in uso nei link pubblicati</h2>';
+        $domains = self::domain_summary();
+        if (empty($domains)) {
+            echo '<p class="description">Nessun link affiliato pubblicato.</p>';
+        } else {
+            echo '<table class="widefat striped" style="max-width:560px;"><thead><tr><th>Dominio</th><th>Link</th><th></th></tr></thead><tbody>';
+            foreach ($domains as $row) {
+                $is_tpx = strpos((string) $row['dominio'], 'tpx.li') !== false;
+                echo '<tr><td><code>' . esc_html((string) $row['dominio']) . '</code></td><td>' . esc_html((string) $row['n']) . '</td><td>' . ($is_tpx ? '<span style="color:#d63638;">⚠️ da bonificare</span>' : '') . '</td></tr>';
+            }
+            echo '</tbody></table>';
+        }
+        $missing_partner = self::gyg_missing_partner_count();
+        if ($missing_partner > 0) {
+            echo '<p style="color:#996800;">⚠️ ' . esc_html(sprintf('%d link getyourguide.* SENZA partner_id: portano traffico ma non commissioni.', $missing_partner)) . '</p>';
+        }
+        echo '</div>';
+
+        // ---- Bonifica tpx.li ----
+        $tpx_pending = self::tpx_count();
+        $failed = self::failed_count();
+        echo '<div style="' . esc_attr($card) . '"><h2 style="margin-top:0;">Bonifica link tpx.li (Travelpayouts → GetYourGuide ufficiale)</h2>';
+        if ($tpx_pending === 0 && $failed === 0) {
+            echo '<p>✅ Nessun link tpx.li da bonificare.</p>';
+        } else {
+            echo '<p>' . esc_html(sprintf('%d link da bonificare.', $tpx_pending)) . ($failed > 0 ? ' <span style="color:#d63638;">' . esc_html(sprintf('%d falliti in run precedenti (elencati sotto, esclusi dai prossimi giri).', $failed)) . '</span>' : '') . '</p>';
+            echo '<p class="description">Per ogni link il server segue i redirect fino al prodotto getyourguide.*, elimina i parametri Travelpayouts e applica il tuo partner_id. L\'URL originale viene salvato in un meta di backup (<code>' . esc_html(self::META_BACKUP) . '</code>) prima di ogni modifica. Batch da ' . esc_html((string) self::BATCH_SIZE) . ' link per click.</p>';
+            echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '" style="display:flex;gap:12px;align-items:flex-end;flex-wrap:wrap;">';
+            wp_nonce_field('alma_link_audit');
+            echo '<input type="hidden" name="action" value="alma_link_audit_fix">';
+            echo '<p style="margin:0;"><label><strong>Partner ID GetYourGuide</strong><br><input type="text" name="partner_id" class="regular-text" value="' . esc_attr(self::detect_partner_id()) . '" placeholder="es. 88HSYUH"></label></p>';
+            echo '<p style="margin:0;"><button class="button button-primary">Bonifica i prossimi ' . esc_html((string) min(self::BATCH_SIZE, max(1, $tpx_pending))) . ' link</button></p>';
+            echo '</form>';
+            if ($failed > 0) {
+                echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '" style="margin-top:8px;">';
+                wp_nonce_field('alma_link_audit');
+                echo '<input type="hidden" name="action" value="alma_link_audit_retry"><button class="button">Ritenta i falliti</button></form>';
+            }
+        }
+        $report = get_option(self::OPTION_LAST_REPORT, null);
+        if (is_array($report) && !empty($report['details'])) {
+            echo '<h3>Ultimo giro — ' . esc_html((string) $report['time']) . ' (corretti ' . esc_html((string) $report['fixed']) . ', falliti ' . esc_html((string) $report['errors']) . ', rimanenti ' . esc_html((string) $report['remaining']) . ')</h3>';
+            echo '<table class="widefat striped"><thead><tr><th>Link</th><th>Esito</th><th>Dettaglio</th></tr></thead><tbody>';
+            foreach ((array) $report['details'] as $detail) {
+                $edit = get_edit_post_link((int) $detail['post_id'], 'raw');
+                echo '<tr><td><a href="' . esc_url($edit) . '">' . esc_html((string) $detail['titolo']) . '</a></td>';
+                echo '<td>' . ($detail['esito'] === 'corretto' ? '✅' : '<span style="color:#d63638;">⚠️</span>') . '</td>';
+                echo '<td style="word-break:break-all;">' . esc_html((string) $detail['nota']) . '</td></tr>';
+            }
+            echo '</tbody></table>';
+        }
+        echo '</div>';
+
+        // ---- Elenco tpx ancora presenti ----
+        $tpx_list = self::tpx_links(30, false);
+        if (!empty($tpx_list)) {
+            echo '<div style="' . esc_attr($card) . '"><h2 style="margin-top:0;">Link tpx.li presenti (primi 30)</h2>';
+            echo '<table class="widefat striped"><thead><tr><th>Link</th><th>URL salvato</th></tr></thead><tbody>';
+            foreach ($tpx_list as $row) {
+                echo '<tr><td><a href="' . esc_url(get_edit_post_link((int) $row['post_id'], 'raw')) . '">' . esc_html((string) $row['post_title']) . '</a></td><td style="word-break:break-all;"><code>' . esc_html((string) $row['url']) . '</code></td></tr>';
+            }
+            echo '</tbody></table></div>';
+        }
+        echo '</div>';
+    }
+}


### PR DESCRIPTION
## Contesto: "0 visite" nel programma partner GetYourGuide

Sulla pagina pubblica i link GetYourGuide risultavano `https://getyourguide.tpx.li/…` (short link **Travelpayouts**) invece del deep link ufficiale `https://www.getyourguide.com/…?partner_id=…` → il programma partner GYG non tracciava nulla.

## Diagnosi (con prove)

- **Il plugin NON altera gli URL in uscita**: nel codice non esiste alcun riferimento a tpx.li/Travelpayouts (unico builder: quello dell'import CSV, che aggiunge `partner_id` "senza convertire domini").
- Nell'HTML **servito dal server** della pagina d'esempio tutti i 20 href GYG sono già `tpx.li` (senza parametri: `journey_id`/`trace_id` li aggiunge il redirect al click) e non c'è alcuno script Travelpayouts esterno → **quegli URL sono salvati così in `_affiliate_url`** per quei link (dati storici, probabilmente da un vecchio import con link copiati da Travelpayouts).
- Il CSV attuale allegato dall'utente contiene URL puliti `getyourguide.com`: l'import corrente produce link corretti.

## Cosa aggiunge la v2.73.0

### Nuova pagina "Verifica link" (menu Affiliate Link AI)
- **Riepilogo dei domini** realmente in uso nei link pubblicati (⚠️ sui tpx.li), conteggio dei link getyourguide.* **senza partner_id**, elenco dei link da bonificare.

### Bonifica guidata
- Batch da **15 link per click** (lock atomico `add_option` con TTL, budget 25s, interrompibile — pattern CLAUDE.md): per ogni link il server **segue i redirect** (max 6 hop, Location relativi risolti) fino al prodotto `getyourguide.*`, valida che sia una pagina attività (`…-t123456/`), **elimina i parametri Travelpayouts** e riapplica `partner_id`/`utm_medium` riusando `ALMA_Affiliate_Source_GYG_CSV_Importer::build_affiliate_url()`.
- **Backup**: l'URL originale viene salvato in `_alma_url_pre_bonifica` prima di ogni modifica (mai sovrascritto se già presente) — nulla va perso.
- I link irrisolvibili vengono **marcati** (`_alma_url_bonifica_failed` con motivo) ed esclusi dai giri successivi; pulsante «Ritenta i falliti». Partner ID **precompilato** da un link GYG già corretto. Report dell'ultimo giro con esito per link. Cache del widget contestuale invalidata a fine giro.

## Verifiche
- `php -l` OK su `includes/class-affiliate-link-auditor.php` e `affiliate-link-manager-ai.php`.
- Test standalone **13/13**: pulizia URL attività (parametri Travelpayouts rimossi), domini .it/.com accettati, tpx.li/pagine città/domini estranei rifiutati, risoluzione header Location (assoluto, root-relative, scheme-relative, path-relative, vuoto), estrazione partner_id, flusso completo fino all'URL ufficiale con il builder reale dell'import CSV.
- Retrocompatibilità: nessuna option/API rimossa; la bonifica parte solo su click esplicito dell'amministratore.
- Bump versione `2.73.0` (feature → minor), CHANGELOG.md e README.md aggiornati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_