### PR TITLE
Bozze agente: universale garantito, widget a metà, grassetti, link interni (v2.94.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.94.0 - 2026-07-08
+
+### Qualità delle bozze dell'agente: universale garantito, widget a metà, grassetti, link interni
+- **Segnalazione** (articolo "Stati Uniti in 3 giorni"): mancavano link universali, il widget era a fine articolo, niente grassetti né link interni. Interventi mirati sul draft-builder (creazione bozze dell'agente):
+- **Link universale garantito anche in CREAZIONE** (`guarantee_universal_link`): stessa ricetta dell'arricchimento (v2.91/2.92). Se l'AI non inserisce un link di tipologia universale (assicurazione/eSIM) e il contenuto non ne contiene già uno, il sistema aggiunge una **card** (immagine + titolo + descrizione) col miglior universale a ~70% dell'articolo, prima del salvataggio. Indipendente dai candidati selezionati: gli universali valgono per qualsiasi articolo. La card entra anche nella coda immagini AI se il link non ha featured.
+- **Esenzione geografica degli universali**: la regola geo delle bozze ("usa solo link coerenti con la destinazione") **scartava attivamente** le assicurazioni (che non hanno geografia). Ora la regola ha un'eccezione esplicita per la tipologia universale, ripetuta anche nelle regole core.
+- **Widget a METÀ articolo** (`insert_block_midpoint`): quando l'AI non mette il segnaposto `[[ALMA_WIDGET]]`, il widget (richiesto o di fallback garantito) non viene più accodato in fondo ma inserito dopo un paragrafo centrale, per spezzare il testo. Il contract del widget ora chiede esplicitamente di posizionare il segnaposto in un punto intermedio, non alla fine.
+- **Grassetti**: nuova regola di formattazione — evidenzia in `<strong>` i concetti chiave, i nomi di luoghi/attrazioni e i dati pratici (con misura, una-due per paragrafo).
+- **Link interni**: rafforzata la regola "2-5 link interni pertinenti"; se la bozza non ne contiene nessuno, viene registrato un avviso nella diagnostica (`_alma_ai_agent_qa_warnings`, visibile nella revisione bozza) per capire se mancano articoli correlati indicizzati.
+- Test standalone 18/18 (card garantita con posizione/formato/anti-doppione/guardie, widget mid-point, smoke test su regole geo/grassetti/interni/contract/warning).
+- Versione plugin aggiornata a `2.94.0`.
+
 ## 2.93.0 - 2026-07-08
 
 ### Geo/mappa: le destinazioni citate nell'articolo entrano nell'indice (e sulla mappa)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.94.0 - 2026-07-08
+
+### Bozze dell'agente più complete
+- Link universale garantito anche in creazione (card a ~70%), universali esentati dalla coerenza geografica, widget inserito a metà articolo invece che in coda, nuova regola per i grassetti sui concetti chiave, regola link interni rafforzata con avviso in diagnostica quando assenti.
+- Versione plugin aggiornata a `2.94.0`.
+
 ## 2.93.0 - 2026-07-08
 
 ### Destinazioni citate → indice geo e mappa

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.93.0
+ * Version: 2.94.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.93.0');
+define('ALMA_VERSION', '2.94.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -408,7 +408,10 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'Esempio HTML esatto per immagini affiliate: <a href="{affiliate_url}" target="_blank" rel="nofollow sponsored noopener"><img class="aligncenter size-full" src="{image.image_url}" alt="{image.image_alt}" /></a>',
             'Fallback HTML esatto per immagini affiliate: <a href="{affiliate_url}" target="_blank" rel="nofollow sponsored noopener"><img class="aligncenter size-full" src="{image.image_url}" alt="{title}" /></a>',
             'Usa solo link interni presenti in internal_links e compila internal_urls_used.',
+            'Inserisci da 2 a 5 link interni pertinenti (se internal_links ne contiene): sono utili per la navigazione e la SEO; non forzarne di non pertinenti.',
             'Usa category_ids, tag_ids e new_tags secondo taxonomy_rules.',
+            'Formatta il testo per la lettura sul web: evidenzia in <strong> i concetti chiave, i nomi di luoghi/attrazioni e i dati pratici (prezzi, periodi consigliati, durate) — con misura, indicativamente una-due evidenziazioni per paragrafo, mai interi periodi.',
+            'I link affiliati di tipologia universale (assicurazione viaggio, eSIM, ecc.) sono pertinenti in QUALSIASI articolo di viaggio, anche multi-destinazione: la coerenza geografica NON si applica a loro. Se ne hai uno tra affiliate_links, inseriscilo nel punto più naturale (consigli pratici, preparativi).',
         );
         $affiliate_rules = self::compact_rule_list(array_merge((array)($payload['affiliate_rules'] ?? array()), array($profile_rules['affiliate_rules'] ?? '')));
         $seo_rules = self::compact_rule_list(array_merge((array)($payload['seo_rules'] ?? array()), array($profile_rules['seo_rules'] ?? '')));
@@ -517,6 +520,44 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'Non forzare link non pertinenti.',
             'Compila internal_urls_used con gli URL interni realmente usati nel contenuto.',
         );
+    }
+
+    /**
+     * Garantisce un link di tipologia universale (assicurazioni/eSIM) nel
+     * contenuto: se non ne contiene già uno e ne esiste uno pubblicato, lo
+     * inserisce come card (immagine + titolo + descrizione) a circa due terzi
+     * dell'articolo. Deterministico, indipendente dai candidati selezionati:
+     * gli universali valgono per qualsiasi articolo di viaggio.
+     *
+     * @return array{content:string,added:bool,link_id:int}
+     */
+    private static function guarantee_universal_link($content) {
+        $result = array('content' => $content, 'added' => false, 'link_id' => 0);
+        if (!class_exists('ALMA_Universal_Link_Types') || !class_exists('ALMA_AI_Post_Optimizer')) {
+            return $result;
+        }
+        $universal_ids = ALMA_Universal_Link_Types::top_universal_links(3);
+        if (empty($universal_ids)) { return $result; }
+        // Già presente nel contenuto (shortcode con uno degli ID universali)?
+        foreach ($universal_ids as $uid) {
+            if (preg_match('/\[affiliate_link[^\]]*\bid="?' . (int) $uid . '"?[\s"\]]/', $content)) {
+                return $result;
+            }
+        }
+        $link_id = (int) $universal_ids[0];
+        $paragraphs = ALMA_AI_Post_Optimizer::paragraph_texts($content);
+        $count = count($paragraphs);
+        if ($count < 3) { return $result; }
+        $rules = class_exists('ALMA_AI_Insertion_Rules') ? ALMA_AI_Insertion_Rules::get_rules() : array('min_paragraphs_before' => 2, 'button_text' => __('Scopri di più', 'affiliate-link-manager-ai'));
+        $min_paragraph = (int) ($rules['min_paragraphs_before'] ?? 2);
+        $paragraph = max($min_paragraph, (int) floor($count * 0.7));
+        $paragraph = min($paragraph, $count - 1);
+        $button_text = sanitize_text_field((string) ($rules['button_text'] ?? __('Scopri di più', 'affiliate-link-manager-ai')));
+        $card = '[affiliate_link id="' . $link_id . '" img="yes" fields="title,content" button="yes" button_text="' . esc_attr($button_text) . '"]';
+        $result['content'] = ALMA_AI_Post_Optimizer::insert_after_paragraph($content, $paragraph, $card, false);
+        $result['added'] = true;
+        $result['link_id'] = $link_id;
+        return $result;
     }
 
     private static function candidate_affiliate_images($affiliate_links) {
@@ -1023,7 +1064,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'seo_rules'=>$seo_rules,
             'media_rules'=>array_filter(array('Usa massimo '.$max_editorial_media_used.' immagini editoriali dalla Media Library nel corpo dell’articolo.','Usare immagini affiliate solo se pertinenti alla sezione.','Non inventare URL immagini.','Usare solo immagini presenti nei link affiliati selezionati.','Non duplicare troppe volte la stessa immagine.','Non scaricare immagini durante la generazione bozza.','Se nessuna immagine della Media Library è adatta a una sezione, puoi inserire su una riga a sé un segnaposto [Immagine: descrizione fotografica dettagliata della scena] (massimo 3 per articolo): verrà generato dall\'AI e sostituito automaticamente dopo la creazione.', $profile_payload['instruction_profile_rules']['image_rules'] ?? '')),
             'output_contract'=>array('title','slug','excerpt','content','seo_title','seo_description','featured_image_id','affiliate_shortcodes_used','affiliate_urls_used','internal_urls_used','media_used','category_ids','tag_ids','new_tags','warnings'),
-            'widget_request_contract'=>'Campo OPZIONALE widget_request nell\'output JSON: {"title":string,"layout":string,"link_ids":[int],"button_text":string,"rewritten":[{"id":int,"title":string,"description":string}]}. Scegli il layout adatto al contesto dell\'articolo: "destination_cards" = griglia di mete/destinazioni con titolo e località sull\'immagine (2-6 link); "experience_cards" = card compatte per tour e attività specifiche con pulsante, carosello su mobile (2-8 link); "hero_spotlight" = UNA sola esperienza di punta in grande evidenza con testo e pulsante (esattamente 1 link). Compilalo SOLO se hai inserito il segnaposto [[ALMA_WIDGET]] nel content; il sistema creerà il widget reale e sostituirà il segnaposto.',
+            'widget_request_contract'=>'Campo OPZIONALE widget_request nell\'output JSON: {"title":string,"layout":string,"link_ids":[int],"button_text":string,"rewritten":[{"id":int,"title":string,"description":string}]}. Scegli il layout adatto al contesto dell\'articolo: "destination_cards" = griglia di mete/destinazioni con titolo e località sull\'immagine (2-6 link); "experience_cards" = card compatte per tour e attività specifiche con pulsante, carosello su mobile (2-8 link); "hero_spotlight" = UNA sola esperienza di punta in grande evidenza con testo e pulsante (esattamente 1 link). Compilalo SOLO se hai inserito il segnaposto [[ALMA_WIDGET]] nel content; il sistema creerà il widget reale e sostituirà il segnaposto. Posiziona il segnaposto [[ALMA_WIDGET]] in un punto INTERMEDIO dell\'articolo (dopo una sezione centrale pertinente) per spezzare visivamente il testo — NON alla fine, dove è meno efficace.',
             'warnings'=>array_values(array_unique($warnings)),
             'agent_behavior'=>$agent_behavior,
         ), $profile_payload);
