### PR TITLE
Dominio ufficiale GetYourGuide: riferimento a www.getyourguide.it (v2.74.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.74.0 - 2026-07-06
+
+### Dominio ufficiale GetYourGuide: riferimento a www.getyourguide.it
+- **Nuova preferenza dominio** (`alma_gyg_preferred_domain`, default `www.getyourguide.it`): il programma partner dell'editore è italiano e i link ufficiali sono su `.it` — gli ID delle attività (`t…`) sono indipendenti dal dominio e GYG reindirizza allo slug italiano mantenendo il `partner_id`, quindi lo spostamento è una pura sostituzione dell'host (percorso, query e fragment conservati). Configurabile nella pagina "Verifica link" (`.it` consigliato / `.com` / "Mantieni il dominio originale" per il comportamento storico).
+- **Applicata ovunque si generino URL**: dentro `build_affiliate_url()` dell'import CSV, quindi vale per tutti gli import futuri E per la bonifica tpx.li (che la riusa) — i link bonificati escono direttamente su `.it`.
+- **Convertitore per l'archivio esistente**: nella pagina "Verifica link", batch da 50 link per click che sposta i link `getyourguide.*` già salvati sul dominio preferito — nessuna chiamata HTTP, backup dell'URL precedente nel meta `_alma_url_pre_bonifica` (mai sovrascritto), cache del widget contestuale invalidata a fine giro. I tpx.li restano esclusi (li gestisce la bonifica dedicata).
+- Test standalone 13/13 (conservazione path/query/fragment, host senza www, `.it` già corretto invariato, tpx.li e domini estranei non toccati, opzione invalida → fallback sicuro, "keep" → comportamento storico, integrazione nel builder dell'import CSV nei due modi).
+- Versione plugin aggiornata a `2.74.0`.
+
 ## 2.73.0 - 2026-07-06
 
 ### Verifica link affiliati: audit degli URL salvati + bonifica tpx.li

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.74.0 - 2026-07-06
+
+### Dominio ufficiale GetYourGuide (.it)
+- I link GetYourGuide fanno riferimento al dominio ufficiale del programma partner italiano (`www.getyourguide.it`), configurabile in "Verifica link": vale per import CSV futuri, bonifica tpx.li e — con il nuovo convertitore batch — per l'archivio esistente (con backup).
+- Versione plugin aggiornata a `2.74.0`.
+
 ## 2.73.0 - 2026-07-06
 
 ### Verifica link affiliati: audit + bonifica tpx.li

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.73.0
+ * Version: 2.74.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.73.0');
+define('ALMA_VERSION', '2.74.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-affiliate-link-auditor.php
+++ b/includes/class-affiliate-link-auditor.php
@@ -35,6 +35,7 @@ class ALMA_Affiliate_Link_Auditor {
     public static function init() {
         add_action('admin_post_alma_link_audit_fix', array(__CLASS__, 'handle_fix'));
         add_action('admin_post_alma_link_audit_retry', array(__CLASS__, 'handle_retry'));
+        add_action('admin_post_alma_link_audit_domain', array(__CLASS__, 'handle_domain'));
     }
 
     /* ---------------------------------------------------------------------
@@ -289,6 +290,80 @@ class ALMA_Affiliate_Link_Auditor {
     }
 
     /* ---------------------------------------------------------------------
+     * Dominio ufficiale GetYourGuide
+     * ------------------------------------------------------------------ */
+
+    /**
+     * Link GYG pubblicati su un dominio diverso da quello preferito
+     * (es. .com quando il programma partner è italiano → .it).
+     */
+    public static function offdomain_count() {
+        global $wpdb;
+        $preferred = ALMA_Affiliate_Source_GYG_CSV_Importer::preferred_domain();
+        if ($preferred === '') { return 0; }
+        return (int) $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM {$wpdb->postmeta} pm
+             INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+             WHERE pm.meta_key = '_affiliate_url' AND pm.meta_value LIKE %s
+               AND pm.meta_value NOT LIKE %s AND pm.meta_value NOT LIKE %s
+               AND p.post_type = 'affiliate_link' AND p.post_status = 'publish'",
+            '%' . $wpdb->esc_like('getyourguide.') . '%',
+            '%' . $wpdb->esc_like('://' . $preferred . '/') . '%',
+            '%' . $wpdb->esc_like('.tpx.li/') . '%'
+        ));
+    }
+
+    /**
+     * Salva la preferenza dominio e/o converte un batch di link esistenti:
+     * pura sostituzione dell'host (percorso, query e partner_id restano),
+     * con backup una-tantum dell'URL precedente. Nessuna chiamata HTTP.
+     */
+    public static function handle_domain() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_link_audit');
+        global $wpdb;
+        $domain = sanitize_text_field(wp_unslash($_POST['alma_gyg_preferred_domain'] ?? 'www.getyourguide.it'));
+        if (!in_array($domain, array('www.getyourguide.it', 'www.getyourguide.com', 'keep'), true)) {
+            $domain = 'www.getyourguide.it';
+        }
+        update_option('alma_gyg_preferred_domain', $domain, false);
+        if (empty($_POST['convert_now']) || $domain === 'keep') {
+            self::redirect_back('success', 'Preferenza dominio salvata.');
+        }
+        if (!self::acquire_lock()) {
+            self::redirect_back('error', 'Un\'operazione è già in corso: riprova tra qualche istante.');
+        }
+        $converted = 0;
+        try {
+            $rows = $wpdb->get_results($wpdb->prepare(
+                "SELECT pm.post_id, pm.meta_value AS url FROM {$wpdb->postmeta} pm
+                 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+                 WHERE pm.meta_key = '_affiliate_url' AND pm.meta_value LIKE %s
+                   AND pm.meta_value NOT LIKE %s AND pm.meta_value NOT LIKE %s
+                   AND p.post_type = 'affiliate_link' AND p.post_status = 'publish'
+                 ORDER BY pm.post_id ASC LIMIT 50",
+                '%' . $wpdb->esc_like('getyourguide.') . '%',
+                '%' . $wpdb->esc_like('://' . $domain . '/') . '%',
+                '%' . $wpdb->esc_like('.tpx.li/') . '%'
+            ), ARRAY_A);
+            foreach ((array) $rows as $row) {
+                $new_url = ALMA_Affiliate_Source_GYG_CSV_Importer::normalize_gyg_domain((string) $row['url'], $domain);
+                if ($new_url === (string) $row['url']) { continue; }
+                add_post_meta((int) $row['post_id'], self::META_BACKUP, (string) $row['url'], true);
+                update_post_meta((int) $row['post_id'], '_affiliate_url', esc_url_raw($new_url));
+                $converted++;
+            }
+            if ($converted > 0 && class_exists('ALMA_Contextual_Affiliate_Widget') && method_exists('ALMA_Contextual_Affiliate_Widget', 'bump_cache_version')) {
+                ALMA_Contextual_Affiliate_Widget::bump_cache_version();
+            }
+        } finally {
+            delete_option(self::LOCK_OPTION);
+        }
+        $remaining = self::offdomain_count();
+        self::redirect_back('success', sprintf('Convertiti %1$d link a %2$s; %3$d ancora da convertire.', $converted, $domain, $remaining) . ($remaining > 0 ? ' Premi di nuovo per continuare.' : ' Conversione completata!'));
+    }
+
+    /* ---------------------------------------------------------------------
      * Pagina
      * ------------------------------------------------------------------ */
 
@@ -320,6 +395,30 @@ class ALMA_Affiliate_Link_Auditor {
         if ($missing_partner > 0) {
             echo '<p style="color:#996800;">⚠️ ' . esc_html(sprintf('%d link getyourguide.* SENZA partner_id: portano traffico ma non commissioni.', $missing_partner)) . '</p>';
         }
+        echo '</div>';
+
+        // ---- Dominio ufficiale ----
+        $preferred = ALMA_Affiliate_Source_GYG_CSV_Importer::preferred_domain();
+        $offdomain = self::offdomain_count();
+        echo '<div style="' . esc_attr($card) . '"><h2 style="margin-top:0;">Dominio ufficiale GetYourGuide</h2>';
+        echo '<p class="description">Il programma partner dell\'editore è italiano: il riferimento ufficiale è <code>www.getyourguide.it</code>. Gli ID delle attività (<code>t…</code>) sono indipendenti dal dominio e GYG reindirizza allo slug italiano mantenendo il partner_id, quindi la conversione è una semplice sostituzione dell\'host — nessuna chiamata esterna. Il dominio scelto viene applicato anche a tutti gli import CSV futuri e alla bonifica tpx.li.</p>';
+        echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '" style="display:flex;gap:12px;align-items:flex-end;flex-wrap:wrap;">';
+        wp_nonce_field('alma_link_audit');
+        echo '<input type="hidden" name="action" value="alma_link_audit_domain">';
+        $current_setting = (string) get_option('alma_gyg_preferred_domain', 'www.getyourguide.it');
+        echo '<p style="margin:0;"><label><strong>Dominio preferito</strong><br><select name="alma_gyg_preferred_domain">';
+        foreach (array('www.getyourguide.it' => 'www.getyourguide.it (consigliato)', 'www.getyourguide.com' => 'www.getyourguide.com', 'keep' => 'Mantieni il dominio originale') as $value => $label) {
+            echo '<option value="' . esc_attr($value) . '"' . selected($current_setting, $value, false) . '>' . esc_html($label) . '</option>';
+        }
+        echo '</select></label></p>';
+        echo '<p style="margin:0;"><button class="button">Salva preferenza</button></p>';
+        if ($preferred !== '' && $offdomain > 0) {
+            echo '<p style="margin:0;"><button class="button button-primary" name="convert_now" value="1">Converti i prossimi ' . esc_html((string) min(50, $offdomain)) . ' link (' . esc_html((string) $offdomain) . ' su altri domini)</button></p>';
+        } elseif ($preferred !== '') {
+            echo '<p style="margin:0;">✅ Tutti i link GYG usano già ' . esc_html($preferred) . '.</p>';
+        }
+        echo '</form>';
+        echo '<p class="description" style="margin-top:8px;">Anche qui l\'URL precedente viene salvato nel meta di backup <code>' . esc_html(self::META_BACKUP) . '</code> prima della modifica.</p>';
         echo '</div>';
 
         // ---- Bonifica tpx.li ----

--- a/includes/class-affiliate-source-gyg-csv-importer.php
+++ b/includes/class-affiliate-source-gyg-csv-importer.php
@@ -130,11 +130,46 @@ class ALMA_Affiliate_Source_GYG_CSV_Importer {
         return true;
     }
 
+    /**
+     * Dominio GetYourGuide preferito per i link generati: il programma
+     * partner dell'editore è italiano, quindi il riferimento ufficiale è
+     * www.getyourguide.it (gli ID l… e t… sono indipendenti dal dominio e
+     * GYG reindirizza allo slug locale mantenendo i parametri). Vuoto =
+     * mantieni il dominio originale (comportamento storico).
+     */
+    public static function preferred_domain() {
+        $domain = sanitize_text_field((string) get_option('alma_gyg_preferred_domain', 'www.getyourguide.it'));
+        if ($domain === 'keep') { return ''; }
+        return preg_match('/^(www\.)?getyourguide\.[a-z.]{2,6}$/', $domain) ? $domain : 'www.getyourguide.it';
+    }
+
+    /**
+     * Sposta un URL getyourguide.* sul dominio indicato, conservando
+     * percorso, query e fragment. Gli URL non-GYG (o tpx.li) e un dominio
+     * vuoto lasciano tutto invariato. Pura, testabile.
+     */
+    public static function normalize_gyg_domain($url, $domain) {
+        $url = trim((string) $url);
+        $domain = trim((string) $domain);
+        if ($url === '' || $domain === '') { return $url; }
+        $parts = wp_parse_url($url);
+        $host = strtolower((string) ($parts['host'] ?? ''));
+        if ($host === '' || strpos($host, 'getyourguide.') === false || strpos($host, 'tpx.li') !== false || $host === strtolower($domain)) {
+            return $url;
+        }
+        $rebuilt = 'https://' . $domain . (string) ($parts['path'] ?? '/');
+        if (!empty($parts['query'])) { $rebuilt .= '?' . $parts['query']; }
+        if (!empty($parts['fragment'])) { $rebuilt .= '#' . $parts['fragment']; }
+        return $rebuilt;
+    }
+
     public static function build_affiliate_url($original_url, $partner_id, $utm_medium = 'online_publisher') {
         $url = esc_url_raw(trim((string)$original_url));
         if ($url === '' || !wp_http_validate_url($url)) {
             return '';
         }
+        // Riferimento ufficiale: dominio del programma partner dell'editore.
+        $url = self::normalize_gyg_domain($url, self::preferred_domain());
         $partner_id = sanitize_text_field((string)$partner_id);
         $utm_medium = sanitize_text_field((string)($utm_medium !== '' ? $utm_medium : 'online_publisher'));
         if ($partner_id === '') {


### PR DESCRIPTION
## Cosa cambia (v2.74.0)

Completa la #342: i link ufficiali del programma partner dell'editore sono su `www.getyourguide.it`, mentre in archivio (e nei redirect risolti dalla bonifica) il dominio era `.com`.

### Preferenza dominio
- Nuova opzione `alma_gyg_preferred_domain` (default **`www.getyourguide.it`**), configurabile nella pagina "Verifica link": `.it` consigliato / `.com` / "Mantieni il dominio originale" (= comportamento storico, per retrocompatibilità).
- Nota tecnica: gli ID delle attività (`t…`) sono indipendenti dal dominio e GYG reindirizza allo slug italiano **mantenendo il partner_id**, quindi lo spostamento è una pura sostituzione dell'host — percorso, query e fragment conservati, nessuna chiamata esterna. Il tracciamento partner funziona su entrambi i domini: la preferenza serve per coerenza col programma ufficiale e per l'esperienza utente italiana.

### Applicata ovunque
- `normalize_gyg_domain()` dentro `build_affiliate_url()` dell'import CSV → vale per **tutti gli import futuri** e per la **bonifica tpx.li** (che riusa il builder): i link bonificati escono direttamente su `.it`.
- **Convertitore per l'archivio esistente**: batch da 50 link per click nella pagina "Verifica link" — backup dell'URL precedente in `_alma_url_pre_bonifica` (mai sovrascritto), tpx.li esclusi (li gestisce la bonifica dedicata), cache del widget contestuale invalidata a fine giro.

## Verifiche
- `php -l` OK su tutti i file modificati.
- Test standalone **13/13**: `.com`→`.it` con path/query/fragment conservati, host senza `www`, `.it` già corretto invariato, tpx.li e domini estranei non toccati, opzione invalida → fallback sicuro, `keep` → comportamento storico, integrazione nel builder CSV in entrambe le modalità.
- Bump versione `2.74.0` (feature → minor), CHANGELOG.md e README.md aggiornati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_