### PR TITLE
Scrittura bozze: schede località (clima, fatti, territorio) nel payload del writer (v2.95.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.95.0 - 2026-07-08
+
+### Schede località nella scrittura: l'agente usa i dati reali (clima, fatti, territorio)
+- **Domanda dalla verifica** ("sta realmente usando le Schede località / fonti esterne?"): NO. `scheda_localita` (clima Open-Meteo, fatti Wikidata, territorio OSM, tendenze) era un tool disponibile solo all'agente di IDEAZIONE per scegliere il taglio stagionale; chi SCRIVE l'articolo (draft-builder) non riceveva alcun dato, così gli articoli restavano generici sui dati concreti.
+- **Fix**: il payload inviato al modello per la scrittura ora include `location_facts` — la scheda della località dell'idea in forma compatta: mesi migliori/da evitare e sintesi del clima, fatti verificati (popolazione, patrimonio UNESCO, fino a 6 attrazioni notevoli) e sintesi del territorio. Stessi dati del tool `scheda_localita`, proiettati su ciò che serve al testo (niente serie mensili grezze né dati interni).
+- **Regola di scrittura**: "se è presente location_facts, integra nel testo i dati reali (mesi consigliati, clima, attrazioni verificate, UNESCO, territorio) citandoli con naturalezza; NON inventare numeri o fatti non presenti" — così l'articolo diventa concreto e autorevole senza rischio di allucinazioni.
+- **Iniezione nel punto giusto** (`normalize_payload_for_openai`, unico choke point verso OpenAI usato da tutti i percorsi di generazione): la località è dedotta dall'idea attiva (o dal `geo_context` del payload). Mai bloccante: guardie ovunque, disattivabile col filtro `alma_ai_writer_use_location_facts`.
+- I dati arrivano dalla cache delle Schede località (già scaldata dall'ideazione) o via fetch on-demand con i timeout esistenti; nessun dato inventato.
+- Test standalone 17/17 (proiezione compatta, filtro campi vuoti, cap attrazioni, risoluzione da idea attiva/geo_context, guardie errore/filtro, wiring).
+- Versione plugin aggiornata a `2.95.0`.
+
 ## 2.94.0 - 2026-07-08
 
 ### Qualità delle bozze dell'agente: universale garantito, widget a metà, grassetti, link interni

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.95.0 - 2026-07-08
+
+### L'agente scrive con i dati reali della località
+- Il payload di scrittura ora include location_facts (clima, mesi consigliati, attrazioni verificate, patrimonio UNESCO, territorio) dalle Schede località, con la regola di citarli senza inventare. Prima questi dati li usava solo l'ideazione, non la scrittura. Disattivabile con il filtro alma_ai_writer_use_location_facts.
+- Versione plugin aggiornata a `2.95.0`.
+
 ## 2.94.0 - 2026-07-08
 
 ### Bozze dell'agente più complete

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.94.0
+ * Version: 2.95.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.94.0');
+define('ALMA_VERSION', '2.95.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -412,10 +412,12 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'Usa category_ids, tag_ids e new_tags secondo taxonomy_rules.',
             'Formatta il testo per la lettura sul web: evidenzia in <strong> i concetti chiave, i nomi di luoghi/attrazioni e i dati pratici (prezzi, periodi consigliati, durate) — con misura, indicativamente una-due evidenziazioni per paragrafo, mai interi periodi.',
             'I link affiliati di tipologia universale (assicurazione viaggio, eSIM, ecc.) sono pertinenti in QUALSIASI articolo di viaggio, anche multi-destinazione: la coerenza geografica NON si applica a loro. Se ne hai uno tra affiliate_links, inseriscilo nel punto più naturale (consigli pratici, preparativi).',
+            'Se è presente location_facts, integra nel testo i DATI REALI della scheda località — mesi migliori/da evitare e clima (temperature, piogge), attrazioni verificate, patrimonio UNESCO, elementi del territorio — citandoli con naturalezza per rendere l\'articolo concreto e autorevole. NON inventare numeri o fatti non presenti in location_facts.',
         );
         $affiliate_rules = self::compact_rule_list(array_merge((array)($payload['affiliate_rules'] ?? array()), array($profile_rules['affiliate_rules'] ?? '')));
         $seo_rules = self::compact_rule_list(array_merge((array)($payload['seo_rules'] ?? array()), array($profile_rules['seo_rules'] ?? '')));
         $source_rules = self::compact_rule_list(array($profile_rules['source_rules'] ?? '', $profile_rules['anti_duplication_rules'] ?? '', $profile_rules['avoid_rules'] ?? '', $profile_rules['disclosure_policy'] ?? ''));
+        $location_facts = self::build_writer_location_facts($payload);
 
         return array(
             'task' => 'create_article_draft_from_selected_sources',
@@ -444,8 +446,79 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'media_candidates' => self::compact_media_candidates((array)($payload['media_candidates'] ?? array()), 12),
             'max_editorial_media_used' => self::max_editorial_media_used($payload),
             'source_policies' => $source_rules,
+            'location_facts' => $location_facts,
             'warnings' => self::compact_rule_list((array)($payload['warnings'] ?? array())),
         );
+    }
+
+    /**
+     * Scheda località compatta (clima, fatti Wikidata, territorio) per il
+     * writer: gli stessi dati del tool scheda_localita dell'agente di
+     * ideazione, così l'articolo cita mesi consigliati, temperature,
+     * attrazioni verificate e patrimonio UNESCO invece di restare generico.
+     * Località dedotta dall'idea attiva; mai bloccante (guardie ovunque).
+     *
+     * @return array Vuoto se non c'è località o la scheda non è disponibile.
+     */
+    private static function build_writer_location_facts($payload) {
+        if (!apply_filters('alma_ai_writer_use_location_facts', true)) { return array(); }
+        if (!class_exists('ALMA_Geo_Facts') || !class_exists('ALMA_AI_Content_Agent_Ideas')) { return array(); }
+
+        $label = '';
+        if (is_array($payload['geo_context'] ?? null)) {
+            $label = sanitize_text_field((string) ($payload['geo_context']['location'] ?? ''));
+        }
+        if ($label === '') {
+            $idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true));
+            if ($idea_id > 0) {
+                $label = sanitize_text_field((string) get_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_LOCATION_LABEL, true));
+            }
+        }
+        if ($label === '') { return array(); }
+
+        $card = ALMA_Geo_Facts::agent_payload($label);
+        if (!is_array($card) || !empty($card['error'])) { return array(); }
+        return self::compact_location_facts($card);
+    }
+
+    /**
+     * Proietta la scheda località completa (agent_payload) su un sottoinsieme
+     * utile alla scrittura: niente serie mensili grezze né dati interni,
+     * solo sintesi e liste brevi che l'AI può citare.
+     */
+    private static function compact_location_facts($card) {
+        $out = array('localita' => sanitize_text_field((string) ($card['localita'] ?? '')));
+        if (($card['paese'] ?? '') !== '') { $out['paese'] = sanitize_text_field((string) $card['paese']); }
+
+        if (is_array($card['clima'] ?? null)) {
+            $clima = $card['clima'];
+            $out['clima'] = array_filter(array(
+                'mesi_migliori' => sanitize_text_field((string) ($clima['mesi_migliori'] ?? '')),
+                'mesi_da_evitare' => sanitize_text_field((string) ($clima['mesi_da_evitare'] ?? '')),
+                'sintesi' => sanitize_text_field((string) ($clima['sintesi'] ?? '')),
+            ), function ($v) { return $v !== ''; });
+        }
+        if (is_array($card['fatti'] ?? null)) {
+            $fatti = $card['fatti'];
+            $attrazioni = array();
+            foreach ((array) ($fatti['attrazioni'] ?? array()) as $a) {
+                $name = is_array($a) ? (string) ($a['nome'] ?? ($a['name'] ?? '')) : (string) $a;
+                $name = sanitize_text_field($name);
+                if ($name !== '') { $attrazioni[] = $name; }
+                if (count($attrazioni) >= 6) { break; }
+            }
+            $out['fatti'] = array_filter(array(
+                'sintesi' => sanitize_text_field((string) ($fatti['sintesi'] ?? '')),
+                'popolazione' => absint($fatti['popolazione'] ?? 0),
+                'patrimonio_unesco' => sanitize_text_field((string) ($fatti['patrimonio_unesco'] ?? '')),
+                'attrazioni' => $attrazioni,
+            ), function ($v) { return $v !== '' && $v !== 0 && $v !== array(); });
+        }
+        if (is_array($card['territorio'] ?? null)) {
+            $sintesi = sanitize_text_field((string) ($card['territorio']['sintesi'] ?? ''));
+            if ($sintesi !== '') { $out['territorio'] = array('sintesi' => $sintesi); }
+        }
+        return $out;
     }
 
 