@@ -1136,7 +1177,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             if ($geo_label !== '') {
                 $ctx['geo_context'] = array(
                     'location' => $geo_label,
-                    'rules' => 'L\'articolo riguarda la località "' . $geo_label . '". Usa SOLO link affiliati e link interni geograficamente coerenti con questa destinazione; non citare né linkare destinazioni diverse, se non per confronti esplicitamente richiesti dal prompt.',
+                    'rules' => 'L\'articolo riguarda la località "' . $geo_label . '". Usa link affiliati e link interni geograficamente coerenti con questa destinazione; non citare né linkare destinazioni diverse, se non per confronti esplicitamente richiesti dal prompt. ECCEZIONE: i link affiliati di tipologia universale (assicurazione viaggio, eSIM, ecc.) valgono per qualsiasi destinazione e vanno inseriti a prescindere dalla località.',
                 );
             }
         }
@@ -1255,6 +1296,19 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             $enforced = ALMA_AI_Insertion_Rules::enforce($clean['content'], $rules_snapshot);
             $clean['content'] = $enforced['content'];
             $clean['warnings'] = array_values(array_unique(array_merge((array)$clean['warnings'], (array)$widget_result['warnings'], (array)$enforced['warnings'])));
+        }
+        // Garanzia deterministica del link universale (assicurazioni/eSIM):
+        // se l'AI non ne ha inserito uno e il contenuto non lo contiene già,
+        // lo aggiunge il sistema come card a ~70% dell'articolo — stessa
+        // ricetta dell'arricchimento, così ogni articolo lo propone davvero.
+        $universal_guarantee = self::guarantee_universal_link((string) $clean['content']);
+        if ($universal_guarantee['added']) {
+            $clean['content'] = $universal_guarantee['content'];
+            $clean['warnings'][] = 'Link universale (assicurazione/eSIM) aggiunto automaticamente: l\'AI non l\'aveva inserito.';
+        }
+        // Segnalazione qualità: nessun link interno (utile per SEO e navigazione).
+        if (empty($clean['internal_urls_used'])) {
+            $clean['warnings'][] = 'Nessun link interno inserito: verifica che esistano articoli correlati indicizzati per questa destinazione.';
         }
         // Difesa: gli URL GYG con parametri di sessione (deeplink_id/page_id
         // dai CSV) non devono entrare negli articoli — l'AI può scrivere

