### PR TITLE
Link GYG: rimossi i parametri di sessione (deeplink_id/page_id) da import e archivio (v2.87.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.87.1 - 2026-07-08
+
+### Link GYG: rimossi i parametri di sessione (deeplink_id/page_id) da import e archivio
+- **Verifica sul link segnalato**: il plugin NON riscrive gli URL — i parametri extra arrivano dai **CSV esportati da GetYourGuide**, i cui deep link contengono ID di sessione (`deeplink_id`, `page_id`, a volte `visitor_id`). `build_affiliate_url` conservava i parametri esistenti, quindi finivano salvati nel link: la pagina si apre ma la vendita può **non essere convalidata** al partner (l'attribuzione corretta è solo `partner_id` + `utm_medium`).
+- **Import futuri**: nuova funzione pura `strip_gyg_session_params()` applicata in `build_affiliate_url` — i parametri di sessione vengono eliminati alla costruzione del link, preservando tutto il resto (partner, utm, eventuali parametri custom, fragment). Agisce SOLO sui domini getyourguide.*: link manuali Travelpayouts e ogni altro dominio restano intatti.
+- **Archivio esistente**: nuovo batch in **Verifica link** ("Pulisci i prossimi 50 link…") con conteggio dei link getyourguide.* che contengono parametri di sessione, backup dell'URL originale (`_alma_url_pre_bonifica`, mai sovrascritto) e rigenerazione cache del widget contestuale.
+- Test standalone 9/9 (link reale segnalato ripulito esattamente al formato corretto, link puliti invariati, tpx.li/viator mai toccati, fragment preservato, import CSV con sessione → URL pulito senza duplicare partner_id).
+- Versione plugin aggiornata a `2.87.1`.
+
 ## 2.87.0 - 2026-07-08
 
 ### Immagini AI PR2: segnaposto editoriali generati davvero, featured coerente, bozze mancate spiegate e ritentate

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.87.1 - 2026-07-08
+
+### Link GYG senza parametri di sessione
+- I deep link dei CSV GetYourGuide contengono ID di sessione (deeplink_id, page_id) che possono impedire la convalida della vendita: ora vengono rimossi automaticamente all'import e un nuovo batch in Verifica link pulisce l'archivio esistente (solo domini getyourguide.*, con backup; link manuali intatti).
+- Versione plugin aggiornata a `2.87.1`.
+
 ## 2.87.0 - 2026-07-08
 
 ### Immagini AI PR2 + bozze mancate spiegate

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.87.0
+ * Version: 2.87.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.87.0');
+define('ALMA_VERSION', '2.87.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-affiliate-link-auditor.php
+++ b/includes/class-affiliate-link-auditor.php
@@ -42,6 +42,7 @@ class ALMA_Affiliate_Link_Auditor {
         add_action('admin_post_alma_link_audit_fix', array(__CLASS__, 'handle_fix'));
         add_action('admin_post_alma_link_audit_retry', array(__CLASS__, 'handle_retry'));
         add_action('admin_post_alma_link_audit_domain', array(__CLASS__, 'handle_domain'));
+        add_action('admin_post_alma_link_audit_strip_session', array(__CLASS__, 'handle_strip_session'));
         add_action('admin_post_alma_link_audit_clear_diag', array(__CLASS__, 'handle_clear_diag'));
     }
 
@@ -456,6 +457,64 @@ class ALMA_Affiliate_Link_Auditor {
         self::redirect_back('success', sprintf('Convertiti %1$d link a %2$s; %3$d ancora da convertire.', $converted, $domain, $remaining) . ($remaining > 0 ? ' Premi di nuovo per continuare.' : ' Conversione completata!'));
     }
 
+    /**
+     * Link getyourguide.* pubblicati che contengono ancora parametri di
+     * SESSIONE dell'export (deeplink_id/page_id/visitor_id): il link apre
+     * la pagina giusta ma può non essere convalidato dal programma partner.
+     */
+    public static function session_params_count() {
+        global $wpdb;
+        return (int) $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM {$wpdb->postmeta} pm
+             INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+             WHERE pm.meta_key = '_affiliate_url' AND pm.meta_value LIKE %s
+               AND (pm.meta_value LIKE %s OR pm.meta_value LIKE %s OR pm.meta_value LIKE %s)
+               AND p.post_type = 'affiliate_link' AND p.post_status = 'publish'",
+            '%' . $wpdb->esc_like('getyourguide.') . '%',
+            '%' . $wpdb->esc_like('deeplink_id=') . '%',
+            '%' . $wpdb->esc_like('page_id=') . '%',
+            '%' . $wpdb->esc_like('visitor_id=') . '%'
+        ));
+    }
+
+    public static function handle_strip_session() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_link_audit');
+        if (!self::acquire_lock()) {
+            self::redirect_back('error', 'Un\'operazione è già in corso: riprova tra qualche istante.');
+        }
+        global $wpdb;
+        $cleaned = 0;
+        try {
+            $rows = $wpdb->get_results($wpdb->prepare(
+                "SELECT pm.post_id, pm.meta_value AS url FROM {$wpdb->postmeta} pm
+                 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+                 WHERE pm.meta_key = '_affiliate_url' AND pm.meta_value LIKE %s
+                   AND (pm.meta_value LIKE %s OR pm.meta_value LIKE %s OR pm.meta_value LIKE %s)
+                   AND p.post_type = 'affiliate_link' AND p.post_status = 'publish'
+                 ORDER BY pm.post_id ASC LIMIT 50",
+                '%' . $wpdb->esc_like('getyourguide.') . '%',
+                '%' . $wpdb->esc_like('deeplink_id=') . '%',
+                '%' . $wpdb->esc_like('page_id=') . '%',
+                '%' . $wpdb->esc_like('visitor_id=') . '%'
+            ), ARRAY_A);
+            foreach ((array) $rows as $row) {
+                $new_url = ALMA_Affiliate_Source_GYG_CSV_Importer::strip_gyg_session_params((string) $row['url']);
+                if ($new_url === (string) $row['url'] || $new_url === '') { continue; }
+                add_post_meta((int) $row['post_id'], self::META_BACKUP, (string) $row['url'], true);
+                update_post_meta((int) $row['post_id'], '_affiliate_url', esc_url_raw($new_url));
+                $cleaned++;
+            }
+            if ($cleaned > 0 && class_exists('ALMA_Contextual_Affiliate_Widget') && method_exists('ALMA_Contextual_Affiliate_Widget', 'bump_cache_version')) {
+                ALMA_Contextual_Affiliate_Widget::bump_cache_version();
+            }
+        } finally {
+            delete_option(self::LOCK_OPTION);
+        }
+        $remaining = self::session_params_count();
+        self::redirect_back('success', sprintf('Puliti %1$d link dai parametri di sessione; %2$d ancora da pulire.', $cleaned, $remaining) . ($remaining > 0 ? ' Premi di nuovo per continuare.' : ' Pulizia completata!'));
+    }
+
     /* ---------------------------------------------------------------------
      * Pagina
      * ------------------------------------------------------------------ */
