### PR TITLE
Mappa interattiva "I luoghi di questo articolo" a fine articolo (v2.89.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.89.0 - 2026-07-08
+
+### Mappa interattiva "I luoghi di questo articolo" a fine articolo
+- **Nuova mappa automatica a fine articolo** (`ALMA_Article_Locations_Map`): mostra le località citate nell'articolo prese dall'indice geografico (solo quelle con coordinate geocodificate, max 10, deduplicate), con la **località primaria evidenziata** nel colore accento e le secondarie in grigio. Se l'articolo non ha località geocodificate non compare nulla.
+- **Marker → Google Maps**: ogni marker apre un popup con nome, paese e pulsante **"Apri in Google Maps"** in nuova scheda; quando la località ha il **place_id di Google** salvato si apre la **scheda esatta del luogo** (foto, recensioni, indicazioni), altrimenti le coordinate. URL ufficiali `google.com/maps/search/?api=1` — nessuna API key.
+- **Prestazioni**: Leaflet incluso nel plugin (stesso stack e stesse tile della mappa Trova Viaggio, colore accento condiviso); la mappa viene inizializzata **solo quando l'utente ci scrolla vicino** (IntersectionObserver, margine 400px) — zero impatto sul caricamento; dati dei marker inline, nessuna chiamata AJAX; marker a cerchio senza immagini. Elenco testuale in `<noscript>`.
+- **Controlli**: opzione globale in Impostazioni → Generale (default attiva, solo articoli); shortcode `[alma_mappa_articolo]` per il posizionamento manuale (disattiva l'append automatico in quel post); metabox "📍 Mappa località" per escludere il singolo articolo (mostra anche quante località geocodificate ha il post).
+- Test standalone 5/5 sugli URL Google Maps (place_id, fallback coordinate, encoding, precisione 7 decimali).
+- Versione plugin aggiornata a `2.89.0`.
+
 ## 2.88.1 - 2026-07-08
 
 ### Arricchimento: "Esegui ora" tracciato, forzato e mai più muto

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.89.0 - 2026-07-08
+
+### Mappa "I luoghi di questo articolo"
+- Mappa interattiva automatica a fine articolo con le località geocodificate citate (primaria evidenziata); i marker aprono la scheda Google Maps del luogo in nuova scheda (place_id quando disponibile). Leaflet locale, caricamento pigro allo scroll, shortcode [alma_mappa_articolo], opzione globale e esclusione per articolo.
+- Versione plugin aggiornata a `2.89.0`.
+
 ## 2.88.1 - 2026-07-08
 
 ### "Esegui ora" dell'arricchimento affidabile

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.88.1
+ * Version: 2.89.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.88.1');
+define('ALMA_VERSION', '2.89.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -67,6 +67,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-link-auditor.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-link-health-checker.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-universal-link-types.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-ai-image-generator.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-article-locations-map.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-google-trends.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-facts.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-url-validator.php';
@@ -181,6 +182,7 @@ class AffiliateManagerAI {
         ALMA_Link_Health_Checker::init();
         ALMA_Universal_Link_Types::init();
         ALMA_AI_Image_Generator::init();
+        ALMA_Article_Locations_Map::init();
         ALMA_Geo_Facts::init();
         add_action('init', array($this, 'init'));
         add_action('widgets_init', array('ALMA_Contextual_Affiliate_Widget', 'register_widget'));
@@ -2344,6 +2346,7 @@ class AffiliateManagerAI {
             update_option('alma_track_logged_out', sanitize_text_field($_POST['track_logged_out'] ?? 'yes'));
             update_option('alma_enable_ai', sanitize_text_field($_POST['enable_ai'] ?? 'yes'));
             update_option('alma_ai_auto_publish', ($_POST['alma_ai_auto_publish'] ?? 'no') === 'yes' ? 'yes' : 'no');
+            update_option('alma_article_map_enabled', empty($_POST['alma_article_map_enabled']) ? '0' : '1', false);
 
             $selected_types = array_map('sanitize_text_field', $_POST['alma_link_post_types'] ?? array());
             update_option('alma_link_post_types', $selected_types);
@@ -2446,6 +2449,13 @@ class AffiliateManagerAI {
                                     <option value="yes" <?php selected(get_option('alma_ai_auto_publish', 'no'), 'yes'); ?>><?php _e('Sì — pubblica subito gli articoli generati', 'affiliate-link-manager-ai'); ?></option>
                                 </select>
                                 <p class="description"><?php _e('⚠️ Con "Sì" TUTTI gli articoli generati dall\'AI (workspace, runner programmato, agente) vanno online immediatamente senza revisione umana, con immagine in evidenza e meta SEO già applicati. Attivalo solo quando la qualità delle bozze ti soddisfa costantemente.', 'affiliate-link-manager-ai'); ?></p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php _e('Mappa località negli articoli', 'affiliate-link-manager-ai'); ?></th>
+                            <td>
+                                <label><input type="checkbox" name="alma_article_map_enabled" value="1" <?php checked(get_option('alma_article_map_enabled', '1'), '1'); ?>> <?php _e('Mostra a fine articolo la mappa interattiva delle località citate (solo articoli con località geocodificate)', 'affiliate-link-manager-ai'); ?></label>
+                                <p class="description"><?php _e('I marker aprono la scheda Google Maps del luogo in una nuova scheda. Shortcode per posizionarla a mano: [alma_mappa_articolo]; esclusione per singolo articolo dalla metabox "📍 Mappa località".', 'affiliate-link-manager-ai'); ?></p>
                             </td>
                         </tr>
                     </table>

--- a/assets/article-map.js
+++ b/assets/article-map.js
@@ -1,0 +1,101 @@
+/**
+ * Mappa delle località di fine articolo.
+ * Inizializzazione pigra: la mappa Leaflet viene costruita solo quando il
+ * contenitore entra (quasi) nel viewport, così il caricamento della pagina
+ * non paga nulla. Marker a cerchio (nessuna immagine da caricare), popup con
+ * pulsante "Apri in Google Maps" in nuova scheda.
+ */
+(function () {
+    'use strict';
+
+    function initMap(el) {
+        if (el.dataset.almaMapReady === '1' || typeof window.L === 'undefined') {
+            return;
+        }
+        el.dataset.almaMapReady = '1';
+
+        var locations;
+        try {
+            locations = JSON.parse(el.getAttribute('data-locations') || '[]');
+        } catch (e) {
+            locations = [];
+        }
+        if (!locations.length) {
+            return;
+        }
+
+        var accent = el.getAttribute('data-accent') || '#1a6ee0';
+        var openLabel = el.getAttribute('data-open-label') || 'Apri in Google Maps';
+        var map = window.L.map(el, { scrollWheelZoom: false });
+        window.L.tileLayer(el.getAttribute('data-tile-url'), {
+            attribution: el.getAttribute('data-tile-attribution'),
+            maxZoom: 18
+        }).addTo(map);
+
+        var bounds = [];
+        locations.forEach(function (loc) {
+            if (typeof loc.lat !== 'number' || typeof loc.lng !== 'number') {
+                return;
+            }
+            var isPrimary = !!loc.primary;
+            var marker = window.L.circleMarker([loc.lat, loc.lng], {
+                radius: isPrimary ? 11 : 8,
+                color: '#ffffff',
+                weight: 2,
+                fillColor: isPrimary ? accent : '#5f6b7a',
+                fillOpacity: 0.95
+            }).addTo(map);
+
+            var html = '<div style="min-width:170px;text-align:center;">'
+                + '<div style="font-size:15px;font-weight:700;margin-bottom:2px;">' + escapeHtml(loc.name || '') + '</div>'
+                + (loc.country ? '<div style="color:#5f6b7a;font-size:12px;margin-bottom:8px;">' + escapeHtml(loc.country) + '</div>' : '')
+                + '<a href="' + escapeAttr(loc.gmaps || '#') + '" target="_blank" rel="noopener nofollow" '
+                + 'style="display:inline-block;background:' + escapeAttr(accent) + ';color:#fff;padding:7px 14px;border-radius:999px;font-size:13px;font-weight:600;text-decoration:none;">'
+                + escapeHtml(openLabel) + ' ↗</a></div>';
+            marker.bindPopup(html);
+            bounds.push([loc.lat, loc.lng]);
+        });
+
+        if (bounds.length === 1) {
+            map.setView(bounds[0], 10);
+        } else if (bounds.length > 1) {
+            map.fitBounds(bounds, { padding: [36, 36], maxZoom: 11 });
+        }
+    }
+
+    function escapeHtml(value) {
+        var div = document.createElement('div');
+        div.textContent = String(value == null ? '' : value);
+        return div.innerHTML;
+    }
+
+    function escapeAttr(value) {
+        return escapeHtml(value).replace(/"/g, '&quot;');
+    }
+
+    function setup() {
+        var maps = document.querySelectorAll('.alma-article-map');
+        if (!maps.length) {
+            return;
+        }
+        if ('IntersectionObserver' in window) {
+            var observer = new IntersectionObserver(function (entries) {
+                entries.forEach(function (entry) {
+                    if (entry.isIntersecting) {
+                        observer.unobserve(entry.target);
+                        initMap(entry.target);
+                    }
+                });
+            }, { rootMargin: '400px 0px' });
+            maps.forEach(function (el) { observer.observe(el); });
+        } else {
+            maps.forEach(initMap);
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', setup);
+    } else {
+        setup();
+    }
+})();

--- a/includes/class-article-locations-map.php
+++ b/includes/class-article-locations-map.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Mappa interattiva delle località citate nell'articolo, a fine contenuto.
+ *
+ * Dati: le località associate all'articolo dall'indice geografico
+ * (content_index → locations) con coordinate già geocodificate. La località
+ * primaria è evidenziata nel colore accento. Ogni marker apre un popup con
+ * il pulsante "Apri in Google Maps" (nuova scheda): quando la località ha il
+ * place_id di Google salvato si apre la scheda esatta del luogo, altrimenti
+ * si usano le coordinate. Nessuna API key necessaria.
+ *
+ * Rendering: Leaflet incluso nel plugin (stesso stack della mappa Trova
+ * Viaggio) + tile OpenStreetMap; la mappa viene inizializzata SOLO quando
+ * l'utente ci scrolla vicino (IntersectionObserver): zero impatto sul
+ * caricamento della pagina. Se l'articolo non ha località geocodificate non
+ * viene mostrato nulla.
+ *
+ * Controlli: opzione globale (default attiva), shortcode [alma_mappa_articolo]
+ * per il posizionamento manuale (disattiva l'append automatico in quel post),
+ * metabox per escludere il singolo articolo.
+ */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ALMA_Article_Locations_Map {
+    const OPTION_ENABLED = 'alma_article_map_enabled';
+    const META_DISABLE = '_alma_article_map_disable';
+    const SHORTCODE = 'alma_mappa_articolo';
+    const MAX_MARKERS = 10;
+
+    public static function init() {
+        add_shortcode(self::SHORTCODE, array(__CLASS__, 'render_shortcode'));
+        // Dopo i filtri standard (shortcode degli articoli a 11): priorità 30.
+        add_filter('the_content', array(__CLASS__, 'append_to_content'), 30);
+        add_action('add_meta_boxes_post', array(__CLASS__, 'register_metabox'));
+        add_action('save_post_post', array(__CLASS__, 'save_metabox'));
+    }
+
+    public static function is_enabled() {
+        return get_option(self::OPTION_ENABLED, '1') === '1';
+    }
+
+    /* ---------------------------------------------------------------------
+     * Dati
+     * ------------------------------------------------------------------ */
+
+    /**
+     * Località geocodificate dell'articolo: primaria per prima, poi per peso.
+     */
+    public static function get_locations($post_id) {
+        if (!class_exists('ALMA_Geo_Index_Store')) { return array(); }
+        $store = new ALMA_Geo_Index_Store();
+        if (!$store->tables_exist()) { return array(); }
+        global $wpdb;
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT l.id, l.canonical_name, l.country, l.type, l.lat, l.lng, l.geo_provider_place_id, ci.is_primary
+             FROM {$store->table_content_index()} ci
+             INNER JOIN {$store->table_locations()} l ON l.id = ci.location_id
+             WHERE ci.object_id = %d AND ci.object_type = %s
+               AND l.lat IS NOT NULL AND l.lng IS NOT NULL
+             ORDER BY ci.is_primary DESC, ci.match_weight DESC, l.id ASC
+             LIMIT %d",
+            absint($post_id), ALMA_Geo_Index_Store::OBJECT_TYPE_POST, self::MAX_MARKERS
+        ), ARRAY_A);
+        $out = array();
+        $seen = array();
+        foreach ((array) $rows as $row) {
+            $lat = (float) $row['lat'];
+            $lng = (float) $row['lng'];
+            if ($lat === 0.0 && $lng === 0.0) { continue; }
+            $name = html_entity_decode(sanitize_text_field((string) $row['canonical_name']), ENT_QUOTES, 'UTF-8');
+            $key = strtolower($name) . '|' . round($lat, 4) . '|' . round($lng, 4);
+            if ($name === '' || isset($seen[$key])) { continue; }
+            $seen[$key] = true;
+            $out[] = array(
+                'name' => $name,
+                'country' => html_entity_decode(sanitize_text_field((string) $row['country']), ENT_QUOTES, 'UTF-8'),
+                'lat' => $lat,
+                'lng' => $lng,
+                'primary' => !empty($row['is_primary']),
+                'gmaps' => self::build_gmaps_url($name, $lat, $lng, (string) $row['geo_provider_place_id']),
+            );
+        }
+        return $out;
+    }
+
+    /**
+     * URL Google Maps ufficiale (nessuna API key). Con place_id si apre la
+     * scheda esatta del luogo; altrimenti le coordinate. Funzione pura.
+     */
+    public static function build_gmaps_url($name, $lat, $lng, $place_id = '') {
+        $place_id = trim((string) $place_id);
+        $name = trim((string) $name);
+        if ($place_id !== '' && $name !== '') {
+            return 'https://www.google.com/maps/search/?api=1&query=' . rawurlencode($name) . '&query_place_id=' . rawurlencode($place_id);
+        }
+        return 'https://www.google.com/maps/search/?api=1&query=' . rawurlencode(round((float) $lat, 7) . ',' . round((float) $lng, 7));
+    }
+
+    /* ---------------------------------------------------------------------
+     * Rendering
+     * ------------------------------------------------------------------ */
+
+    public static function render_shortcode($atts = array()) {
+        $post_id = get_the_ID();
+        if (!$post_id) { return ''; }
+        return self::render_map($post_id);
+    }
+
+    public static function append_to_content($content) {
+        if (!self::is_enabled() || is_admin() || !is_singular('post') || !in_the_loop() || !is_main_query()) {
+            return $content;
+        }
+        $post_id = get_the_ID();
+        if (!$post_id) { return $content; }
+        if (get_post_meta($post_id, self::META_DISABLE, true) === '1') { return $content; }
+        // Posizionamento manuale via shortcode: niente doppioni in coda.
+        if (has_shortcode((string) get_post_field('post_content', $post_id), self::SHORTCODE)) { return $content; }
+        $map = self::render_map($post_id);
+        return $map === '' ? $content : $content . "\n" . $map;
+    }
+
+    private static function render_map($post_id) {
+        $locations = self::get_locations($post_id);
+        if (empty($locations)) { return ''; }
+
+        wp_enqueue_style('alma-leaflet', ALMA_PLUGIN_URL . 'assets/vendor/leaflet/leaflet.css', array(), '1.9.4');
+        wp_enqueue_script('alma-leaflet', ALMA_PLUGIN_URL . 'assets/vendor/leaflet/leaflet.js', array(), '1.9.4', true);
+        wp_enqueue_script('alma-article-map', ALMA_PLUGIN_URL . 'assets/article-map.js', array('alma-leaflet'), ALMA_VERSION, true);
+
+        $accent = class_exists('ALMA_Geo_Map') ? ALMA_Geo_Map::get_accent_color() : '#1a6ee0';
+        $tile_url = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+        $tile_attribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>';
+        $saved_tile = trim((string) get_option('alma_geo_map_tile_url', ''));
+        if ($saved_tile !== '' && strpos($saved_tile, '{z}') !== false) { $tile_url = $saved_tile; }
+        $saved_attr = trim((string) get_option('alma_geo_map_tile_attribution', ''));
+        if ($saved_attr !== '') { $tile_attribution = $saved_attr; }
+
+        static $instance = 0;
+        $instance++;
+        $map_id = 'alma-article-map-' . $instance;
+
+        $output = '<div class="alma-article-map-wrap" style="margin:28px 0 8px;">';
+        $output .= '<h3 class="alma-article-map-title" style="margin:0 0 10px;">📍 ' . esc_html__('I luoghi di questo articolo', 'affiliate-link-manager-ai') . '</h3>';
+        $output .= '<div id="' . esc_attr($map_id) . '" class="alma-article-map"'
+            . ' data-locations="' . esc_attr(wp_json_encode($locations)) . '"'
+            . ' data-accent="' . esc_attr($accent) . '"'
+            . ' data-tile-url="' . esc_attr($tile_url) . '"'
+            . ' data-tile-attribution="' . esc_attr($tile_attribution) . '"'
+            . ' data-open-label="' . esc_attr__('Apri in Google Maps', 'affiliate-link-manager-ai') . '"'
+            . ' style="width:100%;height:400px;border-radius:10px;background:#e8ecf1;"></div>';
+        // Accessibilità/SEO: l'elenco testuale esiste anche senza JavaScript.
+        $output .= '<noscript><ul>';
+        foreach ($locations as $location) {
+            $output .= '<li><a href="' . esc_url($location['gmaps']) . '" target="_blank" rel="noopener nofollow">' . esc_html($location['name']) . ($location['country'] !== '' ? ' (' . esc_html($location['country']) . ')' : '') . '</a></li>';
+        }
+        $output .= '</ul></noscript>';
+        $output .= '</div>';
+        return $output;
+    }
+
+    /* ---------------------------------------------------------------------
+     * Metabox di esclusione per singolo articolo
+     * ------------------------------------------------------------------ */
+
+    public static function register_metabox() {
+        add_meta_box('alma_article_map', __('📍 Mappa località', 'affiliate-link-manager-ai'), array(__CLASS__, 'render_metabox'), 'post', 'side', 'low');
+    }
+
+    public static function render_metabox($post) {
+        // Nessun <form> qui: la metabox vive dentro il form del post.
+        wp_nonce_field('alma_article_map_meta', 'alma_article_map_nonce');
+        $disabled = get_post_meta($post->ID, self::META_DISABLE, true) === '1';
+        $count = count(self::get_locations($post->ID));
+        echo '<label><input type="checkbox" name="' . esc_attr(self::META_DISABLE) . '" value="1" ' . checked($disabled, true, false) . '> ' . esc_html__('Non mostrare la mappa in questo articolo', 'affiliate-link-manager-ai') . '</label>';
+        echo '<p class="description">' . esc_html(sprintf(__('Località geocodificate trovate: %d. La mappa compare a fine articolo solo se ce n\'è almeno una. Shortcode per posizionarla a mano: [%s].', 'affiliate-link-manager-ai'), $count, self::SHORTCODE)) . '</p>';
+    }
+
+    public static function save_metabox($post_id) {
+        if (!isset($_POST['alma_article_map_nonce']) || !wp_verify_nonce($_POST['alma_article_map_nonce'], 'alma_article_map_meta')) { return; }
+        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) { return; }
+        if (!current_user_can('edit_post', $post_id)) { return; }
+        if (!empty($_POST[self::META_DISABLE])) {
+            update_post_meta($post_id, self::META_DISABLE, '1');
+        } else {
+            delete_post_meta($post_id, self::META_DISABLE);
+        }
+    }
+}


### PR DESCRIPTION
## Cosa fa

Nuova mappa interattiva a fine articolo con le **località citate nell'articolo**, come da analisi approvata.

### Dati (`ALMA_Article_Locations_Map`)
- Località dall'**indice geografico** (`content_index` → `locations`), solo quelle con **coordinate geocodificate** (max 10, deduplicate per nome+coordinate); la **primaria evidenziata** nel colore accento, le secondarie in grigio. Articolo senza località geocodificate → nessuna mappa (mai scatole vuote).

### Marker → Google Maps
- Popup con nome, paese e pulsante **"Apri in Google Maps"** in nuova scheda (`rel="noopener nofollow"`).
- Con **place_id di Google** salvato → si apre la **scheda esatta del luogo** (`?api=1&query=NOME&query_place_id=…`); altrimenti coordinate. URL ufficiali, **nessuna API key**.

### Prestazioni
- **Leaflet incluso nel plugin** (stesso stack, tile e colore accento della mappa Trova Viaggio: coerenza visiva, zero CDN).
- Inizializzazione **pigra con IntersectionObserver** (margine 400px): la mappa nasce solo quando l'utente ci scrolla vicino — zero impatto sul caricamento.
- Dati marker inline (niente AJAX), marker a cerchio (nessuna immagine), `scrollWheelZoom` disattivato (niente zoom accidentali durante lo scroll), elenco testuale in `<noscript>`.

### Controlli
- Opzione globale in **Impostazioni → Generale** (default attiva, solo articoli).
- Shortcode `[alma_mappa_articolo]` per il posizionamento manuale (se presente, l'append automatico si disattiva per quel post).
- Metabox **"📍 Mappa località"** nell'editor per escludere il singolo articolo (mostra anche quante località geocodificate ha il post). Nessun form annidato: solo checkbox salvata con il post.

## Verifiche
- Test standalone **5/5** sugli URL Google Maps (place_id, fallback coordinate, nome vuoto, encoding, precisione 7 decimali); `node --check` OK sul JS; `php -l` OK.
- CHANGELOG.md e README.md aggiornati; versione `2.89.0`.

Dopo il merge: apri un articolo geolocalizzato (es. uno dei nuovi su Dubai) e scorri in fondo — la mappa appare con i marker; click sul marker → popup → "Apri in Google Maps". Fase 2 disponibile a richiesta: link "Tour e attività a X" nel popup per la monetizzazione.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_