### PR TITLE
Agente più affidabile: profili strategici, widget garantito, geolocalizzazione articoli, report su misura (v2.85.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.85.0 - 2026-07-07
+
+### Agente più affidabile: profili strategici, widget garantito, geolocalizzazione degli articoli, report su misura
+- **Report Telegram con pubblicazione automatica attiva**: niente più elenco delle idee create (ridondante); per ogni articolo pubblicato il report mostra **titolo, link all'articolo e link ✏️ Modifica**. Anche la notifica "Articolo pubblicato" ha ora il pulsante **✏️ Modifica** accanto ad "Apri articolo".
+- **Conflitto "Link massimi nel widget" risolto**: il limite delle Regole inserimento vale solo per i widget creati dall'AI e viene riconciliato con i limiti del layout scelto — il più basso vince ma **mai sotto il minimo del layout** (prima, con limite basso, un layout valido poteva diventare impossibile). Descrizione del campo aggiornata (i widget manuali di Crea Widget Link non c'entrano, fino a 20 link).
+- **L'agente ora usa i Profili di Istruzioni AI e sceglie quale strategicamente**: il prompt dell'agente elenca i profili attivi (nome, tono, target) e `crea_idea` accetta `profilo_id` — per ogni idea l'agente indica il profilo più adatto al taglio dell'articolo (validato contro i profili attivi) e la bozza viene scritta con quel tono e quelle regole. Prima le idee dell'agente nascevano sempre senza profilo.
+- **Widget garantito in ogni articolo dell'agente**: se l'AI non compila la `widget_request` (o la compila male), il sistema crea comunque un widget deterministico dai migliori candidati (Vetrina con 1 candidato, Card esperienza con 2-4) e lo aggiunge all'articolo; le istruzioni al modello ora dicono di inserire SEMPRE il segnaposto, con la scelta del layout.
+- **Rimosso il vincolo "mai più di una al giorno se possibile"** dai prompt dell'agente: era inutile (la distribuzione viene comunque imposta da `enforce_schedule` sul piano richiesto) e produceva note operative confuse nei riepiloghi.
+- **Geolocalizzazione degli articoli dell'agente (bug risolto)**: l'auto-indexer geografico lavora solo sui post *pubblicati*, quindi le bozze dell'agente restavano senza località; inoltre la pubblicazione dal pulsante Telegram (`wp_publish_post`) non passa da `save_post` e non veniva mai indicizzata. Ora: (1) alla creazione della bozza la **località già risolta dell'idea** viene assegnata direttamente all'articolo (fonte `ai_agent`, mai sovrascrittura di località esistenti); (2) nuovo hook alla **pubblicazione** che indicizza qualsiasi post/link che arrivi a publish senza località, incluso il percorso Telegram.
+- Test standalone 13/13 sui sei interventi + 46/46 Telegram invariati.
+- Versione plugin aggiornata a `2.85.0`.
+
 ## 2.84.0 - 2026-07-07
 
 ### Chiave OpenAI solo in wp-config.php + Telegram riallineato con regia completa

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.85.0 - 2026-07-07
+
+### Agente più affidabile
+- Report Telegram su misura con auto-pubblicazione (articoli con link e Modifica, senza elenco idee); "Link massimi nel widget" riconciliato con i limiti dei layout; l'agente sceglie strategicamente il Profilo di Istruzioni per ogni idea; widget garantito in ogni articolo (fallback deterministico); rimosso il vincolo "una al giorno"; risolta la geolocalizzazione mancante degli articoli dell'agente (località dell'idea assegnata alla bozza + indicizzazione alla pubblicazione, anche da Telegram).
+- Versione plugin aggiornata a `2.85.0`.
+
 ## 2.84.0 - 2026-07-07
 
 ### Chiave OpenAI in wp-config + Telegram completo per la regia

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.84.0
+ * Version: 2.85.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.84.0');
+define('ALMA_VERSION', '2.85.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -407,7 +407,7 @@ class ALMA_AI_Content_Agent_Admin {
 
         echo '<tr><th scope="row"><label for="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_WIDGET_MAX_LINKS).'">Link massimi nel widget</label></th><td>';
         echo '<input type="number" min="2" max="8" class="small-text" name="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_WIDGET_MAX_LINKS).'" id="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_WIDGET_MAX_LINKS).'" value="'.esc_attr((string)$rules['widget_max_links']).'">';
-        echo '<p class="description">Il widget di raccolta finale contiene da 2 a N link; massimo un widget per articolo (applicato dal QA).</p></td></tr>';
+        echo '<p class="description">Tetto per i widget creati dall\'AI (massimo un widget per articolo, applicato dal QA). Vale insieme ai limiti del layout scelto: Vetrina in evidenza usa sempre 1 link, Card destinazione 2-6, Card esperienza 2-8 — il limite più basso vince, senza mai scendere sotto il minimo del layout. Non riguarda i widget creati manualmente in Crea Widget Link (fino a 20 link).</p></td></tr>';
 
         echo '<tr><th scope="row"><label for="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_BUTTON_TEXT).'">Testo bottone di default</label></th><td>';
         echo '<input type="text" class="regular-text" name="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_BUTTON_TEXT).'" id="'.esc_attr(ALMA_AI_Insertion_Rules::OPTION_BUTTON_TEXT).'" value="'.esc_attr($rules['button_text']).'"></td></tr>';

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -1233,7 +1233,26 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             $widget_request = is_array($parsed['widget_request'] ?? null) ? $parsed['widget_request'] : array();
             $widget_result = ALMA_AI_Insertion_Rules::apply_widget_request($clean['content'], $widget_request, $candidate_affiliate_ids);
             $ai_widget_id = (int) $widget_result['widget_id'];
-            $enforced = ALMA_AI_Insertion_Rules::enforce($widget_result['content'], ALMA_AI_Insertion_Rules::get_rules());
+            $clean['content'] = $widget_result['content'];
+            // Garanzia: almeno UN widget per articolo. Se l'AI non lo ha
+            // richiesto (o la richiesta era invalida) e il pattern widget è
+            // abilitato, se ne crea uno deterministico dai migliori candidati.
+            $rules_snapshot = ALMA_AI_Insertion_Rules::get_rules();
+            if ($ai_widget_id < 1 && in_array('widget', (array) $rules_snapshot['patterns'], true) && !empty($candidate_affiliate_ids)) {
+                $fallback_ids = array_slice(array_map('absint', (array) $candidate_affiliate_ids), 0, 4);
+                $fallback_request = array(
+                    'title' => __('Esperienze consigliate', 'affiliate-link-manager-ai'),
+                    'layout' => count($fallback_ids) === 1 ? 'hero_spotlight' : 'experience_cards',
+                    'link_ids' => $fallback_ids,
+                );
+                $fallback_result = ALMA_AI_Insertion_Rules::apply_widget_request($clean['content'], $fallback_request, $candidate_affiliate_ids);
+                if ((int) $fallback_result['widget_id'] > 0) {
+                    $ai_widget_id = (int) $fallback_result['widget_id'];
+                    $clean['content'] = $fallback_result['content'];
+                    $widget_result['warnings'][] = 'Widget non richiesto dall\'AI: aggiunto automaticamente con i migliori candidati.';
+                }
+            }
+            $enforced = ALMA_AI_Insertion_Rules::enforce($clean['content'], $rules_snapshot);
             $clean['content'] = $enforced['content'];
             $clean['warnings'] = array_values(array_unique(array_merge((array)$clean['warnings'], (array)$widget_result['warnings'], (array)$enforced['warnings'])));
         }

