### PR TITLE
Arricchimento: link universale garantito in ogni articolo (v2.91.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.91.0 - 2026-07-08
+
+### Arricchimento: link universale GARANTITO in ogni articolo (non più a discrezione dell'AI)
+- **Segnalazione**: 6 link Assicurazioni universali disponibili, 10 articoli arricchiti, zero usi. Le cause possibili (esclusione dei mai-cliccati fixata in 2.90.3 + modello che ignora l'istruzione "se coerente") vengono superate alla radice con la stessa ricetta dei widget garantiti: **se l'AI non lo propone, lo propone il sistema**.
+- **Garanzia deterministica** (`ensure_universal_proposal`, motore condiviso arricchimento + metabox AI Affiliati): se nessuna proposta usa un link universale E l'articolo non ne contiene già uno (né in shortcode né nel widget proposto), viene aggiunta una **proposta button col miglior universale a ~70% dell'articolo** (zona consigli pratici), con motivazione esplicita "proposta garantita dal sistema". Mai doppioni: salta se l'AI l'ha proposto, se è già nel contenuto o se non esistono candidati universali.
+- **Prompt rafforzato**: da "se coerente, includi sempre" a "**DEVI includere** una proposta con un universale; omettilo SOLO se l'articolo lo rende assurdo".
+- Nota: i 10 articoli già arricchiti non verranno rianalizzati prima del cooldown — per quelli si può usare la metabox "AI Affiliati" (le proposte ora includono sempre l'universale garantito).
+- Test standalone 10/10 (aggiunta garantita con posizione ~70% e clamp, skip se già proposto/nell'articolo/nel widget, senza candidati, con zero proposte AI).
+- Versione plugin aggiornata a `2.91.0`.
+
 ## 2.90.3 - 2026-07-08
 
 ### Fix: tipologie universali mai cliccate escluse da bozze, arricchimento e mappa

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.91.0 - 2026-07-08
+
+### Link universale garantito nell'arricchimento
+- Se l'AI non propone un link universale (Assicurazioni/eSIM), il sistema aggiunge una proposta button deterministica a ~70% dell'articolo; prompt rafforzato; mai doppioni.
+- Versione plugin aggiornata a `2.91.0`.
+
 ## 2.90.3 - 2026-07-08
 
 ### Fix tipologie universali mai cliccate

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.90.3
+ * Version: 2.91.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.90.3');
+define('ALMA_VERSION', '2.91.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-post-optimizer.php
+++ b/includes/class-ai-post-optimizer.php
@@ -421,7 +421,7 @@ class ALMA_AI_Post_Optimizer {
         if ($widget_allowed) {
             $prompt .= 'DOVE POSSIBILE proponi anche UN widget di link affiliati (blocco grafico a card, massimo uno): serve a SPEZZARE VISIVAMENTE il testo, quindi scegli un paragrafo INTERMEDIO dell\'articolo (dopo una sezione centrale pertinente), NON necessariamente la chiusura. Aggiungi alle proposte {"pattern":"widget","paragrafo":int,"layout":"destination_cards|experience_cards|hero_spotlight","link_ids":[int (solo da link_candidati)],"titolo":string,"button_text":string,"motivo":string}. Layout: destination_cards = griglia di mete/destinazioni (2-6 link); experience_cards = card di tour/attività specifiche (2-8 link); hero_spotlight = UNA sola esperienza di punta (1 link). ';
         }
-        $prompt .= 'I link_candidati con "universale":true (assicurazione viaggio, eSIM…) valgono per QUALSIASI articolo: se coerente col contenuto, includi SEMPRE uno di questi tra le proposte (massimo 1, pattern anchor o button, nel punto più naturale, es. consigli pratici o preparativi). ';
+        $prompt .= 'I link_candidati con "universale":true (assicurazione viaggio, eSIM…) sono pertinenti in QUALSIASI articolo di viaggio: DEVI includere UNA proposta con uno di questi (pattern anchor o button), nel punto più naturale — consigli pratici, preparativi, informazioni utili. Ometti l\'universale SOLO se l\'articolo lo rende assurdo. ';
         if ($allow_replacements) {
             $existing_analysis = self::analyze_content($post->ID, $post->post_content);
             $existing_links = array();
@@ -457,10 +457,56 @@ class ALMA_AI_Post_Optimizer {
         if ($allow_replacements) {
             $proposals = array_merge($proposals, self::validate_replacements($raw_proposals, $candidates, $post->post_content));
         }
+        // Garanzia deterministica: se l'AI ha ignorato i link universali
+        // (assicurazioni/eSIM) e l'articolo non ne contiene già uno, la
+        // proposta viene aggiunta dal sistema — come per i widget garantiti.
+        $proposals = self::ensure_universal_proposal($proposals, $candidates, $paragraphs, $rules, $post);
         if (empty($proposals)) {
             return array('proposals' => array(), 'error' => __('L\'AI non ha prodotto proposte valide per questo articolo.', 'affiliate-link-manager-ai'));
         }
         return array('proposals' => $proposals, 'error' => '');
+    }
+
+    /**
+     * Se nessuna proposta usa un link di tipologia universale e il contenuto
+     * non ne contiene già uno, aggiunge una proposta button deterministica
+     * col miglior universale, a circa due terzi dell'articolo (zona consigli
+     * pratici), oltre il budget di densità se necessario (max 1).
+     */
+    private static function ensure_universal_proposal($proposals, $candidates, $paragraphs, $rules, $post) {
+        $universal_ids = array();
+        foreach ((array) $candidates as $candidate) {
+            if (!empty($candidate['universale'])) { $universal_ids[(int) $candidate['id']] = sanitize_text_field((string) $candidate['titolo']); }
+        }
+        if (empty($universal_ids)) { return $proposals; }
+        foreach ((array) $proposals as $proposal) {
+            if (isset($universal_ids[(int) ($proposal['link_id'] ?? 0)])) { return $proposals; }
+            foreach ((array) ($proposal['widget_request']['link_ids'] ?? array()) as $wid) {
+                if (isset($universal_ids[(int) $wid])) { return $proposals; }
+            }
+        }
+        // L'articolo contiene già uno shortcode con un link universale?
+        foreach (array_keys($universal_ids) as $uid) {
+            if (preg_match('/\[affiliate_link[^\]]*\bid="?' . $uid . '"?[\s"\]]/', $post->post_content)) { return $proposals; }
+        }
+        reset($universal_ids);
+        $link_id = (int) key($universal_ids);
+        $min_paragraph = (int) $rules['min_paragraphs_before'];
+        $paragraph = max($min_paragraph, (int) floor(count($paragraphs) * 0.7));
+        $paragraph = min($paragraph, max($min_paragraph, count($paragraphs) - 1));
+        $button_text = sanitize_text_field((string) $rules['button_text']);
+        $proposal = array(
+            'pattern' => 'button',
+            'link_id' => $link_id,
+            'link_title' => $universal_ids[$link_id],
+            'paragraph' => $paragraph,
+            'insertion' => '[affiliate_link id="' . $link_id . '" button="yes" button_text="' . esc_attr($button_text) . '"]',
+            'inline' => false,
+            'reason' => __('Tipologia universale (assicurazioni/eSIM): pertinente in ogni articolo di viaggio — proposta garantita dal sistema perché l\'AI non l\'aveva inclusa.', 'affiliate-link-manager-ai'),
+            'created_at' => current_time('mysql'),
+        );
+        $proposals[md5(wp_json_encode(array('universal_guarantee', $link_id, $paragraph)))] = $proposal;
+        return $proposals;
     }
 
     /**


### PR DESCRIPTION
## Segnalazione

6 link Assicurazioni (tipologia universale) disponibili, 10 articoli arricchiti, **zero usi**. Oltre al bug dei mai-cliccati (fixato in 2.90.3, che da solo può spiegare i 10 casi se quelle assicurazioni non hanno click), resta il rischio strutturale: il modello può ignorare l'istruzione "se coerente, includi sempre".

## Fix: garanzia deterministica (stessa ricetta dei widget garantiti)

Nuovo `ensure_universal_proposal()` nel **motore condiviso** (arricchimento notturno + metabox "AI Affiliati"), eseguito dopo la validazione delle proposte AI:

- se **nessuna proposta** usa un link universale (né come link né dentro un widget proposto),
- e l'articolo **non ne contiene già uno** (controllo shortcode sul contenuto),
- allora viene aggiunta una **proposta button deterministica** col miglior universale, posizionata a **~70% dell'articolo** (zona consigli pratici; clamp tra `min_paragraphs_before` e l'ultimo paragrafo), con motivazione esplicita *"proposta garantita dal sistema perché l'AI non l'aveva inclusa"*.
- Mai doppioni, max 1, funziona anche quando l'AI non produce alcuna proposta valida.

**Prompt rafforzato**: da "se coerente, includi sempre" a "**DEVI includere** una proposta con un universale; omettilo SOLO se l'articolo lo rende assurdo".

## Nota operativa

I 10 articoli già arricchiti non verranno rianalizzati prima del cooldown: per quelli si può usare subito la **metabox AI Affiliati** (le proposte ora includono sempre l'universale garantito) — oppure attendere il ciclo di ri-analisi.

## Verifiche
- Test standalone **10/10**: aggiunta garantita (button, primo universale, paragrafo 7/10, shortcode esatto), skip se già proposto / già nell'articolo / dentro widget proposto / senza candidati, funzionamento con zero proposte AI, clamp su articoli corti.
- `php -l` OK; CHANGELOG.md e README.md aggiornati; versione `2.91.0`.

Dopo il merge: "Esegui ora" nell'Arricchimento — nel report ogni articolo aggiornato dovrà avere almeno un link Assicurazioni (verificabile aprendo l'articolo, zona ultimo terzo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_