### PR TITLE
Metabox AI Affiliati: revisione geo on-demand (località + mappa) (v2.96.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.96.0 - 2026-07-08
+
+### Revisione geo dal metabox "AI Affiliati": località e mappa on-demand
+- **Richiesta**: rendere il pulsante di ottimizzazione un vero strumento di revisione dell'articolo (link affiliati + contenuti + geo). Questa release aggiunge l'**asse geo**, riusando l'integrazione località della 2.93.0.
+- **Nuova sezione "Località e mappa"** nella metabox degli articoli: il pulsante **"Analizza località dal contenuto"** estrae le destinazioni citate nell'articolo, le aggiunge all'indice geografico come località secondarie (senza toccare la primaria né il testo) e le avvia al geocoding — così popolano la mappa di fine articolo. Utile per gli articoli multi-destinazione (es. "Stati Uniti in 3 giorni") dove la mappa restava con la sola località principale.
+- **Revisione forzata** (`review_post_locations`): a differenza del cron automatico, l'azione admin ignora l'hash del contenuto e l'opzione globale, e se l'articolo non ha ancora una località primaria la ricava (livelli deterministici + estrazione AI su azione esplicita). Riporta località primaria, quante ne ha aggiunte e quante sono in attesa di geocoding.
+- **Sicurezza**: stesso controllo nonce + capability delle altre azioni della metabox (`verify_request`); nessuna modifica al contenuto dell'articolo. La sezione compare solo se la mappa articolo è attiva.
+- Esito dell'ultima analisi mostrato nella metabox (nota `_alma_geo_integration_note`).
+- Nota: la revisione dei CONTENUTI testuali (grassetti, link interni, riscrittura) resta un'evoluzione successiva; la qualità del testo è già rafforzata alla creazione (2.94.0/2.95.0) e le proposte affiliati della metabox includono già l'universale garantito e le descrizioni (2.92.0).
+- Test standalone 19/19 (parametro force, review_post_locations, wiring AJAX/metabox, gating sull'opzione mappa, JS).
+- Versione plugin aggiornata a `2.96.0`.
+
 ## 2.95.0 - 2026-07-08
 
 ### Schede località nella scrittura: l'agente usa i dati reali (clima, fatti, territorio)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.96.0 - 2026-07-08
+
+### Revisione geo dal metabox articolo
+- Nuovo pulsante "Analizza località dal contenuto" nella metabox AI Affiliati: estrae le destinazioni citate, le aggiunge all'indice (senza toccare la primaria né il testo) e le avvia al geocoding per popolare la mappa di fine articolo. Azione admin forzata, con nonce e capability.
+- Versione plugin aggiornata a `2.96.0`.
+
 ## 2.95.0 - 2026-07-08
 
 ### L'agente scrive con i dati reali della località

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.95.0
+ * Version: 2.96.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.95.0');
+define('ALMA_VERSION', '2.96.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-post-optimizer.php
+++ b/includes/class-ai-post-optimizer.php
@@ -28,6 +28,7 @@ class ALMA_AI_Post_Optimizer {
         add_action('wp_ajax_alma_post_optimizer_propose', array(__CLASS__, 'ajax_propose'));
         add_action('wp_ajax_alma_post_optimizer_apply', array(__CLASS__, 'ajax_apply'));
         add_action('wp_ajax_alma_post_optimizer_reject', array(__CLASS__, 'ajax_reject'));
+        add_action('wp_ajax_alma_post_optimizer_geo', array(__CLASS__, 'ajax_geo_review'));
     }
 
     public static function register_metabox() {
@@ -157,6 +158,23 @@ class ALMA_AI_Post_Optimizer {
         self::render_proposals_rows($proposals);
         echo '</div>';
 
+        // Revisione geo/mappa: estrae le località citate nell'articolo, le
+        // aggiunge all'indice (senza toccare la primaria) e le avvia al
+        // geocoding, così popolano la mappa di fine articolo.
+        if (get_option('alma_article_map_enabled', '1') === '1' && class_exists('ALMA_Geo_Auto_Indexer')) {
+            $map_note = trim((string) get_post_meta($post->ID, '_alma_geo_integration_note', true));
+            echo '<h4 style="margin:16px 0 6px;">'.esc_html__('Località e mappa', 'affiliate-link-manager-ai').'</h4>';
+            echo '<p class="description" style="margin-top:0;">'.esc_html__('Analizza il contenuto ed estrae le destinazioni citate (oltre alla località principale), le aggiunge all\'indice geografico e le avvia al geocoding: compaiono sulla mappa di fine articolo. Non modifica il testo dell\'articolo né la località primaria.', 'affiliate-link-manager-ai').'</p>';
+            if ($post->post_status !== 'publish') {
+                echo '<p class="description">'.esc_html__('Disponibile dopo la pubblicazione dell\'articolo.', 'affiliate-link-manager-ai').'</p>';
+            } else {
+                echo '<p><button type="button" class="button" id="alma-optimizer-geo">🗺️ '.esc_html__('Analizza località dal contenuto', 'affiliate-link-manager-ai').'</button> <span id="alma-optimizer-geo-feedback" style="color:#2271b1;"></span></p>';
+            }
+            if ($map_note !== '') {
+                echo '<p class="description" style="font-style:italic;">'.esc_html__('Ultima analisi:', 'affiliate-link-manager-ai').' '.esc_html($map_note).'</p>';
+            }
+        }
+
         ?>
         <script>
         (function(){
@@ -199,6 +217,19 @@ class ALMA_AI_Post_Optimizer {
                             document.getElementById('alma-optimizer-proposals').innerHTML = resp.data.html || '';
                         } else if (feedback) {
                             feedback.textContent = (resp && resp.data && resp.data.message) ? resp.data.message : 'Errore.';
+                        }
+                    });
+                    return;
+                }
+                if (target.id === 'alma-optimizer-geo') {
+                    var geoFeedback = document.getElementById('alma-optimizer-geo-feedback');
+                    target.disabled = true;
+                    if (geoFeedback) { geoFeedback.textContent = 'Analisi delle località in corso…'; }
+                    post('alma_post_optimizer_geo', {}, function (resp) {
+                        target.disabled = false;
+                        if (geoFeedback) {
+                            geoFeedback.textContent = (resp && resp.data && resp.data.message) ? resp.data.message : 'Errore analisi località.';
+                            geoFeedback.style.color = (resp && resp.success) ? '#1a7f37' : '#d63638';
                         }
                     });
                     return;
@@ -776,5 +807,22 @@ class ALMA_AI_Post_Optimizer {
             update_post_meta($post_id, self::META_PROPOSALS, $stored);
         }
         wp_send_json_success(array('rejected' => true));
+    }
+
+    /**
+     * Revisione geo on-demand: estrae e indicizza le località citate
+     * nell'articolo (senza toccare la primaria) e le avvia al geocoding.
+     */
+    public static function ajax_geo_review() {
+        $post_id = self::verify_request();
+        if (!class_exists('ALMA_Geo_Auto_Indexer')) {
+            wp_send_json_error(array('message' => __('Indicizzazione geografica non disponibile.', 'affiliate-link-manager-ai')));
+        }
+        $indexer = new ALMA_Geo_Auto_Indexer();
+        $result = $indexer->review_post_locations($post_id);
+        if (empty($result['ok'])) {
+            wp_send_json_error(array('message' => sanitize_text_field((string) ($result['message'] ?? __('Analisi non riuscita.', 'affiliate-link-manager-ai')))));
+        }
+        wp_send_json_success(array('message' => sanitize_text_field((string) $result['message']), 'added' => (array) $result['added'], 'pending_geocoding' => (int) $result['pending_geocoding']));
     }
 }

--- a/includes/class-geo-auto-indexer.php
+++ b/includes/class-geo-auto-indexer.php
@@ -848,14 +848,16 @@ class ALMA_Geo_Auto_Indexer {
      *
      * @return array{added:int,skipped:string} Esito sintetico.
      */
-    public function integrate_post_locations($post_id) {
-        $none = array('added' => 0, 'skipped' => '');
+    public function integrate_post_locations($post_id, $force = false) {
+        $none = array('added' => 0, 'skipped' => '', 'names' => array());
         $post = get_post($post_id);
         if (!$post instanceof WP_Post || $post->post_type !== 'post' || $post->post_status !== 'publish') {
             $none['skipped'] = 'post_non_valido';
             return $none;
         }
-        if (get_option(self::INTEGRATION_OPTION, '1') !== '1') {
+        // Il force salta l'opzione globale: è un'azione admin esplicita
+        // (revisione dal metabox "AI Affiliati").
+        if (!$force && get_option(self::INTEGRATION_OPTION, '1') !== '1') {
             $none['skipped'] = 'disabilitata';
             return $none;
         }
@@ -868,7 +870,7 @@ class ALMA_Geo_Auto_Indexer {
             return $none;
         }
         $hash = md5($post->post_title . '|' . $post->post_content);
-        if (get_post_meta($post->ID, self::INTEGRATION_HASH_META, true) === $hash) {
+        if (!$force && get_post_meta($post->ID, self::INTEGRATION_HASH_META, true) === $hash) {
             $none['skipped'] = 'contenuto_invariato';
             return $none;
         }
@@ -924,7 +926,57 @@ class ALMA_Geo_Auto_Indexer {
             empty($added) ? __('Nessuna località aggiuntiva trovata nel contenuto', 'affiliate-link-manager-ai') : sprintf(__('+%d località dal contenuto: %s', 'affiliate-link-manager-ai'), count($added), implode(', ', wp_list_pluck($added, 'name'))),
             current_time('mysql')
         ));
-        return array('added' => count($added), 'skipped' => '');
+        return array('added' => count($added), 'skipped' => '', 'names' => wp_list_pluck($added, 'name'));
+    }
+
+    /**
+     * Revisione geo ON-DEMAND dal metabox "AI Affiliati": stabilisce la
+     * località primaria se manca (livelli deterministici + AI su azione
+     * esplicita) e completa l'articolo con le altre destinazioni citate.
+     * A differenza del cron, forza l'analisi (ignora hash e opzione globale).
+     *
+     * @return array{ok:bool,message:string,primary:string,added:array,pending_geocoding:int}
+     */
+    public function review_post_locations($post_id) {
+        $post = get_post($post_id);
+        if (!$post instanceof WP_Post || $post->post_type !== 'post') {
+            return array('ok' => false, 'message' => __('Articolo non valido.', 'affiliate-link-manager-ai'), 'primary' => '', 'added' => array(), 'pending_geocoding' => 0);
+        }
+        if ($post->post_status !== 'publish') {
+            return array('ok' => false, 'message' => __('La revisione geo è disponibile solo per gli articoli pubblicati.', 'affiliate-link-manager-ai'), 'primary' => '', 'added' => array(), 'pending_geocoding' => 0);
+        }
+        // Nessuna località primaria: prova prima i livelli deterministici e,
+        // se non bastano, l'estrazione AI (qui l'azione è esplicita).
+        if (!$this->object_is_indexed($post->ID, ALMA_Geo_Index_Store::OBJECT_TYPE_POST)) {
+            $this->resolve_object($post->ID, true);
+        }
+        if (!$this->object_is_indexed($post->ID, ALMA_Geo_Index_Store::OBJECT_TYPE_POST)) {
+            return array('ok' => false, 'message' => __('Nessuna località riconosciuta nel titolo o nel contenuto: aggiungine una dalla metabox Geo per popolare la mappa.', 'affiliate-link-manager-ai'), 'primary' => '', 'added' => array(), 'pending_geocoding' => 0);
+        }
+        $primary = html_entity_decode((string) get_post_meta($post->ID, '_alma_geo_primary_name', true), ENT_QUOTES, 'UTF-8');
+        $integration = $this->integrate_post_locations($post->ID, true);
+        $added = (array) ($integration['names'] ?? array());
+
+        // Quante località dell'articolo attendono ancora coordinate: finché
+        // sono in geocoding pending non compaiono sulla mappa.
+        $pending = 0;
+        if ($this->store->tables_exist()) {
+            global $wpdb;
+            $pending = (int) $wpdb->get_var($wpdb->prepare(
+                "SELECT COUNT(DISTINCT l.id) FROM {$this->store->table_content_index()} ci
+                 INNER JOIN {$this->store->table_locations()} l ON l.id = ci.location_id
+                 WHERE ci.object_id = %d AND ci.object_type = %s AND l.geocoding_status = 'pending'",
+                $post->ID,
+                ALMA_Geo_Index_Store::OBJECT_TYPE_POST
+            ));
+        }
+        $parts = array();
+        if ($primary !== '') { $parts[] = sprintf(__('Località primaria: %s.', 'affiliate-link-manager-ai'), $primary); }
+        $parts[] = empty($added)
+            ? __('Nessuna nuova località trovata nel contenuto.', 'affiliate-link-manager-ai')
+            : sprintf(__('Aggiunte %d località dal contenuto: %s.', 'affiliate-link-manager-ai'), count($added), implode(', ', $added));
+        if ($pending > 0) { $parts[] = sprintf(__('%d in attesa di geocoding: compariranno sulla mappa una volta ottenute le coordinate.', 'affiliate-link-manager-ai'), $pending); }
+        return array('ok' => true, 'message' => implode(' ', $parts), 'primary' => $primary, 'added' => $added, 'pending_geocoding' => $pending);
     }
 
     /**


### PR DESCRIPTION
## Contesto

Richiesta: rendere il pulsante "Proponi ottimizzazioni AI" un vero strumento di revisione dell'articolo su più assi (link affiliati + contenuti + geo). Questa release aggiunge l'**asse geo**, riusando l'integrazione località introdotta nella v2.93.0.

## Modifiche

### `class-geo-auto-indexer.php`
- `integrate_post_locations($post_id, $force = false)`: nuovo parametro `$force` che salta il guard sull'hash del contenuto e l'opzione globale (per l'azione admin esplicita); il return espone ora i nomi delle località aggiunte.
- Nuovo `review_post_locations($post_id)` (on-demand, admin): se l'articolo non ha una località primaria la ricava (livelli deterministici + estrazione AI su azione esplicita), poi forza l'integrazione delle destinazioni citate nel contenuto (senza toccare la primaria né il testo) e riporta località primaria, quante ne ha aggiunte e quante sono in attesa di geocoding.

### `class-ai-post-optimizer.php` (metabox articolo)
- Nuova sezione **"Località e mappa"** con il pulsante **"Analizza località dal contenuto"**, visibile solo se la mappa articolo è attiva e l'articolo è pubblicato; mostra l'esito dell'ultima analisi (`_alma_geo_integration_note`).
- Handler AJAX `ajax_geo_review` con lo stesso controllo nonce + capability delle altre azioni (`verify_request`); nessuna modifica al contenuto dell'articolo.
- Gestione del click nel JS inline della metabox (verificata con `node --check`).

Utile per gli articoli multi-destinazione (es. "Stati Uniti in 3 giorni") dove la mappa restava con la sola località principale: ora, con un clic, le città citate entrano nell'indice e — dopo il geocoding — sulla mappa.

## Nota di scope

La revisione dei **contenuti testuali** (grassetti, link interni, riscrittura con dati reali) resta un'evoluzione successiva: richiede un motore di riscrittura-e-diff con revisione, feature a sé. La qualità del testo è già rafforzata alla creazione (v2.94.0/2.95.0) e le proposte affiliati della metabox includono già l'universale garantito e le descrizioni (v2.92.0).

## Verifiche

- `php -l` sui file modificati: OK; JS inline verificato con `node --check`
- Test standalone 19/19 (parametro `force`, `review_post_locations`, wiring AJAX/metabox, gating sull'opzione mappa, JS)
- Retrocompatibilità: `$force` con default `false` (comportamento cron invariato); nessuna option/API rimossa; nessuna scrittura sul contenuto

## Versione

`2.95.0` → `2.96.0` (minor) + sezioni CHANGELOG.md e README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_