### PR TITLE
Bozze agente: affiliati sempre come link (arsenale completo) + varietà offerta (v2.98.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.98.0 - 2026-07-08
+
+### Affiliati SEMPRE inseriti come link (arsenale completo) + varietà dell'offerta
+- **Richiesta**: quando l'agent trova link affiliati utili deve sempre trattarli come link e inserirli con tutte le modalità (link, descrizione, immagine, call to action, widget) scegliendo le migliori per la conversione — non solo il link sull'immagine (v2.97). E non deve preferire sempre i link con più click: variare, usandoli tutti man mano in base al contesto.
+- **Prompt rafforzato**: OGNI link affiliato pertinente va SEMPRE reso cliccabile, non solo usato come fonte di foto/descrizione; l'AI deve sfruttare tutto l'arsenale (anchor col nome, immagine avvolta, bottone CTA, card, widget per le raccolte) e scegliere la modalità che converte di più. Regola aggiuntiva di **varietà**: linkare CIASCUNA struttura/esperienza al suo affiliate_link, non concentrarsi su uno solo.
+- **Garanzia deterministica estesa** (`link_used_affiliate_images`): oltre ad avvolgere l'immagine (v2.97), ora se il link non ha immagine da avvolgere il sistema rende cliccabile il **nome del link in grassetto** (es. `<strong>Signature Hotel</strong>`), conservativo (solo match esatto del titolo, mai doppioni). Così anche gli affiliati citati per nome senza foto vengono monetizzati.
+- **Varietà nella selezione** (richiesta 2): il tool `cerca_link_affiliati` dell'agente ora riporta per ogni link `usato_in_articoli` (quante volte già usato nelle bozze) e un `suggerimento_varieta`: a parità di pertinenza l'agent preferisce i link meno utilizzati, ruotando l'offerta. Nuovo `ALMA_AI_Content_Agent_Result_Usage::get_counts_by_source`.
+- **Nota**: le tipologie del link (v2.97) e la varietà aiutano l'agent a capire cosa sta linkando e a distribuire le scelte; la selezione resta guidata dalla pertinenza al contesto dell'articolo.
+- Test standalone 28/28.
+- Versione plugin aggiornata a `2.98.0`.
+
 ## 2.97.0 - 2026-07-08
 
 ### Bozze agente: garanzia link affiliato sulle immagini usate (hotel non più mostrati senza link)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.98.0 - 2026-07-08
+
+### Affiliati sempre come link + varietà
+- L'agent ora inserisce ogni link affiliato pertinente come vero link (anchor, immagine avvolta, bottone, card, widget) scegliendo la modalità migliore, mai solo foto/descrizione; la garanzia deterministica copre anche il nome in grassetto oltre all'immagine. Il tool di ricerca affiliati riporta l'uso pregresso e suggerisce di variare, preferendo i link meno usati a parità di pertinenza.
+- Versione plugin aggiornata a `2.98.0`.
+
 ## 2.97.0 - 2026-07-08
 
 ### Hotel (e affiliati) non più mostrati senza link

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.97.0
+ * Version: 2.98.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.97.0');
+define('ALMA_VERSION', '2.98.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -413,7 +413,8 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'Formatta il testo per la lettura sul web: evidenzia in <strong> i concetti chiave, i nomi di luoghi/attrazioni e i dati pratici (prezzi, periodi consigliati, durate) — con misura, indicativamente una-due evidenziazioni per paragrafo, mai interi periodi.',
             'I link affiliati di tipologia universale (assicurazione viaggio, eSIM, ecc.) sono pertinenti in QUALSIASI articolo di viaggio, anche multi-destinazione: la coerenza geografica NON si applica a loro. Se ne hai uno tra affiliate_links, inseriscilo nel punto più naturale (consigli pratici, preparativi).',
             'Se è presente location_facts, integra nel testo i DATI REALI della scheda località — mesi migliori/da evitare e clima (temperature, piogge), attrazioni verificate, patrimonio UNESCO, elementi del territorio — citandoli con naturalezza per rendere l\'articolo concreto e autorevole. NON inventare numeri o fatti non presenti in location_facts.',
-            'REGOLA CRITICA di monetizzazione: se usi l\'immagine o descrivi in modo specifico una struttura/prodotto presente in affiliate_links (es. un hotel, un tour), DEVI renderlo cliccabile con il suo affiliate_url — immagine avvolta in <a href="{affiliate_url}" target="_blank" rel="nofollow sponsored noopener"> oppure lo shortcode [affiliate_link id="ID"]. MAI mostrare foto o descrizione di un affiliato senza il suo link: una foto senza link è un\'occasione di guadagno persa. Considera le link_types (es. "Hotel e Resort") per capire che è una struttura prenotabile.',
+            'REGOLA CRITICA di monetizzazione: OGNI link affiliato pertinente in affiliate_links va SEMPRE inserito come vero link cliccabile, non solo come fonte di foto o descrizione. Puoi usarlo anche come fonte, ma DEVI comunque linkarlo. Scegli per ogni link la modalità che converte di più e sfrutta tutto l\'arsenale: nome/anchor nel testo con lo shortcode [affiliate_link id="ID" text="…"], immagine avvolta in <a href="{affiliate_url}" target="_blank" rel="nofollow sponsored noopener">, bottone CTA (button="yes"), card (img+descrizione+bottone) e, per raccolte di più strutture/esperienze, il widget [[ALMA_WIDGET]]. MAI mostrare foto o descrizione di un affiliato senza il suo link: è guadagno perso. Usa le link_types (es. "Hotel e Resort") per capire che è una struttura prenotabile e proporre la giusta call to action.',
+            'Varia l\'offerta: usa i DIVERSI link affiliati pertinenti disponibili, non concentrarti su uno solo. In un articolo che elenca più strutture/esperienze, linka CIASCUNA al suo affiliate_link corrispondente.',
         );
         $affiliate_rules = self::compact_rule_list(array_merge((array)($payload['affiliate_rules'] ?? array()), array($profile_rules['affiliate_rules'] ?? '')));
         $seo_rules = self::compact_rule_list(array_merge((array)($payload['seo_rules'] ?? array()), array($profile_rules['seo_rules'] ?? '')));
@@ -524,12 +525,14 @@ class ALMA_AI_Content_Agent_Draft_Builder {
 
 
     /**
-     * Garanzia di monetizzazione: quando l'AI usa l'immagine di un link
-     * affiliato SENZA renderlo cliccabile (foto + descrizione ma niente
-     * link — tipico con hotel/strutture nuove), il sistema avvolge quella
-     * immagine nel link affiliato con gli attributi di tracking. Salta i
-     * link già presenti (href o shortcode) e le immagini già dentro un
-     * anchor, quindi mai doppioni.
+     * Garanzia di monetizzazione: ogni link affiliato SELEZIONATO ma usato
+     * senza renderlo cliccabile (solo foto o solo nome/descrizione) viene
+     * reso un vero link affiliato con tracking. Due livelli, nell'ordine:
+     *   1) avvolge l'IMMAGINE del link (anche in variante ridimensionata);
+     *   2) se non c'è immagine da avvolgere, avvolge il NOME del link se
+     *      compare in grassetto nel testo (es. "<strong>Signature Hotel</strong>").
+     * Salta i link già presenti (href o shortcode) e ciò che è già dentro
+     * un anchor: mai doppioni.
      *
      * @return array{content:string,linked:int[]}
      */
@@ -544,21 +547,43 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             // Già monetizzato (href con questo URL o shortcode con questo id)?
             if (strpos($content, $url) !== false) { continue; }
             if (preg_match('/\[affiliate_link[^\]]*\bid="?' . $id . '"?[\s"\]]/', $content)) { continue; }
+
+            $anchor_open = '<a href="' . esc_url($url) . '" target="_blank" rel="nofollow sponsored noopener" data-link-id="' . $id . '" data-track="1" data-source="agent_content">';
+            $wrapped = false;
+
+            // Livello 1: immagine del link.
             $img_url = (string) ($link['featured_image_url'] ?? '');
             if ($img_url === '' && is_array($link['image'] ?? null)) { $img_url = (string) ($link['image']['image_url'] ?? ''); }
             $base = self::image_base_token($img_url);
-            if ($base === '') { continue; }
-            $wrapped = false;
-            // L'alternanza cattura PRIMA gli anchor completi (le immagini già
-            // linkate vengono così saltate) e poi le <img> isolate.
-            $new = preg_replace_callback('/<a\b[^>]*>.*?<\/a>|<img\b[^>]*>/is', function ($m) use (&$wrapped, $base, $url, $id) {
-                $tag = $m[0];
-                if ($wrapped || strncasecmp($tag, '<a', 2) === 0) { return $tag; }
-                if (stripos($tag, $base) === false) { return $tag; }
-                $wrapped = true;
-                return '<a href="' . esc_url($url) . '" target="_blank" rel="nofollow sponsored noopener" data-link-id="' . $id . '" data-track="1" data-source="agent_content">' . $tag . '</a>';
-            }, $content);
-            if ($wrapped && $new !== null) { $content = $new; $linked[] = $id; }
+            if ($base !== '') {
+                // L'alternanza cattura PRIMA gli anchor completi (le immagini
+                // già linkate vengono così saltate) e poi le <img> isolate.
+                $new = preg_replace_callback('/<a\b[^>]*>.*?<\/a>|<img\b[^>]*>/is', function ($m) use (&$wrapped, $base, $anchor_open) {
+                    $tag = $m[0];
+                    if ($wrapped || strncasecmp($tag, '<a', 2) === 0) { return $tag; }
+                    if (stripos($tag, $base) === false) { return $tag; }
+                    $wrapped = true;
+                    return $anchor_open . $tag . '</a>';
+                }, $content);
+                if ($wrapped && $new !== null) { $content = $new; }
+            }
+
+            // Livello 2: nome del link in grassetto (per gli affiliati senza
+            // immagine ma citati per nome — "non solo link all'immagine").
+            if (!$wrapped) {
+                $title = trim((string) ($link['title'] ?? ''));
+                if ($title !== '' && mb_strlen($title) >= 4) {
+                    $qt = preg_quote($title, '/');
+                    $new = preg_replace_callback('/<strong>\s*(' . $qt . ')\s*<\/strong>/iu', function ($m) use (&$wrapped, $anchor_open) {
+                        if ($wrapped) { return $m[0]; }
+                        $wrapped = true;
+                        return '<strong>' . $anchor_open . $m[1] . '</a></strong>';
+                    }, $content, 1);
+                    if ($wrapped && $new !== null) { $content = $new; }
+                }
+            }
+
+            if ($wrapped) { $linked[] = $id; }
         }
         return array('content' => $content, 'linked' => $linked);
     }
