### PR TITLE
Filtro Sources senza archiviate + verifica percorsi import (v2.75.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.75.1 - 2026-07-06
+
+### Filtro Sources senza archiviate + verifica dei percorsi d'import
+- **Filtro "Sources" nell'elenco Link Affiliati**: le source archiviate non compaiono più nel menu a tendina (prima erano elencate con suffisso "(eliminata)"). Il filtro per ID resta applicabile via URL, così i link di una source archiviata restano raggiungibili all'occorrenza.
+- **Verifica dei prossimi import (documentata)**: il percorso **Viator API** usa il `productUrl` restituito dall'API partner così com'è (già con `pid`, `mcid` e `medium=api`) e lo salva senza alcuna trasformazione; il percorso **GetYourGuide CSV** passa dal builder che normalizza al dominio ufficiale `.it` e aggiunge `partner_id` (v2.74.0); l'import su una source archiviata è bloccato; la deduplica lavora per `external_id` e per URL; la normalizzazione dominio non tocca URL non-GetYourGuide. I prossimi import producono quindi URL corretti su entrambi i canali.
+- Versione plugin aggiornata a `2.75.1`.
+
 ## 2.75.0 - 2026-07-06
 
 ### Verifica link: bonifica anche per Viator + protezione esplicita dei link Travelpayouts manuali

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.75.1 - 2026-07-06
+
+### Filtro Sources senza archiviate
+- Il filtro "Sources" nell'elenco Link Affiliati non mostra più le source archiviate; verificati i percorsi d'import (Viator API e GetYourGuide CSV producono URL corretti).
+- Versione plugin aggiornata a `2.75.1`.
+
 ## 2.75.0 - 2026-07-06
 
 ### Verifica link: bonifica anche per Viator

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.75.0
+ * Version: 2.75.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.75.0');
+define('ALMA_VERSION', '2.75.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-affiliate-links-source-filter.php
+++ b/includes/class-affiliate-links-source-filter.php
@@ -31,7 +31,6 @@ class ALMA_Affiliate_Links_Source_Filter {
         foreach ($sources as $source) {
             $source_id   = (int) ($source['id'] ?? 0);
             $source_name = sanitize_text_field($source['name'] ?? '');
-            if (!empty($source['deleted_at'])) { $source_name .= ' (eliminata)'; }
 
             if ($source_id <= 0 || $source_name === '') {
                 continue;
@@ -93,8 +92,12 @@ class ALMA_Affiliate_Links_Source_Filter {
     private function get_sources() {
         global $wpdb;
 
+        // Solo le source attive: quelle archiviate (deleted_at valorizzato)
+        // non compaiono nel filtro. Il filtro per ID resta comunque
+        // applicabile via URL, così i link di una source archiviata
+        // restano raggiungibili se serve.
         return (array) $wpdb->get_results(
-            "SELECT id, name, deleted_at FROM {$wpdb->prefix}alma_affiliate_sources ORDER BY name ASC",
+            "SELECT id, name FROM {$wpdb->prefix}alma_affiliate_sources WHERE deleted_at IS NULL ORDER BY name ASC",
             ARRAY_A
         );
     }


### PR DESCRIPTION
## Cosa cambia (v2.75.1)

### Filtro "Sources" nell'elenco Link Affiliati
- Le source **archiviate** (`deleted_at` valorizzato) non compaiono più nel menu a tendina — prima erano elencate con suffisso "(eliminata)". Il filtro per ID resta applicabile via URL, così i link di una source archiviata restano raggiungibili all'occorrenza.

### Verifica dei prossimi import (Affiliate Sources)
Percorsi verificati sul codice, esito positivo per entrambi i canali:
- **Viator API**: il client restituisce i prodotti grezzi dell'API partner; il normalizer usa `productUrl` **così come arriva** (già con `pid`, `mcid`, `medium=api`) e l'importer lo salva in `_affiliate_url` senza alcuna trasformazione.
- **GetYourGuide CSV**: ogni riga passa da `build_affiliate_url()`, che normalizza al dominio ufficiale `www.getyourguide.it` e aggiunge `partner_id` (v2.74.0, testato).
- L'import su una source archiviata è **bloccato** ("Source archiviata: import bloccato"); la deduplica lavora per `external_id` e per URL; la normalizzazione dominio non tocca URL non-GetYourGuide.

## Verifiche
- `php -l` OK su `includes/class-affiliate-links-source-filter.php` e `affiliate-link-manager-ai.php`.
- Bump versione `2.75.1` (bugfix → patch), CHANGELOG.md e README.md aggiornati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_