@@ -517,6 +576,20 @@ class ALMA_Affiliate_Link_Auditor {
             echo '<p style="margin:0;">✅ Tutti i link GYG usano già ' . esc_html($preferred) . '.</p>';
         }
         echo '</form>';
+
+        // ---- Parametri di sessione GYG (deeplink_id / page_id / visitor_id) ----
+        $session_count = self::session_params_count();
+        echo '<hr style="margin:14px 0;">';
+        echo '<p class="description">I deep link esportati da GetYourGuide possono contenere <strong>ID di sessione</strong> (<code>deeplink_id</code>, <code>page_id</code>, <code>visitor_id</code>): il link apre la pagina giusta ma può <strong>non essere convalidato</strong> come vendita partner. Dagli import futuri vengono rimossi automaticamente; qui si puliscono quelli già in archivio (solo domini getyourguide.*, con backup dell\'URL originale — gli altri domini e i link manuali non vengono toccati).</p>';
+        if ($session_count > 0) {
+            echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '" style="margin:0;">';
+            wp_nonce_field('alma_link_audit');
+            echo '<input type="hidden" name="action" value="alma_link_audit_strip_session">';
+            echo '<p style="margin:0;"><button class="button button-primary">Pulisci i prossimi ' . esc_html((string) min(50, $session_count)) . ' link (' . esc_html((string) $session_count) . ' con parametri di sessione)</button></p>';
+            echo '</form>';
+        } else {
+            echo '<p style="margin:0;">✅ Nessun link GYG con parametri di sessione.</p>';
+        }
         echo '<p class="description" style="margin-top:8px;">Anche qui l\'URL precedente viene salvato nel meta di backup <code>' . esc_html(self::META_BACKUP) . '</code> prima della modifica.</p>';
         echo '</div>';
 

--- a/includes/class-affiliate-source-gyg-csv-importer.php
+++ b/includes/class-affiliate-source-gyg-csv-importer.php
@@ -163,6 +163,35 @@ class ALMA_Affiliate_Source_GYG_CSV_Importer {
         return $rebuilt;
     }
 