@@ -1436,12 +1461,12 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             $clean['warnings'] = array_values(array_unique(array_merge((array)$clean['warnings'], (array)$widget_result['warnings'], (array)$enforced['warnings'])));
         }
         // Garanzia di monetizzazione: gli affiliati (es. hotel) mostrati con
-        // foto/descrizione ma senza link vengono resi cliccabili avvolgendo
-        // la loro immagine nel link affiliato con tracking.
+        // foto o solo nome/descrizione ma senza link vengono resi cliccabili
+        // (immagine o nome in grassetto avvolti nel link affiliato con tracking).
         $img_link_guarantee = self::link_used_affiliate_images((string) $clean['content'], (array) $ctx['affiliate_links']);
         if (!empty($img_link_guarantee['linked'])) {
             $clean['content'] = $img_link_guarantee['content'];
-            $clean['warnings'][] = sprintf('%d immagini di link affiliati rese cliccabili automaticamente (usate senza link dall\'AI).', count($img_link_guarantee['linked']));
+            $clean['warnings'][] = sprintf('%d link affiliati resi cliccabili automaticamente (usati senza link dall\'AI).', count($img_link_guarantee['linked']));
             if (class_exists('ALMA_AI_Image_Generator')) { ALMA_AI_Image_Generator::queue_links($img_link_guarantee['linked']); }
         }
         // Garanzia deterministica del link universale (assicurazioni/eSIM):

--- a/includes/class-ai-content-agent-result-usage.php
+++ b/includes/class-ai-content-agent-result-usage.php
@@ -36,6 +36,31 @@ class ALMA_AI_Content_Agent_Result_Usage {
         foreach ((array)$rows as $row) { $counts[sanitize_text_field($row['result_key'])] = max(0, (int)$row['usage_count']); }
         return $counts;
     }
+    /**
+     * Conteggio d'uso per source_id (aggregato su tutte le result_key dello
+     * stesso oggetto): usato per variare l'offerta affiliata preferendo i
+     * link meno utilizzati a parità di pertinenza.
+     *
+     * @return array<int,int> source_id => quante volte usato in bozze
+     */
+    public static function get_counts_by_source($source_ids, $source_group = 'affiliate_link') {
+        global $wpdb;
+        $ids = array_values(array_unique(array_filter(array_map('absint', (array) $source_ids))));
+        if (empty($ids)) { return array(); }
+        $table = self::table_name();
+        if ($wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table)) !== $table) { return array_fill_keys($ids, 0); }
+        $ph = implode(',', array_fill(0, count($ids), '%d'));
+        $params = $ids;
+        $params[] = sanitize_key($source_group);
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT source_id, SUM(usage_count) AS c FROM $table WHERE source_id IN ($ph) AND source_group = %s GROUP BY source_id",
+            $params
+        ), ARRAY_A);
+        $counts = array_fill_keys($ids, 0);
+        foreach ((array) $rows as $row) { $counts[(int) $row['source_id']] = max(0, (int) $row['c']); }
+        return $counts;
+    }
+
     public static function increment_for_results($results, $draft_post_id) {
         global $wpdb;
         $table = self::table_name();

--- a/includes/class-ai-idea-agent.php
+++ b/includes/class-ai-idea-agent.php
@@ -472,11 +472,20 @@ class ALMA_AI_Idea_Agent {
             'geo_link_ids' => $geo_link_ids,
         ));
         $rows = array_slice((array)($search['groups']['affiliate_link'] ?? array()), 0, 10);
+        $usage = class_exists('ALMA_AI_Content_Agent_Result_Usage')
+            ? ALMA_AI_Content_Agent_Result_Usage::get_counts_by_source(wp_list_pluck($rows, 'source_id'))
+            : array();
         $out = array();
         foreach ($rows as $row) {
-            $out[] = array('id' => (int)$row['source_id'], 'titolo' => $row['title'], 'tipologie' => $row['link_types'], 'score' => (int)$row['score'], 'motivo' => $row['reason']);
+            $sid = (int)$row['source_id'];
+            $out[] = array('id' => $sid, 'titolo' => $row['title'], 'tipologie' => $row['link_types'], 'score' => (int)$row['score'], 'usato_in_articoli' => (int)($usage[$sid] ?? 0), 'motivo' => $row['reason']);
         }
-        return array('localita_risolta' => $location_label, 'link_trovati' => count($out), 'link' => $out);
+        return array(
+            'localita_risolta' => $location_label,
+            'link_trovati' => count($out),
+            'suggerimento_varieta' => __('A parità di pertinenza preferisci i link con "usato_in_articoli" più basso: usa progressivamente tutti i link disponibili per variare l\'offerta, non sempre i soliti.', 'affiliate-link-manager-ai'),
+            'link' => $out,
+        );
     }
 
     private static function tool_existing_articles($query) {


### PR DESCRIPTION
## Contesto

Richiesta: quando l'agent trova link affiliati utili deve **sempre** trattarli come link e inserirli con tutte le modalità (link, descrizione, immagine, call to action, widget), scegliendo le migliori per la conversione — non solo il link sull'immagine (come corretto in v2.97). E non deve preferire sempre i link con più click: variare l'offerta, usandoli tutti man mano in base al contesto.

## Modifiche

### Richiesta 1 — affiliati sempre come link, arsenale completo
- **Prompt rafforzato** (`class-ai-content-agent-draft-builder.php`): OGNI link affiliato pertinente va SEMPRE reso cliccabile, non solo usato come fonte di foto/descrizione; l'AI deve sfruttare tutto l'arsenale (anchor col nome via shortcode, immagine avvolta, bottone CTA, card, widget per le raccolte) e scegliere la modalità che converte di più. Regola aggiuntiva: linkare CIASCUNA struttura/esperienza al suo affiliate_link.
- **Garanzia deterministica estesa** (`link_used_affiliate_images`): oltre ad avvolgere l'immagine (v2.97), se il link non ha un'immagine da avvolgere il sistema rende cliccabile il **nome del link in grassetto** (es. `<strong>Signature Hotel</strong>`) — conservativo (solo match esatto del titolo dentro `<strong>`, mai doppioni, l'immagine ha precedenza). Copre gli affiliati citati per nome senza foto.

### Richiesta 2 — varietà dell'offerta
- Il tool `cerca_link_affiliati` dell'agente ora riporta per ogni link `usato_in_articoli` (quante volte già usato nelle bozze) e un `suggerimento_varieta`: a parità di pertinenza l'agent preferisce i link meno utilizzati, ruotando l'offerta invece di ripetere sempre i più popolari.
- Nuovo `ALMA_AI_Content_Agent_Result_Usage::get_counts_by_source($ids)` che aggrega l'uso per `source_id`.

## Verifiche

- `php -l` sui file modificati: OK
- Test standalone 28/28 (wrapping immagine caso reale, livello 2 nome-in-grassetto con guardie conservative, no doppioni su href/shortcode/anchor/immagine+nome, esposizione uso e varietà nel tool, `get_counts_by_source`)
- Retrocompatibilità: la garanzia salta i link già presenti; il livello 2 agisce solo su match esatto del titolo in grassetto; nessuna option/API rimossa

## Nota di scope

Questa è la **PR A** della richiesta. La **PR B** — avviare più piani editoriali contemporaneamente (che si sommano) + spunta "avvia subito la creazione" nella Regia — segue separatamente perché tocca il sottosistema regia/piani.

## Versione

`2.97.0` → `2.98.0` (minor) + sezioni CHANGELOG.md e README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_