--- a/includes/class-ai-content-agent-idea-importer.php
+++ b/includes/class-ai-content-agent-idea-importer.php
@@ -517,7 +517,40 @@ class ALMA_AI_Content_Agent_Idea_Importer {
         update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_EXECUTED_AT, current_time('mysql'));
         if (!empty($result['success']) && !empty($result['post_id'])) {
             update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_DRAFT_POST_ID, absint($result['post_id']));
+            self::assign_idea_location_to_post($idea_id, absint($result['post_id']));
         }
         return is_array($result) ? $result : array('success' => false, 'error' => 'Risposta generazione non valida');
+    }
+
+    /**
+     * Geolocalizza subito l'articolo generato con la località già risolta
+     * dell'idea: l'auto-indexer lavora solo sui post pubblicati, quindi le
+     * bozze dell'agente restavano senza geolocalizzazione. Mai sovrascrittura
+     * di una località già presente.
+     */
+    private static function assign_idea_location_to_post($idea_id, $post_id) {
+        if (!class_exists('ALMA_Geo_Index_Store') || $post_id < 1) { return; }
+        $location_id = absint(get_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_LOCATION_ID, true));
+        if ($location_id < 1) { return; }
+        if (trim((string) get_post_meta($post_id, '_alma_geo_primary_name', true)) !== '') { return; }
+        $store = new ALMA_Geo_Index_Store();
+        $row = $store->get_location($location_id);
+        if (!is_array($row) || empty($row['canonical_name'])) { return; }
+        $store->save_geo_meta_for_object($post_id, ALMA_Geo_Index_Store::OBJECT_TYPE_POST, array(
+            'primary_location' => array(
+                'location_id' => $location_id,
+                'name' => (string) $row['canonical_name'],
+                'canonical_name' => (string) $row['canonical_name'],
+                'type' => (string) ($row['type'] ?? ''),
+                'country' => (string) ($row['country'] ?? ''),
+                'country_code' => (string) ($row['country_code'] ?? ''),
+                'region' => (string) ($row['region'] ?? ''),
+                'city' => (string) ($row['city'] ?? ''),
+                'lat' => (string) ($row['lat'] ?? ''),
+                'lng' => (string) ($row['lng'] ?? ''),
+                'is_primary' => true,
+            ),
+            'derive_from_primary' => true,
+        ), 'ai_agent');
     }
 }

