### PR TITLE
Elenco Articoli: nascoste le colonne dei campi tema + larghezze minime per Categorie e Geo (v2.86.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.86.1 - 2026-07-07
+
+### Elenco Articoli: nascoste le colonne dei campi tema, più spazio a Categorie e Geo
+- Nell'elenco Articoli le colonne dei campi tema **Come, Cosa, Perché, People, Quando e Durata** vengono nascoste (erano ridotte a una lettera per riga e senza utilità nella lista): la rimozione avviene per **etichetta**, così funziona qualunque sia la chiave tecnica usata dal tema. Restano visibili nella modifica dell'articolo, dove si compilano.
+- **Categorie** (min 140px) e **Geo** (min 110px) hanno ora una larghezza minima: niente più testo verticale.
+- Versione plugin aggiornata a `2.86.1`.
+
 ## 2.86.0 - 2026-07-07
 
 ### Colonna Titolo leggibile negli elenchi Articoli e Link Affiliati

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.86.1 - 2026-07-07
+
+### Elenco Articoli ripulito
+- Nascoste le colonne dei campi tema (Come, Cosa, Perché, People, Quando, Durata) nell'elenco Articoli; larghezza minima per Categorie e Geo.
+- Versione plugin aggiornata a `2.86.1`.
+
 ## 2.86.0 - 2026-07-07
 
 ### Colonna Titolo leggibile negli elenchi

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.86.0
+ * Version: 2.86.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.86.0');
+define('ALMA_VERSION', '2.86.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -16,6 +16,7 @@ class ALMA_Assets {
     public function init() {
         add_action('admin_enqueue_scripts', array($this, 'admin_enqueue_scripts'));
         add_action('admin_head-edit.php', array($this, 'print_posts_list_css'));
+        add_filter('manage_edit-post_columns', array($this, 'hide_theme_posts_columns'), PHP_INT_MAX);
         add_action('wp_enqueue_scripts', array($this, 'enqueue_frontend_scripts'));
         add_action('wp_head', array($this, 'output_custom_css'), 100);
     }
@@ -67,7 +68,24 @@ class ALMA_Assets {
         if (!$screen || !in_array($screen->post_type, array('post', 'affiliate_link'), true)) {
             return;
         }
-        echo '<style id="alma-posts-list-title-width">.wp-list-table .column-title{width:28%;min-width:280px;}@media screen and (max-width:1400px){.wp-list-table .column-title{width:34%;}}</style>';
+        echo '<style id="alma-posts-list-title-width">.wp-list-table .column-title{width:28%;min-width:280px;}.wp-list-table .column-categories{width:14%;min-width:140px;}.wp-list-table .column-alma_geo{width:120px;min-width:110px;}@media screen and (max-width:1400px){.wp-list-table .column-title{width:34%;}}</style>';
+    }
+
+    /**
+     * Nasconde nell'elenco Articoli le colonne dei campi tema (Come, Cosa,
+     * Perché, People, Quando, Durata): con tutte le colonne di SEO e plugin
+     * il contenuto diventava illeggibile (una lettera per riga). Il match è
+     * sull'ETICHETTA, così funziona qualunque sia la chiave usata dal tema.
+     */
+    public function hide_theme_posts_columns($columns) {
+        $hidden_labels = array('come', 'cosa', 'perché', 'perche', 'people', 'quando', 'durata');
+        foreach ((array) $columns as $key => $label) {
+            $plain = trim(function_exists('mb_strtolower') ? mb_strtolower(wp_strip_all_tags((string) $label)) : strtolower(wp_strip_all_tags((string) $label)));
+            if (in_array($plain, $hidden_labels, true)) {
+                unset($columns[$key]);
+            }
+        }
+        return $columns;
     }
 
     public function admin_enqueue_scripts($hook) {


### PR DESCRIPTION
## Cosa fa

Dopo l'allargamento del Titolo (v2.86.0), le colonne dei campi tema restavano schiacciate a una lettera per riga (vedi screenshot segnalato). Interventi:

- **Nascoste nell'elenco Articoli le colonne Come, Cosa, Perché, People, Quando e Durata**: nella lista non erano leggibili né utili. La rimozione avviene con un filtro a priorità massima su `manage_edit-post_columns` con **match sull'etichetta** (case-insensitive, accenti inclusi), così funziona qualunque sia la chiave tecnica usata dal tema. I campi restano ovviamente disponibili nella schermata di modifica dell'articolo.
- **Larghezze minime** per **Categorie** (140px) e **Geo** (110px): eliminato il testo verticale.

## Verifiche
- `php -l` OK; CHANGELOG.md e README.md aggiornati; versione `2.86.1` (patch, correzione di visualizzazione).
- Solo elenco Articoli (`edit-post`): nessun impatto su altri post type o sulla modifica dei post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_