### PR TITLE
Fix: mappa articolo inserita più volte (the_content multipli del tema) (v2.90.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.90.1 - 2026-07-08
+
+### Fix: mappa articolo inserita più volte
+- **Causa** (segnalata sull'articolo Dubai): BeTheme/WPBakery e i plugin SEO applicano il filtro `the_content` **più volte sulla stessa pagina** (contenuto principale, generazione schema/meta, sezioni del builder) e ogni passaggio superava i controlli, accodando una mappa a ciascuno.
+- **Fix — tripla difesa**: (1) nessun inserimento nei passaggi eseguiti **prima di `wp_head`** (generatori SEO/schema); (2) se il contenuto contiene già `alma-article-map` non si aggiunge nulla; (3) guardia statica **una-sola-volta per articolo per richiesta**. La mappa compare ora una sola volta, in fondo al contenuto principale.
+- Versione plugin aggiornata a `2.90.1`.
+
 ## 2.90.0 - 2026-07-08
 
 ### Mappa articolo, fase 2: "Tour e attività" nel popup — la mappa diventa canale di conversione

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.90.1 - 2026-07-08
+
+### Fix mappa duplicata
+- La mappa articolo veniva accodata a ogni applicazione di the_content (BeTheme/builder/SEO): ora una sola volta per articolo, mai nei passaggi prima di wp_head.
+- Versione plugin aggiornata a `2.90.1`.
+
 ## 2.90.0 - 2026-07-08
 
 ### Mappa articolo fase 2: monetizzazione nel popup

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.90.0
+ * Version: 2.90.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.90.0');
+define('ALMA_VERSION', '2.90.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-article-locations-map.php
+++ b/includes/class-article-locations-map.php
@@ -151,13 +151,21 @@ class ALMA_Article_Locations_Map {
         if (!self::is_enabled() || is_admin() || !is_singular('post') || !in_the_loop() || !is_main_query()) {
             return $content;
         }
+        // Temi e builder (BeTheme/WPBakery) applicano the_content più volte
+        // sulla stessa pagina: la mappa va aggiunta UNA sola volta.
+        if (!did_action('wp_head')) { return $content; } // passaggi in <head> (SEO/schema)
+        if (strpos((string) $content, 'alma-article-map') !== false) { return $content; }
         $post_id = get_the_ID();
         if (!$post_id) { return $content; }
+        static $rendered = array();
+        if (isset($rendered[$post_id])) { return $content; }
         if (get_post_meta($post_id, self::META_DISABLE, true) === '1') { return $content; }
         // Posizionamento manuale via shortcode: niente doppioni in coda.
         if (has_shortcode((string) get_post_field('post_content', $post_id), self::SHORTCODE)) { return $content; }
         $map = self::render_map($post_id);
-        return $map === '' ? $content : $content . "\n" . $map;
+        if ($map === '') { return $content; }
+        $rendered[$post_id] = true;
+        return $content . "\n" . $map;
     }
 
     private static function render_map($post_id) {


### PR DESCRIPTION
## Causa

Verificato sull'articolo segnalato (Dubai): **BeTheme/WPBakery e i plugin SEO applicano il filtro `the_content` più volte sulla stessa pagina** — contenuto principale, generazione schema/meta in `<head>`, sezioni del builder. Ogni passaggio superava i controlli (`is_singular` + `in_the_loop` + `is_main_query`, che restano veri in tutti i passaggi del post principale) e accodava una mappa.

## Fix — tripla difesa in `append_to_content`

1. **Nessun inserimento prima di `wp_head`**: i passaggi dei generatori SEO/schema avvengono nell'`<head>`, la mappa non deve finire lì.
2. **Skip se il contenuto contiene già `alma-article-map`**: copre i filtri riapplicati su contenuto già filtrato.
3. **Guardia statica una-sola-volta per articolo per richiesta**: qualunque sia il numero di passaggi, la mappa viene resa una volta e le successive richieste tornano il contenuto invariato.

La mappa ora compare una sola volta, in fondo al contenuto principale. Shortcode `[alma_mappa_articolo]` invariato.

## Verifiche
- `php -l` OK; test esistenti 5/5 + 7/7 invariati; CHANGELOG.md e README.md aggiornati; versione `2.90.1` (patch).

Dopo il merge: ricarica l'articolo su Dubai — una sola mappa in fondo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_