### PR TITLE
Vista "Articoli AI" nell'elenco articoli + verifica tracking post-bonifica (v2.78.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.78.0 - 2026-07-06
+
+### Vista "Articoli AI" nell'elenco articoli + verifica tracking post-bonifica
+- **Nuova vista "🤖 Articoli AI"** accanto a Tutti | Pubblicati | Bozze negli elenchi articoli, con conteggio: un click filtra l'elenco ai soli post scritti dall'agente (meta `_alma_ai_agent_generated`). Combinabile con gli altri filtri standard (stato, data, categoria).
+- **Verifica documentata: il conteggio click resta pienamente attivo dopo le bonifiche degli URL.** Il tracking è agganciato all'ID del Link Affiliato (`data-link-id` nel markup → `link_id` nell'endpoint AJAX), mai all'URL: cambiare `_affiliate_url` (bonifica tpx.li, conversione dominio .it) non tocca né il contatore `_click_count` né la tabella analytics. La cache del widget contestuale conserva gli ID e viene comunque invalidata a ogni bonifica.
+- Versione plugin aggiornata a `2.78.0`.
+
 ## 2.77.0 - 2026-07-06
 
 ### Etichetta "Scritto dall'Agente AI" negli elenchi articoli

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.78.0 - 2026-07-06
+
+### Vista "Articoli AI" nell'elenco articoli
+- Nuova vista con conteggio accanto a Tutti | Pubblicati | Bozze per filtrare i soli post scritti dall'agente; verificato che il tracking click è indipendente dagli URL bonificati (aggancio per ID link).
+- Versione plugin aggiornata a `2.78.0`.
+
 ## 2.77.0 - 2026-07-06
 
 ### Etichetta "Scritto dall'Agente AI" negli elenchi articoli

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.77.0
+ * Version: 2.78.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.77.0');
+define('ALMA_VERSION', '2.78.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-agent-control-room.php
+++ b/includes/class-ai-agent-control-room.php
@@ -26,6 +26,8 @@ class ALMA_AI_Agent_Control_Room {
     public static function init() {
         add_action('admin_post_alma_ai_regia_advice', array(__CLASS__, 'handle_advice'));
         add_filter('display_post_states', array(__CLASS__, 'mark_agent_posts'), 10, 2);
+        add_filter('views_edit-post', array(__CLASS__, 'add_ai_posts_view'));
+        add_action('pre_get_posts', array(__CLASS__, 'filter_ai_posts_query'));
     }
 
     /**
@@ -39,6 +41,35 @@ class ALMA_AI_Agent_Control_Room {
             $states['alma_ai_agent'] = __('🤖 Scritto dall\'Agente AI', 'affiliate-link-manager-ai');
         }
         return $states;
+    }
+
+    /**
+     * Vista "Articoli AI" accanto a Tutti | Pubblicati | Bozze: filtra
+     * l'elenco ai soli post scritti dall'agente.
+     */
+    public static function add_ai_posts_view($views) {
+        global $wpdb;
+        $count = (int) $wpdb->get_var(
+            "SELECT COUNT(DISTINCT pm.post_id) FROM {$wpdb->postmeta} pm
+             INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+             WHERE pm.meta_key = '_alma_ai_agent_generated' AND pm.meta_value = '1'
+               AND p.post_type = 'post' AND p.post_status NOT IN ('trash', 'auto-draft')"
+        );
+        $current = !empty($_GET['alma_ai_agent']);
+        $views['alma_ai_agent'] = '<a href="' . esc_url(admin_url('edit.php?post_type=post&alma_ai_agent=1')) . '"' . ($current ? ' class="current" aria-current="page"' : '') . '>🤖 ' . esc_html__('Articoli AI', 'affiliate-link-manager-ai') . ' <span class="count">(' . (int) $count . ')</span></a>';
+        return $views;
+    }
+
+    public static function filter_ai_posts_query($query) {
+        if (!is_admin() || !$query->is_main_query() || empty($_GET['alma_ai_agent'])) {
+            return;
+        }
+        if (($query->get('post_type') ?: 'post') !== 'post') {
+            return;
+        }
+        $meta_query = (array) $query->get('meta_query');
+        $meta_query[] = array('key' => '_alma_ai_agent_generated', 'value' => '1');
+        $query->set('meta_query', $meta_query);
     }
 
     /* ---------------------------------------------------------------------


### PR DESCRIPTION
## Cosa cambia (v2.78.0)

### Vista "🤖 Articoli AI"
- Nuova vista con conteggio accanto a **Tutti | Pubblicati | Bozze** negli elenchi articoli: un click filtra ai soli post scritti dall'agente (meta `_alma_ai_agent_generated`). Combinabile con i filtri standard (stato, data, categoria). Implementata con `views_edit-post` + `pre_get_posts` sulla main query admin.

### Verifica: il conteggio click resta pienamente attivo dopo le bonifiche degli URL
- Il tracking è agganciato all'**ID del Link Affiliato**, mai all'URL: il markup pubblica `data-link-id`, il JS invia `link_id` all'endpoint AJAX, il server verifica il post e incrementa `_click_count` + tabella analytics. Cambiare `_affiliate_url` (bonifica tpx.li, conversione dominio `.it`) non tocca nulla del tracking; la cache del widget contestuale conserva gli ID e viene comunque invalidata a ogni bonifica.

## Verifiche
- `php -l` OK su `includes/class-ai-agent-control-room.php` e `affiliate-link-manager-ai.php`.
- Bump versione `2.78.0` (feature → minor), CHANGELOG.md e README.md aggiornati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_