### PR TITLE
Colonna Titolo leggibile negli elenchi Articoli e Link Affiliati (v2.86.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.86.0 - 2026-07-07
+
+### Colonna Titolo leggibile negli elenchi Articoli e Link Affiliati
+- Con le molte colonne aggiunte dai plugin (SEO, campi tema, Geo…) la colonna **Titolo** negli elenchi admin si riduceva a una parola per riga. Ora ha una **larghezza garantita** (28% della tabella, minimo 280px; 34% sotto i 1400px di viewport) tramite CSS mirato alle liste di Articoli e Link Affiliati — le tabelle di WordPress usano `table-layout: fixed`, quindi la larghezza è rispettata e le altre colonne si adattano.
+- Versione plugin aggiornata a `2.86.0`.
+
 ## 2.85.0 - 2026-07-07
 
 ### Agente più affidabile: profili strategici, widget garantito, geolocalizzazione degli articoli, report su misura

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.86.0 - 2026-07-07
+
+### Colonna Titolo leggibile negli elenchi
+- Larghezza minima garantita alla colonna Titolo negli elenchi Articoli e Link Affiliati, che veniva schiacciata dalle colonne di altri plugin.
+- Versione plugin aggiornata a `2.86.0`.
+
 ## 2.85.0 - 2026-07-07
 
 ### Agente più affidabile

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.85.0
+ * Version: 2.86.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.85.0');
+define('ALMA_VERSION', '2.86.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -15,6 +15,7 @@ class ALMA_Assets {
 
     public function init() {
         add_action('admin_enqueue_scripts', array($this, 'admin_enqueue_scripts'));
+        add_action('admin_head-edit.php', array($this, 'print_posts_list_css'));
         add_action('wp_enqueue_scripts', array($this, 'enqueue_frontend_scripts'));
         add_action('wp_head', array($this, 'output_custom_css'), 100);
     }
@@ -53,6 +54,20 @@ class ALMA_Assets {
         if (!empty($css)) {
             echo "<style id='alma-custom-css'>" . wp_strip_all_tags($css) . '</style>';
         }
+    }
+
+    /**
+     * Negli elenchi Articoli/Link Affiliati le molte colonne aggiunte dai
+     * plugin (SEO, campi tema, Geo…) schiacciano il Titolo fino a una parola
+     * per riga: gli si garantisce una larghezza minima leggibile. La tabella
+     * di WordPress usa table-layout fixed, quindi la larghezza è rispettata.
+     */
+    public function print_posts_list_css() {
+        $screen = function_exists('get_current_screen') ? get_current_screen() : null;
+        if (!$screen || !in_array($screen->post_type, array('post', 'affiliate_link'), true)) {
+            return;
+        }
+        echo '<style id="alma-posts-list-title-width">.wp-list-table .column-title{width:28%;min-width:280px;}@media screen and (max-width:1400px){.wp-list-table .column-title{width:34%;}}</style>';
     }
 
     public function admin_enqueue_scripts($hook) {


### PR DESCRIPTION
## Cosa fa

Negli elenchi admin di **Articoli** e **Link Affiliati** le molte colonne aggiunte dai plugin (SEO, campi tema Come/Cosa/Perché, Geo…) schiacciavano la colonna **Titolo** fino a una parola per riga (vedi screenshot segnalato).

Fix: CSS mirato stampato solo su `edit.php` per i post type `post` e `affiliate_link` — la colonna Titolo ha ora **larghezza garantita** (28% della tabella, minimo 280px; 34% sotto i 1400px di viewport). Le tabelle di WordPress usano `table-layout: fixed`, quindi la larghezza è rispettata e le altre colonne si adattano automaticamente.

## Verifiche
- `php -l` OK; CHANGELOG.md e README.md aggiornati; versione `2.86.0`.
- Nessuna option/API toccata; solo CSS admin scoped ai due elenchi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_