--- a/includes/class-ai-idea-agent.php
+++ b/includes/class-ai-idea-agent.php
@@ -302,14 +302,41 @@ class ALMA_AI_Idea_Agent {
     private static function system_prompt($max_ideas, $days_span = 14, $start_date = '') {
         $prompt = 'Sei l\'agente strategico di ideazione contenuti di un blog di viaggi italiano monetizzato con link affiliati. '
             . 'Il tuo compito: analizzare i DATI REALI del sito tramite gli strumenti disponibili e creare fino a ' . (int)$max_ideas . ' nuove idee di articolo ad alto potenziale. '
-            . 'Metodo obbligatorio: 1) analizza le performance, i gap geografici e — se disponibile — le ricerche reali con analizza_ricerche_google (le "opportunità" con impression alte e posizione debole sono il segnale più prezioso: domanda dimostrata senza contenuto adeguato); 2) per ogni opportunità verifica con cerca_link_affiliati che esistano link da monetizzare, con elenca_articoli_esistenti che il tema non sia già coperto (evita duplicati) e con cerca_media se la Media Library ha già immagini utilizzabili sul tema (se sì, segnalalo nel prompt dell\'idea); per le idee legate a una destinazione consulta scheda_localita e usa il clima reale per il taglio stagionale (es. proponi "quando andare" o contenuti per i mesi migliori in arrivo, citando i mesi consigliati nel prompt dell\'idea) e i fatti Wikidata (patrimonio UNESCO, attrazioni notevoli) per angoli accurati e non ancora coperti; per validare un tema usa tendenze_google (Italia, 5 anni): domanda in crescita e mesi di picco delle ricerche indicano COSA proporre e QUANDO pubblicare (prima del picco); 3) crea le idee con crea_idea, includendo località (se pertinente), un prompt editoriale ricco che citi le query target, e una data programmata (data_programmata) distribuita ' . ($start_date !== '' ? 'tra il ' . $start_date . ' e i successivi ' . (int)$days_span . ' giorni' : 'nei prossimi ' . (int)$days_span . ' giorni') . ', al massimo una idea per giorno quando possibile. '
+            . 'Metodo obbligatorio: 1) analizza le performance, i gap geografici e — se disponibile — le ricerche reali con analizza_ricerche_google (le "opportunità" con impression alte e posizione debole sono il segnale più prezioso: domanda dimostrata senza contenuto adeguato); 2) per ogni opportunità verifica con cerca_link_affiliati che esistano link da monetizzare, con elenca_articoli_esistenti che il tema non sia già coperto (evita duplicati) e con cerca_media se la Media Library ha già immagini utilizzabili sul tema (se sì, segnalalo nel prompt dell\'idea); per le idee legate a una destinazione consulta scheda_localita e usa il clima reale per il taglio stagionale (es. proponi "quando andare" o contenuti per i mesi migliori in arrivo, citando i mesi consigliati nel prompt dell\'idea) e i fatti Wikidata (patrimonio UNESCO, attrazioni notevoli) per angoli accurati e non ancora coperti; per validare un tema usa tendenze_google (Italia, 5 anni): domanda in crescita e mesi di picco delle ricerche indicano COSA proporre e QUANDO pubblicare (prima del picco); 3) crea le idee con crea_idea, includendo località (se pertinente), un prompt editoriale ricco che citi le query target, e una data programmata (data_programmata) distribuita ' . ($start_date !== '' ? 'tra il ' . $start_date . ' e i successivi ' . (int)$days_span . ' giorni' : 'nei prossimi ' . (int)$days_span . ' giorni') . '. '
             . 'Privilegia: località con link affiliati ma senza click (offerta inutilizzata), località con molti articoli ma senza copertura pratica/commerciale, trend di click in crescita. '
             . 'Non inventare dati: basa ogni decisione sugli output degli strumenti. Non superare il numero massimo di idee. '
             . 'Alla fine rispondi in italiano con un riepilogo: per ogni idea creata, titolo e motivazione basata sui numeri.';
+        $profiles_hint = self::instruction_profiles_hint();
+        if ($profiles_hint !== '') {
+            $prompt .= ' ' . $profiles_hint;
+        }
         if (self::get_vector_store_id() !== '') {
             $prompt .= ' Hai inoltre accesso allo storage documenti dell\'editore su OpenAI tramite file_search: consultalo per linee guida editoriali, brief e materiali di contesto prima di decidere le idee.';
         }
         return $prompt;
+    }
+
+    /**
+     * Profili istruzioni attivi da proporre all'agente: per ogni idea deve
+     * scegliere STRATEGICAMENTE il profilo editoriale più adatto.
+     */
+    private static function instruction_profiles_hint() {
+        if (!class_exists('ALMA_AI_Content_Agent_Instructions_Manager')) { return ''; }
+        $profiles = ALMA_AI_Content_Agent_Instructions_Manager::get_active_profiles(15);
+        if (empty($profiles)) { return ''; }
+        $rows = array();
+        foreach ($profiles as $profile) {
+            $summary_parts = array_filter(array(
+                trim(wp_strip_all_tags((string) ($profile['tone_of_voice'] ?? ''))),
+                trim(wp_strip_all_tags((string) ($profile['target_audience'] ?? ''))),
+            ));
+            $summary = wp_trim_words(implode(' · ', $summary_parts), 20, '…');
+            $rows[] = 'id ' . (int) $profile['id'] . ': "' . sanitize_text_field((string) $profile['profile_name']) . '"'
+                . (!empty($profile['is_default']) ? ' (default)' : '')
+                . ($summary !== '' ? ' — ' . $summary : '');
+        }
+        return 'PROFILI ISTRUZIONI DISPONIBILI (Istruzioni AI → Profili): ' . implode('; ', $rows) . '. '
+            . 'Per OGNI idea scegli strategicamente il profilo più adatto al taglio dell\'articolo e passane l\'id in profilo_id a crea_idea: la bozza verrà scritta con quel tono, target e regole.';
     }
 
     private static function get_vector_store_id() {
@@ -325,7 +352,9 @@ class ALMA_AI_Idea_Agent {
             $window = $start_date !== ''
                 ? 'tra il ' . $start_date . ' e il ' . gmdate('Y-m-d', strtotime($start_date) + ($days - 1) * DAY_IN_SECONDS) . ' (incluse)'
                 : 'nei prossimi ' . $days . ' giorni';
-            $base = 'Piano editoriale richiesto dall\'editore: crea ESATTAMENTE ' . (int)$num_ideas . ' idee di contenuto, con date programmate (data_programmata) distribuite in modo sensato ' . $window . ', mai più di una al giorno se possibile.';
+            // Nessun vincolo "una al giorno": la distribuzione finale viene
+            // comunque imposta da enforce_schedule sul piano richiesto.
+            $base = 'Piano editoriale richiesto dall\'editore: crea ESATTAMENTE ' . (int)$num_ideas . ' idee di contenuto, con date programmate (data_programmata) distribuite in modo sensato ' . $window . '.';
         }
         return $objective !== '' ? $base . ' Obiettivo e suggerimenti dell\'editore: ' . $objective : $base;
     }
@@ -357,6 +386,7 @@ class ALMA_AI_Idea_Agent {
                 'prompt' => array('type' => 'string', 'description' => 'Istruzioni editoriali per la bozza: taglio, cosa includere, perché l\'idea è promettente'),
                 'keywords' => array('type' => 'array', 'items' => array('type' => 'string'), 'description' => 'Keyword SEO (max 5)'),
                 'data_programmata' => array('type' => 'string', 'description' => 'Data generazione bozza YYYY-MM-DD (opzionale)'),
+                'profilo_id' => array('type' => 'integer', 'description' => 'ID del profilo istruzioni più adatto (dall\'elenco PROFILI ISTRUZIONI DISPONIBILI): la bozza verrà scritta con quel tono e quelle regole'),
             ), 'required' => array('titolo', 'prompt'), 'additionalProperties' => false)),
         ));
     }
@@ -485,7 +515,15 @@ class ALMA_AI_Idea_Agent {
         $prompt = sanitize_textarea_field((string)($arguments['prompt'] ?? ''));
         if ($title === '' || $prompt === '') { return array('error' => 'titolo e prompt sono obbligatori.'); }
 
-        $idea_id = ALMA_AI_Content_Agent_Ideas::create($title);
+        // Profilo istruzioni scelto strategicamente dall'agente: validato
+        // contro i profili attivi; 0 = istruzioni globali.
+        $profile_id = absint($arguments['profilo_id'] ?? 0);
+        if ($profile_id > 0) {
+            $profile = class_exists('ALMA_AI_Content_Agent_Instructions_Manager') ? ALMA_AI_Content_Agent_Instructions_Manager::get_profile($profile_id) : array();
+            if (empty($profile) || empty($profile['is_active'])) { $profile_id = 0; }
+        }
+
+        $idea_id = ALMA_AI_Content_Agent_Ideas::create($title, $profile_id);
         if ($idea_id < 1) { return array('error' => 'Errore creazione idea.'); }
         update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_PROMPT, $prompt);
         update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_SOURCE, 'agent');

--- a/includes/class-ai-insertion-rules.php
+++ b/includes/class-ai-insertion-rules.php
@@ -84,7 +84,7 @@ class ALMA_AI_Insertion_Rules {
             $lines[] = '- card prodotto: [affiliate_link id="ID" img="yes" fields="title,content" button="yes"] quando dedichi un blocco a una singola esperienza importante (max 1-2 per articolo).';
         }
         if (in_array('widget', $rules['patterns'], true)) {
-            $lines[] = '- widget di raccolta: UNA sola volta, in chiusura dell\'articolo, inserisci il segnaposto ' . self::WIDGET_PLACEHOLDER . ' e compila il campo widget_request dell\'output con: title (es. "Le migliori esperienze a X"), link_ids (2-' . $rules['widget_max_links'] . ' ID dei link più pertinenti), button_text, e per ogni link rewritten[{id,title,description}] con titolo e descrizione riscritti nel tono dell\'articolo (descrizione 1-2 frasi orientate al beneficio).';
+            $lines[] = '- widget di raccolta: inserisci SEMPRE (almeno una volta per articolo, nel punto più naturale — tipicamente prima della conclusione) il segnaposto ' . self::WIDGET_PLACEHOLDER . ' e compila il campo widget_request dell\'output con: title (es. "Le migliori esperienze a X"), layout ("destination_cards" per griglie di mete, "experience_cards" per tour/attività, "hero_spotlight" per UNA sola esperienza di punta), link_ids (fino a ' . $rules['widget_max_links'] . ' ID dei link più pertinenti, nel rispetto dei limiti del layout), button_text, e per ogni link rewritten[{id,title,description}] con titolo e descrizione riscritti nel tono dell\'articolo (descrizione 1-2 frasi orientate al beneficio).';
         }
         $lines[] = 'REGOLE DI DENSITÀ E POSIZIONE (verranno comunque applicate dal sistema):';
         $lines[] = '- massimo 1 inserimento ogni ' . $rules['density_words'] . ' parole di contenuto;';
