### PR TITLE
Regia: piani editoriali multipli che si sommano + avvia subito (v2.99.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.99.0 - 2026-07-08
+
+### Piani editoriali multipli (si sommano) + spunta "Avvia subito la creazione"
+- **Richiesta**: poter avviare più piani editoriali alla volta senza limiti se non la quantità di ciascun piano (i piani si sommano); e una spunta per avviare/creare subito le bozze (es. 3 post immediatamente).
+- **I piani si SOMMANO** (`enqueue_or_start_plan` + coda `alma_ai_idea_agent_queue`): la Regia non rifiuta più un nuovo piano se uno è in corso — lo **accoda** (FIFO) e lo avvia automaticamente al termine di quello attuale (guardia: massimo 20 piani in coda). Nessun tetto giornaliero, solo la quantità dettata da ogni piano. Il pulsante resta sempre attivo ("Avvia il piano" / "Accoda un piano") e la Regia mostra lo stato (in corso + numero in coda).
+- **Spunta "Avvia subito la creazione delle bozze"**: nuovo parametro `immediate` di `run()` che genera IMMEDIATAMENTE le bozze di TUTTE le idee del piano, ignorando la distribuzione sui giorni. Senza spunta, comportamento invariato (bozze di oggi subito, le future nel giorno previsto).
+- **Telegram allineato**: il comando `/agente` accoda invece di rifiutare quando un piano è in corso, con messaggio di conferma della posizione in coda.
+- **Stop completo**: fermare l'agente svuota anche i piani accodati (stop = ferma tutto), con conferma di quanti ne sono stati rimossi.
+- Retrocompatibilità: `run()` con `immediate` opzionale (default 0), cron portato a 8 argomenti; i vecchi eventi a 7 argomenti restano validi (immediate=0).
+- Test standalone 23/23 (avvio immediato vs accodamento, ordine FIFO, avvio del prossimo al termine, tetto coda, propagazione flag immediate, wiring Regia/Telegram/stop).
+- Versione plugin aggiornata a `2.99.0`.
+
 ## 2.98.0 - 2026-07-08
 
 ### Affiliati SEMPRE inseriti come link (arsenale completo) + varietà dell'offerta

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.99.0 - 2026-07-08
+
+### Più piani editoriali insieme + avvio immediato
+- Ora puoi avviare più piani editoriali contemporaneamente: se uno è in corso i nuovi vengono accodati e partono automaticamente al termine (i piani si sommano, nessun tetto giornaliero). Nuova spunta "Avvia subito la creazione delle bozze" per generare immediatamente tutte le bozze del piano (es. 3 post subito). Comando Telegram /agente allineato; lo Stop svuota anche la coda.
+- Versione plugin aggiornata a `2.99.0`.
+
 ## 2.98.0 - 2026-07-08
 
 ### Affiliati sempre come link + varietà

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.98.0
+ * Version: 2.99.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.98.0');
+define('ALMA_VERSION', '2.99.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-agent-control-room.php
+++ b/includes/class-ai-agent-control-room.php
@@ -301,9 +301,17 @@ class ALMA_AI_Agent_Control_Room {
         echo '<p style="margin:0;"><label><strong>' . esc_html__('In quanti giorni', 'affiliate-link-manager-ai') . '</strong><br><input type="number" id="alma-regia-giorni" name="agent_days" min="1" max="60" value="14" class="small-text"></label></p>';
         echo '<p style="margin:0;"><label><strong>' . esc_html__('A partire dal', 'affiliate-link-manager-ai') . '</strong><br><input type="date" id="alma-regia-inizio" name="agent_start_date" value="' . esc_attr(current_time('Y-m-d')) . '" min="' . esc_attr(current_time('Y-m-d')) . '"></label></p>';
         echo '<p style="margin:0;flex:1 1 340px;"><label><strong>' . esc_html__('Obiettivo e suggerimenti (opzionale)', 'affiliate-link-manager-ai') . '</strong><br><input type="text" id="alma-regia-obiettivo" name="agent_objective" class="widefat" placeholder="' . esc_attr__('Es. destinazioni per l\'autunno, focus Sicilia, taglio pratico…', 'affiliate-link-manager-ai') . '"></label></p>';
-        echo '<p style="margin:0;"><button class="button button-primary button-hero" ' . disabled($running, true, false) . '>' . esc_html($running ? __('Esecuzione in corso…', 'affiliate-link-manager-ai') : __('Avvia il piano', 'affiliate-link-manager-ai')) . '</button></p>';
+        // I piani si sommano: il pulsante resta sempre attivo, se un piano è
+        // in corso il nuovo viene accodato e parte al termine.
+        echo '<p style="margin:0;"><button class="button button-primary button-hero">' . esc_html($running ? __('Accoda un piano', 'affiliate-link-manager-ai') : __('Avvia il piano', 'affiliate-link-manager-ai')) . '</button></p>';
         echo '</div>';
-        echo '<p class="description" style="margin:8px 0 0;">' . esc_html__('Ogni piano è indipendente e si somma a quelli già programmati: le idee ricevono date distribuite dalla data di inizio scelta; le bozze delle idee di oggi si generano subito, le altre nel giorno previsto. Nessun tetto giornaliero: il ritmo lo decide il piano.', 'affiliate-link-manager-ai') . '</p>';
+        echo '<p style="margin:8px 0 0;"><label><input type="checkbox" name="agent_immediate" value="1"> <strong>' . esc_html__('Avvia subito la creazione delle bozze', 'affiliate-link-manager-ai') . '</strong> — ' . esc_html__('genera immediatamente TUTTE le bozze del piano, ignorando la distribuzione sui giorni (es. 3 post subito).', 'affiliate-link-manager-ai') . '</label></p>';
+        $queued = class_exists('ALMA_AI_Idea_Agent') ? ALMA_AI_Idea_Agent::queued_count() : 0;
+        $sum_note = __('I piani si SOMMANO: puoi avviarne più di uno: se uno è in corso, il nuovo viene accodato e parte automaticamente al termine. Senza la spunta, le idee ricevono date distribuite dalla data di inizio e le bozze di oggi si generano subito, le altre nel giorno previsto. Nessun tetto giornaliero: il ritmo lo decide il piano.', 'affiliate-link-manager-ai');
+        if ($running || $queued > 0) {
+            $sum_note .= ' ' . sprintf(__('Stato attuale: %1$s%2$s.', 'affiliate-link-manager-ai'), $running ? __('un piano in corso', 'affiliate-link-manager-ai') : __('nessun piano in corso', 'affiliate-link-manager-ai'), $queued > 0 ? sprintf(__(', %d in coda', 'affiliate-link-manager-ai'), $queued) : '');
+        }
+        echo '<p class="description" style="margin:8px 0 0;">' . esc_html($sum_note) . '</p>';
         echo '</form>';
 
         // ---- Consiglio AI (accorpa i "Consigli strategici AI" della dashboard) ----

--- a/includes/class-ai-idea-agent.php
+++ b/includes/class-ai-idea-agent.php
@@ -30,9 +30,11 @@ class ALMA_AI_Idea_Agent {
     const OPTION_RUN_HISTORY = 'alma_ai_idea_agent_history';
     const HISTORY_MAX = 30;
     const OPTION_CANCEL = 'alma_ai_idea_agent_cancel';
+    const OPTION_QUEUE = 'alma_ai_idea_agent_queue';   // piani accodati (si sommano)
+    const QUEUE_MAX = 20;
 
     public static function init() {
-        add_action(self::CRON_HOOK, array(__CLASS__, 'run'), 10, 7);
+        add_action(self::CRON_HOOK, array(__CLASS__, 'run'), 10, 8);
         add_action('admin_post_alma_ai_idea_agent_start', array(__CLASS__, 'handle_start'));
         add_action('admin_post_alma_ai_idea_agent_stop', array(__CLASS__, 'handle_stop'));
         add_action('admin_post_alma_ai_idea_agent_settings', array(__CLASS__, 'handle_settings'));
@@ -88,22 +90,64 @@ class ALMA_AI_Idea_Agent {
 
         if (empty(get_option('alma_openai_api_key', ''))) {
             $notice = array('type' => 'error', 'message' => __('OpenAI non è configurata.', 'affiliate-link-manager-ai'));
-        } elseif (get_option(self::LOCK_OPTION)) {
-            $notice = array('type' => 'error', 'message' => __('Un\'esecuzione dell\'agente è già in corso: attendila o fermala prima di avviare un nuovo piano.', 'affiliate-link-manager-ai'));
         } else {
             $objective = sanitize_textarea_field(wp_unslash($_POST['agent_objective'] ?? ''));
             $num_ideas = max(0, min(10, absint($_POST['agent_num_ideas'] ?? 0)));
             $days_span = max(0, min(60, absint($_POST['agent_days'] ?? 0)));
             $start_date = self::sanitize_start_date(wp_unslash($_POST['agent_start_date'] ?? ''));
-            // Le bozze si creano SEMPRE secondo la programmazione: quelle di
-            // oggi subito, le future nel giorno previsto (runner giornaliero).
-            delete_option(self::OPTION_CANCEL);
-            wp_schedule_single_event(time() + 5, self::CRON_HOOK, array(get_current_user_id(), $objective, 1, 1, $num_ideas, $days_span, $start_date));
-            if (function_exists('spawn_cron')) { spawn_cron(); }
+            // Spunta "Avvia subito la creazione": genera SUBITO le bozze di
+            // tutte le idee del piano, ignorando la distribuzione sui giorni.
+            $immediate = !empty($_POST['agent_immediate']) ? 1 : 0;
+            // I piani si SOMMANO: se un'esecuzione è già in corso il nuovo
+            // piano viene accodato e parte al termine di quello attuale
+            // (nessun rifiuto). Nessun tetto se non la quantità del piano.
+            $args = array(get_current_user_id(), $objective, 1, 1, $num_ideas, $days_span, $start_date, $immediate);
+            $notice = self::enqueue_or_start_plan($args);
         }
         set_transient('alma_ai_agent_admin_notice_' . get_current_user_id(), $notice, 120);
         wp_safe_redirect(wp_get_referer() ?: admin_url('edit.php?post_type=affiliate_link&page=alma-ai-regia'));
         exit;
+    }
+
+    /**
+     * Avvia un piano subito se libero, altrimenti lo ACCODA (i piani si
+     * sommano). Ritorna array('type','message','queued'=>bool,'position'=>int).
+     */
+    public static function enqueue_or_start_plan($args) {
+        if (get_option(self::LOCK_OPTION)) {
+            $queue = array_values((array) get_option(self::OPTION_QUEUE, array()));
+            if (count($queue) >= self::QUEUE_MAX) {
+                return array('type' => 'error', 'message' => sprintf(__('Coda piani piena (max %d in attesa): attendi che ne partano alcuni.', 'affiliate-link-manager-ai'), self::QUEUE_MAX), 'queued' => false, 'position' => 0);
+            }
+            $queue[] = array_values((array) $args);
+            update_option(self::OPTION_QUEUE, $queue, false);
+            return array('type' => 'success', 'message' => sprintf(__('Un piano è già in corso: questo è stato accodato (posizione %d). Partirà automaticamente al termine di quello attuale.', 'affiliate-link-manager-ai'), count($queue)), 'queued' => true, 'position' => count($queue));
+        }
+        delete_option(self::OPTION_CANCEL);
+        wp_schedule_single_event(time() + 5, self::CRON_HOOK, array_values((array) $args));
+        if (function_exists('spawn_cron')) { spawn_cron(); }
+        return array('type' => 'success', 'message' => __('Agente ideazione avviato in background: il report comparirà nella Regia AI entro qualche minuto.', 'affiliate-link-manager-ai'), 'queued' => false, 'position' => 0);
+    }
+
+    /**
+     * Estrae e avvia il prossimo piano accodato (chiamato al termine di un
+     * run). Nessun rischio di sovrapposizione: parte come nuovo evento cron,
+     * il lock è già stato rilasciato.
+     */
+    /** Numero di piani editoriali attualmente in coda (accodati). */
+    public static function queued_count() {
+        return count((array) get_option(self::OPTION_QUEUE, array()));
+    }
+
+    private static function start_next_queued_plan() {
+        $queue = array_values((array) get_option(self::OPTION_QUEUE, array()));
+        if (empty($queue)) { return; }
+        $next = array_shift($queue);
+        update_option(self::OPTION_QUEUE, $queue, false);
+        if (!is_array($next) || empty($next)) { return; }
+        delete_option(self::OPTION_CANCEL);
+        wp_schedule_single_event(time() + 10, self::CRON_HOOK, array_values($next));
+        if (function_exists('spawn_cron')) { spawn_cron(); }
     }
 
     /**
@@ -114,11 +158,15 @@ class ALMA_AI_Idea_Agent {
     public static function handle_stop() {
         if (!current_user_can('manage_options')) { wp_die('forbidden'); }
         check_admin_referer('alma_ai_idea_agent_stop');
+        // Lo stop ferma TUTTO: il piano in corso e quelli accodati.
+        $queued = self::queued_count();
+        delete_option(self::OPTION_QUEUE);
+        $queue_note = $queued > 0 ? sprintf(__(' Svuotati anche %d piani in coda.', 'affiliate-link-manager-ai'), $queued) : '';
         if (get_option(self::LOCK_OPTION)) {
             update_option(self::OPTION_CANCEL, (string) time(), false);
-            $notice = array('type' => 'success', 'message' => __('Richiesta di stop inviata: l\'agente si fermerà entro pochi secondi (al termine del passo in corso).', 'affiliate-link-manager-ai'));
+            $notice = array('type' => 'success', 'message' => __('Richiesta di stop inviata: l\'agente si fermerà entro pochi secondi (al termine del passo in corso).', 'affiliate-link-manager-ai') . $queue_note);
         } else {
-            $notice = array('type' => 'success', 'message' => __('Nessuna esecuzione in corso.', 'affiliate-link-manager-ai'));
+            $notice = array('type' => 'success', 'message' => __('Nessuna esecuzione in corso.', 'affiliate-link-manager-ai') . $queue_note);
         }
         set_transient('alma_ai_agent_admin_notice_' . get_current_user_id(), $notice, 120);
         wp_safe_redirect(wp_get_referer() ?: admin_url('edit.php?post_type=affiliate_link&page=alma-ai-regia'));
@@ -148,7 +196,7 @@ class ALMA_AI_Idea_Agent {
         return false;
     }
 
-    public static function run($user_id = 0, $objective = '', $create_drafts = 0, $force = 0, $num_ideas = 0, $days_span = 0, $start_date = '') {
+    public static function run($user_id = 0, $objective = '', $create_drafts = 0, $force = 0, $num_ideas = 0, $days_span = 0, $start_date = '', $immediate = 0) {
         if (!self::acquire_lock()) { return; }
         $started_at = current_time('mysql');
         $report = array(
@@ -232,8 +280,10 @@ class ALMA_AI_Idea_Agent {
                         $report['error'] = 'Interrotto dall\'amministratore (le bozze rimanenti verranno generate nei giorni programmati).';
                         break;
                     }
+                    // Con "Avvia subito" (immediate) si generano TUTTE le bozze
+                    // ora, ignorando la distribuzione sui giorni.
                     $scheduled = (string) get_post_meta((int)$idea['id'], ALMA_AI_Content_Agent_Ideas::META_SCHEDULED_AT, true);
-                    if ($scheduled !== '' && $scheduled > $today) {
+                    if (empty($immediate) && $scheduled !== '' && $scheduled > $today) {
                         $report['drafts_created'][] = array('idea_id' => (int)$idea['id'], 'titolo' => $idea['titolo'], 'post_id' => 0, 'error' => '', 'programmata' => $scheduled);
                         continue;
                     }
@@ -285,6 +335,9 @@ class ALMA_AI_Idea_Agent {
             if (class_exists('ALMA_Telegram_Bot')) {
                 ALMA_Telegram_Bot::notify_agent_report($report);
             }
+            // Piani accodati (che si sommano): avvia il prossimo, ora che il
+            // lock è libero. Ogni piano resta indipendente e completo.
+            self::start_next_queued_plan();
         }
     }
 

--- a/includes/class-telegram-bot.php
+++ b/includes/class-telegram-bot.php
@@ -270,22 +270,27 @@ class ALMA_Telegram_Bot {
             self::send_message($chat_id, '❌ OpenAI non è configurata nel plugin.');
             return;
         }
-        if (get_option(ALMA_AI_Idea_Agent::LOCK_OPTION)) {
-            self::send_message($chat_id, '⏳ Un\'esecuzione dell\'agente è già in corso: riceverai il report al termine.');
-            return;
-        }
-        // Lancio dalla regia Telegram: force=1 (parte anche oltre il limite
-        // giornaliero) e bozze immediate attive, come dalla pagina Regia AI.
-        // Firma allineata a run() a 7 argomenti (num/giorni/data del piano).
+        // I piani si sommano: se uno è in corso, questo viene accodato
+        // (nessun rifiuto), coerente con la pagina Regia AI.
         $num_ideas = max(0, min(10, absint($num_ideas)));
         $days_span = max(0, min(60, absint($days_span)));
         // Autore delle idee: il primo amministratore.
         $admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 'ID'));
         $user_id = !empty($admins) ? (int) $admins[0] : 1;
-        delete_option(ALMA_AI_Idea_Agent::OPTION_CANCEL);
-        wp_schedule_single_event(time() + 5, ALMA_AI_Idea_Agent::CRON_HOOK, array($user_id, sanitize_textarea_field($objective), 1, 1, $num_ideas, $days_span, ''));
-        if (function_exists('spawn_cron')) { spawn_cron(); }
+        // force=1 (oltre il limite giornaliero); immediate=0 (bozze secondo la
+        // programmazione, come default della Regia).
+        $result = ALMA_AI_Idea_Agent::enqueue_or_start_plan(array($user_id, sanitize_textarea_field($objective), 1, 1, $num_ideas, $days_span, '', 0));
+        if (($result['type'] ?? '') === 'error') {
+            self::send_message($chat_id, '⚠️ ' . self::esc((string) ($result['message'] ?? 'Impossibile avviare il piano.')));
+            return;
+        }
         $plan_note = $num_ideas > 0 ? sprintf("\n📋 Piano: %d articoli in %d giorni a partire da oggi.", $num_ideas, max(1, $days_span)) : '';
+        if (!empty($result['queued'])) {
+            self::send_message($chat_id, '🕓 Un piano è già in corso: questo è stato <b>accodato</b> (posizione ' . (int) ($result['position'] ?? 1) . ').'
+                . $plan_note
+                . "\nPartirà automaticamente al termine di quello attuale. Riceverai il report al termine.");
+            return;
+        }
         self::send_message($chat_id, '🤖 Agente di ideazione avviato' . ($objective !== '' ? ' sul tema: <i>' . self::esc($objective) . '</i>' : '')
             . $plan_note
             . "\nOgni idea creerà la sua bozza nel giorno programmato."


### PR DESCRIPTION
## Contesto

Richiesta: poter avviare **più piani editoriali alla volta** senza limiti se non la quantità di ciascun piano (i piani si sommano); e una **spunta per avviare subito** la creazione delle bozze (es. 3 post immediatamente).

## Modifiche

### I piani si sommano (coda) — `class-ai-idea-agent.php`
- Nuovo `enqueue_or_start_plan()` + coda persistente (`alma_ai_idea_agent_queue`): la Regia **non rifiuta più** un nuovo piano se uno è in corso — lo **accoda** (FIFO) e lo avvia automaticamente al termine di quello attuale (`start_next_queued_plan()` chiamato nel `finally` di `run()`, a lock già rilasciato). Guardia: massimo 20 piani in coda. Nessun tetto giornaliero, solo la quantità di ogni piano.

### Spunta "Avvia subito la creazione delle bozze"
- Nuovo parametro `immediate` di `run()`: genera IMMEDIATAMENTE le bozze di TUTTE le idee del piano, ignorando la distribuzione sui giorni. Senza spunta il comportamento è invariato (bozze di oggi subito, le future nel giorno previsto).

### UI Regia — `class-ai-agent-control-room.php`
- Pulsante sempre attivo: "Avvia il piano" quando libero, "Accoda un piano" quando uno è in corso; checkbox "Avvia subito la creazione delle bozze"; stato mostrato (piano in corso + numero in coda).

### Telegram e Stop
- `/agente` accoda invece di rifiutare quando un piano è in corso (messaggio con la posizione in coda).
- Lo **Stop** svuota anche i piani accodati (stop = ferma tutto), con conferma di quanti rimossi.

## Verifiche

- `php -l` sui 4 file modificati: OK
- Test standalone 23/23 (avvio immediato vs accodamento, ordine FIFO, avvio del prossimo al termine, tetto coda a 20, propagazione del flag `immediate` come 8° argomento, wiring Regia/Telegram/stop)
- Retrocompatibilità: `run()` con `immediate` opzionale (default 0), cron portato a 8 argomenti; i vecchi eventi a 7 argomenti restano validi

## Versione

`2.98.0` → `2.99.0` (minor) + sezioni CHANGELOG.md e README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_