### PR TITLE
Fix salvataggio manuale link: rimosso form annidato del retry immagine (v2.80.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.80.2 - 2026-07-07
+
+### Risolto il bug del salvataggio manuale dei Link Affiliati (causa trovata con la diagnostica 2.80.1)
+- **Causa individuata dai log della diagnostica**: la richiesta di pubblicazione arrivava a `post.php` con `action=alma_retry_affiliate_image` invece di `editpost`. Il colpevole era il pulsante **"Riprova import immagine"** nella metabox "Affiliate Source (tecnico)": era un `<form>` **annidato** dentro il form di modifica del post. I form annidati non sono validi in HTML: il browser scarta il tag interno e ne fonde i campi (incluso `action=alma_retry_affiliate_image`) nel form principale. Alla pubblicazione WordPress riceveva quindi un'azione sconosciuta: nessun salvataggio (URL affiliato, tipologie e stato di pubblicazione persi — restava solo l'autosave del titolo) e redirect di ripiego all'elenco articoli.
+- **Fix**: il form annidato è stato sostituito da **due link con nonce** verso `admin-post.php` ("Riprova import immagine" e "Riprova sovrascrivendo l'immagine esistente", quest'ultimo con conferma): nessun form dentro il form del post, il salvataggio del link non può più essere dirottato. Il comportamento del retry è invariato.
+- **Difese in profondità** (per eventuale markup vecchio ancora in cache dell'editor): l'handler del retry accetta ora sia GET sia POST e viene registrato anche su `admin_action_alma_retry_affiliate_image`, così una vecchia pagina che inviasse ancora il form fuso a `post.php` esegue comunque il retry e torna all'editor del link; la guardia sui redirect tratta inoltre `alma_retry_affiliate_image` come un salvataggio, riscrivendo ogni eventuale rimbalzo verso l'elenco.
+- Verificato che nessun'altra metabox del plugin renderizza `<form>` dentro la schermata di modifica dei post (tutti gli altri form sono in pagine admin autonome).
+- Versione plugin aggiornata a `2.80.2`.
+
 ## 2.80.1 - 2026-07-07
 
 ### Salvataggio manuale dei Link Affiliati: difese rafforzate + diagnostica visibile

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.80.2 - 2026-07-07
+
+### Risolto il bug del salvataggio manuale dei Link Affiliati
+- Causa trovata con la diagnostica 2.80.1: il pulsante "Riprova import immagine" nella metabox tecnica era un form annidato nel form del post e ne dirottava la pubblicazione (dati persi + redirect all'elenco). Sostituito con link con nonce; handler compatibile GET/POST e guardia estesa come difese per markup in cache.
+- Versione plugin aggiornata a `2.80.2`.
+
 ## 2.80.1 - 2026-07-07
 
 ### Salvataggio manuale link: difese rafforzate + diagnostica visibile

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.80.1
+ * Version: 2.80.2
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.80.1');
+define('ALMA_VERSION', '2.80.2');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -1943,7 +1943,10 @@ class AffiliateManagerAI {
         if ($this->is_affiliate_link_blocked_admin_action($request_action) || $this->is_affiliate_link_blocked_admin_action($request_action2)) {
             return 'blocked_action';
         }
-        if ($request_action !== 'editpost') {
+        // 'alma_retry_affiliate_image': se markup vecchio (form annidato) dirotta
+        // il form del post su questa azione, il redirect di fallback verso il
+        // plain edit.php va comunque riscritto verso l'editor del link.
+        if ($request_action !== 'editpost' && $request_action !== 'alma_retry_affiliate_image') {
             return 'not_editpost';
         }
         return '';

--- a/includes/class-affiliate-source-manager.php
+++ b/includes/class-affiliate-source-manager.php
@@ -26,6 +26,10 @@ class ALMA_Affiliate_Source_Manager {
         add_action('admin_post_alma_gyg_csv_download_session_file', array($this, 'handle_gyg_csv_download_session_file'));
         add_action(ALMA_Affiliate_Source_GYG_CSV_Import_Job_Service::CRON_HOOK, array($this, 'cron_run_gyg_csv_import_job_batch'));
         add_action('admin_post_alma_retry_affiliate_image', array($this, 'handle_single_image_retry'));
+        // Difesa: se markup vecchio (form annidato) finisce su post.php con
+        // action=alma_retry_affiliate_image, gestiamo comunque la richiesta
+        // invece di lasciare che WordPress reindirizzi all'elenco post.
+        add_action('admin_action_alma_retry_affiliate_image', array($this, 'handle_single_image_retry'));
         add_action('admin_notices', array($this, 'render_image_retry_notice'));
     }
     public static function create_tables() { global $wpdb; require_once ABSPATH.'wp-admin/includes/upgrade.php'; $c=$wpdb->get_charset_collate();
@@ -542,18 +546,26 @@ class ALMA_Affiliate_Source_Manager {
         echo '<p><strong>'.esc_html__('Hash immagine:','affiliate-link-manager-ai').'</strong> '.esc_html($hash?substr((string)$hash,0,16).'…':'—').'</p>';
         if($attachment_id>0 && current_user_can('edit_post',$attachment_id)){ $media_url=get_edit_post_link($attachment_id,''); if($media_url) echo '<p><a class="button button-small" href="'.esc_url($media_url).'">'.esc_html__('Apri immagine in Media Library','affiliate-link-manager-ai').'</a></p>'; }
         if(current_user_can('edit_post',$post_id)){
-            echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'; wp_nonce_field('alma_retry_affiliate_image_'.$post_id,'alma_retry_affiliate_image_nonce'); echo '<input type="hidden" name="action" value="alma_retry_affiliate_image"/><input type="hidden" name="post_id" value="'.intval($post_id).'"/>';
-            echo '<p><label><input type="checkbox" name="overwrite_existing" value="1"/> '.esc_html__('Sovrascrivi l’immagine in evidenza esistente','affiliate-link-manager-ai').'</label></p>';
-            echo '<p><button type="submit" class="button">'.esc_html__('Riprova import immagine','affiliate-link-manager-ai').'</button></p>';
+            // Niente <form> qui: la metabox vive DENTRO il form di modifica del post
+            // e un form annidato viene fuso dal browser, dirottando il salvataggio
+            // del link (action=alma_retry_affiliate_image al posto di editpost).
+            // Si usano link con nonce verso admin-post.php.
+            $retry_base=admin_url('admin-post.php?action=alma_retry_affiliate_image&post_id='.intval($post_id));
+            $retry_url=wp_nonce_url($retry_base,'alma_retry_affiliate_image_'.$post_id,'alma_retry_affiliate_image_nonce');
+            $retry_overwrite_url=wp_nonce_url($retry_base.'&overwrite_existing=1','alma_retry_affiliate_image_'.$post_id,'alma_retry_affiliate_image_nonce');
+            echo '<p><a class="button" href="'.esc_url($retry_url).'">'.esc_html__('Riprova import immagine','affiliate-link-manager-ai').'</a></p>';
+            echo '<p><a class="button" href="'.esc_url($retry_overwrite_url).'" onclick="return confirm(\''.esc_js(__('Sovrascrivere l’immagine in evidenza esistente?','affiliate-link-manager-ai')).'\');">'.esc_html__('Riprova sovrascrivendo l’immagine esistente','affiliate-link-manager-ai').'</a></p>';
             if($source_url==='') echo '<p class="description">'.esc_html__('Il retry richiede _alma_featured_image_source_url oppure _alma_featured_image_url.','affiliate-link-manager-ai').'</p>';
-            echo '</form>';
         }
         echo '</div>';
     }
 
     public function handle_single_image_retry(){
-        $post_id=absint($_POST['post_id']??0); if($post_id<1 || !current_user_can('edit_post',$post_id)) wp_die('Unauthorized'); if(!wp_verify_nonce($_POST['alma_retry_affiliate_image_nonce']??'','alma_retry_affiliate_image_'.$post_id)) wp_die('Nonce non valido');
-        $result=$this->retry_featured_image_for_post($post_id,!empty($_POST['overwrite_existing'])); $status=is_array($result)?sanitize_key($result['status']??'error'):'error'; $success=(is_array($result)&&!empty($result['success'])) || in_array($status,array('skipped_existing_thumbnail'),true); do_action('alma_affiliate_source_image_admin_event','single_retry_'.($success?'ok':'failed'),array('post_id'=>$post_id,'status'=>$status));
+        // Accetta GET (nuovi link con nonce) e POST (eventuale markup vecchio
+        // in cache dell'editor): in entrambi i casi si esegue il retry e si
+        // torna SEMPRE all'editor del link, mai all'elenco post.
+        $post_id=absint($_REQUEST['post_id']??($_REQUEST['post_ID']??0)); if($post_id<1 || !current_user_can('edit_post',$post_id)) wp_die('Unauthorized'); if(!wp_verify_nonce($_REQUEST['alma_retry_affiliate_image_nonce']??'','alma_retry_affiliate_image_'.$post_id)) wp_die('Nonce non valido');
+        $result=$this->retry_featured_image_for_post($post_id,!empty($_REQUEST['overwrite_existing'])); $status=is_array($result)?sanitize_key($result['status']??'error'):'error'; $success=(is_array($result)&&!empty($result['success'])) || in_array($status,array('skipped_existing_thumbnail'),true); do_action('alma_affiliate_source_image_admin_event','single_retry_'.($success?'ok':'failed'),array('post_id'=>$post_id,'status'=>$status));
         $redirect=get_edit_post_link($post_id,''); if(!$redirect) $redirect=admin_url('edit.php?post_type=affiliate_link'); wp_safe_redirect(add_query_arg(array('alma_image_retry'=>($success?'success':'error'),'alma_image_status'=>$status),$redirect)); exit;
     }
 


### PR DESCRIPTION
## Causa trovata (grazie ai log della diagnostica 2.80.1)

Il log chiave mostrava la pubblicazione arrivare a `post.php` con `action=alma_retry_affiliate_image` invece di `editpost`. Il colpevole: il pulsante **"Riprova import immagine"** nella metabox "Affiliate Source (tecnico)" era un `<form>` **annidato** dentro il form di modifica del post. I form annidati non sono validi in HTML: il browser scarta il tag interno e ne fonde i campi nel form principale, quindi alla pubblicazione WordPress riceveva un'azione sconosciuta → nessun salvataggio (URL affiliato, tipologie e stato persi, restava solo l'autosave del titolo) → redirect di ripiego all'elenco articoli.

## Fix

- **Rimosso il form annidato**: sostituito con due link con nonce verso `admin-post.php` ("Riprova import immagine" e "Riprova sovrascrivendo l'immagine esistente" con conferma). Comportamento del retry invariato.
- **Difese in profondità** per eventuale markup vecchio in cache dell'editor:
  - l'handler del retry accetta GET e POST ed è registrato anche su `admin_action_alma_retry_affiliate_image` (una vecchia pagina che inviasse ancora il form fuso a `post.php` esegue il retry e torna all'editor del link);
  - la guardia sui redirect tratta `alma_retry_affiliate_image` come un salvataggio e riscrive ogni rimbalzo verso l'elenco.
- Verificato che nessun'altra metabox del plugin renderizza `<form>` dentro le schermate di modifica dei post.

## Verifiche

- `php -l` OK su `affiliate-link-manager-ai.php` e `includes/class-affiliate-source-manager.php`.
- CHANGELOG.md e README.md aggiornati; versione `2.80.2` (patch, solo bugfix).

Dopo il merge: ripubblicare un link di prova — la card "🧪 Diagnostica salvataggio link" dovrà mostrare `request_action=editpost` e `affiliate_url_salvato=sì`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_