### PR TITLE
Chiave OpenAI solo in wp-config + Telegram riallineato con regia completa (v2.84.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 2.84.0 - 2026-07-07
+
+### Chiave OpenAI solo in wp-config.php + Telegram riallineato con regia completa
+- **Chiave API OpenAI solo in `wp-config.php`** (costante `ALMA_OPENAI_API_KEY`, già supportata in lettura): il campo nel form Impostazioni è stato **rimosso** insieme al suo salvataggio — così il salvataggio delle impostazioni non può più toccarla né cancellarla (bug segnalato). Quando la costante è definita, l'**eventuale copia storica nel database viene eliminata automaticamente** (con notice di conferma). Retrocompatibilità: senza costante, una chiave già salvata nel DB continua a funzionare, con avviso che invita a spostarla in wp-config (istruzioni con lo snippet `define(...)` direttamente nella pagina).
+- **Notifica Telegram a ogni articolo pubblicato** (manuale o AI): titolo, estratto, badge 🤖 se scritto dall'Agente e pulsante **"🔗 Apri articolo"**; una sola notifica per articolo (meta di deduplica); attivabile/disattivabile con la nuova spunta "Notifica pubblicazioni" (default attiva).
+- **Telegram riallineato alle funzioni attuali**:
+  - `/agente` ora schedula con la **firma a 7 argomenti** della Regia v2 (prima mancava la data di inizio) e azzera un eventuale stop precedente; testo aggiornato (niente più riferimenti al vecchio limite bozze).
+  - Nuovo **`/piano <articoli> <giorni> <tema>`** — programma un piano editoriale come «Applica il piano» in Regia AI (es. `/piano 5 10 borghi siciliani`).
+  - Nuovo **`/stato`** — agente in esecuzione/in arresto, bozze programmate in attesa, immagini AI (oggi/limite, coda prioritaria, link senza immagine), salute link (ok/sospetti/morti), arricchimento articoli.
+  - Nuovo **`/stop`** — ferma l'agente in corso (stesso meccanismo del pulsante in Regia AI).
+  - Nuovi **`/salute`** (sintesi Link Health con data ultima verifica) e **`/immagini`** (stato generatore, ultime immagini generate con costo).
+- **Usabilità Telegram**: «Registra webhook» ora imposta anche il **menu comandi nativo** del bot (`setMyCommands`, il pulsante «/» in chat mostra tutti i comandi con descrizione); `/help` riorganizzato per sezioni (🎬 Regia AI, 📝 Contenuti, 📊 Strategia, 🛠 Manutenzione); guida nella tab Telegram riscritta con esempi per gestire l'AI e la regia dal telefono.
+- Test standalone 46/46 (ogni comando del menu documentato in /help e gestito dal router, firma cron a 7 argomenti, notifica pubblicazione con deduplica e link).
+- Versione plugin aggiornata a `2.84.0`.
+
 ## 2.83.0 - 2026-07-07
 
 ### Widget Link v3: anteprima live, widget nell'arricchimento, click per widget, immagini AI on-demand

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.84.0 - 2026-07-07
+
+### Chiave OpenAI in wp-config + Telegram completo per la regia
+- La chiave OpenAI vive solo in wp-config.php (`ALMA_OPENAI_API_KEY`): campo e salvataggio rimossi dalle Impostazioni (non può più essere persa salvando), copia nel database eliminata automaticamente quando la costante è definita. Telegram: notifica di ogni articolo pubblicato con link, nuovi comandi /piano /stato /stop /salute /immagini, /agente allineato alla Regia v2, menu comandi nativo del bot e guida riscritta.
+- Versione plugin aggiornata a `2.84.0`.
+
 ## 2.83.0 - 2026-07-07
 
 ### Widget Link v3

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.83.0
+ * Version: 2.84.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.83.0');
+define('ALMA_VERSION', '2.84.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -2351,27 +2351,9 @@ class AffiliateManagerAI {
             $analysis_types = array_map('sanitize_text_field', $_POST['alma_content_analysis_post_types'] ?? array());
             update_option('alma_content_analysis_post_types', $analysis_types);
 
-            // OpenAI API settings
-            if (!empty($_POST['alma_clear_openai_api_key'])) {
-                delete_option('alma_openai_api_key');
-            } elseif (!empty($_POST['openai_api_key'])) {
-                // Il filtro pre_option (costante wp-config) va sospeso durante la
-                // scrittura: altrimenti add_option/update_option confrontano il valore
-                // della costante e non salvano nulla nel database.
-                remove_filter('pre_option_alma_openai_api_key', array(__CLASS__, 'filter_openai_api_key_constant'));
-                $new_api_key = sanitize_text_field(wp_unslash($_POST['openai_api_key']));
-                if (false === get_option('alma_openai_api_key', false)) {
-                    // Nuova option: creata direttamente con autoload=no, senza
-                    // finestra delete→add in cui la chiave non esiste.
-                    add_option('alma_openai_api_key', $new_api_key, '', 'no');
-                } else {
-                    update_option('alma_openai_api_key', $new_api_key);
-                    if (function_exists('wp_set_option_autoload')) {
-                        wp_set_option_autoload('alma_openai_api_key', false);
-                    }
-                }
-                add_filter('pre_option_alma_openai_api_key', array(__CLASS__, 'filter_openai_api_key_constant'));
-            }
+            // OpenAI API key: vive SOLO in wp-config.php (ALMA_OPENAI_API_KEY).
+            // Nessun salvataggio dal form: così il salvataggio delle
+            // impostazioni non può più toccarla né cancellarla.
             $selected_model = sanitize_text_field($_POST['openai_model'] ?? 'gpt-5.4-mini');
             $custom_model = sanitize_text_field($_POST['openai_model_custom'] ?? '');
             update_option('alma_openai_model', $custom_model !== '' ? $custom_model : $selected_model);
@@ -2393,6 +2375,18 @@ class AffiliateManagerAI {
             echo '<div class="notice notice-success"><p>' . __('Impostazioni salvate!', 'affiliate-link-manager-ai') . '</p></div>';
         }
         
+        // La chiave OpenAI vive in wp-config.php: se la costante è definita,
+        // l'eventuale copia storica nel database viene eliminata per sicurezza.
+        $openai_constant_defined = defined('ALMA_OPENAI_API_KEY') && ALMA_OPENAI_API_KEY !== '';
+        remove_filter('pre_option_alma_openai_api_key', array(__CLASS__, 'filter_openai_api_key_constant'));
+        $openai_db_key = trim((string) get_option('alma_openai_api_key', ''));
+        add_filter('pre_option_alma_openai_api_key', array(__CLASS__, 'filter_openai_api_key_constant'));
+        if ($openai_constant_defined && $openai_db_key !== '') {
+            delete_option('alma_openai_api_key');
+            $openai_db_key = '';
+            echo '<div class="notice notice-success"><p>' . __('Chiave OpenAI rimossa dal database: ora viene usata solo la costante ALMA_OPENAI_API_KEY di wp-config.php.', 'affiliate-link-manager-ai') . '</p></div>';
+        }
+
         // Recupera impostazioni attuali
         $track_logged_out = get_option('alma_track_logged_out', 'yes');
         $enable_ai = get_option('alma_enable_ai', 'yes');
@@ -2481,19 +2475,21 @@ class AffiliateManagerAI {
                     <h2>🧠 OpenAI API Configuration</h2>
                     <table class="form-table">
                         <tr>
-                            <th scope="row">
-                                <label for="openai_api_key">API Key</label>
-                            </th>
+                            <th scope="row">API Key</th>
                             <td>
-                                <input type="password" 
-                                       name="openai_api_key" 
-                                       id="openai_api_key" 
-                                       value="" 
-                                       class="regular-text" />
-                                <button type="button" class="button alma-toggle-api-key">👁 Mostra</button>
-                                <label><input type="checkbox" name="alma_clear_openai_api_key" value="1" /> Cancella API key salvata</label><p class="description">Ottieni la tua API key da 
-                                    <a href="https://platform.openai.com/" target="_blank">OpenAI Platform</a>
-                                </p>
+                                <?php if ($openai_constant_defined) : ?>
+                                    <p><span class="alma-badge is-success">✅ Configurata in wp-config.php</span> <code>ALMA_OPENAI_API_KEY</code></p>
+                                    <p class="description"><?php _e('La chiave vive solo in wp-config.php, mai nel database: non può essere letta dall\'admin né persa salvando le impostazioni.', 'affiliate-link-manager-ai'); ?></p>
+                                <?php else : ?>
+                                    <p><span class="alma-badge is-warning">Non configurata in wp-config.php</span></p>
+                                    <p><?php _e('Aggiungi a', 'affiliate-link-manager-ai'); ?> <code>wp-config.php</code> (<?php _e('sopra la riga', 'affiliate-link-manager-ai'); ?> <code>/* That's all, stop editing! */</code>):</p>
+                                    <p><code>define( 'ALMA_OPENAI_API_KEY', 'sk-...' );</code></p>
+                                    <?php if ($openai_db_key !== '') : ?>
+                                        <p class="description">⚠️ <?php _e('È presente una chiave salvata nel database (funziona ancora, per retrocompatibilità): appena definisci la costante, la copia nel database verrà eliminata automaticamente.', 'affiliate-link-manager-ai'); ?></p>
+                                    <?php else : ?>
+                                        <p class="description"><?php printf(__('Ottieni la tua API key da %s.', 'affiliate-link-manager-ai'), '<a href="https://platform.openai.com/" target="_blank" rel="noopener">OpenAI Platform</a>'); ?></p>
+                                    <?php endif; ?>
+                                <?php endif; ?>
                             </td>
                         </tr>
                         <tr>
@@ -2720,14 +2716,6 @@ class AffiliateManagerAI {
 
                 $('.alma-settings-section').hide();
                 $(target).show();
-            });
-
-            // Toggle API key visibility
-            $('.alma-toggle-api-key').on('click', function() {
-                var $input = $('#openai_api_key');
-                var type = $input.attr('type') === 'password' ? 'text' : 'password';
-                $input.attr('type', type);
-                $(this).text(type === 'password' ? '👁 Mostra' : '🙈 Nascondi');
             });
 
             // Verifica accesso allo Storage OpenAI (Vector Store)

--- a/includes/class-telegram-bot.php
+++ b/includes/class-telegram-bot.php
@@ -23,6 +23,8 @@ class ALMA_Telegram_Bot {
     const OPTION_CHAT_IDS = 'alma_telegram_chat_ids';
     const OPTION_RECENT_CHATS = 'alma_telegram_recent_chats';
     const OPTION_NOTIFY_DRAFTS = 'alma_telegram_notify_drafts';
+    const OPTION_NOTIFY_PUBLISH = 'alma_telegram_notify_publish';
+    const META_PUBLISH_NOTIFIED = '_alma_telegram_publish_notified';
     const REST_NAMESPACE = 'alma/v1';
     const REST_ROUTE = '/telegram';
 
@@ -32,6 +34,8 @@ class ALMA_Telegram_Bot {
         add_action('admin_post_alma_telegram_check_webhook', array(__CLASS__, 'handle_check_webhook'));
         add_action('admin_post_alma_telegram_send_instructions', array(__CLASS__, 'handle_send_instructions'));
         add_action('admin_post_alma_telegram_add_chat', array(__CLASS__, 'handle_add_chat'));
+        // Notifica di OGNI articolo pubblicato (manuale o AI) con link.
+        add_action('transition_post_status', array(__CLASS__, 'notify_post_published'), 10, 3);
     }
 
     public static function get_token() {
@@ -181,6 +185,15 @@ class ALMA_Telegram_Bot {
             case '/idea':
                 self::command_agent($chat_id, $argument);
                 break;
+            case '/piano':
+                self::command_plan($chat_id, $argument);
+                break;
+            case '/stato':
+                self::command_status($chat_id);
+                break;
+            case '/stop':
+                self::command_stop($chat_id);
+                break;
             case '/report':
                 self::command_report($chat_id);
                 break;
@@ -193,27 +206,62 @@ class ALMA_Telegram_Bot {
             case '/consigli':
                 self::command_advice($chat_id);
                 break;
+            case '/salute':
+                self::command_health($chat_id);
+                break;
+            case '/immagini':
+                self::command_images($chat_id);
+                break;
             default:
                 self::send_message($chat_id, 'Comando non riconosciuto. ' . "\n" . self::instructions_text());
         }
     }
 
     public static function instructions_text() {
-        return "<b>Comandi disponibili</b>\n"
-            . "/agente &lt;argomento&gt; — avvia l'agente: crea idee E bozze sul tema indicato (opzionale); parte anche oltre il limite giornaliero\n"
-            . "/report — esito dell'ultima esecuzione dell'agente\n"
+        return "<b>🎬 Regia AI</b>\n"
+            . "/agente &lt;tema&gt; — avvia subito l'agente: crea idee E bozze sul tema (opzionale); parte anche oltre il limite giornaliero\n"
+            . "/piano &lt;articoli&gt; &lt;giorni&gt; &lt;tema&gt; — programma un piano editoriale, es. <code>/piano 5 10 borghi siciliani</code> (come «Applica il piano» in Regia AI)\n"
+            . "/stato — l'agente è in esecuzione? bozze programmate, immagini AI, salute link\n"
+            . "/stop — ferma l'esecuzione dell'agente in corso\n"
+            . "/report — esito dell'ultima esecuzione\n"
+            . "\n<b>📝 Contenuti</b>\n"
             . "/bozze — ultime bozze AI con pulsanti Pubblica/Cestina\n"
-            . "/top — report sintetico: click e gap geografici\n"
+            . "<i>In automatico ricevi: nuove bozze AI (con pulsanti) e ogni articolo pubblicato (con link).</i>\n"
+            . "\n<b>📊 Strategia</b>\n"
+            . "/top — click e gap geografici\n"
             . "/consigli — ultimi consigli strategici AI\n"
+            . "\n<b>🛠 Manutenzione</b>\n"
+            . "/salute — stato dei link affiliati (morti/sospetti)\n"
+            . "/immagini — immagini AI: generate oggi, coda, ultime create\n"
             . "/id — mostra la tua Chat ID\n"
             . "/help — questo elenco";
+    }
+
+    /**
+     * Elenco comandi per il menu nativo di Telegram (setMyCommands).
+     */
+    public static function bot_commands() {
+        return array(
+            array('command' => 'agente', 'description' => 'Avvia l\'agente AI (tema opzionale)'),
+            array('command' => 'piano', 'description' => 'Piano editoriale: articoli giorni tema'),
+            array('command' => 'stato', 'description' => 'Stato agente, bozze, immagini, link'),
+            array('command' => 'stop', 'description' => 'Ferma l\'agente in esecuzione'),
+            array('command' => 'report', 'description' => 'Report ultima esecuzione'),
+            array('command' => 'bozze', 'description' => 'Bozze AI con Pubblica/Cestina'),
+            array('command' => 'top', 'description' => 'Click e gap geografici'),
+            array('command' => 'consigli', 'description' => 'Consigli strategici AI'),
+            array('command' => 'salute', 'description' => 'Salute dei link affiliati'),
+            array('command' => 'immagini', 'description' => 'Stato immagini AI'),
+            array('command' => 'id', 'description' => 'Mostra la tua Chat ID'),
+            array('command' => 'help', 'description' => 'Elenco comandi'),
+        );
     }
 
     /* ---------------------------------------------------------------------
      * Comandi
      * ------------------------------------------------------------------ */
 
-    private static function command_agent($chat_id, $objective) {
+    private static function command_agent($chat_id, $objective, $num_ideas = 0, $days_span = 0) {
         if (!class_exists('ALMA_AI_Idea_Agent')) {
             self::send_message($chat_id, 'Agente non disponibile.');
             return;
@@ -228,16 +276,117 @@ class ALMA_Telegram_Bot {
         }
         // Lancio dalla regia Telegram: force=1 (parte anche oltre il limite
         // giornaliero) e bozze immediate attive, come dalla pagina Regia AI.
-        $over_limit = ALMA_AI_Idea_Agent::runs_today() >= ALMA_AI_Idea_Agent::get_daily_runs_limit();
+        // Firma allineata a run() a 7 argomenti (num/giorni/data del piano).
+        $num_ideas = max(0, min(10, absint($num_ideas)));
+        $days_span = max(0, min(60, absint($days_span)));
         // Autore delle idee: il primo amministratore.
         $admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 'ID'));
         $user_id = !empty($admins) ? (int) $admins[0] : 1;
-        wp_schedule_single_event(time() + 5, ALMA_AI_Idea_Agent::CRON_HOOK, array($user_id, sanitize_textarea_field($objective), 1, 1, 0, 0));
+        delete_option(ALMA_AI_Idea_Agent::OPTION_CANCEL);
+        wp_schedule_single_event(time() + 5, ALMA_AI_Idea_Agent::CRON_HOOK, array($user_id, sanitize_textarea_field($objective), 1, 1, $num_ideas, $days_span, ''));
         if (function_exists('spawn_cron')) { spawn_cron(); }
+        $plan_note = $num_ideas > 0 ? sprintf("\n📋 Piano: %d articoli in %d giorni a partire da oggi.", $num_ideas, max(1, $days_span)) : '';
         self::send_message($chat_id, '🤖 Agente di ideazione avviato' . ($objective !== '' ? ' sul tema: <i>' . self::esc($objective) . '</i>' : '')
-            . "\nCreerà idee e le relative bozze (nel rispetto del limite giornaliero bozze)."
-            . ($over_limit ? "\n✋ Limite esecuzioni giornaliere già raggiunto: il lancio manuale viene eseguito comunque." : '')
-            . "\nRiceverai qui il report al termine (2-5 minuti).");
+            . $plan_note
+            . "\nOgni idea creerà la sua bozza nel giorno programmato."
+            . "\nRiceverai qui il report al termine (2-5 minuti). Usa /stato per seguirlo o /stop per fermarlo.");
+    }
+
+    /**
+     * /piano <articoli> <giorni> <tema…> — come «Applica il piano» in Regia AI.
+     */
+    private static function command_plan($chat_id, $argument) {
+        if (!preg_match('/^(\d{1,2})\s+(\d{1,2})\s*(.*)$/s', trim($argument), $m)) {
+            self::send_message($chat_id, "Formato: <code>/piano articoli giorni tema</code>\nEs. <code>/piano 5 10 borghi siciliani</code> = 5 articoli in 10 giorni sul tema indicato (tema opzionale).");
+            return;
+        }
+        self::command_agent($chat_id, trim((string) $m[3]), absint($m[1]), absint($m[2]));
+    }
+
+    /**
+     * /stato — fotografia operativa: agente, bozze programmate, immagini, link.
+     */
+    private static function command_status($chat_id) {
+        $running = class_exists('ALMA_AI_Idea_Agent') && get_option(ALMA_AI_Idea_Agent::LOCK_OPTION);
+        $stopping = class_exists('ALMA_AI_Idea_Agent') && get_option(ALMA_AI_Idea_Agent::OPTION_CANCEL);
+        $text = "<b>📡 Stato operativo</b>\n";
+        $text .= '🤖 Agente: ' . ($running ? ($stopping ? '<b>in arresto…</b>' : '<b>in esecuzione</b> (usa /stop per fermarlo)') : 'fermo') . "\n";
+        if (class_exists('ALMA_AI_Content_Agent_Idea_Importer') && method_exists('ALMA_AI_Content_Agent_Idea_Importer', 'due_ideas_count')) {
+            $text .= '📋 Bozze programmate in attesa: <b>' . (int) ALMA_AI_Content_Agent_Idea_Importer::due_ideas_count() . "</b>\n";
+        }
+        if (class_exists('ALMA_AI_Image_Generator')) {
+            $queue = count((array) get_option(ALMA_AI_Image_Generator::OPTION_PRIORITY_QUEUE, array()));
+            $text .= '🖼 Immagini AI: oggi ' . (int) ALMA_AI_Image_Generator::generated_today() . '/' . (int) ALMA_AI_Image_Generator::get_daily_limit()
+                . ' · link senza immagine: ' . (int) ALMA_AI_Image_Generator::pending_count()
+                . ($queue > 0 ? ' · in coda prioritaria: ' . $queue : '') . "\n";
+        }
+        if (class_exists('ALMA_Link_Health_Checker')) {
+            $counts = ALMA_Link_Health_Checker::status_counts();
+            $text .= '🩺 Link: ✅ ' . (int) ($counts['ok'] ?? 0) . ' · ⚠️ sospetti ' . (int) ($counts['suspect'] ?? 0) . ' · ❌ morti ' . (int) ($counts['dead'] ?? 0) . "\n";
+        }
+        if (class_exists('ALMA_AI_Post_Enricher')) {
+            $text .= '🔗 Arricchimento articoli: oggi ' . (int) ALMA_AI_Post_Enricher::processed_today() . '/' . (int) ALMA_AI_Post_Enricher::get_daily_limit() . ' (' . (ALMA_AI_Post_Enricher::is_enabled() ? 'attivo' : 'spento') . ")\n";
+        }
+        $text .= "\n/report per l'ultima esecuzione · /bozze per revisionare";
+        self::send_message($chat_id, $text);
+    }
+
+    /**
+     * /stop — richiede l'arresto dell'agente (come il pulsante in Regia AI).
+     */
+    private static function command_stop($chat_id) {
+        if (!class_exists('ALMA_AI_Idea_Agent')) {
+            self::send_message($chat_id, 'Agente non disponibile.');
+            return;
+        }
+        if (!get_option(ALMA_AI_Idea_Agent::LOCK_OPTION)) {
+            self::send_message($chat_id, 'ℹ️ Nessuna esecuzione dell\'agente in corso.');
+            return;
+        }
+        update_option(ALMA_AI_Idea_Agent::OPTION_CANCEL, (string) time(), false);
+        self::send_message($chat_id, '🛑 Arresto richiesto: l\'agente si fermerà al prossimo punto sicuro (le idee già create restano).');
+    }
+
+    /**
+     * /salute — sintesi Link Health.
+     */
+    private static function command_health($chat_id) {
+        if (!class_exists('ALMA_Link_Health_Checker')) {
+            self::send_message($chat_id, 'Link Health non disponibile.');
+            return;
+        }
+        $counts = ALMA_Link_Health_Checker::status_counts();
+        $report = (array) get_option(ALMA_Link_Health_Checker::OPTION_LAST_REPORT, array());
+        $text = "<b>🩺 Salute dei link affiliati</b>\n";
+        $text .= '✅ OK: <b>' . (int) ($counts['ok'] ?? 0) . '</b> · ⚠️ Sospetti: <b>' . (int) ($counts['suspect'] ?? 0) . '</b> · ❌ Morti: <b>' . (int) ($counts['dead'] ?? 0) . '</b> · ⏳ Mai verificati: <b>' . (int) ($counts['mai-verificato'] ?? 0) . "</b>\n";
+        if (!empty($report['finished_at'])) {
+            $text .= 'Ultima verifica: ' . self::esc((string) $report['finished_at']) . "\n";
+        }
+        $text .= "\nI link morti sono esclusi da widget e nuove bozze. Dettagli e bonifica: Link Affiliati → Verifica link.";
+        self::send_message($chat_id, $text);
+    }
+
+    /**
+     * /immagini — stato del generatore di immagini AI.
+     */
+    private static function command_images($chat_id) {
+        if (!class_exists('ALMA_AI_Image_Generator')) {
+            self::send_message($chat_id, 'Generatore immagini non disponibile.');
+            return;
+        }
+        $queue = count((array) get_option(ALMA_AI_Image_Generator::OPTION_PRIORITY_QUEUE, array()));
+        $log = (array) get_option(ALMA_AI_Image_Generator::OPTION_LOG, array());
+        $text = "<b>🖼 Immagini AI</b>\n";
+        $text .= 'Notturno: ' . (ALMA_AI_Image_Generator::is_enabled() ? 'attivo' : 'spento') . ' · oggi ' . (int) ALMA_AI_Image_Generator::generated_today() . '/' . (int) ALMA_AI_Image_Generator::get_daily_limit() . "\n";
+        $text .= 'Link pubblicati senza immagine: <b>' . (int) ALMA_AI_Image_Generator::pending_count() . '</b>' . ($queue > 0 ? ' · coda prioritaria: <b>' . $queue . '</b>' : '') . "\n";
+        $recent = array_slice(array_filter($log, function ($e) { return is_array($e) && ($e['status'] ?? '') === 'generated'; }), 0, 3);
+        if (!empty($recent)) {
+            $text .= "\n<b>Ultime generate</b>\n";
+            foreach ($recent as $entry) {
+                $text .= '• ' . self::esc((string) ($entry['title'] ?? '')) . (isset($entry['cost']) && $entry['cost'] !== null ? ' — $' . number_format((float) $entry['cost'], 4) : '') . "\n";
+            }
+        }
+        self::send_message($chat_id, $text);
     }
 
     private static function command_report($chat_id) {
@@ -390,6 +539,27 @@ class ALMA_Telegram_Bot {
         self::broadcast(self::format_agent_report((array) $report));
     }
 
+    /**
+     * Ogni articolo pubblicato (manuale o AI) arriva in chat con il link
+     * alla visualizzazione. Una sola notifica per articolo.
+     */
+    public static function notify_post_published($new_status, $old_status, $post) {
+        if ($new_status !== 'publish' || $old_status === 'publish') { return; }
+        if (!($post instanceof WP_Post) || $post->post_type !== 'post') { return; }
+        if (wp_is_post_revision($post->ID) || wp_is_post_autosave($post->ID)) { return; }
+        if (!self::is_enabled() || get_option(self::OPTION_NOTIFY_PUBLISH, '1') !== '1') { return; }
+        if (get_post_meta($post->ID, self::META_PUBLISH_NOTIFIED, true) !== '') { return; }
+        update_post_meta($post->ID, self::META_PUBLISH_NOTIFIED, current_time('mysql'));
+
+        $is_ai = get_post_meta($post->ID, '_alma_ai_agent_generated', true) === '1';
+        $excerpt = wp_trim_words(wp_strip_all_tags($post->post_excerpt ?: $post->post_content), 30, '…');
+        $text = '📣 <b>Articolo pubblicato</b>' . ($is_ai ? ' · 🤖 scritto dall\'Agente AI' : '') . "\n"
+            . '<b>' . self::esc(html_entity_decode(get_the_title($post), ENT_QUOTES, 'UTF-8')) . "</b>\n"
+            . self::esc($excerpt);
+        $keyboard = array(array(array('text' => '🔗 Apri articolo', 'url' => get_permalink($post))));
+        self::broadcast($text, $keyboard);
+    }
+
     /* ---------------------------------------------------------------------
      * Azioni admin (webhook, istruzioni, chat)
      * ------------------------------------------------------------------ */
@@ -416,7 +586,9 @@ class ALMA_Telegram_Bot {
             'allowed_updates' => array('message', 'callback_query'),
         ));
         if (!empty($result['ok'])) {
-            self::redirect_back('success', 'Webhook registrato: ' . self::webhook_url());
+            // Menu comandi nativo di Telegram (pulsante "/" nella chat).
+            self::api_request('setMyCommands', array('commands' => self::bot_commands()));
+            self::redirect_back('success', 'Webhook registrato e menu comandi aggiornato: ' . self::webhook_url());
         }
         self::redirect_back('error', 'Registrazione webhook fallita: ' . sanitize_text_field((string)($result['description'] ?? 'errore sconosciuto')));
     }
@@ -462,6 +634,7 @@ class ALMA_Telegram_Bot {
     public static function save_settings($post) {
         update_option(self::OPTION_ENABLED, empty($post[self::OPTION_ENABLED]) ? '0' : '1', false);
         update_option(self::OPTION_NOTIFY_DRAFTS, empty($post[self::OPTION_NOTIFY_DRAFTS]) ? '0' : '1', false);
+        update_option(self::OPTION_NOTIFY_PUBLISH, empty($post[self::OPTION_NOTIFY_PUBLISH]) ? '0' : '1', false);
         $chat_ids = array_values(array_unique(array_filter(array_map('trim', explode(',', sanitize_text_field(wp_unslash($post['alma_telegram_chat_ids_raw'] ?? '')))), function ($id) {
             return preg_match('/^-?\d{1,20}$/', $id);
         })));
@@ -488,7 +661,14 @@ class ALMA_Telegram_Bot {
         echo '<li>Spunta "Abilita Telegram", salva, poi clicca <strong>Registra webhook</strong> e <strong>Verifica stato webhook</strong> per conferma.</li>';
         echo '<li>Scopri la tua Chat ID: apri il bot su Telegram e invia <code>/id</code> (il bot risponde con l\'ID). L\'ID comparirà anche qui sotto in "Chat ID viste di recente", con un pulsante <strong>Aggiungi</strong>.</li>';
         echo '<li>Aggiungi le Chat ID autorizzate e salva di nuovo le impostazioni.</li></ol>';
-        echo '<p><strong>Cosa puoi fare dal bot:</strong> avviare l\'agente di ideazione con un obiettivo (<code>/agente idee per l\'estate in Puglia</code>), ricevere il report di idee e bozze create, ottenere i link alle bozze con pulsanti <em>Pubblica/Cestina</em> (<code>/bozze</code>), un report sintetico su click e gap (<code>/top</code>) e i consigli strategici AI (<code>/consigli</code>). Le nuove bozze AI arrivano in chat automaticamente con i pulsanti di revisione.</p>';
+        echo '<p><strong>Cosa puoi fare dal bot (il pulsante <code>/</code> in chat mostra il menu completo):</strong></p>';
+        echo '<ul style="list-style:disc;margin-left:20px;">';
+        echo '<li><strong>Regia AI</strong>: <code>/agente borghi siciliani</code> avvia subito l\'agente sul tema; <code>/piano 5 10 borghi siciliani</code> programma 5 articoli in 10 giorni (come «Applica il piano» in Regia AI); <code>/stato</code> mostra agente in esecuzione, bozze programmate, immagini AI e salute link; <code>/stop</code> ferma l\'esecuzione; <code>/report</code> l\'esito dell\'ultima.</li>';
+        echo '<li><strong>Contenuti</strong>: <code>/bozze</code> con pulsanti <em>Pubblica/Cestina</em>; in automatico ricevi ogni nuova bozza AI e <strong>ogni articolo pubblicato</strong> con il link.</li>';
+        echo '<li><strong>Strategia</strong>: <code>/top</code> click e gap geografici; <code>/consigli</code> i consigli strategici AI.</li>';
+        echo '<li><strong>Manutenzione</strong>: <code>/salute</code> link morti/sospetti; <code>/immagini</code> stato del generatore di immagini AI.</li>';
+        echo '</ul>';
+        echo '<p class="description">«Registra webhook» aggiorna anche il menu comandi nativo del bot su Telegram.</p>';
         echo '</div>';
 
         echo '<table class="form-table" role="presentation">';
@@ -506,6 +686,7 @@ class ALMA_Telegram_Bot {
         echo '<table class="form-table" role="presentation">';
         echo '<tr><th scope="row">Abilita Telegram</th><td><label><input type="checkbox" name="'.esc_attr(self::OPTION_ENABLED).'" value="1" '.checked($enabled, true, false).'> Attiva webhook, comandi e notifiche</label></td></tr>';
         echo '<tr><th scope="row">Notifica nuove bozze</th><td><label><input type="checkbox" name="'.esc_attr(self::OPTION_NOTIFY_DRAFTS).'" value="1" '.checked(get_option(self::OPTION_NOTIFY_DRAFTS, '1'), '1', false).'> Invia in chat ogni nuova bozza AI con i pulsanti Pubblica/Cestina</label></td></tr>';
+        echo '<tr><th scope="row">Notifica pubblicazioni</th><td><label><input type="checkbox" name="'.esc_attr(self::OPTION_NOTIFY_PUBLISH).'" value="1" '.checked(get_option(self::OPTION_NOTIFY_PUBLISH, '1'), '1', false).'> Invia in chat ogni articolo pubblicato (manuale o AI) con il link alla visualizzazione</label></td></tr>';
         echo '<tr><th scope="row"><label for="alma_telegram_chat_ids_raw">Chat ID autorizzate</label></th><td>';
         echo '<input type="text" class="regular-text" id="alma_telegram_chat_ids_raw" name="alma_telegram_chat_ids_raw" value="'.esc_attr(implode(', ', $chat_ids)).'" placeholder="Es. 123456789, -100987654321">';
         echo '<p class="description">Separate da virgola. Solo queste chat possono usare i comandi e ricevere le notifiche.</p></td></tr>';


### PR DESCRIPTION
## Chiave API OpenAI → wp-config.php

- La chiave vive **solo** nella costante `ALMA_OPENAI_API_KEY` (già supportata in lettura da tutto il plugin via filtro `pre_option`): il campo API Key e il suo salvataggio sono stati **rimossi** dalle Impostazioni — il salvataggio delle impostazioni non può più toccarla né cancellarla (bug segnalato).
- Quando la costante è definita, l'**eventuale copia storica nel database viene eliminata automaticamente** alla prima visita delle Impostazioni (con notice di conferma).
- Retrocompatibilità: senza costante, una chiave già salvata nel DB continua a funzionare; la pagina mostra lo stato e lo snippet `define( 'ALMA_OPENAI_API_KEY', 'sk-...' );` da copiare in wp-config.php.

## Telegram: notifica pubblicazioni + riallineamento + usabilità

- **Ogni articolo pubblicato** (manuale o AI) arriva in chat con titolo, estratto, badge 🤖 se scritto dall'Agente e pulsante **"🔗 Apri articolo"**. Una sola notifica per articolo (meta di deduplica). Nuova spunta "Notifica pubblicazioni" (default attiva).
- **Riallineamento alle funzioni attuali**:
  - `/agente` schedula ora con la **firma a 7 argomenti** della Regia v2 (mancava la data di inizio), azzera un eventuale stop precedente e ha testi aggiornati (via i riferimenti al vecchio limite bozze);
  - nuovo `/piano <articoli> <giorni> <tema>` — come «Applica il piano» in Regia AI (es. `/piano 5 10 borghi siciliani`);
  - nuovo `/stato` — agente in esecuzione/in arresto, bozze programmate, immagini AI (oggi/limite, coda prioritaria), salute link, arricchimento;
  - nuovo `/stop` — ferma l'agente (stesso meccanismo del pulsante in Regia AI);
  - nuovi `/salute` (Link Health) e `/immagini` (stato generatore + ultime generate con costo).
- **Usabilità**: «Registra webhook» imposta anche il **menu comandi nativo** del bot (`setMyCommands` — il pulsante «/» in chat mostra tutti i comandi con descrizione); `/help` riorganizzato per sezioni (🎬 Regia AI, 📝 Contenuti, 📊 Strategia, 🛠 Manutenzione); guida della tab Telegram riscritta con esempi pratici per gestire l'AI dal telefono.

## Verifiche
- Test standalone **46/46**: ogni comando del menu nativo è documentato in `/help` e gestito dal router; firma cron a 7 argomenti; notifica pubblicazione con deduplica e pulsante link.
- `php -l` OK; CHANGELOG.md e README.md aggiornati; versione `2.84.0`.

Dopo il merge: aggiungi `define( 'ALMA_OPENAI_API_KEY', '...' );` in wp-config.php, visita Impostazioni (vedrai la conferma di pulizia del database), poi nella tab Telegram premi **Registra webhook** per aggiornare il menu comandi del bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_