### PR TITLE
Arricchimento dai post più vecchi + link universali sempre candidati + widget a metà testo (v2.88.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.88.0 - 2026-07-08
+
+### Arricchimento: si parte dagli articoli più vecchi, con link universali e widget a metà testo
+- **Coda invertita: dai più vecchi ai più recenti.** L'arricchimento automatico analizzava prima gli ultimi articoli pubblicati — in genere già ottimizzati (nascono con link e widget). Ora la coda dei mai-analizzati parte **dalle prime pubblicazioni (gennaio 2020)** in ordine di data crescente. Metodo scelto: **deterministico per data**, non random — copre tutto l'archivio senza buchi, non rilavora due volte lo stesso periodo ed è prevedibile ("a che punto siamo" si capisce dalla data dell'ultimo articolo arricchito). La ri-analisi post-cooldown resta per anzianità di analisi.
+- **Link universali sempre in gara**: i 2 migliori link di tipologia universale (Assicurazioni, eSIM…) entrano sempre tra i candidati dell'arricchimento e della metabox AI Affiliati, marcati `universale`; il prompt istruisce l'AI a includerne **sempre uno se coerente** col contenuto (max 1, anchor o button, nel punto naturale: consigli pratici/preparativi).
+- **Widget per spezzare il testo**: il prompt ora chiede di proporre il widget **dove possibile** (non più "se l'articolo si presta") e in un **paragrafo intermedio** dell'articolo, non necessariamente in chiusura — la funzione è anche visiva: spezzare i muri di testo dei vecchi articoli.
+- Descrizione della tab Arricchimento aggiornata. Test standalone 8/8.
+- Versione plugin aggiornata a `2.88.0`.
+
 ## 2.87.3 - 2026-07-08
 
 ### Parametri di sessione GYG: pulizia anche negli ARTICOLI e sui link in ogni stato

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.88.0 - 2026-07-08
+
+### Arricchimento dai post più vecchi
+- La coda parte dalle prime pubblicazioni (2020), le meno ottimizzate; i link universali (Assicurazioni, eSIM) sono sempre candidati e l'AI ne include uno se coerente; il widget viene proposto dove possibile in un punto intermedio per spezzare il testo.
+- Versione plugin aggiornata a `2.88.0`.
+
 ## 2.87.3 - 2026-07-08
 
 ### Parametri di sessione GYG: pulizia completa

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.87.3
+ * Version: 2.88.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.87.3');
+define('ALMA_VERSION', '2.88.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-post-enricher.php
+++ b/includes/class-ai-post-enricher.php
@@ -10,7 +10,8 @@
  * revisione WordPress (rollback nativo).
  *
  * Ciclo di copertura:
- * 1. prima gli articoli MAI analizzati (priorità a quelli senza shortcode);
+ * 1. prima gli articoli MAI analizzati, dai PIÙ VECCHI per data di
+ *    pubblicazione (i primi articoli del blog sono i meno ottimizzati);
  * 2. finiti tutti, si riparte dai più "vecchi" di analisi — ma un articolo
  *    non viene mai ri-analizzato prima del cooldown configurato (default 60
  *    giorni), per controllare i costi ed evitare churn. Nelle ri-analisi
@@ -103,9 +104,12 @@ class ALMA_AI_Post_Enricher {
     }
 
     /**
-     * Coda di lavoro: prima i post mai analizzati (i senza-shortcode hanno
-     * priorità naturale perché più redditizi), poi i più vecchi di analisi
+     * Coda di lavoro: prima i post mai analizzati partendo DAI PIÙ VECCHI
+     * (le prime pubblicazioni — 2020 — sono quelle meno ottimizzate: i
+     * recenti nascono già con link e widget), poi i più vecchi di analisi
      * oltre il cooldown — il ciclo riparte da solo dopo aver coperto tutto.
+     * Metodo deterministico (data di pubblicazione crescente): prevedibile,
+     * copre tutto l'archivio senza buchi e senza rilavorare due volte.
      */
     public static function next_posts($limit) {
         $limit = max(1, absint($limit));
@@ -115,7 +119,7 @@ class ALMA_AI_Post_Enricher {
             'posts_per_page' => $limit,
             'fields' => 'ids',
             'orderby' => 'date',
-            'order' => 'DESC',
+            'order' => 'ASC',
             'no_found_rows' => true,
             'meta_query' => array(array('key' => self::META_LAST_RUN, 'compare' => 'NOT EXISTS')),
         ));
@@ -275,7 +279,7 @@ class ALMA_AI_Post_Enricher {
         $next_run = wp_next_scheduled(self::CRON_HOOK);
 
         echo '<h2>Arricchimento automatico dei post pubblicati</h2>';
-        echo '<p class="description" style="max-width:900px;">Ogni giorno l\'AI analizza gli articoli pubblicati e <strong>aggiunge</strong> (mai riscrive) link affiliati coerenti con contenuto e località, secondo le Regole inserimento, aggiornando il post direttamente. Ciclo: prima tutti gli articoli mai analizzati, poi ri-analisi dei più vecchi oltre il cooldown — nelle ri-analisi l\'AI può anche sostituire link incoerenti. Ogni modifica crea una revisione (rollback nativo). Nessuna notifica per articolo: un solo digest Telegram per esecuzione.</p>';
+        echo '<p class="description" style="max-width:900px;">Ogni giorno l\'AI analizza gli articoli pubblicati e <strong>aggiunge</strong> (mai riscrive) link affiliati coerenti con contenuto e località, secondo le Regole inserimento, aggiornando il post direttamente. Ciclo: prima tutti gli articoli mai analizzati <strong>partendo dai più vecchi</strong> (le prime pubblicazioni sono le meno ottimizzate; i recenti nascono già con link e widget), poi ri-analisi dei più vecchi di analisi oltre il cooldown — nelle ri-analisi l\'AI può anche sostituire link incoerenti. Dove coerente propone anche <strong>un link di tipologia universale</strong> (Assicurazioni, eSIM) e <strong>un widget a metà articolo</strong> per spezzare il testo. Ogni modifica crea una revisione (rollback nativo). Nessuna notifica per articolo: un solo digest Telegram per esecuzione.</p>';
 
         echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">';
         wp_nonce_field('alma_ai_agent_action');

--- a/includes/class-ai-post-optimizer.php
+++ b/includes/class-ai-post-optimizer.php
@@ -419,8 +419,9 @@ class ALMA_AI_Post_Optimizer {
         $prompt = 'Analizza l\'articolo e proponi al massimo ' . $budget . ' inserimenti di link affiliati che aumentino la conversione SENZA rompere il flusso di lettura. '
             . 'Rispondi SOLO JSON: {"proposte":[{"paragrafo":int (indice del paragrafo DOPO il quale inserire, >= primo_paragrafo_utilizzabile),"pattern":"anchor|button|card","link_id":int (solo da link_candidati),"frase":string (SOLO per anchor: una frase completa e naturale che prosegue il paragrafo e contiene lo shortcode [affiliate_link id="ID" text="anchor descrittiva"]),"button_text":string (per button/card),"motivo":string (perché qui, orientato alla conversione)}]}. ';
         if ($widget_allowed) {
-            $prompt .= 'Puoi inoltre proporre AL MASSIMO UN widget di link affiliati (blocco grafico a card) se l\'articolo si presta: aggiungi alle proposte {"pattern":"widget","paragrafo":int,"layout":"destination_cards|experience_cards|hero_spotlight","link_ids":[int (solo da link_candidati)],"titolo":string,"button_text":string,"motivo":string}. Layout: destination_cards = griglia di mete/destinazioni (2-6 link); experience_cards = card di tour/attività specifiche (2-8 link); hero_spotlight = UNA sola esperienza di punta (1 link). ';
+            $prompt .= 'DOVE POSSIBILE proponi anche UN widget di link affiliati (blocco grafico a card, massimo uno): serve a SPEZZARE VISIVAMENTE il testo, quindi scegli un paragrafo INTERMEDIO dell\'articolo (dopo una sezione centrale pertinente), NON necessariamente la chiusura. Aggiungi alle proposte {"pattern":"widget","paragrafo":int,"layout":"destination_cards|experience_cards|hero_spotlight","link_ids":[int (solo da link_candidati)],"titolo":string,"button_text":string,"motivo":string}. Layout: destination_cards = griglia di mete/destinazioni (2-6 link); experience_cards = card di tour/attività specifiche (2-8 link); hero_spotlight = UNA sola esperienza di punta (1 link). ';
         }
+        $prompt .= 'I link_candidati con "universale":true (assicurazione viaggio, eSIM…) valgono per QUALSIASI articolo: se coerente col contenuto, includi SEMPRE uno di questi tra le proposte (massimo 1, pattern anchor o button, nel punto più naturale, es. consigli pratici o preparativi). ';
         if ($allow_replacements) {
             $existing_analysis = self::analyze_content($post->ID, $post->post_content);
             $existing_links = array();
@@ -538,6 +539,20 @@ class ALMA_AI_Post_Optimizer {
                 'titolo' => sanitize_text_field((string)$row['title']),
                 'tipologie' => is_array($row['link_types'] ?? null) ? implode(', ', $row['link_types']) : '',
             );
+        }
+        // I migliori link di tipologia UNIVERSALE (Assicurazioni, eSIM…)
+        // sono sempre candidati: valgono per qualsiasi articolo.
+        if (class_exists('ALMA_Universal_Link_Types')) {
+            $existing_ids = array_map(function ($c) { return (int) $c['id']; }, $candidates);
+            foreach (ALMA_Universal_Link_Types::top_universal_links(2, $existing_ids) as $universal_id) {
+                $terms = get_the_terms($universal_id, 'link_type');
+                $candidates[] = array(
+                    'id' => (int) $universal_id,
+                    'titolo' => sanitize_text_field((string) get_the_title($universal_id)),
+                    'tipologie' => (is_array($terms) ? implode(', ', wp_list_pluck($terms, 'name')) : ''),
+                    'universale' => true,
+                );
+            }
         }
         return $candidates;
     }


### PR DESCRIPTION
## Cosa fa

Tre modifiche all'**Arricchimento automatico dei post pubblicati** (che valgono anche per le proposte della metabox "AI Affiliati", motore condiviso):

### 1. Coda invertita: si parte dai più vecchi
La coda dei mai-analizzati partiva dagli ultimi articoli pubblicati — in genere già ottimizzati (nascono con link e widget). Ora parte **dalle prime pubblicazioni (gennaio 2020)** in ordine di data crescente.

**Metodo scelto: deterministico per data, non random.** Motivi: copre tutto l'archivio senza buchi, non rischia di rilavorare due volte lo stesso periodo, ed è verificabile a colpo d'occhio ("a che punto siamo" = data dell'ultimo articolo arricchito nel report). La ri-analisi post-cooldown resta ordinata per anzianità di analisi.

### 2. Link universali sempre in gara
I 2 migliori link di tipologia **universale** (Assicurazioni, eSIM…) entrano sempre tra i candidati, marcati `"universale": true` nel payload; il prompt istruisce l'AI: **se coerente col contenuto, includine sempre uno** (max 1, pattern anchor o button, nel punto naturale — consigli pratici/preparativi).

### 3. Widget per spezzare il testo
Il prompt passa da "puoi proporre un widget se l'articolo si presta" a "**dove possibile** proponi un widget": la sua funzione è anche visiva — spezzare i muri di testo dei vecchi articoli — quindi il punto richiesto è un **paragrafo intermedio**, non necessariamente la chiusura. Resta massimo un widget per articolo, creato solo all'applicazione.

## Verifiche
- Test standalone **8/8** (ordine ASC sui mai-analizzati, ri-analisi invariata, universali candidati con flag, istruzioni prompt).
- `php -l` OK; descrizione della tab Arricchimento aggiornata; CHANGELOG.md e README.md aggiornati; versione `2.88.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_