### PR TITLE
Tipologie universali: Assicurazioni/eSIM valide per qualsiasi articolo (v2.80.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.80.0 - 2026-07-07
+
+### Tipologie universali: Assicurazioni, eSIM e simili valide per qualsiasi articolo
+- **Nuovo flag "Tipologia universale"** sui termini di Tipologie Link (checkbox in creazione/modifica + colonna 🌍 nell'elenco): i link della tipologia lo ereditano automaticamente, nessuna migrazione. Da spuntare su Assicurazioni, eSim e future tipologie senza geolocalizzazione.
+- **Widget contestuale — slot universale**: i link universali sono **esenti dalla dominanza geografica** (prima venivano scartati sugli articoli localizzati) e ricevono un bonus di compatibilità neutro-positivo; nei risultati entra però **al massimo 1 link universale** (le esperienze locali restano protagoniste), con **rotazione giornaliera deterministica** tra gli universali quasi a pari punteggio per non mostrare sempre la stessa assicurazione ovunque. `MATCHER_VERSION` a 8 (cache rigenerata; anche al salvataggio del flag).
+- **Nuove bozze AI**: il miglior link universale (per click, vivo) viene sempre aggiunto ai candidati di ogni bozza, marcato con la motivazione "Tipologia universale"; le **regole di inserimento** istruiscono l'AI: massimo UN link universale per articolo, nel punto più naturale (consigli pratici o prima della conclusione), e solo se pertinente.
+- **Auto-indexer geo**: i link di tipologie universali vengono saltati (stato "universal", niente geocoding a vuoto) e la colonna Geo mostra "🌍 Universale" invece del falso "—".
+- Test standalone 8/8 (esenzione dalla dominanza, universale che non attiva la dominanza altrui, slot max 1, rotazione col giorno solo tra quasi-migliori, lista senza universali invariata, slot 0).
+- Versione plugin aggiornata a `2.80.0`.
+
 ## 2.79.1 - 2026-07-07
 
 ### Import CSV GetYourGuide: recupero delle righe a delimitatore misto

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.80.0 - 2026-07-07
+
+### Tipologie universali (Assicurazioni, eSIM…)
+- Flag sulla tipologia: link validi per qualsiasi articolo — esenti dai filtri geografici, slot dedicato nel widget contestuale (max 1, con rotazione giornaliera), sempre candidati nelle nuove bozze AI, esclusi dall'indicizzazione geografica.
+- Versione plugin aggiornata a `2.80.0`.
+
 ## 2.79.1 - 2026-07-07
 
 ### Import CSV GetYourGuide: recupero righe a delimitatore misto

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.79.1
+ * Version: 2.80.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.79.1');
+define('ALMA_VERSION', '2.80.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -65,6 +65,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-ai-post-enricher.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-gsc-connector.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-link-auditor.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-link-health-checker.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-universal-link-types.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-google-trends.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-facts.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-url-validator.php';
@@ -177,6 +178,7 @@ class AffiliateManagerAI {
         ALMA_GSC_Connector::init();
         ALMA_Affiliate_Link_Auditor::init();
         ALMA_Link_Health_Checker::init();
+        ALMA_Universal_Link_Types::init();
         ALMA_Geo_Facts::init();
         add_action('init', array($this, 'init'));
         add_action('widgets_init', array('ALMA_Contextual_Affiliate_Widget', 'register_widget'));

--- a/includes/class-ai-content-agent-idea-importer.php
+++ b/includes/class-ai-content-agent-idea-importer.php
@@ -477,6 +477,30 @@ class ALMA_AI_Content_Agent_Idea_Importer {
         if (class_exists('ALMA_Link_Health_Checker')) {
             $candidates = ALMA_Link_Health_Checker::filter_live_candidates($candidates);
         }
+        // Candidato universale: il miglior link di tipologia universale
+        // (assicurazioni, eSIM…) è sempre disponibile all'AI, per qualsiasi
+        // destinazione — deciderà lei se e dove inserirlo (max 1 per
+        // articolo, come da regole di inserimento).
+        if (class_exists('ALMA_Universal_Link_Types')) {
+            $existing_ids = array();
+            foreach ($candidates as $candidate) { $existing_ids[] = absint($candidate['source_id'] ?? 0); }
+            foreach (ALMA_Universal_Link_Types::top_universal_links(1, $existing_ids) as $universal_id) {
+                $term_labels = array();
+                $terms = get_the_terms($universal_id, 'link_type');
+                if (!is_wp_error($terms) && !empty($terms)) {
+                    foreach ($terms as $term) { $term_labels[] = $term->name; }
+                }
+                $candidates[] = array(
+                    'source_id' => (int) $universal_id,
+                    'title' => html_entity_decode(get_the_title($universal_id), ENT_QUOTES, 'UTF-8'),
+                    'link_types' => implode(', ', $term_labels),
+                    'score' => 1,
+                    'reason' => __('Tipologia universale: valido per qualsiasi articolo (inserire solo se naturale, max 1).', 'affiliate-link-manager-ai'),
+                    'selected' => true,
+                    'universal' => true,
+                );
+            }
+        }
         if (empty($candidates)) {
             update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_EXECUTED_AT, current_time('mysql'));
             return array('success' => false, 'error' => 'Nessun link affiliato candidato per l\'idea #' . $idea_id);

--- a/includes/class-ai-insertion-rules.php
+++ b/includes/class-ai-insertion-rules.php
@@ -90,6 +90,7 @@ class ALMA_AI_Insertion_Rules {
         $lines[] = '- massimo 1 inserimento ogni ' . $rules['density_words'] . ' parole di contenuto;';
         $lines[] = '- nessun inserimento nei primi ' . $rules['min_paragraphs_before'] . ' paragrafi (l\'introduzione crea fiducia, non vende);';
         $lines[] = '- mai due shortcode consecutivi senza testo tra loro; distribuisci gli inserimenti lungo l\'articolo;';
+        $lines[] = '- se tra i link selezionati ce n\'è uno di TIPOLOGIA UNIVERSALE (assicurazione viaggio, eSIM…): puoi inserirne al massimo UNO per articolo, nel punto più naturale (sezione consigli pratici o prima della conclusione), come anchor o bottone; se non è pertinente al taglio dell\'articolo, non inserirlo;';
         $lines[] = '- l\'eleganza della lettura viene prima della conversione: se un inserimento non è naturale, non farlo.';
         return $lines;
     }

--- a/includes/class-contextual-affiliate-matcher.php
+++ b/includes/class-contextual-affiliate-matcher.php
@@ -18,11 +18,17 @@ class ALMA_Contextual_Affiliate_Matcher {
     const MAX_POOL_SIZE = 300;
     // Inclusa nell'hash della cache del widget: cambiarla invalida i risultati
     // calcolati con versioni precedenti dell'algoritmo.
-    const MATCHER_VERSION = 7;
+    const MATCHER_VERSION = 8;
     // Sopra questa soglia il segnale geografico è "locale" (stessa città,
     // contenimento paese/regione o stessa regione): quando almeno un
     // risultato è locale, quelli senza segnale locale vengono scartati.
     const GEO_DOMINANCE_THRESHOLD = 20;
+    // Bonus di compatibilità dei link di tipologia UNIVERSALE (assicurazioni,
+    // eSIM…): neutro-positivo, competono con le keyword ovunque.
+    const UNIVERSAL_GEO_SCORE = 15;
+    // Nel widget al massimo 1 link universale: le esperienze locali restano
+    // protagoniste, l'universale è il complemento.
+    const MAX_UNIVERSAL_RESULTS = 1;
 
     private $settings;
     private $geo_store = null;
@@ -81,8 +87,11 @@ class ALMA_Contextual_Affiliate_Matcher {
         $results = array();
         $min_score = max(0, min(100, absint($settings['min_score'])));
         foreach ($profiles as $profile) {
+            $universal = class_exists('ALMA_Universal_Link_Types') && ALMA_Universal_Link_Types::is_universal_link($profile['id']);
             $link_locations = $geo_map[$profile['id']] ?? array();
-            $geo = $this->geo_score($signals['locations'], $link_locations);
+            // Tipologia universale: nessuna località per definizione, riceve
+            // un bonus di compatibilità neutro invece del punteggio geo.
+            $geo = $universal ? self::UNIVERSAL_GEO_SCORE : $this->geo_score($signals['locations'], $link_locations);
             $score = $this->score_profile($profile, $signals, $df, $pool_size, $geo);
             if ($score < $min_score) {
                 continue;
@@ -91,6 +100,7 @@ class ALMA_Contextual_Affiliate_Matcher {
                 'id' => $profile['id'],
                 'score' => $score,
                 'geo' => $geo,
+                'universal' => $universal,
                 'click_count' => $profile['click_count'],
                 'title' => $profile['display_title'],
                 'affiliate_url' => $profile['affiliate_url'],
@@ -101,11 +111,14 @@ class ALMA_Contextual_Affiliate_Matcher {
         // Dominanza geografica: su un articolo localizzato (es. Cefalù), se
         // esistono risultati locali non devono comparire link di altre zone
         // saliti solo con keyword generiche ("tour", "centro storico"…).
+        // I link universali sono esenti (validi ovunque per definizione).
         $results = self::apply_geo_dominance($results, self::GEO_DOMINANCE_THRESHOLD);
 
         usort($results, array($this, 'sort_results'));
 
-        return array_slice($results, 0, max(1, absint($settings['max_links'])));
+        // Slot universale: al massimo 1 nei risultati, con rotazione
+        // giornaliera tra gli universali quasi a pari punteggio.
+        return self::apply_universal_slot($results, max(1, absint($settings['max_links'])), (int) current_time('z'), self::MAX_UNIVERSAL_RESULTS);
     }
 
     public function extract_post_signals($post) {
@@ -355,14 +368,48 @@ class ALMA_Contextual_Affiliate_Matcher {
     public static function apply_geo_dominance($results, $threshold = self::GEO_DOMINANCE_THRESHOLD) {
         $best_geo = 0;
         foreach ((array) $results as $result) {
+            if (!empty($result['universal'])) { continue; }
             $best_geo = max($best_geo, (int) ($result['geo'] ?? 0));
         }
         if ($best_geo < $threshold) {
             return $results;
         }
         return array_values(array_filter((array) $results, function ($result) use ($threshold) {
-            return (int) ($result['geo'] ?? 0) >= $threshold;
+            return !empty($result['universal']) || (int) ($result['geo'] ?? 0) >= $threshold;
         }));
+    }
+
+    /**
+     * Slot universale: nei primi $max_links risultati possono entrare al
+     * massimo $max_universal link di tipologie universali. Tra gli
+     * universali quasi a pari punteggio (entro 5 punti dal migliore) si
+     * ruota in modo deterministico col giorno dell'anno, per non mostrare
+     * sempre la stessa assicurazione ovunque. Pura, testabile.
+     */
+    public static function apply_universal_slot($results, $max_links, $day_seed = 0, $max_universal = self::MAX_UNIVERSAL_RESULTS) {
+        $results = array_values((array) $results);
+        $universal_indexes = array();
+        foreach ($results as $i => $result) {
+            if (!empty($result['universal'])) { $universal_indexes[] = $i; }
+        }
+        if (count($universal_indexes) > $max_universal && $max_universal >= 1) {
+            // Rotazione tra i quasi-migliori.
+            $best_score = (int) $results[$universal_indexes[0]]['score'];
+            $near_best = array();
+            foreach ($universal_indexes as $i) {
+                if ((int) $results[$i]['score'] >= $best_score - 5) { $near_best[] = $i; }
+            }
+            $chosen = $near_best[absint($day_seed) % count($near_best)];
+            $keep = array_slice(array_merge(array($chosen), array_values(array_diff($universal_indexes, array($chosen)))), 0, $max_universal);
+            foreach ($universal_indexes as $i) {
+                if (!in_array($i, $keep, true)) { unset($results[$i]); }
+            }
+            $results = array_values($results);
+        } elseif ($max_universal < 1 && !empty($universal_indexes)) {
+            foreach ($universal_indexes as $i) { unset($results[$i]); }
+            $results = array_values($results);
+        }
+        return array_slice($results, 0, max(1, absint($max_links)));
     }
 
     private function score_profile($profile, $signals, $df, $pool_size, $geo_score) {

--- a/includes/class-geo-auto-indexer.php
+++ b/includes/class-geo-auto-indexer.php
@@ -224,6 +224,14 @@ class ALMA_Geo_Auto_Indexer {
             return array('outcome' => 'auto_applied', 'method' => 'already_indexed', 'location_label' => '');
         }
 
+        // Tipologie universali (assicurazioni, eSIM…): per definizione senza
+        // geolocalizzazione — niente tentativi di indicizzazione né
+        // geocoding a vuoto, e nessun falso "senza località".
+        if ($post->post_type === 'affiliate_link' && class_exists('ALMA_Universal_Link_Types') && ALMA_Universal_Link_Types::is_universal_link($post->ID)) {
+            update_post_meta($post->ID, self::STATUS_META, 'universal');
+            return array('outcome' => 'auto_applied', 'method' => 'universal_type', 'location_label' => '');
+        }
+
         // Livello 1: meta strutturati del provider (solo link affiliati).
         if ($post->post_type === 'affiliate_link') {
             $provider_locations = $this->locations_from_provider_meta($post->ID);
@@ -678,7 +686,9 @@ class ALMA_Geo_Auto_Indexer {
             return;
         }
         $status = get_post_meta($post_id, self::STATUS_META, true);
-        if ($status === 'suggested') {
+        if ($status === 'universal') {
+            echo '<span title="' . esc_attr__('Tipologia universale: valido per qualsiasi articolo', 'affiliate-link-manager-ai') . '">🌍 ' . esc_html__('Universale', 'affiliate-link-manager-ai') . '</span>';
+        } elseif ($status === 'suggested') {
             echo '<span style="color:#996800;">' . esc_html__('In revisione', 'affiliate-link-manager-ai') . '</span>';
         } else {
             echo '<span style="color:#999;">—</span>';

--- a/includes/class-universal-link-types.php
+++ b/includes/class-universal-link-types.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Tipologie di link "universali" — valide per qualsiasi articolo.
+ *
+ * Alcune tipologie (Assicurazioni viaggio, eSIM, VPN, bagagli…) non hanno
+ * una geolocalizzazione precisa e il sistema geo-centrico le penalizzava:
+ * la dominanza geografica del widget le scartava, la selezione geo-first
+ * delle bozze non le sceglieva mai, e l'auto-indexer le contava tra i
+ * "senza località" come fossero errori.
+ *
+ * Soluzione: un flag sul TERMINE della tassonomia link_type (una spunta,
+ * tutti i link della tipologia la ereditano). Effetti:
+ * - widget contestuale: esenzione dalla dominanza geografica + bonus di
+ *   compatibilità neutro, con SLOT massimo di 1 link universale nei
+ *   risultati (le esperienze locali restano protagoniste) e rotazione
+ *   giornaliera tra gli universali quasi a pari punteggio;
+ * - nuove bozze AI: il miglior link universale viene sempre aggiunto ai
+ *   candidati (l'AI può inserire l'assicurazione/eSIM dove naturale);
+ * - auto-indexer geo: questi link vengono saltati (stato "universal"),
+ *   niente geocoding a vuoto né falsi "senza località".
+ */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALMA_Universal_Link_Types {
+    const TERM_META = 'alma_universal';
+
+    public static function init() {
+        add_action('link_type_add_form_fields', array(__CLASS__, 'render_add_field'));
+        add_action('link_type_edit_form_fields', array(__CLASS__, 'render_edit_field'), 10, 1);
+        add_action('created_link_type', array(__CLASS__, 'save_field'));
+        add_action('edited_link_type', array(__CLASS__, 'save_field'));
+        add_filter('manage_edit-link_type_columns', array(__CLASS__, 'add_column'));
+        add_filter('manage_link_type_custom_column', array(__CLASS__, 'render_column'), 10, 3);
+    }
+
+    /* ---------------------------------------------------------------------
+     * Interrogazioni
+     * ------------------------------------------------------------------ */
+
+    /**
+     * ID dei termini link_type marcati come universali (cache per richiesta).
+     */
+    public static function universal_term_ids() {
+        static $ids = null;
+        if ($ids !== null) { return $ids; }
+        $terms = get_terms(array(
+            'taxonomy' => 'link_type',
+            'hide_empty' => false,
+            'fields' => 'ids',
+            'meta_query' => array(array('key' => self::TERM_META, 'value' => '1')),
+        ));
+        $ids = is_wp_error($terms) ? array() : array_map('absint', (array) $terms);
+        return $ids;
+    }
+
+    /**
+     * Il link appartiene a una tipologia universale?
+     */
+    public static function is_universal_link($link_id) {
+        $universal = self::universal_term_ids();
+        if (empty($universal)) { return false; }
+        $terms = get_the_terms(absint($link_id), 'link_type');
+        if (is_wp_error($terms) || empty($terms)) { return false; }
+        foreach ($terms as $term) {
+            if (in_array((int) $term->term_id, $universal, true)) { return true; }
+        }
+        return false;
+    }
+
+    /**
+     * Migliori link universali pubblicati (per click), esclusi i morti e
+     * gli ID indicati: usati come candidato extra per le nuove bozze.
+     */
+    public static function top_universal_links($limit = 3, $exclude_ids = array()) {
+        $universal = self::universal_term_ids();
+        if (empty($universal)) { return array(); }
+        $ids = get_posts(array(
+            'post_type' => 'affiliate_link',
+            'post_status' => 'publish',
+            'posts_per_page' => max(1, absint($limit)) + count((array) $exclude_ids) + 5,
+            'fields' => 'ids',
+            'orderby' => 'meta_value_num',
+            'meta_key' => '_click_count',
+            'order' => 'DESC',
+            'no_found_rows' => true,
+            'tax_query' => array(array('taxonomy' => 'link_type', 'field' => 'term_id', 'terms' => $universal)),
+        ));
+        $out = array();
+        $exclude_ids = array_map('absint', (array) $exclude_ids);
+        foreach ((array) $ids as $id) {
+            $id = (int) $id;
+            if (in_array($id, $exclude_ids, true)) { continue; }
+            if (trim((string) get_post_meta($id, '_affiliate_url', true)) === '') { continue; }
+            if (class_exists('ALMA_Link_Health_Checker') && ALMA_Link_Health_Checker::is_dead($id)) { continue; }
+            $out[] = $id;
+            if (count($out) >= max(1, absint($limit))) { break; }
+        }
+        return $out;
+    }
+
+    /* ---------------------------------------------------------------------
+     * UI tassonomia
+     * ------------------------------------------------------------------ */
+
+    public static function render_add_field() {
+        echo '<div class="form-field">';
+        echo '<label><input type="checkbox" name="' . esc_attr(self::TERM_META) . '" value="1"> ' . esc_html__('Tipologia universale', 'affiliate-link-manager-ai') . '</label>';
+        echo '<p class="description">' . esc_html__('Link validi per qualsiasi articolo, senza geolocalizzazione (es. Assicurazioni, eSIM): esenti dai filtri geografici, con slot dedicato nel widget e candidati nelle nuove bozze AI.', 'affiliate-link-manager-ai') . '</p>';
+        echo '</div>';
+    }
+
+    public static function render_edit_field($term) {
+        $checked = get_term_meta($term->term_id, self::TERM_META, true) === '1';
+        echo '<tr class="form-field"><th scope="row">' . esc_html__('Tipologia universale', 'affiliate-link-manager-ai') . '</th><td>';
+        echo '<label><input type="checkbox" name="' . esc_attr(self::TERM_META) . '" value="1"' . checked($checked, true, false) . '> ' . esc_html__('Link validi per qualsiasi articolo, senza geolocalizzazione', 'affiliate-link-manager-ai') . '</label>';
+        echo '<p class="description">' . esc_html__('Es. Assicurazioni viaggio, eSIM, VPN: esenti dai filtri geografici, slot dedicato nel widget contestuale (max 1), sempre candidati nelle nuove bozze AI, esclusi dall\'indicizzazione geografica.', 'affiliate-link-manager-ai') . '</p>';
+        echo '</td></tr>';
+    }
+
+    public static function save_field($term_id) {
+        if (!current_user_can('manage_categories')) { return; }
+        if (!empty($_POST[self::TERM_META])) {
+            update_term_meta($term_id, self::TERM_META, '1');
+        } else {
+            delete_term_meta($term_id, self::TERM_META);
+        }
+        // Il widget contestuale deve rigenerare i risultati.
+        if (class_exists('ALMA_Contextual_Affiliate_Widget') && method_exists('ALMA_Contextual_Affiliate_Widget', 'bump_cache_version')) {
+            ALMA_Contextual_Affiliate_Widget::bump_cache_version();
+        }
+    }
+
+    public static function add_column($columns) {
+        $columns['alma_universal'] = __('Universale', 'affiliate-link-manager-ai');
+        return $columns;
+    }
+
+    public static function render_column($content, $column, $term_id) {
+        if ($column !== 'alma_universal') { return $content; }
+        return get_term_meta($term_id, self::TERM_META, true) === '1' ? '🌍 ' . esc_html__('Sì', 'affiliate-link-manager-ai') : '—';
+    }
+}


### PR DESCRIPTION
## Cosa cambia (v2.80.0)

Le tipologie senza geolocalizzazione (Assicurazioni viaggio, eSIM, VPN…) erano penalizzate dal sistema geo-centrico: la dominanza geografica del widget le scartava sugli articoli localizzati, la selezione geo-first delle bozze non le sceglieva mai, e l'auto-indexer le contava tra i "senza località".

### Flag "Tipologia universale" (nuova classe `ALMA_Universal_Link_Types`)
- Checkbox sul termine di **Tipologie Link** (schermate aggiungi/modifica + colonna 🌍 nell'elenco): tutti i link della tipologia ereditano il comportamento, **nessuna migrazione**. Da spuntare su Assicurazioni, eSim e simili.

### Widget contestuale: slot universale
- Universali **esenti dalla dominanza geografica** + bonus di compatibilità neutro-positivo (competono con le keyword) — ma **al massimo 1 nei risultati**: il mix tipico diventa "esperienze locali + 1 assicurazione".
- **Rotazione giornaliera deterministica** tra gli universali quasi a pari punteggio (entro 5 punti), per non mostrare sempre lo stesso link ovunque.
- Gli universali **non attivano** la dominanza per gli altri (un'assicurazione non fa scartare i link non-geo di un articolo generico). `MATCHER_VERSION` 8; cache invalidata anche al salvataggio del flag.

### Nuove bozze AI
- Il miglior link universale (per click, escluso se in quarantena Link Health) viene **sempre aggiunto ai candidati** di ogni bozza, marcato "Tipologia universale".
- Le **regole di inserimento** istruiscono l'AI: massimo UN link universale per articolo, nel punto più naturale (consigli pratici o prima della conclusione), e solo se pertinente al taglio.

### Auto-indexer geo
- Link universali **saltati** (stato `universal`: niente geocoding a vuoto, niente falsi "senza località"); colonna Geo: "🌍 Universale".

## Verifiche
- `php -l` OK su tutti i file modificati.
- Test standalone **8/8**: esenzione dalla dominanza, universale che non attiva la dominanza altrui, slot max 1 (seed 0 → migliore), rotazione col giorno (seed 1 → secondo quasi-migliore), rotazione solo entro 5 punti, lista senza universali invariata, slice max_links, slot 0 → esclusi.
- Bump versione `2.80.0` (feature → minor), CHANGELOG.md e README.md aggiornati.

## Dopo il merge
Spuntare "Tipologia universale" su **Assicurazioni** ed **eSim** in Affiliate Link AI → Tipologie Link: da lì in poi widget e agente li useranno su qualsiasi articolo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_