--- a/includes/class-ai-insertion-rules.php
+++ b/includes/class-ai-insertion-rules.php
@@ -320,9 +320,31 @@ class ALMA_AI_Insertion_Rules {
         if ($has_placeholder) {
             $content = str_replace(self::WIDGET_PLACEHOLDER, $created['shortcode'], $content);
         } else {
-            $content .= "\n\n" . $created['shortcode'];
-            $warnings[] = 'Segnaposto widget mancante: widget aggiunto in coda all\'articolo.';
+            // Segnaposto mancante: inserisci il widget a METÀ articolo (spezza
+            // il testo), non in coda dove è meno efficace.
+            $content = self::insert_block_midpoint($content, $created['shortcode']);
+            $warnings[] = 'Segnaposto widget mancante: widget inserito a metà articolo.';
         }
         return array('content' => $content, 'warnings' => $warnings, 'widget_id' => $widget_id);
+    }
+
+    /**
+     * Inserisce un blocco (shortcode widget) dopo un paragrafo intermedio del
+     * contenuto, per spezzare visivamente il testo. Usa il divisore dei
+     * paragrafi del post optimizer quando disponibile; in caso contrario
+     * accoda in fondo (comportamento storico, mai peggiore).
+     */
+    private static function insert_block_midpoint($content, $block) {
+        if (class_exists('ALMA_AI_Post_Optimizer')) {
+            $paragraphs = ALMA_AI_Post_Optimizer::paragraph_texts($content);
+            $count = count($paragraphs);
+            if ($count >= 4) {
+                // Circa a metà, ma mai nei primi due paragrafi (introduzione).
+                $index = max(2, (int) floor($count / 2));
+                $index = min($index, $count - 1);
+                return ALMA_AI_Post_Optimizer::insert_after_paragraph($content, $index, $block, false);
+            }
+        }
+        return rtrim($content) . "\n\n" . $block;
     }
 }


