### PR TITLE
Fix: mappa articolo in chiusura dell'articolo e a larghezza piena (v2.90.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.90.2 - 2026-07-08
+
+### Fix: mappa articolo in chiusura e a larghezza piena
+- Con BeTheme il primo passaggio **visualizzato** di `the_content` non coincide con la fine del corpo articolo: la mappa (una sola dopo la 2.90.1) poteva comparire nel punto sbagliato e in un contenitore stretto.
+- **Fix**: prima dell'inizializzazione il JS **sposta il blocco mappa in coda al contenitore principale del contenuto** del tema — `.the_content_wrapper` (BeTheme) con fallback `.entry-content`, `.post-content`, `article .content`, `article`; se è già in coda non fa nulla. La mappa Leaflet si inizializza dopo lo spostamento (lazy allo scroll), quindi calcola le dimensioni nel contenitore giusto.
+- **Larghezza garantita**: wrapper con `clear:both; width:100%; max-width:100%; box-sizing:border-box` — mai più schiacciato da float o colonne del builder.
+- Versione plugin aggiornata a `2.90.2`.
+
 ## 2.90.1 - 2026-07-08
 
 ### Fix: mappa articolo inserita più volte

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.90.2 - 2026-07-08
+
+### Fix posizione e larghezza mappa articolo
+- Il blocco mappa viene spostato via JS in coda al contenitore del contenuto del tema (.the_content_wrapper di BeTheme, con fallback) prima dell'inizializzazione; larghezza piena garantita.
+- Versione plugin aggiornata a `2.90.2`.
+
 ## 2.90.1 - 2026-07-08
 
 ### Fix mappa duplicata

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.90.1
+ * Version: 2.90.2
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.90.1');
+define('ALMA_VERSION', '2.90.2');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/assets/article-map.js
+++ b/assets/article-map.js
@@ -104,7 +104,36 @@
         return escapeHtml(value).replace(/"/g, '&quot;');
     }
 
+    /**
+     * Con i temi a builder (BeTheme) the_content viene applicato più volte e
+     * il blocco mappa può finire in un frammento sbagliato (posizione e
+     * larghezza errate). Prima dell'inizializzazione il wrapper viene
+     * SPOSTATO in coda al contenitore principale del contenuto del tema.
+     */
+    function relocate() {
+        var wrap = document.querySelector('.alma-article-map-wrap');
+        if (!wrap) {
+            return;
+        }
+        var selectors = ['.the_content_wrapper', '.entry-content', '.post-content', 'article .content', 'article'];
+        for (var i = 0; i < selectors.length; i++) {
+            var target = document.querySelector(selectors[i]);
+            if (target && !target.contains(wrap)) {
+                target.appendChild(wrap);
+                return;
+            }
+            if (target && target.lastElementChild !== wrap) {
+                target.appendChild(wrap); // già dentro ma non in coda
+                return;
+            }
+            if (target) {
+                return; // già dentro e in coda: posizione corretta
+            }
+        }
+    }
+
     function setup() {
+        relocate();
         var maps = document.querySelectorAll('.alma-article-map');
         if (!maps.length) {
             return;

--- a/includes/class-article-locations-map.php
+++ b/includes/class-article-locations-map.php
@@ -188,7 +188,7 @@ class ALMA_Article_Locations_Map {
         $instance++;
         $map_id = 'alma-article-map-' . $instance;
 
-        $output = '<div class="alma-article-map-wrap" style="margin:28px 0 8px;">';
+        $output = '<div class="alma-article-map-wrap" style="clear:both;width:100%;max-width:100%;box-sizing:border-box;margin:28px 0 8px;">';
         $output .= '<h3 class="alma-article-map-title" style="margin:0 0 10px;">📍 ' . esc_html__('I luoghi di questo articolo', 'affiliate-link-manager-ai') . '</h3>';
         $output .= '<div id="' . esc_attr($map_id) . '" class="alma-article-map"'
             . ' data-locations="' . esc_attr(wp_json_encode($locations)) . '"'


### PR DESCRIPTION
## Causa

Dopo il fix dei duplicati (2.90.1) la mappa è una sola, ma con BeTheme **il primo passaggio visualizzato di `the_content` non coincide con la fine del corpo articolo**: il blocco finiva nel punto sbagliato e dentro un contenitore stretto (da cui anche la dimensione errata — Leaflet calcola le dimensioni dal contenitore in cui nasce).

## Fix

- **Ricollocazione via JS prima dell'inizializzazione**: il wrapper della mappa viene spostato **in coda al contenitore principale del contenuto** del tema — `.the_content_wrapper` (BeTheme), con fallback `.entry-content`, `.post-content`, `article .content`, `article`. Se è già in coda al contenitore giusto, non fa nulla. Poiché la mappa si inizializza lazy (allo scroll) **dopo** lo spostamento, le dimensioni vengono calcolate nel contenitore corretto.
- **Larghezza garantita**: wrapper con `clear:both; width:100%; max-width:100%; box-sizing:border-box` — immune da float e colonne del builder.
- Fallback no-JS invariato (elenco testuale in `noscript`).

## Verifiche
- `node --check` OK; `php -l` OK; CHANGELOG.md e README.md aggiornati; versione `2.90.2` (patch).

Dopo il merge: ricarica l'articolo su Dubai (svuota eventuale cache pagina) — la mappa deve comparire **una sola volta, in fondo al corpo dell'articolo, a larghezza piena**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_