### PR TITLE
Import CSV GetYourGuide: recupero righe a delimitatore misto (v2.79.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.79.1 - 2026-07-07
+
+### Import CSV GetYourGuide: recupero delle righe a delimitatore misto
+- **Caso reale (File_3.csv)**: un CSV con 583 righe dati conteneva 188 righe con **delimitatore virgola** incollate dentro un file a punto e virgola (blocchi provenienti da esportazioni diverse) più 3 righe vuote. Lette col delimitatore del file, le righe a virgola collassavano in una sola cella e venivano scartate come "URL non valido" — **188 record validi persi silenziosamente**.
+- **Nuovo recupero per riga** (`recover_mixed_delimiter_row`, puro e testato): se una riga ha una sola cella piena che contiene l'altro delimitatore e un URL, viene ri-divisa; le eventuali virgole eccedenti (dentro la descrizione non quotata) vengono ricompattate nella colonna descrizione preservando il titolo. Applicato a tutti i punti di lettura: riepilogo upload, anteprima, conteggi e import batch. Le righe normali, vuote o senza URL restano intatte.
+- **Verifica completa dell'importazione simulata sul file reale**: colonne rilevate per nome con la colonna extra "File origine" correttamente ignorata; con il fix **583/583 righe importabili** (prima 395), 0 URL invalidi, 0 senza descrizione/città/regione/titolo, 0 duplicati interni; link affiliato costruito correttamente (`www.getyourguide.it/...?partner_id=...&utm_medium=online_publisher`). Confermati i feedback di processo già presenti: conteggi per esito (importati/aggiornati/già presenti/saltati/URL invalidi), log per record scartato con external_id, stato sessione persistito con ultimo errore, batch con cursore ripristinabile.
+- Test standalone 10/10 (riga reale ricostruita, virgole nella descrizione ricompattate senza doppi spazi, titolo preservato, righe normali/vuote/note senza URL intatte).
+- Versione plugin aggiornata a `2.79.1`.
+
 ## 2.79.0 - 2026-07-06
 
 ### Link Health Checker (PR 1): verifica 404 e prodotti rimossi, con quarantena

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.79.1 - 2026-07-07
+
+### Import CSV GetYourGuide: recupero righe a delimitatore misto
+- Le righe con delimitatore diverso dal resto del file (virgole in un CSV a punto e virgola) non vengono più scartate: recupero automatico per riga con ricompattazione delle virgole nella descrizione. Verificato sul file reale: 583/583 righe importabili (prima 395).
+- Versione plugin aggiornata a `2.79.1`.
+
 ## 2.79.0 - 2026-07-06
 
 ### Link Health Checker (PR 1)

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.79.0
+ * Version: 2.79.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.79.0');
+define('ALMA_VERSION', '2.79.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-affiliate-source-gyg-csv-importer.php
+++ b/includes/class-affiliate-source-gyg-csv-importer.php
@@ -414,6 +414,54 @@ class ALMA_Affiliate_Source_GYG_CSV_Importer {
         return substr_count($line, ';') > substr_count($line, ',') ? ';' : ',';
     }
 
+    /**
+     * Recupero delle righe a delimitatore misto: le esportazioni reali a
+     * volte incollano blocchi con delimitatore diverso dal resto del file
+     * (righe a virgola in un CSV a punto e virgola). Letta col delimitatore
+     * del file, una riga così collassa in una sola cella e verrebbe
+     * scartata come "URL non valido" pur essendo valida. Se la riga ha una
+     * sola cella piena che contiene l'altro delimitatore e un URL, viene
+     * ri-divisa; le eventuali virgole eccedenti (dentro la descrizione)
+     * vengono ricompattate nella penultima colonna. Pura, testabile.
+     */
+    public static function recover_mixed_delimiter_row($row, $delimiter, $expected_columns) {
+        $non_empty = 0;
+        foreach ((array)$row as $cell) {
+            if (trim((string)$cell) !== '') { $non_empty++; }
+        }
+        if ($non_empty > 1) { return $row; }
+        $first = trim((string)($row[0] ?? ''));
+        $alt = $delimiter === ';' ? ',' : ';';
+        if ($first === '' || strpos($first, $alt) === false || stripos($first, 'http') === false) {
+            return $row;
+        }
+        $parts = str_getcsv($first, $alt);
+        $expected_columns = max(3, (int)$expected_columns);
+        if (count($parts) > $expected_columns) {
+            // Delimitatori extra quasi sempre dentro la descrizione
+            // (penultima colonna): l'ultima colonna è il titolo, il centro
+            // eccedente torna nella descrizione.
+            $title = (string) array_pop($parts);
+            $head = array_slice($parts, 0, $expected_columns - 2);
+            $description = implode($alt . ' ', array_map('trim', array_slice($parts, $expected_columns - 2)));
+            $parts = array_merge($head, array($description, $title));
+        }
+        $last = count($parts) - 1;
+        if ($last >= 0) {
+            // Coda di delimitatori originali rimasta attaccata (riga mista).
+            $parts[$last] = rtrim((string)$parts[$last], $delimiter);
+        }
+        return array_map('strval', $parts);
+    }
+
+    /**
+     * Numero di colonne atteso dal mapping (indice massimo + 1).
+     */
+    private static function expected_columns_from_mapping($columns) {
+        $columns = array_map('absint', (array)$columns);
+        return empty($columns) ? 0 : (max($columns) + 1);
+    }
+
 
     public function get_column_example($path, $column_index) {
         $column_index = absint($column_index);
@@ -437,7 +485,9 @@ class ALMA_Affiliate_Source_GYG_CSV_Importer {
         $summary = array('types'=>array(), 'total'=>0, 'invalid_urls'=>0, 'without_city'=>0, 'without_region'=>0);
         $handle = fopen($path, 'r'); if (!$handle) return $summary;
         $delimiter = $this->delimiter($path); fgetcsv($handle, 0, $delimiter);
+        $expected = self::expected_columns_from_mapping($columns);
         while (($row = fgetcsv($handle, 0, $delimiter)) !== false) {
+            $row = self::recover_mixed_delimiter_row($row, $delimiter, $expected);
             $summary['total']++;
             $type = sanitize_text_field((string)($row[$columns['activity_type']] ?? ''));
             if ($type === '') $type = __('(vuota)', 'affiliate-link-manager-ai');
@@ -562,7 +612,9 @@ class ALMA_Affiliate_Source_GYG_CSV_Importer {
         $region_filter = strtolower(sanitize_text_field((string)($filters['region'] ?? '')));
         $search = strtolower(sanitize_text_field((string)($filters['search'] ?? '')));
         $show_existing = !empty($filters['show_existing']);
+        $expected = self::expected_columns_from_mapping($columns);
         while (($row = fgetcsv($handle, 0, $delimiter)) !== false) {
+            $row = self::recover_mixed_delimiter_row($row, $delimiter, $expected);
             $item = $this->row_to_item($row, $columns, $source, $partner_id, $utm);
             if ($activity_type !== '' && $item['activity_type'] !== $activity_type) continue;
             if ($city_filter !== '' && strpos(strtolower($item['city']), $city_filter) === false) continue;
@@ -731,10 +783,12 @@ class ALMA_Affiliate_Source_GYG_CSV_Importer {
         $activity_type = sanitize_text_field((string)$activity_type);
         $delimiter = $this->delimiter($path);
         fgetcsv($handle, 0, $delimiter);
+        $expected = self::expected_columns_from_mapping($columns);
         while (($row = fgetcsv($handle, 0, $delimiter)) !== false) {
             if ($this->is_empty_csv_row($row)) {
                 continue;
             }
+            $row = self::recover_mixed_delimiter_row($row, $delimiter, $expected);
             $item = $this->row_to_item($row, $columns, $source_for_count, $partner_id, $utm);
             if ($activity_type !== '' && $item['activity_type'] !== $activity_type) {
                 continue;
@@ -832,8 +886,10 @@ class ALMA_Affiliate_Source_GYG_CSV_Importer {
         $delimiter = $this->delimiter($path);
         fgetcsv($handle, 0, $delimiter);
         $matched_index = 0;
+        $expected = self::expected_columns_from_mapping($columns);
         while (($row = fgetcsv($handle, 0, $delimiter)) !== false) {
             if ($this->is_empty_csv_row($row)) continue;
+            $row = self::recover_mixed_delimiter_row($row, $delimiter, $expected);
             $item = $this->row_to_item($row, $columns, $source, $partner_id, $utm);
             if ($activity_type !== '' && $item['activity_type'] !== $activity_type) continue;
             if ($matched_index++ < $cursor) continue;


### PR DESCRIPTION
## Contesto: verifica del File_3.csv reale (587 righe) prima dell'import

Simulazione completa dell'importazione con le funzioni reali del plugin. Esiti:

- **Colonne compatibili** ✅: mappatura per **nome** con alias — la colonna extra "File origine" in prima posizione viene **ignorata** senza effetti; le obbligatorie (Url, Tipologia, Descrizione) rilevate correttamente.
- **Link affiliato costruito correttamente** ✅: `https://www.getyourguide.it/…-t132309/?partner_id=88HSYUH&utm_medium=online_publisher` (dominio ufficiale + partner_id, v2.74.0).
- **Feedback e gestione errori** ✅ (già presenti): conteggi per esito (importati/aggiornati/già presenti/saltati/URL invalidi/senza descrizione), log per record scartato con external_id, stato sessione persistito con ultimo errore, batch con cursore ripristinabile, deduplica per external_id e URL.
- **Bug trovato** ❌→✅: il file è a **delimitatori misti** — 188 righe usano la virgola dentro un CSV a punto e virgola (blocchi da esportazioni diverse) + 3 righe vuote. Lette col delimitatore del file collassavano in una cella e venivano **scartate come "URL non valido"**: 188 record validi persi silenziosamente.

## Fix (v2.79.1)

- Nuovo **`recover_mixed_delimiter_row()`** (puro): se una riga ha una sola cella piena che contiene l'altro delimitatore e un URL, viene ri-divisa; le virgole eccedenti (descrizione non quotata) vengono **ricompattate nella descrizione** preservando il titolo (ultima colonna). Righe normali, vuote o note senza URL restano intatte.
- Applicato a tutti i punti di lettura: riepilogo upload, anteprima, conteggi pre-import e import batch.

## Verifiche
- `php -l` OK. Test standalone **10/10** (riga reale ricostruita in 7 colonne, URL/città/titolo ai posti giusti, virgole nella descrizione ricompattate senza doppi spazi, righe normali/vuote intatte).
- **Simulazione sul file reale dopo il fix: 583/583 righe importabili** (prima 395), 0 URL invalidi, 0 senza descrizione/città/regione/titolo, 0 duplicati interni. 20 tipologie attività pronte per il mapping.
- Bump versione `2.79.1` (bugfix → patch), CHANGELOG.md e README.md aggiornati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_