@@ -223,7 +223,12 @@ class ALMA_AI_Insertion_Rules {
         $link_ids = array_values(array_unique(array_filter(array_map('absint', (array)($request['link_ids'] ?? array())))));
         // Solo link candidati del payload: l'AI non può inventare ID.
         $link_ids = array_values(array_intersect($link_ids, array_map('absint', (array)$candidate_affiliate_ids)));
+        // Riconciliazione col limite "Link massimi nel widget" delle Regole
+        // inserimento: il tetto è il più basso tra regola e layout, ma mai
+        // sotto il minimo del layout (es. hero=1, destinazioni=2), altrimenti
+        // la regola renderebbe impossibile un layout valido.
         $max_links = min(absint($rules['widget_max_links']), absint($preset['max_links']));
+        $max_links = max($max_links, absint($preset['min_links']));
         if (count($link_ids) > $max_links) {
             // A parità di scelta dell'AI, nel taglio sopravvivono prima i link
             // CON immagine (le card vivono di immagini); ordine stabile.

--- a/includes/class-geo-auto-indexer.php
+++ b/includes/class-geo-auto-indexer.php
@@ -655,6 +655,10 @@ class ALMA_Geo_Auto_Indexer {
     public function init_hooks() {
         add_action('save_post_affiliate_link', array($this, 'queue_deferred_index'), 200);
         add_action('save_post_post', array($this, 'queue_deferred_index'), 200);
+        // Alla pubblicazione: copre wp_publish_post (es. pulsante Pubblica su
+        // Telegram) che non passa da save_post, e le bozze che al salvataggio
+        // erano ancora draft (l'indexer lavora solo sui post pubblicati).
+        add_action('transition_post_status', array($this, 'queue_index_on_publish'), 20, 3);
         add_action('shutdown', array($this, 'run_deferred_index'));
 
         if (is_admin()) {
@@ -743,6 +747,16 @@ class ALMA_Geo_Auto_Indexer {
      * (destinazione inclusa) dopo wp_insert_post: durante save_post i dati
      * del provider non sono ancora disponibili.
      */
+    public function queue_index_on_publish($new_status, $old_status, $post) {
+        if ($new_status !== 'publish' || $old_status === 'publish') {
+            return;
+        }
+        if (!($post instanceof WP_Post) || !in_array($post->post_type, array('post', 'affiliate_link'), true)) {
+            return;
+        }
+        $this->queue_deferred_index($post->ID);
+    }
+
     public function queue_deferred_index($post_id) {
         if (wp_is_post_autosave($post_id) || wp_is_post_revision($post_id)) {
             return;

--- a/includes/class-telegram-bot.php
+++ b/includes/class-telegram-bot.php
@@ -401,15 +401,31 @@ class ALMA_Telegram_Bot {
     public static function format_agent_report($report) {
         $ideas = (array) ($report['ideas_created'] ?? array());
         $drafts = array_filter((array) ($report['drafts_created'] ?? array()), function ($d) { return !empty($d['post_id']); });
+        $auto_publish = get_option('alma_ai_auto_publish', 'no') === 'yes';
         $text = "<b>🤖 Report agente ideazione</b>\n";
         $text .= 'Avviato: ' . self::esc($report['started_at'] ?? '') . "\n";
         $text .= 'Idee create: <b>' . count($ideas) . '</b> · Bozze: <b>' . count($drafts) . '</b> · Costo stimato: ~$' . number_format((float) ($report['cost_total'] ?? 0), 4) . "\n";
-        foreach (array_slice($ideas, 0, 8) as $idea) {
-            $text .= '• ' . self::esc($idea['titolo']) . (!empty($idea['localita']) ? ' — 📍 ' . self::esc($idea['localita']) : '') . "\n";
-        }
-        foreach (array_slice($drafts, 0, 5) as $draft) {
-            $preview = get_preview_post_link((int) $draft['post_id']);
-            $text .= '📝 <a href="' . esc_url($preview) . '">' . self::esc($draft['titolo']) . "</a>\n";
+        if ($auto_publish) {
+            // Pubblicazione automatica attiva: niente elenco idee (ridondante),
+            // per ogni articolo pubblicato titolo + link + modifica.
+            foreach (array_slice($drafts, 0, 10) as $draft) {
+                $post_id = (int) $draft['post_id'];
+                $edit_url = admin_url('post.php?post=' . $post_id . '&action=edit');
+                if (get_post_status($post_id) === 'publish') {
+                    $text .= '📣 <a href="' . esc_url(get_permalink($post_id)) . '">' . self::esc($draft['titolo']) . '</a> · <a href="' . esc_url($edit_url) . '">✏️ Modifica</a>' . "\n";
+                } else {
+                    $preview = get_preview_post_link($post_id);
+                    $text .= '📝 <a href="' . esc_url($preview ?: $edit_url) . '">' . self::esc($draft['titolo']) . '</a> · <a href="' . esc_url($edit_url) . '">✏️ Modifica</a>' . "\n";
+                }
+            }
+        } else {
+            foreach (array_slice($ideas, 0, 8) as $idea) {
+                $text .= '• ' . self::esc($idea['titolo']) . (!empty($idea['localita']) ? ' — 📍 ' . self::esc($idea['localita']) : '') . "\n";
+            }
+            foreach (array_slice($drafts, 0, 5) as $draft) {
+                $preview = get_preview_post_link((int) $draft['post_id']);
+                $text .= '📝 <a href="' . esc_url($preview) . '">' . self::esc($draft['titolo']) . "</a>\n";
+            }
         }
         if (!empty($report['error'])) { $text .= '⚠️ ' . self::esc($report['error']) . "\n"; }
         if (!empty($report['summary'])) { $text .= "\n" . self::esc(wp_trim_words($report['summary'], 80, '…')); }
@@ -556,7 +572,10 @@ class ALMA_Telegram_Bot {
         $text = '📣 <b>Articolo pubblicato</b>' . ($is_ai ? ' · 🤖 scritto dall\'Agente AI' : '') . "\n"
             . '<b>' . self::esc(html_entity_decode(get_the_title($post), ENT_QUOTES, 'UTF-8')) . "</b>\n"
             . self::esc($excerpt);
-        $keyboard = array(array(array('text' => '🔗 Apri articolo', 'url' => get_permalink($post))));
+        $keyboard = array(array(
+            array('text' => '🔗 Apri articolo', 'url' => get_permalink($post)),
+            array('text' => '✏️ Modifica', 'url' => admin_url('post.php?post=' . (int) $post->ID . '&action=edit')),
+        ));
         self::broadcast($text, $keyboard);
     }
 


### PR DESCRIPTION
## Sei interventi richiesti

### 1. Report Telegram con pubblicazione automatica
Con `alma_ai_auto_publish` attivo il report dell'agente non elenca più le idee create (ridondante): per ogni articolo pubblicato mostra **titolo, link all'articolo e link ✏️ Modifica** (per le eventuali bozze non ancora pubblicate: anteprima + modifica). Anche la notifica "Articolo pubblicato" ha ora il pulsante **✏️ Modifica** accanto ad "Apri articolo".

### 2. Conflitto "Link massimi nel widget"
Il limite delle Regole inserimento vale solo per i widget creati dall'AI e viene riconciliato con i limiti del layout: **il più basso vince, ma mai sotto il minimo del layout** (prima un limite basso poteva rendere impossibile un layout valido, es. Card destinazione con minimo 2). Descrizione del campo aggiornata: chiarito che i widget manuali di Crea Widget Link (fino a 20 link) non sono toccati.

### 3. L'agente usa i Profili di Istruzioni AI, scegliendo strategicamente
**Verificato: prima le idee dell'agente nascevano sempre senza profilo** (`Ideas::create($title)` senza id). Ora il prompt dell'agente elenca i profili attivi (nome, tono, target) e `crea_idea` accetta `profilo_id`: per ogni idea l'agente sceglie il profilo più adatto al taglio dell'articolo (validato contro i profili attivi; 0 = istruzioni globali) e la bozza viene scritta con quel tono e quelle regole.

### 4. Widget garantito in ogni articolo dell'agente
Le istruzioni al modello ora chiedono di inserire **sempre** il segnaposto widget con la scelta del layout; se l'AI non compila la `widget_request` (o la compila male), il sistema crea comunque un **widget deterministico** dai migliori candidati (Vetrina in evidenza con 1 candidato, Card esperienza con 2-4) e lo aggiunge all'articolo, con warning tracciato.

### 5. Vincolo "mai più di una al giorno se possibile" eliminato
Rimosso da entrambi i prompt (piano e metodo): era inutile perché la distribuzione viene comunque imposta da `enforce_schedule`, e produceva note operative confuse nei riepiloghi (come quella segnalata su 6 idee in 2 date).

### 6. Geolocalizzazione degli articoli dell'agente (bug trovato e risolto)
Causa: l'auto-indexer geografico lavora **solo sui post pubblicati**, quindi le bozze dell'agente non venivano mai indicizzate; inoltre la pubblicazione dal pulsante Telegram (`wp_publish_post`) non passa da `save_post`. Fix doppio:
- alla creazione della bozza, la **località già risolta dell'idea** viene assegnata direttamente all'articolo (`save_geo_meta_for_object`, fonte `ai_agent`, mai sovrascrittura di località esistenti);
- nuovo hook su `transition_post_status` che accoda l'indicizzazione **alla pubblicazione** di qualsiasi post/link (copre Telegram e ogni percorso che non passa da save_post).

## Verifiche
- Test standalone **13/13** sui sei interventi + **46/46** Telegram invariati; `php -l` OK su tutti i file.
- CHANGELOG.md e README.md aggiornati; versione `2.85.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_