### PR DESCRIPTION
## Contesto

Segnalazione sull'articolo "Stati Uniti in 3 giorni": mancavano link universali, il widget era a fine articolo, niente grassetti né link interni. Interventi mirati sul **draft-builder** (creazione bozze dell'agente).

## Modifiche

### Link universale garantito anche in CREAZIONE (`class-ai-content-agent-draft-builder.php`)
- Nuovo `guarantee_universal_link`: stessa ricetta dell'arricchimento (v2.91/2.92). Se l'AI non inserisce un link di tipologia universale (assicurazione/eSIM) e il contenuto non ne contiene già uno, il sistema aggiunge una **card** (immagine + titolo + descrizione) col miglior universale a ~70% dell'articolo, prima del salvataggio. Deterministico e indipendente dai candidati selezionati. La card entra anche nella coda immagini AI (il regex esistente su `[affiliate_link id=...]` la intercetta).

### Esenzione geografica degli universali
- La regola geo delle bozze ("usa solo link coerenti con la destinazione") **scartava attivamente** le assicurazioni (che non hanno geografia). Aggiunta un'eccezione esplicita per la tipologia universale, ribadita anche nelle regole core.

### Widget a METÀ articolo (`class-ai-insertion-rules.php`)
- Nuovo `insert_block_midpoint`: quando l'AI non mette il segnaposto `[[ALMA_WIDGET]]`, il widget (richiesto o di fallback garantito) non viene più accodato in fondo ma inserito dopo un paragrafo centrale (mai nei primi due; fallback all'accodamento solo per articoli < 4 paragrafi). Il contract del widget ora chiede esplicitamente di posizionare il segnaposto in un punto intermedio.

### Grassetti e link interni
- Nuova regola di formattazione: evidenzia in `<strong>` i concetti chiave, i nomi di luoghi/attrazioni e i dati pratici (con misura).
- Rafforzata la regola "2-5 link interni pertinenti"; se la bozza non ne contiene nessuno, avviso in `_alma_ai_agent_qa_warnings` (visibile nella revisione bozza / metabox AI Affiliati) per capire se mancano articoli correlati indicizzati.

## Verifiche

- `php -l` sui file modificati: OK
- Test standalone 18/18 (card garantita: posizione ~70%, formato, anti-doppione, guardie senza-universali/troppo-breve; widget mid-point con fallback; smoke test su regole geo/grassetti/interni/contract/warning/wiring)
- Retrocompatibilità: nessuna option/API rimossa; la garanzia salta se un universale è già presente; il widget mid-point degrada all'accodamento storico sugli articoli brevi

## Versione

`2.93.0` → `2.94.0` (minor) + sezioni CHANGELOG.md e README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_