### PR TITLE
Fix: tipologie universali mai cliccate escluse da bozze e arricchimento (v2.90.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.90.3 - 2026-07-08
+
+### Fix: tipologie universali mai cliccate escluse da bozze, arricchimento e mappa
+- **Verifica richiesta sull'uso degli universali in Arricchimento**: il collegamento c'era già (candidati marcati `universale` + istruzione nel prompt del motore condiviso, v2.88.0), ma la verifica ha scoperto un **bug silenzioso a monte**: `top_universal_links()` ordinava con `meta_key = _click_count`, e quel meta **nasce solo al primo click** — con `meta_key` WordPress fa INNER JOIN sul meta, quindi i link universali **mai cliccati** (tipico di Assicurazioni/eSIM appena create) sparivano del tutto dalla selezione: zero candidati universali in bozze, arricchimento e metabox AI Affiliati.
+- **Fix**: query senza `meta_key` (tutti gli universali pubblicati) e **ordinamento per click in PHP** con 0 per i mai cliccati; filtri esistenti invariati (URL presente, non morti, esclusioni). Ora un link universale nuovo entra subito in gara.
+- Beneficiano tutti i chiamanti: candidati delle bozze AI, candidati dell'arricchimento/metabox (v2.88.0) e ogni uso futuro.
+- Test standalone 7/7 (query senza meta_key, ordinamento PHP, filtri, integrazione arricchimento con flag e prompt).
+- Versione plugin aggiornata a `2.90.3`.
+
 ## 2.90.2 - 2026-07-08
 
 ### Fix: mappa articolo in chiusura e a larghezza piena

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.90.3 - 2026-07-08
+
+### Fix tipologie universali mai cliccate
+- I link universali senza click (meta _click_count assente) venivano esclusi dalla selezione per bozze e arricchimento: ora la query non filtra più sul meta e l'ordinamento per click avviene in PHP.
+- Versione plugin aggiornata a `2.90.3`.
+
 ## 2.90.2 - 2026-07-08
 
 ### Fix posizione e larghezza mappa articolo

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.90.2
+ * Version: 2.90.3
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.90.2');
+define('ALMA_VERSION', '2.90.3');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-universal-link-types.php
+++ b/includes/class-universal-link-types.php
@@ -76,28 +76,30 @@ class ALMA_Universal_Link_Types {
     public static function top_universal_links($limit = 3, $exclude_ids = array()) {
         $universal = self::universal_term_ids();
         if (empty($universal)) { return array(); }
+        // NIENTE meta_key nella query: con meta_key WordPress fa INNER JOIN
+        // sul meta e i link MAI cliccati (senza _click_count, che nasce al
+        // primo click) sparivano del tutto — proprio gli universali nuovi
+        // (Assicurazioni, eSIM) restavano fuori da bozze e arricchimento.
+        // L'ordinamento per click avviene in PHP, con 0 per i mai cliccati.
         $ids = get_posts(array(
             'post_type' => 'affiliate_link',
             'post_status' => 'publish',
-            'posts_per_page' => max(1, absint($limit)) + count((array) $exclude_ids) + 5,
+            'posts_per_page' => max(1, absint($limit)) + count((array) $exclude_ids) + 10,
             'fields' => 'ids',
-            'orderby' => 'meta_value_num',
-            'meta_key' => '_click_count',
-            'order' => 'DESC',
             'no_found_rows' => true,
             'tax_query' => array(array('taxonomy' => 'link_type', 'field' => 'term_id', 'terms' => $universal)),
         ));
-        $out = array();
         $exclude_ids = array_map('absint', (array) $exclude_ids);
+        $rows = array();
         foreach ((array) $ids as $id) {
             $id = (int) $id;
             if (in_array($id, $exclude_ids, true)) { continue; }
             if (trim((string) get_post_meta($id, '_affiliate_url', true)) === '') { continue; }
             if (class_exists('ALMA_Link_Health_Checker') && ALMA_Link_Health_Checker::is_dead($id)) { continue; }
-            $out[] = $id;
-            if (count($out) >= max(1, absint($limit))) { break; }
+            $rows[] = array('id' => $id, 'clicks' => (int) get_post_meta($id, '_click_count', true));
         }
-        return $out;
+        usort($rows, function ($a, $b) { return $b['clicks'] <=> $a['clicks']; });
+        return array_slice(wp_list_pluck($rows, 'id'), 0, max(1, absint($limit)));
     }
 
     /* ---------------------------------------------------------------------


### PR DESCRIPTION
## Verifica richiesta: gli universali vengono usati in Arricchimento?

**Il collegamento c'era già** (v2.88.0: i 2 migliori universali entrano tra i candidati del motore condiviso arricchimento/metabox, marcati `"universale": true`, e il prompt chiede di includerne sempre uno se coerente). Ma la verifica ha scoperto un **bug silenzioso a monte** che poteva azzerare tutto.

## Il bug

`top_universal_links()` ordinava la query con `meta_key = '_click_count'`. Quel meta però **nasce solo al primo click** sul link — e con `meta_key` impostato WordPress fa un **INNER JOIN** sul meta: i link universali **mai cliccati** (esattamente il caso delle tipologie Assicurazioni/eSIM appena create) **sparivano del tutto dalla selezione**. Risultato possibile: zero candidati universali in bozze, arricchimento e metabox AI Affiliati, senza alcun errore visibile.

## Fix

- Query **senza** `meta_key`: tutti gli universali pubblicati della tipologia.
- **Ordinamento per click in PHP** (0 per i mai cliccati): i più cliccati restano davanti, i nuovi entrano comunque in gara.
- Filtri invariati: URL presente, non morti (Link Health), esclusioni.
- Beneficiano tutti i chiamanti: candidati delle bozze AI, arricchimento/metabox, usi futuri.

## Verifiche
- Test standalone **7/7** (query senza meta_key, ordinamento PHP con default 0, filtri invariati, integrazione arricchimento: candidati con flag + istruzione nel prompt).
- `php -l` OK; CHANGELOG.md e README.md aggiornati; versione `2.90.3` (patch).

Dopo il merge: lancia "Esegui ora" nell'Arricchimento su un articolo di prova — nelle proposte dovresti vedere anche il link universale (Assicurazioni/eSIM) quando coerente col contenuto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_