### PR TITLE
Parametri di sessione GYG: pulizia completa (link + articoli) e Ispettore URL salvati (v2.87.2 + v2.87.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.87.3 - 2026-07-08
+
+### Parametri di sessione GYG: pulizia anche negli ARTICOLI e sui link in ogni stato
+- **Percorso completo del problema ricostruito** (grazie al "copia link senza cliccare" dell'editore): i deep link del CSV contenevano `deeplink_id`/`page_id` → salvati nel meta dei Link Affiliati (prima della 2.87.1) → il payload dei candidati passa all'AI l'`affiliate_url` grezzo → l'AI può scrivere **href diretti nel corpo dell'articolo** con l'URL sporco. Risultato: URL sporco *dentro il post_content*, che la pulizia dei soli meta non toccava; in più il contatore guardava solo i link `publish`. Nota: quei parametri NON sono tracking del plugin (il click tracking del plugin usa `data-link-id` e una tabella propria, mai parametri URL) e la stringa `deeplink_id` non esiste nel codice: sono gli ID di sessione dell'export GetYourGuide (il nome della source "GetYourGuide Deep Link" è una coincidenza lessicale).
+- **Batch di pulizia esteso**: ora pulisce sia i **Link Affiliati in ogni stato** (publish/draft/pending/private, con backup) sia il **contenuto di articoli e pagine** che contengono URL getyourguide.* con parametri di sessione (fino a 20 articoli per click, con revisione WordPress per il rollback); contatori separati per link e articoli nella card e nel messaggio di esito.
+- **Nuova funzione pura `strip_gyg_session_params_from_content()`**: ripulisce tutti gli URL GYG dentro un HTML preservando lo stile degli ampersand (`&` o `&amp;`); altri domini mai toccati.
+- **Prevenzione alla fonte**: il draft-builder applica la pulizia al contenuto di OGNI nuova bozza prima del salvataggio — anche se l'AI incolla un URL sporco dal payload, non arriva mai nell'articolo.
+- Test standalone 13/13 (aggiunti: href nel contenuto ripulito, `&amp;` preservato, altri domini/contenuti senza GYG invariati).
+- Versione plugin aggiornata a `2.87.3`.
+
 ## 2.87.2 - 2026-07-08
 
 ### Verifica link: Ispettore degli URL salvati

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.87.2 - 2026-07-08
+
+### Verifica link: Ispettore degli URL salvati
+- **Contesto**: dopo la pulizia dei parametri di sessione (2.87.1) il contatore risultava a zero. Le spiegazioni possibili sono due, e ora la pagina permette di distinguerle: (a) gli URL salvati sono davvero puliti e i `deeplink_id`/`page_id` visti nel browser li aggiunge **GetYourGuide stesso durante il redirect dopo il click** (è il loro tracking: il `partner_id` resta nell'URL e la vendita viene attribuita normalmente); (b) esistono ancora URL sporchi che la query non intercettava.
+- **Nuova card "🔎 Ispettore URL salvati"** in Verifica link: cerca per titolo o per pezzo di URL (es. `t160202`, `dubai`, `deeplink_id`) e mostra fino a 20 link con l'URL **esattamente come salvato nel database** (bozze incluse), con gli eventuali parametri di sessione evidenziati in rosso e l'indicazione se il link è già stato bonificato (backup presente).
+- Messaggio del contatore a zero riformulato per spiegare il comportamento del redirect GYG.
+- Versione plugin aggiornata a `2.87.2`.
+
 ## 2.87.1 - 2026-07-08
 
 ### Link GYG: rimossi i parametri di sessione (deeplink_id/page_id) da import e archivio

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.87.3 - 2026-07-08
+
+### Parametri di sessione GYG: pulizia completa
+- Il batch di Verifica link ora pulisce anche il contenuto di articoli/pagine (l'AI poteva scrivere href diretti con l'URL sporco preso dal payload) e i link in ogni stato; il draft-builder ripulisce ogni nuova bozza prima del salvataggio. I parametri non sono tracking del plugin: arrivano dall'export GetYourGuide.
+- Versione plugin aggiornata a `2.87.3`.
+
 ## 2.87.2 - 2026-07-08
 
 ### Ispettore URL salvati in Verifica link

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.87.2 - 2026-07-08
+
+### Ispettore URL salvati in Verifica link
+- Nuova card di ricerca che mostra gli URL esattamente come salvati nel database (parametri di sessione evidenziati): distingue un problema di salvataggio dal tracking che GYG aggiunge nel browser dopo il click.
+- Versione plugin aggiornata a `2.87.2`.
+
 ## 2.87.1 - 2026-07-08
 
 ### Link GYG senza parametri di sessione

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.87.1
+ * Version: 2.87.2
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.87.1');
+define('ALMA_VERSION', '2.87.2');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.87.2
+ * Version: 2.87.3
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.87.2');
+define('ALMA_VERSION', '2.87.3');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-affiliate-link-auditor.php
+++ b/includes/class-affiliate-link-auditor.php
@@ -588,9 +588,46 @@ class ALMA_Affiliate_Link_Auditor {
             echo '<p style="margin:0;"><button class="button button-primary">Pulisci i prossimi ' . esc_html((string) min(50, $session_count)) . ' link (' . esc_html((string) $session_count) . ' con parametri di sessione)</button></p>';
             echo '</form>';
         } else {
-            echo '<p style="margin:0;">✅ Nessun link GYG con parametri di sessione.</p>';
+            echo '<p style="margin:0;">✅ Nessun link GYG con parametri di sessione salvato nel database. <span class="description">Se nel browser vedi comunque <code>deeplink_id</code>/<code>page_id</code> DOPO aver cliccato un link, li aggiunge GetYourGuide stesso durante il redirect: è il loro tracking, il <code>partner_id</code> resta e la vendita viene attribuita. Verifica l\'URL salvato con l\'ispettore qui sotto.</span></p>';
         }
         echo '<p class="description" style="margin-top:8px;">Anche qui l\'URL precedente viene salvato nel meta di backup <code>' . esc_html(self::META_BACKUP) . '</code> prima della modifica.</p>';
+        echo '</div>';
+
+        // ---- Ispettore URL salvati: mostra ESATTAMENTE cosa c'è nel database ----
+        $url_search = isset($_GET['alma_url_search']) ? sanitize_text_field(wp_unslash($_GET['alma_url_search'])) : '';
+        echo '<div style="' . esc_attr($card) . '"><h2 style="margin-top:0;">🔎 Ispettore URL salvati</h2>';
+        echo '<p class="description">Cerca per titolo o per pezzo di URL (es. <code>t160202</code>, <code>dubai</code>, <code>deeplink_id</code>): mostra l\'URL <strong>esattamente come salvato</strong> nel database, con gli eventuali parametri di sessione evidenziati. Così distingui subito un problema di salvataggio dal tracking che GYG aggiunge nel browser dopo il click.</p>';
+        echo '<form method="get" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin:0 0 10px;">';
+        echo '<input type="hidden" name="post_type" value="affiliate_link"><input type="hidden" name="page" value="' . esc_attr(self::MENU_SLUG) . '">';
+        echo '<input type="search" name="alma_url_search" class="regular-text" value="' . esc_attr($url_search) . '" placeholder="Es. t160202, dubai, deeplink_id">';
+        echo '<button class="button">Cerca</button></form>';
+        if ($url_search !== '') {
+            global $wpdb;
+            $like = '%' . $wpdb->esc_like($url_search) . '%';
+            $rows = $wpdb->get_results($wpdb->prepare(
+                "SELECT p.ID, p.post_title, pm.meta_value AS url FROM {$wpdb->postmeta} pm
+                 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+                 WHERE pm.meta_key = '_affiliate_url' AND p.post_type = 'affiliate_link' AND p.post_status IN ('publish','draft','pending')
+                   AND (pm.meta_value LIKE %s OR p.post_title LIKE %s)
+                 ORDER BY p.ID DESC LIMIT 20",
+                $like, $like
+            ), ARRAY_A);
+            if (empty($rows)) {
+                echo '<p class="description">Nessun link trovato per «' . esc_html($url_search) . '».</p>';
+            } else {
+                echo '<table class="widefat striped"><thead><tr><th style="width:260px;">Link</th><th>URL salvato nel database</th></tr></thead><tbody>';
+                foreach ($rows as $row) {
+                    $stored = (string) $row['url'];
+                    $display = esc_html($stored);
+                    // Evidenzia i parametri di sessione se presenti nell'URL SALVATO.
+                    $display = preg_replace('/((?:deeplink_id|page_id|visitor_id)=[^&\s]*)/', '<mark style="background:#ffd6d6;">$1</mark>', $display);
+                    $backup = (string) get_post_meta((int) $row['ID'], self::META_BACKUP, true);
+                    echo '<tr><td><a href="' . esc_url(get_edit_post_link((int) $row['ID'], 'raw')) . '">' . esc_html($row['post_title']) . '</a> <small>#' . (int) $row['ID'] . '</small>' . ($backup !== '' ? '<br><small class="description">bonificato (backup presente)</small>' : '') . '</td>';
+                    echo '<td style="word-break:break-all;"><code>' . $display . '</code></td></tr>';
+                }
+                echo '</tbody></table>';
+            }
+        }
         echo '</div>';
 
         // ---- Bonifica short link Travelpayouts (solo programmi supportati) ----

--- a/includes/class-affiliate-link-auditor.php
+++ b/includes/class-affiliate-link-auditor.php
@@ -464,12 +464,32 @@ class ALMA_Affiliate_Link_Auditor {
      */
     public static function session_params_count() {
         global $wpdb;
+        // Tutti gli stati utili: anche i link in bozza finiscono nel payload
+        // dell'agente e negli articoli.
         return (int) $wpdb->get_var($wpdb->prepare(
             "SELECT COUNT(*) FROM {$wpdb->postmeta} pm
              INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
              WHERE pm.meta_key = '_affiliate_url' AND pm.meta_value LIKE %s
                AND (pm.meta_value LIKE %s OR pm.meta_value LIKE %s OR pm.meta_value LIKE %s)
-               AND p.post_type = 'affiliate_link' AND p.post_status = 'publish'",
+               AND p.post_type = 'affiliate_link' AND p.post_status IN ('publish','draft','pending','private')",
+            '%' . $wpdb->esc_like('getyourguide.') . '%',
+            '%' . $wpdb->esc_like('deeplink_id=') . '%',
+            '%' . $wpdb->esc_like('page_id=') . '%',
+            '%' . $wpdb->esc_like('visitor_id=') . '%'
+        ));
+    }
+
+    /**
+     * Articoli/pagine il cui CONTENUTO contiene URL getyourguide.* con
+     * parametri di sessione (l'AI può scrivere href diretti dal payload).
+     */
+    public static function session_params_posts_count() {
+        global $wpdb;
+        return (int) $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM {$wpdb->posts}
+             WHERE post_type IN ('post','page') AND post_status IN ('publish','draft','pending','private','future')
+               AND post_content LIKE %s
+               AND (post_content LIKE %s OR post_content LIKE %s OR post_content LIKE %s)",
             '%' . $wpdb->esc_like('getyourguide.') . '%',
             '%' . $wpdb->esc_like('deeplink_id=') . '%',
             '%' . $wpdb->esc_like('page_id=') . '%',
@@ -485,13 +505,14 @@ class ALMA_Affiliate_Link_Auditor {
         }
         global $wpdb;
         $cleaned = 0;
+        $cleaned_posts = 0;
         try {
             $rows = $wpdb->get_results($wpdb->prepare(
                 "SELECT pm.post_id, pm.meta_value AS url FROM {$wpdb->postmeta} pm
                  INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
                  WHERE pm.meta_key = '_affiliate_url' AND pm.meta_value LIKE %s
                    AND (pm.meta_value LIKE %s OR pm.meta_value LIKE %s OR pm.meta_value LIKE %s)
-                   AND p.post_type = 'affiliate_link' AND p.post_status = 'publish'
+                   AND p.post_type = 'affiliate_link' AND p.post_status IN ('publish','draft','pending','private')
                  ORDER BY pm.post_id ASC LIMIT 50",
                 '%' . $wpdb->esc_like('getyourguide.') . '%',
                 '%' . $wpdb->esc_like('deeplink_id=') . '%',
@@ -505,14 +526,39 @@ class ALMA_Affiliate_Link_Auditor {
                 update_post_meta((int) $row['post_id'], '_affiliate_url', esc_url_raw($new_url));
                 $cleaned++;
             }
-            if ($cleaned > 0 && class_exists('ALMA_Contextual_Affiliate_Widget') && method_exists('ALMA_Contextual_Affiliate_Widget', 'bump_cache_version')) {
+
+            // Anche il CONTENUTO di articoli/pagine: l'AI può aver scritto
+            // href diretti con l'URL sporco preso dal payload dei candidati.
+            // wp_update_post crea la revisione (rollback nativo).
+            $post_rows = $wpdb->get_results($wpdb->prepare(
+                "SELECT ID FROM {$wpdb->posts}
+                 WHERE post_type IN ('post','page') AND post_status IN ('publish','draft','pending','private','future')
+                   AND post_content LIKE %s
+                   AND (post_content LIKE %s OR post_content LIKE %s OR post_content LIKE %s)
+                 ORDER BY ID ASC LIMIT 20",
+                '%' . $wpdb->esc_like('getyourguide.') . '%',
+                '%' . $wpdb->esc_like('deeplink_id=') . '%',
+                '%' . $wpdb->esc_like('page_id=') . '%',
+                '%' . $wpdb->esc_like('visitor_id=') . '%'
+            ), ARRAY_A);
+            foreach ((array) $post_rows as $post_row) {
+                $post = get_post((int) $post_row['ID']);
+                if (!$post) { continue; }
+                $new_content = ALMA_Affiliate_Source_GYG_CSV_Importer::strip_gyg_session_params_from_content($post->post_content);
+                if ($new_content === $post->post_content) { continue; }
+                $updated = wp_update_post(array('ID' => $post->ID, 'post_content' => $new_content), true);
+                if (!is_wp_error($updated)) { $cleaned_posts++; }
+            }
+
+            if (($cleaned > 0 || $cleaned_posts > 0) && class_exists('ALMA_Contextual_Affiliate_Widget') && method_exists('ALMA_Contextual_Affiliate_Widget', 'bump_cache_version')) {
                 ALMA_Contextual_Affiliate_Widget::bump_cache_version();
             }
         } finally {
             delete_option(self::LOCK_OPTION);
         }
         $remaining = self::session_params_count();
-        self::redirect_back('success', sprintf('Puliti %1$d link dai parametri di sessione; %2$d ancora da pulire.', $cleaned, $remaining) . ($remaining > 0 ? ' Premi di nuovo per continuare.' : ' Pulizia completata!'));
+        $remaining_posts = self::session_params_posts_count();
+        self::redirect_back('success', sprintf('Puliti %1$d link e %2$d articoli dai parametri di sessione; ancora da pulire: %3$d link, %4$d articoli.', $cleaned, $cleaned_posts, $remaining, $remaining_posts) . (($remaining + $remaining_posts) > 0 ? ' Premi di nuovo per continuare.' : ' Pulizia completata!'));
     }
 
     /* ---------------------------------------------------------------------
@@ -579,16 +625,17 @@ class ALMA_Affiliate_Link_Auditor {
 
         // ---- Parametri di sessione GYG (deeplink_id / page_id / visitor_id) ----
         $session_count = self::session_params_count();
+        $session_posts = self::session_params_posts_count();
         echo '<hr style="margin:14px 0;">';
-        echo '<p class="description">I deep link esportati da GetYourGuide possono contenere <strong>ID di sessione</strong> (<code>deeplink_id</code>, <code>page_id</code>, <code>visitor_id</code>): il link apre la pagina giusta ma può <strong>non essere convalidato</strong> come vendita partner. Dagli import futuri vengono rimossi automaticamente; qui si puliscono quelli già in archivio (solo domini getyourguide.*, con backup dell\'URL originale — gli altri domini e i link manuali non vengono toccati).</p>';
-        if ($session_count > 0) {
+        echo '<p class="description">I deep link esportati da GetYourGuide possono contenere <strong>ID di sessione</strong> (<code>deeplink_id</code>, <code>page_id</code>, <code>visitor_id</code>): il link apre la pagina giusta ma può <strong>non essere convalidato</strong> come vendita partner. Dagli import futuri vengono rimossi automaticamente. Qui si puliscono sia i <strong>Link Affiliati</strong> (ogni stato, con backup dell\'URL originale) sia gli <strong>articoli/pagine</strong> il cui contenuto contiene URL GYG sporchi (con revisione WordPress). Solo domini getyourguide.*: gli altri domini e i link manuali non vengono toccati.</p>';
+        if ($session_count > 0 || $session_posts > 0) {
             echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '" style="margin:0;">';
             wp_nonce_field('alma_link_audit');
             echo '<input type="hidden" name="action" value="alma_link_audit_strip_session">';
-            echo '<p style="margin:0;"><button class="button button-primary">Pulisci i prossimi ' . esc_html((string) min(50, $session_count)) . ' link (' . esc_html((string) $session_count) . ' con parametri di sessione)</button></p>';
+            echo '<p style="margin:0;"><button class="button button-primary">Pulisci parametri di sessione (' . esc_html((string) $session_count) . ' link, ' . esc_html((string) $session_posts) . ' articoli — fino a 50 link e 20 articoli per click)</button></p>';
             echo '</form>';
         } else {
-            echo '<p style="margin:0;">✅ Nessun link GYG con parametri di sessione salvato nel database. <span class="description">Se nel browser vedi comunque <code>deeplink_id</code>/<code>page_id</code> DOPO aver cliccato un link, li aggiunge GetYourGuide stesso durante il redirect: è il loro tracking, il <code>partner_id</code> resta e la vendita viene attribuita. Verifica l\'URL salvato con l\'ispettore qui sotto.</span></p>';
+            echo '<p style="margin:0;">✅ Nessun parametro di sessione GYG nei link salvati né nei contenuti. <span class="description">Se nel browser vedi <code>deeplink_id</code>/<code>page_id</code> DOPO aver cliccato un link, li aggiunge GetYourGuide durante il redirect: è il loro tracking, il <code>partner_id</code> resta e la vendita viene attribuita. Verifica l\'URL salvato con l\'ispettore qui sotto.</span></p>';
         }
         echo '<p class="description" style="margin-top:8px;">Anche qui l\'URL precedente viene salvato nel meta di backup <code>' . esc_html(self::META_BACKUP) . '</code> prima della modifica.</p>';
         echo '</div>';

--- a/includes/class-affiliate-source-gyg-csv-importer.php
+++ b/includes/class-affiliate-source-gyg-csv-importer.php
@@ -192,6 +192,24 @@ class ALMA_Affiliate_Source_GYG_CSV_Importer {
         return $base . ($query !== '' ? '?' . $query : '') . $fragment;
     }
 
+    /**
+     * Applica strip_gyg_session_params a TUTTI gli URL getyourguide.* dentro
+     * un contenuto HTML (href e testo), preservando lo stile di encoding
+     * degli ampersand (& oppure &amp;). Pura.
+     */
+    public static function strip_gyg_session_params_from_content($content) {
+        $content = (string) $content;
+        if ($content === '' || stripos($content, 'getyourguide.') === false) { return $content; }
+        return preg_replace_callback('~https?://[^\s"\'<>]*getyourguide\.[^\s"\'<>]*~i', function ($match) {
+            $original = $match[0];
+            $uses_entities = strpos($original, '&amp;') !== false;
+            $decoded = $uses_entities ? str_replace('&amp;', '&', $original) : $original;
+            $cleaned = self::strip_gyg_session_params($decoded);
+            if ($cleaned === $decoded) { return $original; }
+            return $uses_entities ? str_replace('&', '&amp;', $cleaned) : $cleaned;
+        }, $content);
+    }
+
     public static function build_affiliate_url($original_url, $partner_id, $utm_medium = 'online_publisher') {
         $url = esc_url_raw(trim((string)$original_url));
         if ($url === '' || !wp_http_validate_url($url)) {

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -1256,6 +1256,12 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             $clean['content'] = $enforced['content'];
             $clean['warnings'] = array_values(array_unique(array_merge((array)$clean['warnings'], (array)$widget_result['warnings'], (array)$enforced['warnings'])));
         }
+        // Difesa: gli URL GYG con parametri di sessione (deeplink_id/page_id
+        // dai CSV) non devono entrare negli articoli — l'AI può scrivere
+        // href diretti prendendoli dal payload dei candidati.
+        if (class_exists('ALMA_Affiliate_Source_GYG_CSV_Importer')) {
+            $clean['content'] = ALMA_Affiliate_Source_GYG_CSV_Importer::strip_gyg_session_params_from_content((string) $clean['content']);
+        }
         // Pubblicazione diretta opzionale (Impostazioni → Generale): di
         // default resta bozza da revisionare.
         $auto_publish = get_option('alma_ai_auto_publish', 'no') === 'yes';


### PR DESCRIPTION
## Percorso del problema, ricostruito

Il "copia link senza cliccare" dell'editore ha chiarito il flusso completo:
`deeplink_id`/`page_id` nei deep link del **CSV GetYourGuide** → salvati nel meta dei Link Affiliati (import precedenti alla 2.87.1) → il payload dei candidati passa all'AI l'`affiliate_url` grezzo → **l'AI scrive href diretti nel corpo dell'articolo** con l'URL sporco. Risultato: URL sporco dentro il `post_content`, che la pulizia dei soli meta non toccava; in più il contatore guardava solo i link `publish`.

**Nota importante**: quei parametri NON sono tracking del plugin — il click tracking del plugin usa `data-link-id` e la tabella `alma_analytics`, mai parametri URL; la stringa `deeplink_id` non esiste nel codice. Sono gli ID di sessione dell'export GetYourGuide (il nome della source "GetYourGuide Deep Link" è una coincidenza).

## v2.87.3 — Pulizia completa
- **Batch esteso**: pulisce sia i **Link Affiliati in ogni stato** (publish/draft/pending/private, con backup `_alma_url_pre_bonifica`) sia il **contenuto di articoli e pagine** con URL getyourguide.* sporchi (fino a 20 articoli per click, con revisione WordPress per il rollback). Contatori separati per link e articoli.
- **Nuova funzione pura** `strip_gyg_session_params_from_content()`: ripulisce tutti gli URL GYG dentro un HTML preservando lo stile degli ampersand (`&` o `&amp;`); altri domini mai toccati.
- **Prevenzione alla fonte**: il draft-builder ripulisce il contenuto di OGNI nuova bozza prima del salvataggio.

## v2.87.2 — Ispettore URL salvati
- Card "🔎 Ispettore URL salvati" in Verifica link: ricerca per titolo o pezzo di URL, mostra fino a 20 link con l'URL **esattamente come salvato nel database** (bozze incluse), parametri di sessione evidenziati in rosso, indicazione dei link già bonificati.

## Verifiche
- Test standalone **13/13** (link reale segnalato; href nel contenuto ripulito; `&amp;` preservato; tpx.li/Viator/altri domini mai toccati; import CSV pulito senza duplicare partner_id).
- `php -l` OK; CHANGELOG.md e README.md aggiornati; versioni `2.87.2` + `2.87.3`.

Dopo il merge: **Verifica link → "Pulisci parametri di sessione"** e ripeti finché entrambi i contatori (link e articoli) arrivano a zero; poi con l'Ispettore cerca `t160202` per la conferma finale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM