### PR TITLE
Etichetta "Scritto dall'Agente AI" negli elenchi articoli (v2.77.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.77.0 - 2026-07-06
+
+### Etichetta "Scritto dall'Agente AI" negli elenchi articoli
+- Negli elenchi articoli di WordPress (Tutti, Bozze, Pubblicati) i post generati dall'agente mostrano l'etichetta **🤖 Scritto dall'Agente AI** accanto al titolo (stato post standard di WordPress, come "Bozza" o "In evidenza"). Riconosce tutti i contenuti creati dal Draft Builder — piani della Regia, `/agente` da Telegram, idee programmate da CSV — tramite il meta `_alma_ai_agent_generated` già esistente (lo stesso usato dai pulsanti Pubblica/Cestina di Telegram).
+- Versione plugin aggiornata a `2.77.0`.
+
 ## 2.76.0 - 2026-07-06
 
 ### Regia AI v2: piano con data di inizio, consigli strategici accorpati, stop dell'agente, via il tetto bozze

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.77.0 - 2026-07-06
+
+### Etichetta "Scritto dall'Agente AI" negli elenchi articoli
+- I post generati dall'agente sono riconoscibili a colpo d'occhio in Bozze/Pubblicati/Tutti grazie all'etichetta 🤖 accanto al titolo.
+- Versione plugin aggiornata a `2.77.0`.
+
 ## 2.76.0 - 2026-07-06
 
 ### Regia AI v2

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.76.0
+ * Version: 2.77.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.76.0');
+define('ALMA_VERSION', '2.77.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-agent-control-room.php
+++ b/includes/class-ai-agent-control-room.php
@@ -25,6 +25,20 @@ class ALMA_AI_Agent_Control_Room {
 
     public static function init() {
         add_action('admin_post_alma_ai_regia_advice', array(__CLASS__, 'handle_advice'));
+        add_filter('display_post_states', array(__CLASS__, 'mark_agent_posts'), 10, 2);
+    }
+
+    /**
+     * Etichetta accanto al titolo negli elenchi articoli (Bozze,
+     * Pubblicati, Tutti): rende riconoscibili a colpo d'occhio i post
+     * scritti dall'agente AI (meta impostato dal Draft Builder, lo stesso
+     * usato dai pulsanti Pubblica/Cestina di Telegram).
+     */
+    public static function mark_agent_posts($states, $post) {
+        if ($post instanceof WP_Post && $post->post_type === 'post' && get_post_meta($post->ID, '_alma_ai_agent_generated', true)) {
+            $states['alma_ai_agent'] = __('🤖 Scritto dall\'Agente AI', 'affiliate-link-manager-ai');
+        }
+        return $states;
     }
 
     /* ---------------------------------------------------------------------


### PR DESCRIPTION
## Cosa cambia (v2.77.0)

- Negli elenchi articoli di WordPress (**Tutti, Bozze, Pubblicati**) i post generati dall'agente mostrano l'etichetta **🤖 Scritto dall'Agente AI** accanto al titolo, come stato post standard di WordPress (stesso meccanismo di "Bozza" o "In evidenza").
- Riconosce tutti i contenuti creati dal Draft Builder — piani della Regia, `/agente` da Telegram, idee programmate da CSV — tramite il meta `_alma_ai_agent_generated` già esistente (lo stesso usato dai pulsanti Pubblica/Cestina di Telegram): nessuna migrazione necessaria, l'etichetta compare anche sui post già generati.

## Verifiche
- `php -l` OK; filtro `display_post_states` limitato a `post_type === 'post'`; la meta cache degli elenchi è già primata da WordPress (nessuna query aggiuntiva per riga).
- Bump versione `2.77.0` (feature → minor), CHANGELOG.md e README.md aggiornati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_