### PR TITLE
Geo: integrazione automatica delle destinazioni citate negli articoli (v2.93.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.93.0 - 2026-07-08
+
+### Geo/mappa: le destinazioni citate nell'articolo entrano nell'indice (e sulla mappa)
+- **Segnalazione** (articolo "Stati Uniti in 3 giorni"): l'articolo parla di diverse destinazioni ma nessuna finiva in geo né sulla mappa. **Causa radice**: gli articoli dell'agent ricevono la località dell'idea alla creazione, quindi risultano "già indicizzati" e l'auto-indexer li saltava del tutto (`already_indexed`, "mai sovrascrivere associazioni esistenti") — il contenuto non veniva mai scansionato.
+- **Nuova integrazione automatica** (`integrate_post_locations`): per gli articoli GIÀ indicizzati, un cron asincrono dedicato (mai in save_post) scansiona il contenuto e AGGIUNGE le altre destinazioni come località secondarie (`mentioned_destination`), **senza mai toccare la primaria né le associazioni esistenti**. Due fonti: gazetteer sul testo (solo toponimi che risolvono su UNA località: gli ambigui non vanno auto-applicati alla mappa) + estrattore AI potenziato con i titoli H2/H3 (dove vivono le destinazioni degli articoli-elenco) e fino a 8 località.
+- **Nuovo metodo non distruttivo nello store** (`append_locations_for_object`): accoda righe secondarie al content index con dedup su località già associate (anche via alias); `save_geo_meta_for_object` sarebbe stato distruttivo (cancella e riscrive tutto).
+- **Geocoding e mappa automatici**: le località nuove nascono "pending" ed entrano nella coda di geocoding automatico esistente; la mappa mostra solo quelle con coordinate verificate — è il geocoding a fare da validatore delle estrazioni AI.
+- **Copertura**: (1) alla pubblicazione e al salvataggio degli articoli (hook differiti esistenti); (2) durante l'**arricchimento**, che scorre l'archivio dai post più vecchi: gli articoli storici vengono coperti progressivamente senza lavoro manuale.
+- **Costi sotto controllo**: hash del contenuto in meta (`_alma_geo_integration_hash`) — una sola analisi AI per versione del contenuto, esito leggibile in `_alma_geo_integration_note`; costi tracciati nel log AI (task `geo_location_extraction`).
+- **Opzione dedicata** in Impostazioni → Generale ("Completa automaticamente le località degli articoli dal contenuto", attiva di default, disattivabile).
+- Estrattore AI retrocompatibile: nuovi parametri opzionali `max_locations` e `include_headings`, comportamento invariato per i batch esistenti.
+- Test standalone 17/17 (prompt con SEZIONI, clamp max località, smoke test su guardie, dedup, non-distruttività e wiring).
+- Versione plugin aggiornata a `2.93.0`.
+
 ## 2.92.0 - 2026-07-08
 
 ### Inserimento universale di qualità: card con descrizione + frase introduttiva nel tono dell'articolo

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.93.0 - 2026-07-08
+
+### Destinazioni citate → indice geo e mappa
+- Gli articoli già indicizzati (es. creati dall'agent con la località dell'idea) ora vengono completati in automatico con le altre destinazioni citate nel contenuto: cron asincrono con gazetteer + estrattore AI (titoli H2/H3), località secondarie aggiunte senza toccare la primaria, geocoding automatico e mappa popolata. Copertura alla pubblicazione, al salvataggio e progressivamente sull'archivio via arricchimento. Opzione dedicata nelle impostazioni.
+- Versione plugin aggiornata a `2.93.0`.
+
 ## 2.92.0 - 2026-07-08
 
 ### Inserimento universale di qualità

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.92.0
+ * Version: 2.93.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.92.0');
+define('ALMA_VERSION', '2.93.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -2347,6 +2347,7 @@ class AffiliateManagerAI {
             update_option('alma_enable_ai', sanitize_text_field($_POST['enable_ai'] ?? 'yes'));
             update_option('alma_ai_auto_publish', ($_POST['alma_ai_auto_publish'] ?? 'no') === 'yes' ? 'yes' : 'no');
             update_option('alma_article_map_enabled', empty($_POST['alma_article_map_enabled']) ? '0' : '1', false);
+            update_option('alma_geo_post_integration', empty($_POST['alma_geo_post_integration']) ? '0' : '1', false);
 
             $selected_types = array_map('sanitize_text_field', $_POST['alma_link_post_types'] ?? array());
             update_option('alma_link_post_types', $selected_types);
@@ -2456,6 +2457,8 @@ class AffiliateManagerAI {
                             <td>
                                 <label><input type="checkbox" name="alma_article_map_enabled" value="1" <?php checked(get_option('alma_article_map_enabled', '1'), '1'); ?>> <?php _e('Mostra a fine articolo la mappa interattiva delle località citate (solo articoli con località geocodificate)', 'affiliate-link-manager-ai'); ?></label>
                                 <p class="description"><?php _e('I marker aprono la scheda Google Maps del luogo in una nuova scheda. Shortcode per posizionarla a mano: [alma_mappa_articolo]; esclusione per singolo articolo dalla metabox "📍 Mappa località".', 'affiliate-link-manager-ai'); ?></p>
+                                <label style="display:block;margin-top:8px;"><input type="checkbox" name="alma_geo_post_integration" value="1" <?php checked(get_option('alma_geo_post_integration', '1'), '1'); ?>> <?php _e('Completa automaticamente le località degli articoli dal contenuto (gazetteer + AI)', 'affiliate-link-manager-ai'); ?></label>
+                                <p class="description"><?php _e('Alla pubblicazione/salvataggio e durante l\'arricchimento, le altre destinazioni citate nell\'articolo vengono aggiunte come località secondarie (la primaria non viene mai toccata) e geocodificate in automatico: così finiscono sulla mappa. Una sola analisi AI per versione del contenuto.', 'affiliate-link-manager-ai'); ?></p>
                             </td>
                         </tr>
                     </table>

--- a/includes/class-ai-post-enricher.php
+++ b/includes/class-ai-post-enricher.php
@@ -264,6 +264,13 @@ class ALMA_AI_Post_Enricher {
         }
         update_post_meta($post_id, self::META_LAST_RUN, current_time('mysql'));
 
+        // Integrazione geo dal contenuto (mappa articolo): l'arricchimento
+        // scorre l'archivio dai post più vecchi, quindi copre progressivamente
+        // anche gli articoli pubblicati prima dell'integrazione automatica.
+        if (class_exists('ALMA_Geo_Auto_Indexer')) {
+            ALMA_Geo_Auto_Indexer::schedule_integration($post_id);
+        }
+
         $has_links = (bool) preg_match('/\[affiliate_link(?:s_widget)?[\s\]]/', $post->post_content);
         $result = ALMA_AI_Post_Optimizer::generate_proposals($post, array(
             'allow_replacements' => $has_links,

--- a/includes/class-geo-ai-location-extractor.php
+++ b/includes/class-geo-ai-location-extractor.php
@@ -2,10 +2,11 @@
 /**
  * Estrazione località via OpenAI per l'indicizzazione geografica automatica.
  *
- * Usato solo nei batch admin espliciti (mai su richieste frontend né su save_post)
- * e solo per i contenuti che i livelli deterministici non hanno risolto.
- * I risultati non vengono mai applicati automaticamente: finiscono nella coda
- * di revisione dell'auto-indexer.
+ * Usato nei batch admin espliciti e nell'integrazione asincrona via WP-Cron
+ * delle località citate dagli articoli (mai su richieste frontend, mai in
+ * modo sincrono dentro save_post). Nei batch i risultati finiscono nella coda
+ * di revisione dell'auto-indexer; nell'integrazione vengono aggiunti come
+ * località secondarie e validati dal geocoding prima di comparire sulla mappa.
  */
 if (!defined('ABSPATH')) {
     exit;
@@ -16,20 +17,35 @@ class ALMA_Geo_AI_Location_Extractor {
     const MAX_LOCATIONS = 4;
 
     /**
+     * @param array $args Opzionali: 'max_locations' (int, default 4, max 10)
+     *                    e 'include_headings' (bool: aggiunge i titoli H2/H3,
+     *                    dove vivono le destinazioni degli articoli-elenco).
      * @return array Elenco di località proposte (può essere vuoto) nel formato
      *               accettato da ALMA_Geo_Auto_Indexer::save_suggestion().
      */
-    public static function extract($post) {
+    public static function extract($post, $args = array()) {
         if (!$post instanceof WP_Post) {
             $post = get_post($post);
         }
         if (!$post instanceof WP_Post || trim((string) get_option('alma_openai_api_key', '')) === '') {
             return array();
         }
+        $max_locations = max(1, min(10, absint($args['max_locations'] ?? self::MAX_LOCATIONS)));
 
         $title = wp_strip_all_tags(get_the_title($post));
         $excerpt = wp_strip_all_tags(strip_shortcodes((string) ($post->post_excerpt ?: $post->post_content)));
         $excerpt = mb_substr(preg_replace('/\s+/', ' ', $excerpt), 0, self::MAX_CONTENT_CHARS);
+        $headings_line = '';
+        if (!empty($args['include_headings']) && preg_match_all('/<h[23][^>]*>(.*?)<\/h[23]>/is', (string) $post->post_content, $m)) {
+            $headings = array();
+            foreach (array_slice($m[1], 0, 20) as $h) {
+                $h = trim(preg_replace('/\s+/', ' ', wp_strip_all_tags($h)));
+                if ($h !== '') { $headings[] = $h; }
+            }
+            if (!empty($headings)) {
+                $headings_line = "\nSEZIONI: " . mb_substr(implode(' | ', $headings), 0, 800);
+            }
+        }
 
         $schema = array(
             'type' => 'object',
@@ -37,7 +53,7 @@ class ALMA_Geo_AI_Location_Extractor {
             'properties' => array(
                 'locations' => array(
                     'type' => 'array',
-                    'maxItems' => self::MAX_LOCATIONS,
+                    'maxItems' => $max_locations,
                     'items' => array(
                         'type' => 'object',
                         'additionalProperties' => false,
@@ -59,7 +75,7 @@ class ALMA_Geo_AI_Location_Extractor {
 
         $res = ALMA_OpenAI_Service::request(array(
             'system_prompt' => 'Sei un estrattore di località geografiche per un sito di viaggi. Individua solo le località di cui il contenuto parla realmente (destinazioni del viaggio), non luoghi citati di passaggio. Se il contenuto non riguarda una località specifica restituisci un elenco vuoto. country_code in formato ISO 3166-1 alpha-2, vuoto se incerto.',
-            'user_prompt' => "TITOLO: {$title}\nESTRATTO: {$excerpt}",
+            'user_prompt' => "TITOLO: {$title}{$headings_line}\nESTRATTO: {$excerpt}",
             'response_format' => array(
                 'type' => 'json_schema',
                 'name' => 'geo_locations',
@@ -95,7 +111,7 @@ class ALMA_Geo_AI_Location_Extractor {
         }
 
         $locations = array();
-        foreach (array_slice($parsed['locations'], 0, self::MAX_LOCATIONS) as $location) {
+        foreach (array_slice($parsed['locations'], 0, $max_locations) as $location) {
             if (!is_array($location)) {
                 continue;
             }

--- a/includes/class-geo-auto-indexer.php
+++ b/includes/class-geo-auto-indexer.php
@@ -29,6 +29,14 @@ class ALMA_Geo_Auto_Indexer {
     const SOURCE_AI = 'auto_ai';
     const SOURCE_CONFIRMED = 'auto_confirmed';
 
+    // Integrazione delle località citate nel contenuto dei post già
+    // indicizzati (per la mappa articolo): cron asincrono, mai in save_post.
+    const INTEGRATION_CRON_HOOK = 'alma_geo_integrate_post_locations';
+    const INTEGRATION_OPTION = 'alma_geo_post_integration';
+    const INTEGRATION_HASH_META = '_alma_geo_integration_hash';
+    const INTEGRATION_NOTE_META = '_alma_geo_integration_note';
+    const INTEGRATION_MAX_ADDITIONS = 8;
+
     const CONFIDENCE_HIGH = 0.9;
     const CONFIDENCE_MEDIUM = 0.6;
     const CONFIDENCE_LOW = 0.4;
@@ -660,6 +668,7 @@ class ALMA_Geo_Auto_Indexer {
         // erano ancora draft (l'indexer lavora solo sui post pubblicati).
         add_action('transition_post_status', array($this, 'queue_index_on_publish'), 20, 3);
         add_action('shutdown', array($this, 'run_deferred_index'));
+        add_action(self::INTEGRATION_CRON_HOOK, array(__CLASS__, 'cron_integrate_post'));
 
         if (is_admin()) {
             foreach (array('post', 'affiliate_link') as $post_type) {
@@ -778,13 +787,172 @@ class ALMA_Geo_Auto_Indexer {
             if (!$post instanceof WP_Post || $post->post_status !== 'publish') {
                 continue;
             }
-            // Deterministico soltanto: mai chiamate AI fuori dai batch espliciti.
+            // Gli ARTICOLI già indicizzati (es. località dell'idea assegnata
+            // dall'agent) venivano saltati del tutto: le altre destinazioni
+            // citate nel contenuto non finivano mai su indice e mappa.
+            // L'integrazione gira in un cron asincrono dedicato (mai qui a
+            // shutdown: può chiamare OpenAI) e non tocca la primaria.
+            if ($post->post_type === 'post') {
+                self::schedule_integration($post_id);
+            }
+            // Deterministico soltanto: mai chiamate AI fuori dai batch
+            // espliciti e dal cron di integrazione.
             $status = get_post_meta($post_id, self::STATUS_META, true);
             if (in_array($status, array('suggested', 'rejected'), true)) {
                 continue;
             }
             $this->resolve_object($post_id, false);
         }
+    }
+
+    /* ---------------------------------------------------------------------
+     * Integrazione località dal contenuto (mappa articolo)
+     * ------------------------------------------------------------------ */
+
+    /**
+     * Programma l'integrazione asincrona delle località citate da un post.
+     * Idempotente: se un evento per lo stesso post è già in coda non ne
+     * aggiunge un altro; il cambio-contenuto è gestito dall'hash nel cron.
+     */
+    public static function schedule_integration($post_id) {
+        $post_id = absint($post_id);
+        if ($post_id < 1 || get_option(self::INTEGRATION_OPTION, '1') !== '1') {
+            return false;
+        }
+        if (wp_next_scheduled(self::INTEGRATION_CRON_HOOK, array($post_id))) {
+            return false;
+        }
+        $scheduled = wp_schedule_single_event(time() + 15, self::INTEGRATION_CRON_HOOK, array($post_id));
+        if (false !== $scheduled && function_exists('spawn_cron')) {
+            spawn_cron();
+        }
+        return false !== $scheduled;
+    }
+
+    public static function cron_integrate_post($post_id) {
+        $indexer = new self();
+        $indexer->integrate_post_locations($post_id);
+    }
+
+    /**
+     * Completa l'indice geografico di un ARTICOLO già indicizzato con le
+     * altre località citate nel contenuto, senza toccare le associazioni
+     * esistenti (la primaria — es. località dell'idea — resta intatta).
+     *
+     * Fonti: gazetteer sul testo (solo match non ambigui) + estrattore AI
+     * (con i titoli H2/H3, dove vivono le destinazioni degli elenchi).
+     * Le località nuove nascono in geocoding "pending": è il geocoding a
+     * validarle, e la mappa mostra solo quelle con coordinate verificate.
+     * Un hash del contenuto evita ri-scansioni (e costi AI) sui salvataggi
+     * senza modifiche.
+     *
+     * @return array{added:int,skipped:string} Esito sintetico.
+     */
+    public function integrate_post_locations($post_id) {
+        $none = array('added' => 0, 'skipped' => '');
+        $post = get_post($post_id);
+        if (!$post instanceof WP_Post || $post->post_type !== 'post' || $post->post_status !== 'publish') {
+            $none['skipped'] = 'post_non_valido';
+            return $none;
+        }
+        if (get_option(self::INTEGRATION_OPTION, '1') !== '1') {
+            $none['skipped'] = 'disabilitata';
+            return $none;
+        }
+        // Solo post GIÀ indicizzati: i non indicizzati seguono il flusso
+        // normale (resolve/suggerimenti); integrare senza primaria
+        // creerebbe associazioni orfane che il flusso di revisione
+        // cancellerebbe alla conferma.
+        if (!$this->object_is_indexed($post->ID, ALMA_Geo_Index_Store::OBJECT_TYPE_POST)) {
+            $none['skipped'] = 'non_indicizzato';
+            return $none;
+        }
+        $hash = md5($post->post_title . '|' . $post->post_content);
+        if (get_post_meta($post->ID, self::INTEGRATION_HASH_META, true) === $hash) {
+            $none['skipped'] = 'contenuto_invariato';
+            return $none;
+        }
+
+        $seen = $this->associated_location_norms($post->ID, ALMA_Geo_Index_Store::OBJECT_TYPE_POST);
+        $additions = array();
+
+        // Fonte 1 — gazetteer sul testo: solo nomi che risolvono su UNA
+        // località (i toponimi ambigui non vanno auto-applicati alla mappa).
+        $gazetteer_result = $this->resolve_via_gazetteer($post);
+        $by_name = array();
+        foreach ((array) $gazetteer_result['locations'] as $location) {
+            $norm = $this->normalize_text((string) ($location['name'] ?? ''));
+            if ($norm === '') { continue; }
+            $by_name[$norm][] = $location;
+        }
+        foreach ($by_name as $norm => $rows) {
+            if (count($rows) !== 1 || isset($seen[$norm])) { continue; }
+            $location = $rows[0];
+            $location['is_primary'] = false;
+            $location['role'] = 'mentioned_destination';
+            $additions[] = $location;
+            $seen[$norm] = true;
+        }
+
+        // Fonte 2 — estrattore AI con i titoli di sezione (una sola chiamata
+        // per versione del contenuto grazie all'hash; costi nel log AI).
+        if (class_exists('ALMA_Geo_AI_Location_Extractor') && count($additions) < self::INTEGRATION_MAX_ADDITIONS) {
+            $ai_locations = ALMA_Geo_AI_Location_Extractor::extract($post, array(
+                'max_locations' => self::INTEGRATION_MAX_ADDITIONS,
+                'include_headings' => true,
+            ));
+            $ai_locations = $this->enrich_with_gazetteer($ai_locations);
+            foreach ($ai_locations as $location) {
+                $norm = $this->normalize_text((string) ($location['name'] ?? ''));
+                if ($norm === '' || isset($seen[$norm])) { continue; }
+                $location['is_primary'] = false;
+                $location['role'] = 'mentioned_destination';
+                $location['source'] = self::SOURCE_AI;
+                $additions[] = $location;
+                $seen[$norm] = true;
+            }
+        }
+
+        $added = array();
+        if (!empty($additions)) {
+            $additions = array_slice($additions, 0, self::INTEGRATION_MAX_ADDITIONS);
+            $added = $this->store->append_locations_for_object($post->ID, ALMA_Geo_Index_Store::OBJECT_TYPE_POST, $additions, 'auto_content');
+        }
+        update_post_meta($post->ID, self::INTEGRATION_HASH_META, $hash);
+        update_post_meta($post->ID, self::INTEGRATION_NOTE_META, sprintf(
+            '%s — %s',
+            empty($added) ? __('Nessuna località aggiuntiva trovata nel contenuto', 'affiliate-link-manager-ai') : sprintf(__('+%d località dal contenuto: %s', 'affiliate-link-manager-ai'), count($added), implode(', ', wp_list_pluck($added, 'name'))),
+            current_time('mysql')
+        ));
+        return array('added' => count($added), 'skipped' => '');
+    }
+
+    /**
+     * Nomi normalizzati (canonico + alias) delle località già associate a un
+     * oggetto: base di dedup dell'integrazione.
+     */
+    private function associated_location_norms($object_id, $object_type) {
+        global $wpdb;
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT l.canonical_name, l.aliases FROM {$this->store->table_content_index()} ci
+             INNER JOIN {$this->store->table_locations()} l ON l.id = ci.location_id
+             WHERE ci.object_id = %d AND ci.object_type = %s",
+            absint($object_id),
+            sanitize_key($object_type)
+        ), ARRAY_A);
+        $norms = array();
+        foreach ((array) $rows as $row) {
+            $names = array((string) ($row['canonical_name'] ?? ''));
+            $aliases = json_decode((string) ($row['aliases'] ?? ''), true);
+            if (is_array($aliases)) {
+                foreach ($aliases as $alias) { $names[] = (string) $alias; }
+            }
+            foreach ($names as $name) {
+                $norm = $this->normalize_text($name);
+                if ($norm !== '') { $norms[$norm] = true; }
+            }
+        }
+        return $norms;
     }
 
     /* ---------------------------------------------------------------------

--- a/includes/class-geo-index-store.php
+++ b/includes/class-geo-index-store.php
@@ -480,6 +480,106 @@ class ALMA_Geo_Index_Store {
         return array('location_id' => $primary_location_id, 'content_index_id' => $primary_content_index_id, 'locations' => $updated_locations, 'meta' => $meta);
     }
 
+    /**
+     * AGGIUNGE località secondarie a un oggetto già indicizzato senza toccare
+     * le associazioni esistenti: né la primaria (meta _alma_geo_primary_*
+     * intatti), né le righe già presenti nel content index. Usato
+     * dall'integrazione automatica delle località citate nel contenuto
+     * (mappa articolo): save_geo_meta_for_object qui sarebbe distruttivo
+     * perché cancella e riscrive tutte le righe dell'oggetto.
+     *
+     * @return array Località effettivamente aggiunte (formato JSON interno).
+     */
+    public function append_locations_for_object($object_id, $object_type, $locations, $source = 'auto_content') {
+        global $wpdb;
+        $object_id = absint($object_id);
+        $object_type = sanitize_key($object_type);
+        if (!$object_id || $object_type === '' || empty($locations) || !is_array($locations)) {
+            return array();
+        }
+        if (!$this->tables_exist()) {
+            $this->install_tables();
+        }
+
+        // Località già associate: mai duplicare (nemmeno via alias che
+        // risolvono sulla stessa riga della tabella località).
+        $existing_location_ids = array_map('intval', (array) $wpdb->get_col($wpdb->prepare(
+            "SELECT location_id FROM {$this->table_content_index()} WHERE object_id = %d AND object_type = %s AND location_id IS NOT NULL",
+            $object_id,
+            $object_type
+        )));
+
+        // Contesto dell'oggetto: le righe aggiunte ereditano scope/tipo/intent
+        // correnti, coerenti con la riga primaria.
+        $geo_scope = sanitize_key((string) get_post_meta($object_id, '_alma_geo_scope', true));
+        $content_type = sanitize_key((string) get_post_meta($object_id, '_alma_geo_content_type', true));
+        $commercial_intent = sanitize_key((string) get_post_meta($object_id, '_alma_geo_commercial_intent', true));
+        $widget_eligible = get_post_meta($object_id, '_alma_geo_widget_eligible', true) === 'yes';
+        $now = current_time('mysql');
+
+        $added = array();
+        foreach ((array) $locations as $location) {
+            if (!is_array($location)) { continue; }
+            $item = $this->format_location_for_json($location);
+            if ($item['name'] === '' && $item['canonical_name'] === '') { continue; }
+            $item['is_primary'] = false;
+            if ($item['role'] === '' || $item['role'] === 'main_destination') {
+                $item['role'] = 'mentioned_destination';
+            }
+            $item['match_weight'] = $this->default_match_weight_for_role($item['role']);
+            $item['source'] = $item['source'] !== '' ? $item['source'] : sanitize_text_field($source);
+
+            $location_id = $this->upsert_location(array(
+                'canonical_name' => $item['canonical_name'] ?: $item['name'],
+                'type' => $item['type'],
+                'country' => $item['country'],
+                'country_code' => $item['country_code'],
+                'region' => $item['region'],
+                'city' => $item['city'],
+                'area' => $item['area'],
+                'poi' => $item['poi'],
+                'lat' => $item['lat'],
+                'lng' => $item['lng'],
+                'geo_provider' => $item['geo_provider'],
+                'geo_provider_place_id' => $item['geo_provider_place_id'],
+                'suggested_geocoding_query' => $item['suggested_geocoding_query'],
+                'geocoding_status' => $item['geocoding_status'],
+                'formatted_address' => $item['formatted_address'],
+                'geocoded_at' => $item['geocoding_status'] === 'verified' ? $now : '',
+            ));
+            if (!$location_id || in_array((int) $location_id, $existing_location_ids, true)) {
+                continue;
+            }
+            $item['location_id'] = (int) $location_id;
+            $content_index_id = $this->upsert_content_index($object_id, $object_type, $location_id, array(
+                'is_primary' => 0,
+                'role' => $item['role'],
+                'geo_scope' => $geo_scope,
+                'content_type' => $content_type,
+                'commercial_intent' => $commercial_intent,
+                'widget_eligible' => $widget_eligible,
+                'confidence' => $item['confidence'],
+                'match_weight' => $item['match_weight'],
+                'source' => $item['source'],
+                'raw_payload' => array('location' => $item),
+            ));
+            if (!$content_index_id) {
+                $this->log_geo_store_event('warning', 'Geo Index Store could not append content index relation.', $object_id, $object_type);
+                continue;
+            }
+            $existing_location_ids[] = (int) $location_id;
+            $added[] = $item;
+        }
+
+        if (!empty($added)) {
+            $json = json_decode((string) get_post_meta($object_id, '_alma_geo_locations_json', true), true);
+            $json = is_array($json) ? $json : array();
+            update_post_meta($object_id, '_alma_geo_locations_json', wp_json_encode(array_merge($json, $added)));
+            update_post_meta($object_id, '_alma_geo_updated_at', $now);
+        }
+        return $added;
+    }
+
     private function log_geo_store_event($level, $message, $object_id, $object_type) {
         if (!class_exists('ALMA_Logger')) {
             return;


### PR DESCRIPTION
## Contesto

Segnalazione sull'articolo "Stati Uniti in 3 giorni: dove andare": l'articolo parla di diverse destinazioni ma nessuna finiva nell'indice geo né sulla mappa. **Causa radice**: gli articoli dell'agent ricevono la località dell'idea alla creazione, quindi risultano "già indicizzati" e l'auto-indexer li saltava del tutto (`already_indexed`, regola "mai sovrascrivere associazioni esistenti") — il contenuto non veniva mai scansionato.

## Modifiche

### `includes/class-geo-auto-indexer.php` — integrazione asincrona
- Nuovo cron dedicato `integrate_post_locations` (`alma_geo_integrate_post_locations`, mai sincrono in save_post): per gli articoli **già indicizzati** scansiona il contenuto e AGGIUNGE le destinazioni citate come località secondarie (`mentioned_destination`), senza mai toccare la primaria né le associazioni esistenti.
- Due fonti: **gazetteer** sul testo (solo toponimi che risolvono su UNA località — gli ambigui non vanno auto-applicati alla mappa) + **estrattore AI** con i titoli H2/H3 (dove vivono le destinazioni negli articoli-elenco), fino a 8 località.
- Hash del contenuto in meta (`_alma_geo_integration_hash`): una sola analisi AI per versione del contenuto; esito leggibile in `_alma_geo_integration_note`; costi nel log AI (task `geo_location_extraction`).
- `schedule_integration` idempotente (nessun doppio evento in coda per lo stesso post) con `spawn_cron`.

### `includes/class-geo-index-store.php` — append non distruttivo
- Nuovo `append_locations_for_object`: accoda righe secondarie al content index con dedup sulle località già associate (anche via alias); eredita scope/tipo/intent correnti dell'oggetto; aggiorna solo `_alma_geo_locations_json` e `_alma_geo_updated_at`. (`save_geo_meta_for_object` sarebbe stato distruttivo: cancella e riscrive tutte le righe.)

### `includes/class-geo-ai-location-extractor.php` — retrocompatibile
- Nuovi parametri opzionali `max_locations` (clamp 1-10) e `include_headings` (riga "SEZIONI: …" con gli H2/H3); comportamento invariato per i batch esistenti (default 4, senza sezioni).

### Copertura e validazione
- **Pubblicazione/salvataggio**: `run_deferred_index` programma l'integrazione per ogni post (hook esistenti save_post + transition_post_status).
- **Archivio**: l'arricchimento (che scorre dai post più vecchi) programma l'integrazione per ogni articolo analizzato — copertura progressiva senza lavoro manuale.
- **Geocoding**: le località nuove nascono `pending` ed entrano nella coda di geocoding automatico esistente; la mappa mostra solo coordinate verificate — è il geocoding a validare le estrazioni AI.
- **Opzione dedicata** in Impostazioni → Generale ("Completa automaticamente le località degli articoli dal contenuto"), attiva di default e disattivabile.

## Verifiche

- `php -l` su tutti i file modificati: OK
- Test standalone 17/17 (estrattore reale con capture della richiesta OpenAI: riga SEZIONI, clamp maxItems, default invariati; smoke test su guardie already-indexed/hash/ambiguità, non-distruttività dello store, dedup, wiring enricher e opzione)
- Retrocompatibilità: nessuna option/API rimossa; primaria e associazioni manuali mai toccate; estrattore invariato per i chiamanti esistenti

## Versione

`2.92.0` → `2.93.0` (minor) + sezioni CHANGELOG.md e README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_