### PR TITLE
Salvataggio manuale link: difese redirect a priorità massima + diagnostica visibile (v2.80.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.80.1 - 2026-07-07
+
+### Salvataggio manuale dei Link Affiliati: difese rafforzate + diagnostica visibile
+- **Contesto**: segnalato un caso in cui, pubblicando un nuovo Link Affiliato, la pagina finiva sull'elenco articoli e il link risultava senza URL affiliato, senza tipologia e da ripubblicare. La firma dei dati (titolo salvato, tutto il resto no, stato bozza) indica che la richiesta di pubblicazione non è stata processata (solo l'autosave era andato a buon fine); nel codice del plugin nessun hook del flusso di salvataggio esegue redirect o exit.
+- **Difese rafforzate**: i filtri che riportano il salvataggio di un Link Affiliato sulla sua schermata di modifica (`redirect_post_location` e la guardia su `wp_redirect` contro i rimbalzi verso `edit.php`) passano da priorità 99 a **priorità massima**: nessun altro filtro può più scavalcarli.
+- **Diagnostica sempre attiva e visibile in admin**: gli eventi del flusso di salvataggio (marker, valutazioni dei filtri di redirect con destinazione finale, ricezione del salvataggio meta con validità del nonce) vengono ora registrati in un buffer (ultimi 40) **indipendente da WP_DEBUG e dall'error_log**, più una **fotografia di fine richiesta** per ogni editpost: stato del post, URL affiliato salvato sì/no, numero tipologie, handler eseguiti, header Location reale inviato al browser, presenza dei campi nel POST. Nuova card **"🧪 Diagnostica salvataggio link"** nella pagina Verifica link con gli eventi e il pulsante Svuota: per indagare basta svuotare, riprodurre il salvataggio e ricaricare.
+- Versione plugin aggiornata a `2.80.1`.
+
 ## 2.80.0 - 2026-07-07
 
 ### Tipologie universali: Assicurazioni, eSIM e simili valide per qualsiasi articolo

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.80.1 - 2026-07-07
+
+### Salvataggio manuale link: difese rafforzate + diagnostica visibile
+- Filtri anti-rimbalzo verso l'elenco a priorità massima; nuova card "Diagnostica salvataggio link" in Verifica link che registra ogni passaggio dei salvataggi manuali (destinazione reale, esito meta/tipologie, nonce) per individuare il colpevole alla prossima riproduzione.
+- Versione plugin aggiornata a `2.80.1`.
+
 ## 2.80.0 - 2026-07-07
 
 ### Tipologie universali (Assicurazioni, eSIM…)

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.80.0
+ * Version: 2.80.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.80.0');
+define('ALMA_VERSION', '2.80.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -568,8 +568,11 @@ class AffiliateManagerAI {
         add_action('save_post_affiliate_link', array($this, 'remember_affiliate_link_editor_save'), 1, 3);
         add_action('save_post_affiliate_link', array($this, 'save_link_meta'));
         add_action('admin_init', array($this, 'maybe_recover_affiliate_link_wrong_edit_redirect'), 1);
-        add_filter('redirect_post_location', array($this, 'normalize_affiliate_link_update_redirect'), 99, 2);
-        add_filter('wp_redirect', array($this, 'guard_affiliate_link_editpost_redirect'), 99, 2);
+        // Priorità massima: nessun altro filtro deve poter riportare il
+        // salvataggio di un Link Affiliato sull'elenco articoli.
+        add_filter('redirect_post_location', array($this, 'normalize_affiliate_link_update_redirect'), PHP_INT_MAX, 2);
+        add_filter('wp_redirect', array($this, 'guard_affiliate_link_editpost_redirect'), PHP_INT_MAX, 2);
+        add_action('shutdown', array($this, 'record_affiliate_link_editpost_shutdown'), 1);
         add_action('admin_post_alma_export_affiliate_links_csv', array($this, 'export_affiliate_links_csv'));
         
         // Colonne personalizzate nella lista
@@ -2046,7 +2049,60 @@ class AffiliateManagerAI {
         return false;
     }
 
+    /**
+     * Traccia visibile in admin degli eventi di salvataggio dei Link
+     * Affiliati (ring buffer in option, sempre attivo): una riproduzione
+     * del problema basta per leggere l'intera catena nella card
+     * "Diagnostica salvataggio" della pagina Verifica link.
+     */
+    public static function record_link_save_event($message, $context = array()) {
+        $events = get_option('alma_link_save_diag_events', array());
+        if (!is_array($events)) { $events = array(); }
+        $compact = array();
+        foreach ((array) $context as $key => $value) {
+            if (is_scalar($value) || $value === null) {
+                $compact[$key] = is_string($value) ? mb_substr($value, 0, 200) : $value;
+            }
+        }
+        array_unshift($events, array('time' => current_time('mysql'), 'message' => (string) $message, 'context' => $compact));
+        update_option('alma_link_save_diag_events', array_slice($events, 0, 40), false);
+    }
+
+    /**
+     * Fotografia di fine richiesta per gli editpost dei Link Affiliati:
+     * registra dove il browser è stato mandato davvero (header Location),
+     * lo stato del post e quanti handler di salvataggio sono girati —
+     * l'evidenza che serve quando un salvataggio "sparisce".
+     */
+    public function record_affiliate_link_editpost_shutdown() {
+        if (!is_admin() || (isset($_POST['action']) ? sanitize_key(wp_unslash($_POST['action'])) : '') !== 'editpost') {
+            return;
+        }
+        $post_id = isset($_POST['post_ID']) ? absint(wp_unslash($_POST['post_ID'])) : 0;
+        if (!$post_id || get_post_type($post_id) !== 'affiliate_link') {
+            return;
+        }
+        $location = '';
+        if (function_exists('headers_list')) {
+            foreach ((array) headers_list() as $header) {
+                if (stripos($header, 'Location:') === 0) { $location = trim(substr($header, 9)); }
+            }
+        }
+        self::record_link_save_event('Fine richiesta editpost (shutdown).', array(
+            'post_id' => $post_id,
+            'post_status' => (string) get_post_status($post_id),
+            'affiliate_url_salvato' => trim((string) get_post_meta($post_id, '_affiliate_url', true)) !== '' ? 'sì' : 'NO',
+            'tipologie_salvate' => count((array) wp_get_post_terms($post_id, 'link_type', array('fields' => 'ids'))),
+            'save_post_affiliate_link_eseguiti' => (int) did_action('save_post_affiliate_link'),
+            'header_location' => $location !== '' ? $location : '(nessuno)',
+            'nonce_link_presente' => isset($_POST['affiliate_link_nonce']) ? 'sì' : 'NO',
+            'campo_affiliate_url_in_post' => isset($_POST['affiliate_url']) ? 'sì' : 'NO',
+        ));
+    }
+
     private function log_affiliate_link_save_diagnostic($message, $context = array()) {
+        // Cattura sempre nel buffer visibile in admin (indipendente da WP_DEBUG).
+        self::record_link_save_event($message, $context);
         if (!$this->is_affiliate_link_save_diagnostic_enabled()) {
             return;
         }

--- a/includes/class-affiliate-link-auditor.php
+++ b/includes/class-affiliate-link-auditor.php
@@ -42,6 +42,14 @@ class ALMA_Affiliate_Link_Auditor {
         add_action('admin_post_alma_link_audit_fix', array(__CLASS__, 'handle_fix'));
         add_action('admin_post_alma_link_audit_retry', array(__CLASS__, 'handle_retry'));
         add_action('admin_post_alma_link_audit_domain', array(__CLASS__, 'handle_domain'));
+        add_action('admin_post_alma_link_audit_clear_diag', array(__CLASS__, 'handle_clear_diag'));
+    }
+
+    public static function handle_clear_diag() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_link_audit');
+        delete_option('alma_link_save_diag_events');
+        self::redirect_back('success', 'Diagnostica salvataggio azzerata: riproduci ora il problema e ricarica questa pagina.');
     }
 
     /* ---------------------------------------------------------------------
@@ -558,6 +566,28 @@ class ALMA_Affiliate_Link_Auditor {
         if (class_exists('ALMA_Link_Health_Checker')) {
             ALMA_Link_Health_Checker::render_card();
         }
+
+        // ---- Diagnostica salvataggio manuale ----
+        $diag_events = get_option('alma_link_save_diag_events', array());
+        echo '<div style="' . esc_attr($card) . '"><h2 style="margin-top:0;">🧪 Diagnostica salvataggio link (manuale)</h2>';
+        echo '<p class="description">Registra automaticamente ogni passaggio dei salvataggi manuali dei Link Affiliati (marker, filtri di redirect, fine richiesta con destinazione reale, esito del salvataggio di URL e tipologie). Per indagare un problema: <strong>Svuota</strong>, riproduci il salvataggio che fallisce, poi ricarica questa pagina e leggi gli eventi (il più recente in alto).</p>';
+        echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '" style="margin:0 0 10px;">';
+        wp_nonce_field('alma_link_audit');
+        echo '<input type="hidden" name="action" value="alma_link_audit_clear_diag"><button class="button">Svuota diagnostica</button></form>';
+        if (empty($diag_events) || !is_array($diag_events)) {
+            echo '<p class="description">Nessun evento registrato.</p>';
+        } else {
+            echo '<table class="widefat striped"><thead><tr><th style="width:140px;">Quando</th><th>Evento</th><th>Dettagli</th></tr></thead><tbody>';
+            foreach (array_slice($diag_events, 0, 25) as $event) {
+                $details = array();
+                foreach ((array) ($event['context'] ?? array()) as $key => $value) {
+                    $details[] = $key . '=' . (is_scalar($value) ? (string) $value : wp_json_encode($value));
+                }
+                echo '<tr><td>' . esc_html((string) ($event['time'] ?? '')) . '</td><td>' . esc_html((string) ($event['message'] ?? '')) . '</td><td style="word-break:break-all;"><code style="font-size:11px;">' . esc_html(implode(' · ', $details)) . '</code></td></tr>';
+            }
+            echo '</tbody></table>';
+        }
+        echo '</div>';
 
         // ---- Elenco link bonificabili ancora presenti ----
         foreach (self::programs() as $program) {


### PR DESCRIPTION
## Contesto

Segnalato: pubblicando un **nuovo Link Affiliato manuale**, la pagina finisce sull'elenco articoli e il link risulta **senza URL affiliato, senza tipologia e da ripubblicare**.

## Analisi

- La firma dei dati (titolo salvato, meta/tassonomia/stato no) è quella di una **richiesta di pubblicazione mai processata**: l'unica scrittura andata a buon fine è l'autosave (che per design non salva meta né tassonomie).
- Ho passato in rassegna tutti gli hook del plugin sul flusso di salvataggio (`save_post*`, `admin_init`, filtri di redirect): **nessuno esegue redirect o exit** durante un salvataggio; il sottosistema di difesa esistente (marker + `redirect_post_location` + guardia `wp_redirect` + recovery su `edit.php`) punta sempre all'editor del link.
- Senza una riproduzione strumentata non è possibile attribuire la colpa con certezza (potrebbe anche essere un plugin/tema terzo o un fallimento lato client): questa PR rafforza le difese e rende la diagnostica **visibile e sempre attiva**, così una sola riproduzione fornisce l'intera catena.

## Cosa cambia (v2.80.1)

- **Difese a priorità massima**: `redirect_post_location` e la guardia su `wp_redirect` passano da 99 a `PHP_INT_MAX` — nessun altro filtro può più riportare il salvataggio di un Link Affiliato verso `edit.php`.
- **Diagnostica sempre attiva** (indipendente da WP_DEBUG/error_log): gli eventi del flusso (marker, valutazioni dei filtri con destinazione finale, ricezione salvataggio meta con validità nonce) finiscono in un ring buffer in option (40 eventi), più una **fotografia di fine richiesta** per ogni `editpost` di Link Affiliato: stato post, URL affiliato salvato sì/no, numero tipologie, `save_post_affiliate_link` eseguiti, **header Location reale inviato al browser**, presenza di nonce e campi nel POST.
- **Card "🧪 Diagnostica salvataggio link"** nella pagina Verifica link: elenco eventi (più recente in alto) + pulsante Svuota.

## Procedura per l'utente dopo il merge

1. Verifica link → card Diagnostica → **Svuota diagnostica**.
2. Riproduci: crea un nuovo Link Affiliato manuale con URL e tipologia → Pubblica.
3. Ricarica Verifica link e leggi gli eventi (o incollali in chat): la riga "Fine richiesta editpost" dice esattamente cosa è stato salvato e dove è stato mandato il browser; se la riga **non compare**, la richiesta di pubblicazione non è mai arrivata a WordPress (problema a monte del plugin).

## Verifiche
- `php -l` OK; bump `2.80.1` (bugfix → patch), CHANGELOG.md e README.md aggiornati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_