### PR TITLE
Regia AI v2: piano con data di inizio, consigli accorpati, stop agente, via il tetto bozze (v2.76.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.76.0 - 2026-07-06
+
+### Regia AI v2: piano con data di inizio, consigli strategici accorpati, stop dell'agente, via il tetto bozze
+- **Consigli strategici accorpati nella Regia**: il consiglio del piano ora usa TUTTE le informazioni disponibili — il prompt statistico completo della dashboard (lo stesso dei vecchi "Consigli strategici AI", che si trasferiscono qui), le opportunità Search Console, i gap geografici e il ritmo di produzione — e restituisce **piano consigliato** (articoli/giorni/obiettivo) + motivazione + **3-6 consigli strategici prioritizzati**. «Applica il piano» compila i campi modificabili (Quanti articoli, In quanti giorni, data, obiettivo/suggerimenti dell'admin), poi si rivede e si preme «Avvia il piano». Il box in Dashboard rimanda alla Regia (con gli ultimi consigli in un dettaglio); il comando Telegram `/consigli` riceve i nuovi consigli della Regia (compatibilità mantenuta).
+- **Data di inizio del piano** (nuovo campo, default oggi; date passate → oggi): ogni piano è indipendente e **si somma** a quelli già programmati — le idee ricevono date distribuite dalla data scelta. Guardia deterministica: se l'AI assegna date fuori dalla finestra [inizio, inizio+giorni), vengono ridistribuite in sequenza dentro la finestra (test standalone 11/11).
+- **Via il tetto giornaliero di bozze** (era 3, nascosto in Importazione massiva): ogni idea creata genera la sua bozza — quelle programmate a oggi subito, le future nel giorno previsto dal runner giornaliero, che ora processa TUTTE le idee in scadenza a run brevi (budget 180s) auto-programmandosi ogni 2 minuti finché ce ne sono. Se la pubblicazione automatica è attiva, la bozza viene pubblicata. Il ritmo lo decide solo la programmazione dei piani. Contatore bozze mantenuto come statistica.
+- **Limiti di guardia rimossi** dalla Regia (in conflitto con la nuova logica): niente più tetto di esecuzioni giornaliere (il lock impedisce comunque esecuzioni sovrapposte); le option restano nel database per compatibilità.
+- **Stato esecuzione + pulsante Ferma**: la Regia mostra chiaramente "AGENTE IN ESECUZIONE…" (con auto-refresh della pagina ogni 15s) e un pulsante **🛑 Ferma l'agente**: lo stop agisce ai confini di ogni round del loop e prima di ogni bozza (il passo in corso si conclude, poi il run si interrompe pulitamente registrando "Interrotto dall'amministratore"); le idee già create restano e le loro bozze arriveranno nei giorni programmati.
+- Problematiche valutate e gestite: piani sovrapposti si sommano (più bozze nello stesso giorno → il runner le smaltisce in catena); data nel passato normalizzata a oggi; stop a run non partito neutralizzato dal riavvio pulito del flag; massimo 10 articoli per piano (limite strutturale del loop agente: per piani più grandi, lanciare più piani con date successive).
+- Versione plugin aggiornata a `2.76.0`.
+
 ## 2.75.1 - 2026-07-06
 
 ### Filtro Sources senza archiviate + verifica dei percorsi d'import

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.76.0 - 2026-07-06
+
+### Regia AI v2
+- Consigli strategici accorpati nel consiglio del piano (contesto completo: statistiche, Search Console, gap, ritmo) con «Applica il piano»; piano con data di inizio (i piani si sommano); ogni idea genera la sua bozza nel giorno programmato senza tetto giornaliero; stato "in esecuzione" con pulsante Ferma; limiti di guardia rimossi.
+- Versione plugin aggiornata a `2.76.0`.
+
 ## 2.75.1 - 2026-07-06
 
 ### Filtro Sources senza archiviate

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.75.1
+ * Version: 2.76.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.75.1');
+define('ALMA_VERSION', '2.76.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -1498,20 +1498,12 @@ class AffiliateManagerAI {
 
                 <h2 style="margin-top:24px;">🤖 <?php esc_html_e('Consigli strategici AI', 'affiliate-link-manager-ai'); ?></h2>
                 <div class="postbox"><div class="inside">
-                    <p>
-                        <button type="button" class="button button-primary" id="alma-insights-ai"><?php esc_html_e('Genera consigli AI', 'affiliate-link-manager-ai'); ?></button>
-                        <span id="alma-insights-ai-feedback" style="margin-left:8px;color:#2271b1;"></span>
-                    </p>
-                    <p class="description"><?php esc_html_e('Invia il riepilogo aggregato dello snapshot (nessun dato personale) al modello OpenAI configurato e restituisce 5 raccomandazioni prioritizzate. Solo su richiesta, mai in automatico.', 'affiliate-link-manager-ai'); ?></p>
-                    <pre id="alma-insights-ai-text" style="white-space:pre-wrap;font-family:inherit;font-size:14px;background:#f6f7f7;border:1px solid #dcdcde;border-radius:6px;padding:14px;<?php echo $advice ? '' : 'display:none;'; ?>"><?php echo $advice ? esc_html($advice['text']) : ''; ?></pre>
-                    <p class="description" id="alma-insights-ai-meta"><?php
-                        if ($advice) {
-                            $meta_parts = array($advice['generated_at']);
-                            if (!empty($advice['model'])) { $meta_parts[] = $advice['model']; }
-                            if (!empty($advice['estimated_cost'])) { $meta_parts[] = '~$' . number_format((float) $advice['estimated_cost'], 4); }
-                            echo esc_html(implode(' · ', $meta_parts));
-                        }
-                    ?></p>
+                    <p><?php esc_html_e('I consigli strategici si sono trasferiti nella Regia AI, accorpati al consiglio del piano editoriale: lì l\'AI usa TUTTE le informazioni disponibili (statistiche complete, opportunità Search Console, ritmo di produzione) e ti propone piano + raccomandazioni applicabili con un click.', 'affiliate-link-manager-ai'); ?></p>
+                    <p><a class="button button-primary" href="<?php echo esc_url(admin_url('edit.php?post_type=affiliate_link&page=alma-ai-regia')); ?>">🎬 <?php esc_html_e('Apri la Regia AI', 'affiliate-link-manager-ai'); ?></a></p>
+                    <?php if ($advice) : ?>
+                        <details><summary><?php esc_html_e('Ultimi consigli generati', 'affiliate-link-manager-ai'); ?> · <?php echo esc_html($advice['generated_at']); ?></summary>
+                        <pre style="white-space:pre-wrap;font-family:inherit;font-size:14px;background:#f6f7f7;border:1px solid #dcdcde;border-radius:6px;padding:14px;"><?php echo esc_html($advice['text']); ?></pre></details>
+                    <?php endif; ?>
                 </div></div>
 
             <?php endif; ?>

--- a/includes/class-ai-agent-control-room.php
+++ b/includes/class-ai-agent-control-room.php
@@ -46,19 +46,39 @@ class ALMA_AI_Agent_Control_Room {
         exit;
     }
 
+    /**
+     * Consiglio del piano con TUTTE le informazioni disponibili: statistiche
+     * complete della dashboard (lo stesso contesto dettagliato dei vecchi
+     * "Consigli strategici AI", qui accorpati), opportunità Search Console,
+     * gap geografici e ritmo di produzione. Restituisce un piano strutturato
+     * (articoli/giorni/obiettivo) + motivazione + consigli operativi.
+     */
     private static function generate_advice() {
         if (empty(get_option('alma_openai_api_key', ''))) {
             return new WP_Error('alma_regia', __('OpenAI non è configurata.', 'affiliate-link-manager-ai'));
         }
+        // Contesto ricco: il prompt statistico completo della dashboard…
+        $stats_prompt = '';
+        if (class_exists('ALMA_Dashboard_Insights')) {
+            $snapshot = ALMA_Dashboard_Insights::get_snapshot();
+            if (is_array($snapshot) && method_exists('ALMA_Dashboard_Insights', 'build_advice_prompt')) {
+                $stats_prompt = (string) ALMA_Dashboard_Insights::build_advice_prompt($snapshot);
+            }
+        }
+        // …più i numeri sintetici (GSC, archivio idee, ritmo, limiti bozze).
         $context = self::advice_context();
         $result = ALMA_OpenAI_Service::request(array(
             'system_prompt' => 'Sei il direttore editoriale di un blog di viaggi italiano monetizzato con link affiliati. '
-                . 'Sulla base dei dati ricevi devi consigliare un piano editoriale sostenibile per l\'agente AI di ideazione. '
-                . 'Rispondi SOLO con un oggetto JSON: {"articoli": <1-10>, "giorni": <3-30>, "obiettivo": "<obiettivo editoriale suggerito, 1 frase>", "motivazione": "<perché questo ritmo e questo focus, 2-3 frasi in italiano>"}.',
-            'user_prompt' => 'Dati del sito: ' . wp_json_encode($context, JSON_UNESCAPED_UNICODE),
-            'max_output_tokens' => 400,
+                . 'Ricevi le statistiche complete del sito (click, gap geografici, opportunità di ricerca reali da Google Search Console, ritmo di produzione). '
+                . 'Devi consigliare un piano editoriale concreto per l\'agente AI di ideazione. '
+                . 'Rispondi SOLO con un oggetto JSON: {"articoli": <1-10>, "giorni": <3-30>, '
+                . '"obiettivo": "<obiettivo editoriale operativo per l\'agente: temi e destinazioni prioritarie, 1-2 frasi>", '
+                . '"motivazione": "<perché questo ritmo e questo focus, 2-3 frasi>", '
+                . '"consigli": ["<3-6 raccomandazioni strategiche prioritizzate, concrete e basate sui numeri ricevuti>"]}.',
+            'user_prompt' => ($stats_prompt !== '' ? $stats_prompt . "\n\n" : '') . 'Altri dati: ' . wp_json_encode($context, JSON_UNESCAPED_UNICODE),
+            'max_output_tokens' => 1100,
             'temperature' => 0.3,
-            'timeout' => 60,
+            'timeout' => 90,
         ));
         if (empty($result['success'])) {
             return new WP_Error('alma_regia', sanitize_text_field((string)($result['error'] ?? 'Errore AI')));
@@ -70,12 +90,29 @@ class ALMA_AI_Agent_Control_Room {
         if (!is_array($data) || empty($data['articoli'])) {
             return new WP_Error('alma_regia', __('Risposta AI non interpretabile.', 'affiliate-link-manager-ai'));
         }
-        return array(
+        $consigli = array();
+        foreach ((array) ($data['consigli'] ?? array()) as $tip) {
+            $tip = sanitize_textarea_field((string) $tip);
+            if ($tip !== '' && count($consigli) < 6) { $consigli[] = $tip; }
+        }
+        $advice = array(
             'articoli' => max(1, min(10, absint($data['articoli']))),
             'giorni' => max(3, min(30, absint($data['giorni'] ?? 14))),
-            'obiettivo' => sanitize_text_field((string)($data['obiettivo'] ?? '')),
+            'obiettivo' => sanitize_textarea_field((string)($data['obiettivo'] ?? '')),
             'motivazione' => sanitize_textarea_field((string)($data['motivazione'] ?? '')),
+            'consigli' => $consigli,
         );
+        // Compatibilità: /consigli su Telegram legge i consigli della
+        // dashboard — da qui in poi riceve quelli (più ricchi) della Regia.
+        if (!empty($consigli) && class_exists('ALMA_Dashboard_Insights')) {
+            update_option(ALMA_Dashboard_Insights::OPTION_ADVICE, array(
+                'text' => implode("\n", array_map(function ($i, $tip) { return ($i + 1) . '. ' . $tip; }, array_keys($consigli), $consigli)),
+                'generated_at' => current_time('mysql'),
+                'model' => sanitize_text_field((string)($result['model'] ?? '')),
+                'estimated_cost' => (float) ($result['estimated_cost'] ?? 0),
+            ), false);
+        }
+        return $advice;
     }
 
     /**
@@ -105,9 +142,10 @@ class ALMA_AI_Agent_Control_Room {
         $series = self::activity_series(30);
         $context['idee_create_ultimi_30gg'] = array_sum($series['ideas']);
         $context['bozze_ai_ultimi_30gg'] = array_sum($series['drafts']);
-        if (class_exists('ALMA_AI_Content_Agent_Idea_Importer')) {
-            $context['limite_bozze_automatiche_al_giorno'] = (int) get_option('alma_ai_ideas_daily_draft_limit', 3);
+        if (class_exists('ALMA_AI_Content_Agent_Idea_Importer') && method_exists('ALMA_AI_Content_Agent_Idea_Importer', 'due_ideas_count')) {
+            $context['idee_programmate_in_scadenza'] = ALMA_AI_Content_Agent_Idea_Importer::due_ideas_count();
         }
+        $context['pubblicazione_automatica_attiva'] = get_option('alma_ai_auto_publish', 'no') === 'yes';
         return $context;
     }
 
@@ -168,29 +206,46 @@ class ALMA_AI_Agent_Control_Room {
     public static function render_page() {
         if (!current_user_can('manage_options')) { wp_die('forbidden'); }
         $running = (bool) get_option(ALMA_AI_Idea_Agent::LOCK_OPTION);
+        $stopping = (bool) get_option(ALMA_AI_Idea_Agent::OPTION_CANCEL);
         $runs_today = ALMA_AI_Idea_Agent::runs_today();
-        $runs_limit = ALMA_AI_Idea_Agent::get_daily_runs_limit();
-        $draft_limit = (int) get_option('alma_ai_ideas_daily_draft_limit', 3);
         $draft_counter = get_option('alma_ai_ideas_draft_counter', array());
         $drafts_today = (is_array($draft_counter) && ($draft_counter['date'] ?? '') === current_time('Y-m-d')) ? (int) $draft_counter['count'] : 0;
+        $due_ideas = (class_exists('ALMA_AI_Content_Agent_Idea_Importer') && method_exists('ALMA_AI_Content_Agent_Idea_Importer', 'due_ideas_count')) ? ALMA_AI_Content_Agent_Idea_Importer::due_ideas_count() : 0;
         $advice = get_option(self::OPTION_ADVICE, null);
         $history = ALMA_AI_Idea_Agent::get_run_history();
         $series = self::activity_series(30);
+        $auto_publish = get_option('alma_ai_auto_publish', 'no') === 'yes';
         $card = 'border:1px solid #c3c4c7;border-radius:6px;background:#fff;padding:14px 16px;margin:0 0 14px;';
 
         echo '<div class="wrap">';
         echo '<h1>🎬 Regia AI</h1>';
         self::render_notice();
-        echo '<p class="description" style="max-width:900px;">La camera di regia dell\'agente di ideazione: da qui gli comunichi il piano editoriale (quanti articoli, in quanti giorni, con quale obiettivo), ti fai consigliare il piano dai dati reali, e vedi cosa ha fatto. La stessa regia risponde su Telegram con <code>/agente &lt;argomento&gt;</code>.</p>';
+        echo '<p class="description" style="max-width:900px;">La camera di regia dell\'agente: qui imposti il piano editoriale (quanti articoli, in quanti giorni, da quando), ti fai consigliare il piano dai dati reali e vedi cosa ha fatto. Ogni idea creata genera la sua bozza nel giorno programmato' . ($auto_publish ? ' e viene pubblicata automaticamente (opzione attiva in Impostazioni)' : ' (la pubblicazione automatica è disattivata: restano bozze da revisionare)') . '. La stessa regia risponde su Telegram con <code>/agente &lt;argomento&gt;</code>.</p>';
 
-        // ---- Stato ----
+        // ---- Stato + stop ----
         echo '<div style="' . esc_attr($card) . 'display:flex;gap:22px;flex-wrap:wrap;align-items:center;">';
-        echo '<span><strong>' . esc_html__('Stato', 'affiliate-link-manager-ai') . ':</strong> ' . ($running ? '<span style="color:#996800;">⏳ ' . esc_html__('esecuzione in corso…', 'affiliate-link-manager-ai') . '</span>' : '<span style="color:#00753d;">✅ ' . esc_html__('pronto', 'affiliate-link-manager-ai') . '</span>') . '</span>';
-        echo '<span><strong>' . esc_html__('Esecuzioni oggi', 'affiliate-link-manager-ai') . ':</strong> ' . esc_html($runs_today . ' / ' . $runs_limit) . ' <span class="description">(' . esc_html__('i lanci manuali partono comunque', 'affiliate-link-manager-ai') . ')</span></span>';
-        echo '<span><strong>' . esc_html__('Bozze automatiche oggi', 'affiliate-link-manager-ai') . ':</strong> ' . esc_html($drafts_today . ' / ' . $draft_limit) . '</span>';
+        if ($running && $stopping) {
+            $state = '<span style="color:#d63638;">🛑 ' . esc_html__('stop richiesto: si ferma al termine del passo in corso…', 'affiliate-link-manager-ai') . '</span>';
+        } elseif ($running) {
+            $state = '<span style="color:#996800;">⏳ ' . esc_html__('AGENTE IN ESECUZIONE…', 'affiliate-link-manager-ai') . '</span>';
+        } else {
+            $state = '<span style="color:#00753d;">✅ ' . esc_html__('pronto', 'affiliate-link-manager-ai') . '</span>';
+        }
+        echo '<span><strong>' . esc_html__('Stato', 'affiliate-link-manager-ai') . ':</strong> ' . $state . '</span>';
+        if ($running && !$stopping) {
+            echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '" style="margin:0;">';
+            wp_nonce_field('alma_ai_idea_agent_stop');
+            echo '<input type="hidden" name="action" value="alma_ai_idea_agent_stop"><button class="button" style="border-color:#d63638;color:#d63638;">🛑 ' . esc_html__('Ferma l\'agente', 'affiliate-link-manager-ai') . '</button></form>';
+        }
+        echo '<span><strong>' . esc_html__('Esecuzioni oggi', 'affiliate-link-manager-ai') . ':</strong> ' . esc_html((string) $runs_today) . '</span>';
+        echo '<span><strong>' . esc_html__('Bozze generate oggi', 'affiliate-link-manager-ai') . ':</strong> ' . esc_html((string) $drafts_today) . '</span>';
+        echo '<span><strong>' . esc_html__('Idee in scadenza', 'affiliate-link-manager-ai') . ':</strong> ' . esc_html((string) $due_ideas) . ' <span class="description">(' . esc_html__('bozze in arrivo dal runner', 'affiliate-link-manager-ai') . ')</span></span>';
+        if ($running) {
+            echo '<script>setTimeout(function(){ window.location.reload(); }, 15000);</script>';
+        }
         echo '</div>';
 
-        // ---- Piano editoriale ----
+        // ---- Piano editoriale (con consiglio AI accorpato) ----
         echo '<div style="' . esc_attr($card) . '">';
         echo '<h2 style="margin-top:0;">📋 ' . esc_html__('Piano editoriale', 'affiliate-link-manager-ai') . '</h2>';
         echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
@@ -199,32 +254,36 @@ class ALMA_AI_Agent_Control_Room {
         echo '<div style="display:flex;gap:16px;flex-wrap:wrap;align-items:flex-end;">';
         echo '<p style="margin:0;"><label><strong>' . esc_html__('Quanti articoli', 'affiliate-link-manager-ai') . '</strong><br><input type="number" id="alma-regia-num" name="agent_num_ideas" min="1" max="10" value="' . esc_attr((string) ALMA_AI_Idea_Agent::get_max_ideas()) . '" class="small-text"></label></p>';
         echo '<p style="margin:0;"><label><strong>' . esc_html__('In quanti giorni', 'affiliate-link-manager-ai') . '</strong><br><input type="number" id="alma-regia-giorni" name="agent_days" min="1" max="60" value="14" class="small-text"></label></p>';
-        echo '<p style="margin:0;flex:1 1 340px;"><label><strong>' . esc_html__('Obiettivo (opzionale)', 'affiliate-link-manager-ai') . '</strong><br><input type="text" id="alma-regia-obiettivo" name="agent_objective" class="widefat" placeholder="' . esc_attr__('Es. destinazioni per l\'autunno, focus Sicilia, cammini…', 'affiliate-link-manager-ai') . '"></label></p>';
-        echo '<p style="margin:0;"><label title="' . esc_attr__('Le bozze immediate rispettano il limite giornaliero: le idee oltre quota vengono generate automaticamente nei giorni programmati.', 'affiliate-link-manager-ai') . '"><input type="checkbox" name="agent_create_drafts" value="1" checked> ' . esc_html__('Crea subito anche le bozze', 'affiliate-link-manager-ai') . '</label></p>';
-        echo '<p style="margin:0;"><button class="button button-primary button-hero" ' . disabled($running, true, false) . '>' . esc_html($running ? __('Esecuzione in corso…', 'affiliate-link-manager-ai') : __('Avvia l\'agente', 'affiliate-link-manager-ai')) . '</button></p>';
+        echo '<p style="margin:0;"><label><strong>' . esc_html__('A partire dal', 'affiliate-link-manager-ai') . '</strong><br><input type="date" id="alma-regia-inizio" name="agent_start_date" value="' . esc_attr(current_time('Y-m-d')) . '" min="' . esc_attr(current_time('Y-m-d')) . '"></label></p>';
+        echo '<p style="margin:0;flex:1 1 340px;"><label><strong>' . esc_html__('Obiettivo e suggerimenti (opzionale)', 'affiliate-link-manager-ai') . '</strong><br><input type="text" id="alma-regia-obiettivo" name="agent_objective" class="widefat" placeholder="' . esc_attr__('Es. destinazioni per l\'autunno, focus Sicilia, taglio pratico…', 'affiliate-link-manager-ai') . '"></label></p>';
+        echo '<p style="margin:0;"><button class="button button-primary button-hero" ' . disabled($running, true, false) . '>' . esc_html($running ? __('Esecuzione in corso…', 'affiliate-link-manager-ai') : __('Avvia il piano', 'affiliate-link-manager-ai')) . '</button></p>';
         echo '</div>';
-        echo '<p class="description" style="margin:8px 0 0;">' . esc_html__('L\'agente crea le idee con date di pubblicazione distribuite nel periodo indicato; le bozze non immediate vengono generate automaticamente nei giorni programmati (job notturno), nel rispetto del limite giornaliero.', 'affiliate-link-manager-ai') . '</p>';
+        echo '<p class="description" style="margin:8px 0 0;">' . esc_html__('Ogni piano è indipendente e si somma a quelli già programmati: le idee ricevono date distribuite dalla data di inizio scelta; le bozze delle idee di oggi si generano subito, le altre nel giorno previsto. Nessun tetto giornaliero: il ritmo lo decide il piano.', 'affiliate-link-manager-ai') . '</p>';
         echo '</form>';
-        echo '</div>';
 
-        // ---- Consiglio AI ----
-        echo '<div style="' . esc_attr($card) . '">';
-        echo '<h2 style="margin-top:0;">💡 ' . esc_html__('Fatti consigliare il piano', 'affiliate-link-manager-ai') . '</h2>';
+        // ---- Consiglio AI (accorpa i "Consigli strategici AI" della dashboard) ----
+        echo '<hr style="margin:14px 0;">';
         echo '<div style="display:flex;gap:16px;flex-wrap:wrap;align-items:center;">';
         echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '" style="margin:0;">';
         wp_nonce_field('alma_ai_regia_advice');
-        echo '<input type="hidden" name="action" value="alma_ai_regia_advice"><button class="button">' . esc_html__('Chiedi un consiglio ai dati', 'affiliate-link-manager-ai') . '</button></form>';
-        echo '<span class="description">' . esc_html__('L\'AI analizza click, gap geografici, opportunità Search Console e il tuo ritmo attuale, e propone quanti articoli creare, in quanti giorni e con quale focus.', 'affiliate-link-manager-ai') . '</span>';
+        echo '<input type="hidden" name="action" value="alma_ai_regia_advice"><button class="button">💡 ' . esc_html__('Fatti consigliare il piano dai dati', 'affiliate-link-manager-ai') . '</button></form>';
+        echo '<span class="description">' . esc_html__('L\'AI analizza TUTTE le informazioni disponibili (statistiche complete dei click, gap geografici, opportunità Search Console, ritmo di produzione) e propone piano + consigli strategici.', 'affiliate-link-manager-ai') . '</span>';
         echo '</div>';
         if (is_array($advice) && !empty($advice['data'])) {
             $d = $advice['data'];
-            echo '<div style="margin-top:10px;padding:10px 12px;background:#f0f6fc;border:1px solid #c5d9ed;border-radius:6px;">';
-            echo '<p style="margin:0 0 6px;"><strong>' . esc_html(sprintf(__('Consiglio del %s', 'affiliate-link-manager-ai'), (string) $advice['time'])) . ':</strong> ';
+            echo '<div style="margin-top:10px;padding:12px 14px;background:#f0f6fc;border:1px solid #c5d9ed;border-radius:6px;">';
+            echo '<p style="margin:0 0 6px;"><strong>' . esc_html(sprintf(__('Piano consigliato (%s)', 'affiliate-link-manager-ai'), (string) $advice['time'])) . ':</strong> ';
             echo esc_html(sprintf(__('%1$d articoli in %2$d giorni', 'affiliate-link-manager-ai'), (int) $d['articoli'], (int) $d['giorni']));
             if (!empty($d['obiettivo'])) { echo ' — <em>' . esc_html($d['obiettivo']) . '</em>'; }
             echo '</p>';
             if (!empty($d['motivazione'])) { echo '<p style="margin:0 0 8px;" class="description">' . esc_html($d['motivazione']) . '</p>'; }
-            echo '<button type="button" class="button button-secondary" id="alma-regia-applica" data-articoli="' . esc_attr((string)(int) $d['articoli']) . '" data-giorni="' . esc_attr((string)(int) $d['giorni']) . '" data-obiettivo="' . esc_attr((string) $d['obiettivo']) . '">' . esc_html__('Applica al piano', 'affiliate-link-manager-ai') . '</button>';
+            if (!empty($d['consigli'])) {
+                echo '<p style="margin:0 0 4px;"><strong>' . esc_html__('Consigli strategici', 'affiliate-link-manager-ai') . ':</strong></p><ol style="margin:0 0 10px 20px;">';
+                foreach ((array) $d['consigli'] as $tip) { echo '<li>' . esc_html((string) $tip) . '</li>'; }
+                echo '</ol>';
+            }
+            echo '<button type="button" class="button button-secondary" id="alma-regia-applica" data-articoli="' . esc_attr((string)(int) $d['articoli']) . '" data-giorni="' . esc_attr((string)(int) $d['giorni']) . '" data-obiettivo="' . esc_attr((string) $d['obiettivo']) . '">' . esc_html__('Applica il piano', 'affiliate-link-manager-ai') . '</button> ';
+            echo '<span class="description">' . esc_html__('Compila i campi qui sopra: rivedi, modifica se vuoi, poi Avvia il piano.', 'affiliate-link-manager-ai') . '</span>';
             echo '</div>';
         }
         echo '</div>';
@@ -264,19 +323,6 @@ class ALMA_AI_Agent_Control_Room {
         }
         echo '</div>';
 
-        // ---- Limiti di guardia ----
-        echo '<div style="' . esc_attr($card) . '">';
-        echo '<h2 style="margin-top:0;">🛡️ ' . esc_html__('Limiti di guardia', 'affiliate-link-manager-ai') . '</h2>';
-        echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '" style="display:flex;gap:14px;align-items:center;flex-wrap:wrap;">';
-        wp_nonce_field('alma_ai_idea_agent_settings');
-        echo '<input type="hidden" name="action" value="alma_ai_idea_agent_settings">';
-        echo '<label>' . esc_html__('Idee per esecuzione (default)', 'affiliate-link-manager-ai') . ' <input type="number" min="1" max="10" class="small-text" name="' . esc_attr(ALMA_AI_Idea_Agent::OPTION_MAX_IDEAS) . '" value="' . esc_attr((string) ALMA_AI_Idea_Agent::get_max_ideas()) . '"></label>';
-        echo '<label>' . esc_html__('Esecuzioni automatiche al giorno', 'affiliate-link-manager-ai') . ' <input type="number" min="1" max="20" class="small-text" name="' . esc_attr(ALMA_AI_Idea_Agent::OPTION_DAILY_RUNS) . '" value="' . esc_attr((string) $runs_limit) . '"></label>';
-        echo '<button class="button">' . esc_html__('Salva limiti', 'affiliate-link-manager-ai') . '</button>';
-        echo '<span class="description">' . esc_html(sprintf(__('Il limite bozze automatiche (%d/giorno) si regola in Importazione massiva.', 'affiliate-link-manager-ai'), $draft_limit)) . '</span>';
-        echo '</form>';
-        echo '</div>';
-
         // ---- JS: grafico + applica consiglio ----
         $chart_payload = wp_json_encode(array('labels' => $series['labels'], 'ideas' => $series['ideas'], 'drafts' => $series['drafts']));
         echo '<script>
@@ -301,9 +347,11 @@ class ALMA_AI_Agent_Control_Room {
                     var num = document.getElementById("alma-regia-num");
                     var giorni = document.getElementById("alma-regia-giorni");
                     var obiettivo = document.getElementById("alma-regia-obiettivo");
+                    var inizio = document.getElementById("alma-regia-inizio");
                     if (num) { num.value = this.getAttribute("data-articoli"); }
                     if (giorni) { giorni.value = this.getAttribute("data-giorni"); }
                     if (obiettivo) { obiettivo.value = this.getAttribute("data-obiettivo"); }
+                    if (inizio && inizio.min) { inizio.value = inizio.min; }
                     window.scrollTo({ top: 0, behavior: "smooth" });
                 });
             }

--- a/includes/class-ai-content-agent-idea-importer.php
+++ b/includes/class-ai-content-agent-idea-importer.php
@@ -104,21 +104,14 @@ class ALMA_AI_Content_Agent_Idea_Importer {
 
             <div class="card" style="max-width:860px;">
                 <h2><?php esc_html_e('Generazione automatica in background', 'affiliate-link-manager-ai'); ?></h2>
-                <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
-                    <?php wp_nonce_field('alma_ai_ideas_import_settings'); ?>
-                    <input type="hidden" name="action" value="alma_ai_ideas_import_settings">
-                    <p><label><?php esc_html_e('Massimo bozze generate automaticamente al giorno', 'affiliate-link-manager-ai'); ?>
-                        <input type="number" name="<?php echo esc_attr(self::OPTION_DAILY_LIMIT); ?>" min="0" max="50" value="<?php echo esc_attr((string)self::get_daily_limit()); ?>" class="small-text"></label></p>
-                    <p class="description"><?php esc_html_e('Tetto ai costi OpenAI: il runner giornaliero non supera questo numero di bozze. 0 = generazione automatica sospesa (le idee restano programmate).', 'affiliate-link-manager-ai'); ?></p>
-                    <p><button class="button"><?php esc_html_e('Salva', 'affiliate-link-manager-ai'); ?></button></p>
-                </form>
+                <p class="description"><?php esc_html_e('Ogni idea programmata genera la sua bozza nel giorno previsto, senza tetto giornaliero: il ritmo lo decide la programmazione dei piani (quanti articoli, in quanti giorni, da quando) nella Regia AI. Il runner lavora a run brevi e si auto-programma finché ci sono idee in scadenza.', 'affiliate-link-manager-ai'); ?></p>
                 <?php
                 $counter = get_option(self::OPTION_COUNTER, array());
                 $today = current_time('Y-m-d');
                 $today_count = (is_array($counter) && ($counter['date'] ?? '') === $today) ? (int)$counter['count'] : 0;
                 $next_run = wp_next_scheduled(self::CRON_HOOK);
                 ?>
-                <p class="description"><?php printf(esc_html__('Bozze generate oggi: %1$d / %2$d · Prossima esecuzione automatica: %3$s', 'affiliate-link-manager-ai'), $today_count, self::get_daily_limit(), $next_run ? esc_html(get_date_from_gmt(gmdate('Y-m-d H:i:s', $next_run), 'Y-m-d H:i')) : '—'); ?></p>
+                <p class="description"><?php printf(esc_html__('Bozze generate oggi: %1$d · Prossima esecuzione automatica: %2$s', 'affiliate-link-manager-ai'), $today_count, $next_run ? esc_html(get_date_from_gmt(gmdate('Y-m-d H:i:s', $next_run), 'Y-m-d H:i')) : '—'); ?></p>
             </div>
         </div>
         <?php
@@ -334,26 +327,29 @@ class ALMA_AI_Content_Agent_Idea_Importer {
     }
 
     /**
-     * Genera le bozze delle idee programmate in scadenza, entro il limite
-     * giornaliero. Riusa l'intera pipeline esistente: selezione candidati via
-     * Knowledge Search (geo-first), sessione contenuto, Draft Builder.
+     * Genera le bozze di TUTTE le idee programmate in scadenza: il ritmo lo
+     * decide la programmazione dei piani (quanti articoli, in quanti giorni,
+     * da quando), non un tetto giornaliero. Il run lavora entro un budget di
+     * tempo e, se restano idee in scadenza, si auto-programma un run di
+     * recupero (pattern del warmer). Riusa l'intera pipeline esistente:
+     * selezione candidati via Knowledge Search (geo-first), sessione
+     * contenuto, Draft Builder.
      */
     public static function run_scheduled() {
         if (!self::acquire_lock()) { return; }
         global $wpdb;
         $job_id = 0;
+        $processed = 0;
         try {
-            $limit = self::get_daily_limit();
             $today = current_time('Y-m-d');
             $counter = get_option(self::OPTION_COUNTER, array());
             $done_today = (is_array($counter) && ($counter['date'] ?? '') === $today) ? (int)$counter['count'] : 0;
-            $quota = max(0, $limit - $done_today);
-            if ($quota < 1 || empty(get_option('alma_openai_api_key', ''))) { return; }
+            if (empty(get_option('alma_openai_api_key', ''))) { return; }
 
             $idea_ids = get_posts(array(
                 'post_type' => ALMA_AI_Content_Agent_Ideas::CPT,
                 'post_status' => 'publish',
-                'posts_per_page' => $quota,
+                'posts_per_page' => 10,
                 'fields' => 'ids',
                 'orderby' => 'meta_value',
                 'meta_key' => ALMA_AI_Content_Agent_Ideas::META_SCHEDULED_AT,
@@ -372,11 +368,15 @@ class ALMA_AI_Content_Agent_Idea_Importer {
             $wpdb->insert($jobs_table, array('job_type' => 'scheduled_ideas', 'status' => 'running', 'total_items' => count($idea_ids), 'started_at' => current_time('mysql'), 'updated_at' => current_time('mysql')));
             $job_id = (int) $wpdb->insert_id;
 
-            $processed = 0;
             $errors = 0;
             $last_error = '';
+            $started_ts = time();
             $original_user = get_current_user_id();
             foreach ($idea_ids as $idea_id) {
+                // Budget di tempo per run (hosting condiviso): le idee non
+                // elaborate restano in scadenza e riprendono col run di
+                // recupero auto-programmato qui sotto.
+                if ((time() - $started_ts) > 180) { break; }
                 $result = self::generate_draft_for_scheduled_idea((int) $idea_id);
                 $processed++;
                 if (empty($result['success'])) {
@@ -397,21 +397,44 @@ class ALMA_AI_Content_Agent_Idea_Importer {
         } finally {
             delete_option(self::LOCK_OPTION);
         }
+        // Run di recupero: se questo giro ha prodotto qualcosa e restano
+        // idee in scadenza, si riparte tra 2 minuti (mai loop a vuoto).
+        if ($processed > 0 && self::due_ideas_count() > 0) {
+            wp_schedule_single_event(time() + 120, self::CRON_HOOK);
+            if (function_exists('spawn_cron')) { spawn_cron(); }
+        }
     }
 
     /**
-     * Genera SUBITO la bozza di un'idea rispettando il limite giornaliero di
-     * bozze automatiche (stesso contatore del runner programmato): usato
-     * dall'agente di ideazione quando l'editore chiede anche le bozze.
+     * Idee programmate in scadenza (oggi o prima) senza bozza.
+     */
+    public static function due_ideas_count() {
+        $ids = get_posts(array(
+            'post_type' => ALMA_AI_Content_Agent_Ideas::CPT,
+            'post_status' => 'publish',
+            'posts_per_page' => -1,
+            'fields' => 'ids',
+            'no_found_rows' => true,
+            'meta_query' => array(
+                array('key' => ALMA_AI_Content_Agent_Ideas::META_SCHEDULED_AT, 'value' => '', 'compare' => '!='),
+                array('key' => ALMA_AI_Content_Agent_Ideas::META_SCHEDULED_AT, 'value' => current_time('Y-m-d'), 'compare' => '<='),
+                array('key' => ALMA_AI_Content_Agent_Ideas::META_EXECUTED_AT, 'value' => '', 'compare' => '='),
+                array('key' => ALMA_AI_Content_Agent_Ideas::META_DRAFT_POST_ID, 'value' => 0, 'compare' => '<=', 'type' => 'NUMERIC'),
+            ),
+        ));
+        return count($ids);
+    }
+
+    /**
+     * Genera SUBITO la bozza di un'idea: usato dall'agente di ideazione per
+     * le idee programmate a oggi. Nessun tetto giornaliero: il ritmo lo
+     * decide la programmazione del piano (il contatore resta solo come
+     * statistica visibile in Regia).
      */
     public static function generate_draft_now($idea_id) {
-        $limit = self::get_daily_limit();
         $today = current_time('Y-m-d');
         $counter = get_option(self::OPTION_COUNTER, array());
         $done = (is_array($counter) && ($counter['date'] ?? '') === $today) ? (int)$counter['count'] : 0;
-        if ($limit < 1 || $done >= $limit) {
-            return array('success' => false, 'error' => 'Limite giornaliero di bozze automatiche raggiunto (' . $done . '/' . $limit . ').', 'quota_exhausted' => true);
-        }
         $result = self::generate_draft_for_scheduled_idea(absint($idea_id));
         if (!empty($result['success'])) {
             update_option(self::OPTION_COUNTER, array('date' => $today, 'count' => $done + 1), false);

--- a/includes/class-ai-idea-agent.php
+++ b/includes/class-ai-idea-agent.php
@@ -29,11 +29,25 @@ class ALMA_AI_Idea_Agent {
     const MAX_ROUNDS = 12;
     const OPTION_RUN_HISTORY = 'alma_ai_idea_agent_history';
     const HISTORY_MAX = 30;
+    const OPTION_CANCEL = 'alma_ai_idea_agent_cancel';
 
     public static function init() {
-        add_action(self::CRON_HOOK, array(__CLASS__, 'run'), 10, 6);
+        add_action(self::CRON_HOOK, array(__CLASS__, 'run'), 10, 7);
         add_action('admin_post_alma_ai_idea_agent_start', array(__CLASS__, 'handle_start'));
+        add_action('admin_post_alma_ai_idea_agent_stop', array(__CLASS__, 'handle_stop'));
         add_action('admin_post_alma_ai_idea_agent_settings', array(__CLASS__, 'handle_settings'));
+    }
+
+    /**
+     * Data di inizio piano valida: oggi se assente, malformata o nel passato.
+     */
+    public static function sanitize_start_date($date) {
+        $date = trim((string) $date);
+        $today = current_time('Y-m-d');
+        if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) || $date < $today) {
+            return $today;
+        }
+        return $date;
     }
 
     public static function unschedule() {
@@ -75,19 +89,36 @@ class ALMA_AI_Idea_Agent {
         if (empty(get_option('alma_openai_api_key', ''))) {
             $notice = array('type' => 'error', 'message' => __('OpenAI non è configurata.', 'affiliate-link-manager-ai'));
         } elseif (get_option(self::LOCK_OPTION)) {
-            $notice = array('type' => 'error', 'message' => __('Un\'esecuzione dell\'agente è già in corso.', 'affiliate-link-manager-ai'));
+            $notice = array('type' => 'error', 'message' => __('Un\'esecuzione dell\'agente è già in corso: attendila o fermala prima di avviare un nuovo piano.', 'affiliate-link-manager-ai'));
         } else {
             $objective = sanitize_textarea_field(wp_unslash($_POST['agent_objective'] ?? ''));
-            $create_drafts = empty($_POST['agent_create_drafts']) ? 0 : 1;
             $num_ideas = max(0, min(10, absint($_POST['agent_num_ideas'] ?? 0)));
             $days_span = max(0, min(60, absint($_POST['agent_days'] ?? 0)));
-            // I lanci manuali dalla Regia partono sempre (force=1): il limite
-            // giornaliero protegge solo le esecuzioni non presidiate.
-            if (self::runs_today() >= self::get_daily_runs_limit()) {
-                $notice['message'] .= ' ' . __('Nota: limite giornaliero già raggiunto, il lancio manuale viene eseguito comunque.', 'affiliate-link-manager-ai');
-            }
-            wp_schedule_single_event(time() + 5, self::CRON_HOOK, array(get_current_user_id(), $objective, $create_drafts, 1, $num_ideas, $days_span));
+            $start_date = self::sanitize_start_date(wp_unslash($_POST['agent_start_date'] ?? ''));
+            // Le bozze si creano SEMPRE secondo la programmazione: quelle di
+            // oggi subito, le future nel giorno previsto (runner giornaliero).
+            delete_option(self::OPTION_CANCEL);
+            wp_schedule_single_event(time() + 5, self::CRON_HOOK, array(get_current_user_id(), $objective, 1, 1, $num_ideas, $days_span, $start_date));
             if (function_exists('spawn_cron')) { spawn_cron(); }
+        }
+        set_transient('alma_ai_agent_admin_notice_' . get_current_user_id(), $notice, 120);
+        wp_safe_redirect(wp_get_referer() ?: admin_url('edit.php?post_type=affiliate_link&page=alma-ai-regia'));
+        exit;
+    }
+
+    /**
+     * Ferma l'esecuzione in corso: il flag viene letto dal loop dell'agente
+     * ai confini di ogni round e prima di ogni bozza (una chiamata OpenAI
+     * già partita si conclude, poi il run si interrompe pulitamente).
+     */
+    public static function handle_stop() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_ai_idea_agent_stop');
+        if (get_option(self::LOCK_OPTION)) {
+            update_option(self::OPTION_CANCEL, (string) time(), false);
+            $notice = array('type' => 'success', 'message' => __('Richiesta di stop inviata: l\'agente si fermerà entro pochi secondi (al termine del passo in corso).', 'affiliate-link-manager-ai'));
+        } else {
+            $notice = array('type' => 'success', 'message' => __('Nessuna esecuzione in corso.', 'affiliate-link-manager-ai'));
         }
         set_transient('alma_ai_agent_admin_notice_' . get_current_user_id(), $notice, 120);
         wp_safe_redirect(wp_get_referer() ?: admin_url('edit.php?post_type=affiliate_link&page=alma-ai-regia'));
@@ -117,7 +148,7 @@ class ALMA_AI_Idea_Agent {
         return false;
     }
 
-    public static function run($user_id = 0, $objective = '', $create_drafts = 0, $force = 0, $num_ideas = 0, $days_span = 0) {
+    public static function run($user_id = 0, $objective = '', $create_drafts = 0, $force = 0, $num_ideas = 0, $days_span = 0, $start_date = '') {
         if (!self::acquire_lock()) { return; }
         $started_at = current_time('mysql');
         $report = array(
@@ -127,12 +158,6 @@ class ALMA_AI_Idea_Agent {
             'objective' => sanitize_textarea_field((string) $objective), 'forced' => (int) (bool) $force,
         );
         try {
-            // I lanci manuali (Regia, Telegram) hanno force=1 e partono sempre;
-            // il limite giornaliero ferma solo le esecuzioni non presidiate.
-            if (empty($force) && self::runs_today() >= self::get_daily_runs_limit()) {
-                $report['error'] = 'Limite esecuzioni giornaliere raggiunto.';
-                return;
-            }
             update_option(self::OPTION_RUN_COUNTER, array('date' => current_time('Y-m-d'), 'count' => self::runs_today() + 1), false);
 
             $user_id = absint($user_id) ?: 1;
@@ -140,14 +165,20 @@ class ALMA_AI_Idea_Agent {
 
             $max_ideas = $num_ideas > 0 ? max(1, min(10, absint($num_ideas))) : self::get_max_ideas();
             $days_span = $days_span > 0 ? max(1, min(60, absint($days_span))) : 14;
+            $start_date = self::sanitize_start_date($start_date);
+            $report['start_date'] = $start_date;
             $ideas_created = array();
 
             $input_items = array(
-                array('role' => 'system', 'content' => array(array('type' => 'input_text', 'text' => self::system_prompt($max_ideas, $days_span)))),
-                array('role' => 'user', 'content' => array(array('type' => 'input_text', 'text' => self::user_prompt($objective, $num_ideas, $days_span)))),
+                array('role' => 'system', 'content' => array(array('type' => 'input_text', 'text' => self::system_prompt($max_ideas, $days_span, $start_date)))),
+                array('role' => 'user', 'content' => array(array('type' => 'input_text', 'text' => self::user_prompt($objective, $num_ideas, $days_span, $start_date)))),
             );
 
             for ($round = 1; $round <= self::MAX_ROUNDS; $round++) {
+                if (get_option(self::OPTION_CANCEL)) {
+                    $report['error'] = 'Interrotto dall\'amministratore.';
+                    break;
+                }
                 $report['rounds'] = $round;
                 $res = ALMA_OpenAI_Service::request(array(
                     'input_items' => $input_items,
@@ -186,10 +217,26 @@ class ALMA_AI_Idea_Agent {
             }
             $report['ideas_created'] = $ideas_created;
 
-            // Su richiesta: genera SUBITO le bozze delle idee create, nel
-            // rispetto del limite giornaliero di bozze automatiche (Fase 3).
+            // Guardia deterministica sul piano: le date programmate devono
+            // cadere nella finestra [inizio, inizio+giorni); le idee senza
+            // data o fuori finestra vengono ridistribuite in sequenza.
+            self::enforce_schedule($ideas_created, $start_date, $days_span);
+
+            // Ogni idea crea la sua bozza secondo la programmazione: quelle
+            // di oggi (o senza data futura) subito, le altre verranno
+            // generate dal runner giornaliero nel giorno previsto.
             if (!empty($create_drafts) && !empty($ideas_created) && class_exists('ALMA_AI_Content_Agent_Idea_Importer')) {
+                $today = current_time('Y-m-d');
                 foreach ($ideas_created as $idea) {
+                    if (get_option(self::OPTION_CANCEL)) {
+                        $report['error'] = 'Interrotto dall\'amministratore (le bozze rimanenti verranno generate nei giorni programmati).';
+                        break;
+                    }
+                    $scheduled = (string) get_post_meta((int)$idea['id'], ALMA_AI_Content_Agent_Ideas::META_SCHEDULED_AT, true);
+                    if ($scheduled !== '' && $scheduled > $today) {
+                        $report['drafts_created'][] = array('idea_id' => (int)$idea['id'], 'titolo' => $idea['titolo'], 'post_id' => 0, 'error' => '', 'programmata' => $scheduled);
+                        continue;
+                    }
                     $draft = ALMA_AI_Content_Agent_Idea_Importer::generate_draft_now((int)$idea['id']);
                     $report['drafts_created'][] = array(
                         'idea_id' => (int)$idea['id'],
@@ -197,10 +244,6 @@ class ALMA_AI_Idea_Agent {
                         'post_id' => (int)($draft['post_id'] ?? 0),
                         'error' => empty($draft['success']) ? sanitize_text_field((string)($draft['error'] ?? '')) : '',
                     );
-                    if (!empty($draft['quota_exhausted'])) {
-                        $report['drafts_created'][] = array('idea_id' => 0, 'titolo' => '', 'post_id' => 0, 'error' => 'Limite giornaliero raggiunto: le idee rimanenti restano in coda (generale automaticamente domani o dal workspace).');
-                        break;
-                    }
                 }
             }
         } catch (Throwable $e) {
@@ -225,6 +268,7 @@ class ALMA_AI_Idea_Agent {
                 'forced' => (int) $report['forced'],
             ));
             update_option(self::OPTION_RUN_HISTORY, array_slice($history, 0, self::HISTORY_MAX), false);
+            delete_option(self::OPTION_CANCEL);
             delete_option(self::LOCK_OPTION);
             // Regia Telegram: report di fine esecuzione alle chat autorizzate.
             if (class_exists('ALMA_Telegram_Bot')) {
@@ -233,10 +277,32 @@ class ALMA_AI_Idea_Agent {
         }
     }
 
-    private static function system_prompt($max_ideas, $days_span = 14) {
+    /**
+     * Le date programmate delle idee devono cadere nella finestra del piano
+     * [inizio, inizio+giorni): l'AI potrebbe ignorare le istruzioni, quindi
+     * la finestra viene imposta in modo deterministico dopo il loop. Le idee
+     * senza data o fuori finestra ricevono date sequenziali dall'inizio
+     * (max una per giorno finché la finestra lo consente).
+     */
+    private static function enforce_schedule($ideas_created, $start_date, $days_span) {
+        $days_span = max(1, (int) $days_span);
+        $end_date = gmdate('Y-m-d', strtotime($start_date) + ($days_span - 1) * DAY_IN_SECONDS);
+        $fallback_offset = 0;
+        foreach ((array) $ideas_created as $idea) {
+            $idea_id = (int) ($idea['id'] ?? 0);
+            if ($idea_id < 1) { continue; }
+            $scheduled = (string) get_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_SCHEDULED_AT, true);
+            if ($scheduled !== '' && $scheduled >= $start_date && $scheduled <= $end_date) { continue; }
+            $assigned = gmdate('Y-m-d', strtotime($start_date) + ($fallback_offset % $days_span) * DAY_IN_SECONDS);
+            $fallback_offset++;
+            update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_SCHEDULED_AT, $assigned);
+        }
+    }
+
+    private static function system_prompt($max_ideas, $days_span = 14, $start_date = '') {
         $prompt = 'Sei l\'agente strategico di ideazione contenuti di un blog di viaggi italiano monetizzato con link affiliati. '
             . 'Il tuo compito: analizzare i DATI REALI del sito tramite gli strumenti disponibili e creare fino a ' . (int)$max_ideas . ' nuove idee di articolo ad alto potenziale. '
-            . 'Metodo obbligatorio: 1) analizza le performance, i gap geografici e — se disponibile — le ricerche reali con analizza_ricerche_google (le "opportunità" con impression alte e posizione debole sono il segnale più prezioso: domanda dimostrata senza contenuto adeguato); 2) per ogni opportunità verifica con cerca_link_affiliati che esistano link da monetizzare, con elenca_articoli_esistenti che il tema non sia già coperto (evita duplicati) e con cerca_media se la Media Library ha già immagini utilizzabili sul tema (se sì, segnalalo nel prompt dell\'idea); per le idee legate a una destinazione consulta scheda_localita e usa il clima reale per il taglio stagionale (es. proponi "quando andare" o contenuti per i mesi migliori in arrivo, citando i mesi consigliati nel prompt dell\'idea) e i fatti Wikidata (patrimonio UNESCO, attrazioni notevoli) per angoli accurati e non ancora coperti; per validare un tema usa tendenze_google (Italia, 5 anni): domanda in crescita e mesi di picco delle ricerche indicano COSA proporre e QUANDO pubblicare (prima del picco); 3) crea le idee con crea_idea, includendo località (se pertinente), un prompt editoriale ricco che citi le query target, e una data programmata distribuita nei prossimi ' . (int)$days_span . ' giorni. '
+            . 'Metodo obbligatorio: 1) analizza le performance, i gap geografici e — se disponibile — le ricerche reali con analizza_ricerche_google (le "opportunità" con impression alte e posizione debole sono il segnale più prezioso: domanda dimostrata senza contenuto adeguato); 2) per ogni opportunità verifica con cerca_link_affiliati che esistano link da monetizzare, con elenca_articoli_esistenti che il tema non sia già coperto (evita duplicati) e con cerca_media se la Media Library ha già immagini utilizzabili sul tema (se sì, segnalalo nel prompt dell\'idea); per le idee legate a una destinazione consulta scheda_localita e usa il clima reale per il taglio stagionale (es. proponi "quando andare" o contenuti per i mesi migliori in arrivo, citando i mesi consigliati nel prompt dell\'idea) e i fatti Wikidata (patrimonio UNESCO, attrazioni notevoli) per angoli accurati e non ancora coperti; per validare un tema usa tendenze_google (Italia, 5 anni): domanda in crescita e mesi di picco delle ricerche indicano COSA proporre e QUANDO pubblicare (prima del picco); 3) crea le idee con crea_idea, includendo località (se pertinente), un prompt editoriale ricco che citi le query target, e una data programmata (data_programmata) distribuita ' . ($start_date !== '' ? 'tra il ' . $start_date . ' e i successivi ' . (int)$days_span . ' giorni' : 'nei prossimi ' . (int)$days_span . ' giorni') . ', al massimo una idea per giorno quando possibile. '
             . 'Privilegia: località con link affiliati ma senza click (offerta inutilizzata), località con molti articoli ma senza copertura pratica/commerciale, trend di click in crescita. '
             . 'Non inventare dati: basa ogni decisione sugli output degli strumenti. Non superare il numero massimo di idee. '
             . 'Alla fine rispondi in italiano con un riepilogo: per ogni idea creata, titolo e motivazione basata sui numeri.';
@@ -251,13 +317,17 @@ class ALMA_AI_Idea_Agent {
         return preg_match('/^[A-Za-z0-9_\-]{1,120}$/', $id) ? $id : '';
     }
 
-    private static function user_prompt($objective, $num_ideas = 0, $days_span = 0) {
+    private static function user_prompt($objective, $num_ideas = 0, $days_span = 0, $start_date = '') {
         $objective = trim((string)$objective);
         $base = 'Analizza i dati del sito e crea le idee di contenuto più promettenti.';
         if ($num_ideas > 0) {
-            $base = 'Piano editoriale richiesto dall\'editore: crea ESATTAMENTE ' . (int)$num_ideas . ' idee di contenuto, con date programmate distribuite in modo sensato nei prossimi ' . max(1, (int)$days_span) . ' giorni (mai più di una al giorno se possibile).';
+            $days = max(1, (int)$days_span);
+            $window = $start_date !== ''
+                ? 'tra il ' . $start_date . ' e il ' . gmdate('Y-m-d', strtotime($start_date) + ($days - 1) * DAY_IN_SECONDS) . ' (incluse)'
+                : 'nei prossimi ' . $days . ' giorni';
+            $base = 'Piano editoriale richiesto dall\'editore: crea ESATTAMENTE ' . (int)$num_ideas . ' idee di contenuto, con date programmate (data_programmata) distribuite in modo sensato ' . $window . ', mai più di una al giorno se possibile.';
         }
-        return $objective !== '' ? $base . ' Obiettivo specifico indicato dall\'editore: ' . $objective : $base;
+        return $objective !== '' ? $base . ' Obiettivo e suggerimenti dell\'editore: ' . $objective : $base;
     }
 
     /* ---------------------------------------------------------------------
@@ -509,6 +579,8 @@ class ALMA_AI_Idea_Agent {
                 foreach ($drafts as $draft) {
                     if (!empty($draft['post_id'])) {
                         echo '<li><a href="'.esc_url(get_edit_post_link((int)$draft['post_id'], 'raw')).'">'.esc_html($draft['titolo']).'</a></li>';
+                    } elseif (!empty($draft['programmata'])) {
+                        echo '<li>'.esc_html($draft['titolo']).' — 📅 '.esc_html(sprintf(__('bozza in programma il %s', 'affiliate-link-manager-ai'), (string)$draft['programmata'])).'</li>';
                     } elseif (!empty($draft['error'])) {
                         echo '<li style="color:#996800;">'.esc_html(($draft['titolo'] !== '' ? $draft['titolo'].' — ' : '').$draft['error']).'</li>';
                     }


### PR DESCRIPTION
## Cosa cambia (v2.76.0)

### Consigli strategici accorpati nella Regia
- Il consiglio del piano ora usa **tutte le informazioni disponibili**: il prompt statistico completo della dashboard (lo stesso dei "Consigli strategici AI", che si trasferiscono qui), le opportunità Search Console, i gap geografici e il ritmo di produzione. Output: **piano consigliato** (articoli 1-10, giorni 3-30, obiettivo operativo) + motivazione + **3-6 consigli strategici prioritizzati**.
- «**Applica il piano**» compila i campi modificabili del Piano editoriale (Quanti articoli, In quanti giorni, data di inizio, obiettivo/suggerimenti dell'admin); si rivede e si preme «Avvia il piano».
- Il box in Dashboard rimanda alla Regia (ultimi consigli in un `<details>`); il comando Telegram `/consigli` riceve i nuovi consigli via option condivisa (compatibilità mantenuta).

### Piano con data di inizio, piani sommabili
- Nuovo campo «A partire dal» (default oggi; date passate/malformate → oggi). Ogni piano è indipendente e **si somma** ai piani già programmati.
- **Guardia deterministica**: se l'AI assegna date fuori dalla finestra `[inizio, inizio+giorni)`, `enforce_schedule()` le ridistribuisce in sequenza dentro la finestra (una al giorno, con riciclo se le idee superano i giorni).

### Via il tetto giornaliero di bozze (era 3)
- **Ogni idea creata genera la sua bozza**: quelle programmate a oggi subito (fine run agente), le future nel giorno previsto. Il runner giornaliero ora processa **tutte** le idee in scadenza, a run brevi (budget 180s) auto-programmandosi ogni 2 minuti finché ce ne sono (pattern del warmer, adatto ad Aruba). Con pubblicazione automatica attiva, le bozze vengono pubblicate. Il contatore resta come statistica; il campo limite sparisce da Importazione massiva (option conservata, non più applicata).

### Limiti di guardia rimossi
- La card sparisce dalla Regia e il tetto di esecuzioni giornaliere non è più applicato (in conflitto con la nuova logica, come concordato): il **lock** continua a impedire esecuzioni sovrapposte. Option conservate per retrocompatibilità.

### Stato esecuzione + Ferma l'agente
- Stato ben visibile («⏳ AGENTE IN ESECUZIONE…», auto-refresh 15s) e pulsante **🛑 Ferma l'agente**: flag di cancel letto ai confini di ogni round del loop e prima di ogni bozza — il passo in corso si conclude, poi il run si interrompe pulitamente («Interrotto dall'amministratore» nel report). Le idee già create restano e le loro bozze arrivano nei giorni programmati.

### Problematiche ed eccezioni valutate
- Piani sovrapposti → più bozze lo stesso giorno: il runner le smaltisce in catena senza perderle.
- Data nel passato → normalizzata a oggi; stop richiesto senza run attivo → no-op; il flag cancel viene azzerato a ogni nuovo avvio e a fine run.
- Massimo 10 articoli per piano: limite strutturale del loop agente (12 round) — per piani più grandi si lanciano più piani con date successive.
- Interruzione a metà bozze: le idee restanti hanno data programmata, quindi il runner le completa comunque.

## Verifiche
- `php -l` OK su tutti i file modificati; il JS della dashboard usa event delegation, quindi la rimozione del pulsante non rompe nulla.
- Test standalone **11/11** su `sanitize_start_date` (futura/oggi/passata/vuota/malformata) e `enforce_schedule` (data in finestra intatta, riassegnazioni, overflow con riciclo, lista vuota).
- Bump versione `2.76.0` (feature → minor), CHANGELOG.md e README.md aggiornati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_