+    /**
+     * Rimuove dai link getyourguide.* i parametri di SESSIONE dell'export
+     * (deeplink_id, page_id, visitor_id): sono ID di una sessione altrui e
+     * non vanno pubblicati staticamente — il tracking partner corretto è
+     * partner_id + utm_medium. Ogni altro dominio resta intatto. Pura.
+     */
+    public static function strip_gyg_session_params($url) {
+        $url = trim((string)$url);
+        if ($url === '') { return $url; }
+        $host = strtolower((string) wp_parse_url($url, PHP_URL_HOST));
+        if ($host === '' || strpos($host, 'getyourguide.') === false) { return $url; }
+        $fragment = '';
+        $hash_pos = strpos($url, '#');
+        if ($hash_pos !== false) {
+            $fragment = substr($url, $hash_pos);
+            $url = substr($url, 0, $hash_pos);
+        }
+        $query_pos = strpos($url, '?');
+        if ($query_pos === false) { return $url . $fragment; }
+        $base = substr($url, 0, $query_pos);
+        $params = array();
+        wp_parse_str(substr($url, $query_pos + 1), $params);
+        foreach (array('deeplink_id', 'page_id', 'visitor_id') as $session_param) {
+            unset($params[$session_param]);
+        }
+        $query = http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+        return $base . ($query !== '' ? '?' . $query : '') . $fragment;
+    }
+
     public static function build_affiliate_url($original_url, $partner_id, $utm_medium = 'online_publisher') {
         $url = esc_url_raw(trim((string)$original_url));
         if ($url === '' || !wp_http_validate_url($url)) {
@@ -170,6 +199,9 @@ class ALMA_Affiliate_Source_GYG_CSV_Importer {
         }
         // Riferimento ufficiale: dominio del programma partner dell'editore.
         $url = self::normalize_gyg_domain($url, self::preferred_domain());
+        // I CSV di GYG possono contenere ID di sessione (deeplink_id, page_id):
+        // vanno eliminati PRIMA di salvare, o il link non viene convalidato.
+        $url = self::strip_gyg_session_params($url);
         $partner_id = sanitize_text_field((string)$partner_id);
         $utm_medium = sanitize_text_field((string)($utm_medium !== '' ? $utm_medium : 'online_publisher'));
         if ($partner_id === '') {


### PR DESCRIPTION
## Verifica sul link segnalato

Il plugin **non riscrive** gli URL salvati (nessun punto del codice aggiunge `deeplink_id`/`page_id`): i parametri arrivano dai **CSV esportati da GetYourGuide**, i cui deep link contengono ID di sessione dell'export. `build_affiliate_url` conservava tutti i parametri esistenti, quindi finivano salvati nel Link Affiliato. Effetto: la pagina si apre correttamente ma la vendita può **non essere convalidata** al partner — l'attribuzione corretta è solo `partner_id` + `utm_medium`, come nel formato indicato.

## Fix

- **Import futuri**: nuova funzione pura `strip_gyg_session_params()` applicata in `build_affiliate_url` — `deeplink_id`, `page_id` e `visitor_id` vengono eliminati alla costruzione del link, preservando tutto il resto (partner, utm, parametri custom, fragment). Agisce **solo sui domini getyourguide.***: gli short link manuali Travelpayouts (booking, expedia…) e ogni altro dominio restano intatti.
- **Archivio esistente**: nuovo batch in **Verifica link** (card Dominio ufficiale GetYourGuide): conteggio dei link getyourguide.* con parametri di sessione e pulsante "Pulisci i prossimi 50 link", con **backup dell'URL originale** (`_alma_url_pre_bonifica`, mai sovrascritto, stesso pattern della bonifica tpx.li) e rigenerazione della cache del widget contestuale.

## Verifiche
- Test standalone **9/9**, incluso il link reale segnalato: l'URL con `deeplink_id`+`page_id` viene ripulito **esattamente** al formato corretto (`?partner_id=88HSYUH&utm_medium=online_publisher`); link già puliti invariati; `booking.tpx.li` e Viator mai toccati; fragment preservato; import CSV con sessione → URL pulito senza duplicare `partner_id`.
- `php -l` OK; CHANGELOG.md e README.md aggiornati; versione `2.87.1`.

Dopo il merge: apri **Link Affiliati → Verifica link** e usa il nuovo pulsante di pulizia finché il contatore arriva a zero (50 link per clic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN16M

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_