### PR DESCRIPTION
## Contesto

Dalla verifica sull'articolo "Stati Uniti in 3 giorni" era emersa la domanda: *l'agente sta realmente usando i dati delle Schede località (fonti esterne)?* **No**: `scheda_localita` (clima Open-Meteo, fatti Wikidata, territorio OSM, tendenze) era un tool disponibile solo all'agente di **ideazione** per scegliere il taglio stagionale; chi **scrive** l'articolo non riceveva alcun dato, così gli articoli restavano generici sui dati concreti.

## Modifiche (`class-ai-content-agent-draft-builder.php`)

- **`location_facts` nel payload di scrittura**: il contesto inviato al modello include ora la scheda della località dell'idea in forma compatta — mesi migliori/da evitare e sintesi del clima, fatti verificati (popolazione, patrimonio UNESCO, fino a 6 attrazioni notevoli) e sintesi del territorio. Stessi dati del tool `scheda_localita`, proiettati su ciò che serve al testo (niente serie mensili grezze né dati interni del sito).
- **Iniezione nell'unico choke point** (`normalize_payload_for_openai`, usato da tutti i percorsi di generazione bozza): la località è dedotta dall'idea attiva o dal `geo_context` del payload. Mai bloccante (guardie ovunque), disattivabile col filtro `alma_ai_writer_use_location_facts`.
- **Regola di scrittura**: "se è presente location_facts, integra nel testo i dati reali (mesi consigliati, clima, attrazioni verificate, UNESCO, territorio) citandoli con naturalezza; NON inventare numeri o fatti non presenti" — concretezza senza rischio di allucinazioni.
- I dati provengono dalla cache delle Schede località (già scaldata dall'ideazione) o via fetch on-demand con i timeout esistenti.

## Verifiche

- `php -l`: OK
- Test standalone 17/17 (proiezione compatta con esclusione serie mensili/dati interni, filtro campi vuoti, normalizzazione + cap a 6 attrazioni, risoluzione da idea attiva e da geo_context, guardie su errore/filtro, wiring del key e delle regole)
- Retrocompatibilità: nuova chiave additiva nel payload; nessuna option/API rimossa; assenza di località → nessun impatto

## Versione

`2.94.0` → `2.95.0` (minor) + sezioni CHANGELOG.md e README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_