### PR TITLE
Telegram (report solo pubblicati + /agente immediato) + Import Travelpayouts CSV (v2.100.0 → v2.101.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.101.0 - 2026-07-08
+
+### Import massivo link affiliati da CSV con conversione Travelpayouts
+- Nuova pagina **Link Affiliati → Import Travelpayouts**: importa link affiliati in massa da un CSV e li converte in link affiliati tramite le API Travelpayouts.
+- **CSV** con colonne: Nome (titolo), descrizione, città, url, tipologia link (intestazioni riconosciute in modo flessibile: alias italiani/inglesi, accenti, delimitatore , o ;). Disponibile un **CSV demo** scaricabile dalla pagina.
+- Ogni riga crea un **Link Affiliato** con titolo, descrizione (anche come contesto AI per bozze/arricchimento), **tipologia** (termine `link_type` creato se mancante) e **geolocalizzazione dalla città** (in coda al geocoding automatico esistente). L'URL originale viene salvato in attesa di conversione.
+- **Conversione via API** (`POST https://api.travelpayouts.com/links/v1/create`, header `X-Access-Token`, `trs`/`marker`/`shorten` da impostazioni): un job in background converte l'URL diretto in **partner_url** e aggiorna `_affiliate_url`. Rispetta i limiti dell'API (max 10 link per richiesta, 100 richieste/minuto): blocchi da 10, catena con pausa, lock atomico con TTL, cursore e stato visibile (mai job invisibili). I link non convertibili (brand non supportato/non iscritto) escono dalla coda con il motivo salvato, senza bloccarla.
+- Se le API non sono ancora configurate, l'import crea comunque i link con l'URL originale; la conversione parte appena si salvano token/trs/marker (o con "Converti ora").
+- Test standalone 27/27 (parsing CSV con alias/accenti/delimitatori, righe senza URL scartate, parsing risposta API success/failed, errori 401/400, chunking, wiring creazione link/tipologia/geo/flag e catena del job).
+- Versione plugin aggiornata a `2.101.0`.
+
 ## 2.100.0 - 2026-07-08
 
 ### Telegram: report solo con i post pubblicati + agente senza date crea subito

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.100.0 - 2026-07-08
+
+### Telegram: report solo con i post pubblicati + agente senza date crea subito
+- **Report agente**: ora il messaggio Telegram elenca SOLO gli articoli effettivamente pubblicati, ciascuno con il link alla visualizzazione (+ Modifica). Le idee non vengono più inviate. Le bozze create ma non ancora pubblicate sono indicate solo come conteggio ("N bozze in attesa di revisione, usa /bozze"), senza titoli; gli errori delle bozze mancate restano visibili (vengono ritentate). Rimosso il riassunto testuale e l'elenco delle idee/programmate.
+- **`/agente <tema>` senza date crea subito**: quando l'agente viene lanciato da Telegram senza indicare una finestra di giorni (comando `/agente`, a differenza di `/piano N G`), le bozze vengono generate IMMEDIATAMENTE (immediate=1, riusa il meccanismo della v2.99.0). Con `/piano N giorni` il piano resta distribuito sui giorni come prima.
+- Test standalone 13/13.
+- Versione plugin aggiornata a `2.100.0`.
+
 ## 2.99.0 - 2026-07-08
 
 ### Piani editoriali multipli (si sommano) + spunta "Avvia subito la creazione"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.100.0 - 2026-07-08
+
+### Telegram più essenziale
+- Il report dell'agente su Telegram invia solo i link agli articoli pubblicati (non le idee); il comando /agente senza date crea le bozze subito.
+- Versione plugin aggiornata a `2.100.0`.
+
 ## 2.99.0 - 2026-07-08
 
 ### Più piani editoriali insieme + avvio immediato

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.101.0 - 2026-07-08
+
+### Import Travelpayouts da CSV
+- Nuova pagina "Import Travelpayouts": importi in massa i link affiliati da un CSV (Nome, descrizione, città, url, tipologia link, con CSV demo) e le API Travelpayouts convertono automaticamente ogni URL in link affiliato aggiornando la scheda. Job in background rispettoso dei limiti API, con geolocalizzazione dalla città e tipologia.
+- Versione plugin aggiornata a `2.101.0`.
+
 ## 2.100.0 - 2026-07-08
 
 ### Telegram più essenziale

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.99.0
+ * Version: 2.100.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.99.0');
+define('ALMA_VERSION', '2.100.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.100.0
+ * Version: 2.101.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.100.0');
+define('ALMA_VERSION', '2.101.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);
@@ -70,6 +70,7 @@ require_once ALMA_PLUGIN_DIR . 'includes/class-ai-image-generator.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-article-locations-map.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-google-trends.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-geo-facts.php';
+require_once ALMA_PLUGIN_DIR . 'includes/class-travelpayouts-importer.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-url-validator.php';
 require_once ALMA_PLUGIN_DIR . 'includes/class-affiliate-source-provider-interface.php';
 require_once ALMA_PLUGIN_DIR . 'includes/providers/class-affiliate-source-provider-manual.php';
@@ -184,6 +185,7 @@ class AffiliateManagerAI {
         ALMA_AI_Image_Generator::init();
         ALMA_Article_Locations_Map::init();
         ALMA_Geo_Facts::init();
+        ALMA_Travelpayouts_Importer::init();
         add_action('init', array($this, 'init'));
         add_action('widgets_init', array('ALMA_Contextual_Affiliate_Widget', 'register_widget'));
         // Registrato qui (prima che `widgets_init` scatti) perché ALMA_Shortcodes::init()

--- a/includes/class-telegram-bot.php
+++ b/includes/class-telegram-bot.php
@@ -277,9 +277,11 @@ class ALMA_Telegram_Bot {
         // Autore delle idee: il primo amministratore.
         $admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 'ID'));
         $user_id = !empty($admins) ? (int) $admins[0] : 1;
-        // force=1 (oltre il limite giornaliero); immediate=0 (bozze secondo la
-        // programmazione, come default della Regia).
-        $result = ALMA_AI_Idea_Agent::enqueue_or_start_plan(array($user_id, sanitize_textarea_field($objective), 1, 1, $num_ideas, $days_span, '', 0));
+        // force=1 (oltre il limite giornaliero). "Senza date" (nessuna finestra
+        // di giorni indicata, es. /agente <tema>) ⇒ immediate=1: le bozze si
+        // creano SUBITO. Con /piano N G il piano resta distribuito sui giorni.
+        $immediate = $days_span > 0 ? 0 : 1;
+        $result = ALMA_AI_Idea_Agent::enqueue_or_start_plan(array($user_id, sanitize_textarea_field($objective), 1, 1, $num_ideas, $days_span, '', $immediate));
         if (($result['type'] ?? '') === 'error') {
             self::send_message($chat_id, '⚠️ ' . self::esc((string) ($result['message'] ?? 'Impossibile avviare il piano.')));
             return;
@@ -291,9 +293,12 @@ class ALMA_Telegram_Bot {
                 . "\nPartirà automaticamente al termine di quello attuale. Riceverai il report al termine.");
             return;
         }
+        $draft_note = $immediate
+            ? "\nLe bozze verranno create SUBITO (nessuna data indicata)."
+            : "\nOgni idea creerà la sua bozza nel giorno programmato.";
         self::send_message($chat_id, '🤖 Agente di ideazione avviato' . ($objective !== '' ? ' sul tema: <i>' . self::esc($objective) . '</i>' : '')
             . $plan_note
-            . "\nOgni idea creerà la sua bozza nel giorno programmato."
+            . $draft_note
             . "\nRiceverai qui il report al termine (2-5 minuti). Usa /stato per seguirlo o /stop per fermarlo.");
     }
 
@@ -406,44 +411,35 @@ class ALMA_Telegram_Bot {
     public static function format_agent_report($report) {
         $ideas = (array) ($report['ideas_created'] ?? array());
         $drafts = array_filter((array) ($report['drafts_created'] ?? array()), function ($d) { return !empty($d['post_id']); });
-        $auto_publish = get_option('alma_ai_auto_publish', 'no') === 'yes';
+        // Solo i POST effettivamente PUBBLICATI vengono elencati con il link;
+        // le idee non si inviano mai (richiesta esplicita).
+        $published = array();
+        $unpublished = 0;
+        foreach ($drafts as $draft) {
+            if (get_post_status((int) $draft['post_id']) === 'publish') { $published[] = $draft; }
+            else { $unpublished++; }
+        }
         $text = "<b>🤖 Report agente ideazione</b>\n";
         $text .= 'Avviato: ' . self::esc($report['started_at'] ?? '') . "\n";
-        $text .= 'Idee create: <b>' . count($ideas) . '</b> · Bozze: <b>' . count($drafts) . '</b> · Costo stimato: ~$' . number_format((float) ($report['cost_total'] ?? 0), 4) . "\n";
-        if ($auto_publish) {
-            // Pubblicazione automatica attiva: niente elenco idee (ridondante),
-            // per ogni articolo pubblicato titolo + link + modifica.
-            foreach (array_slice($drafts, 0, 10) as $draft) {
-                $post_id = (int) $draft['post_id'];
-                $edit_url = admin_url('post.php?post=' . $post_id . '&action=edit');
-                if (get_post_status($post_id) === 'publish') {
-                    $text .= '📣 <a href="' . esc_url(get_permalink($post_id)) . '">' . self::esc($draft['titolo']) . '</a> · <a href="' . esc_url($edit_url) . '">✏️ Modifica</a>' . "\n";
-                } else {
-                    $preview = get_preview_post_link($post_id);
-                    $text .= '📝 <a href="' . esc_url($preview ?: $edit_url) . '">' . self::esc($draft['titolo']) . '</a> · <a href="' . esc_url($edit_url) . '">✏️ Modifica</a>' . "\n";
-                }
-            }
-        } else {
-            foreach (array_slice($ideas, 0, 8) as $idea) {
-                $text .= '• ' . self::esc($idea['titolo']) . (!empty($idea['localita']) ? ' — 📍 ' . self::esc($idea['localita']) : '') . "\n";
-            }
-            foreach (array_slice($drafts, 0, 5) as $draft) {
-                $preview = get_preview_post_link((int) $draft['post_id']);
-                $text .= '📝 <a href="' . esc_url($preview) . '">' . self::esc($draft['titolo']) . "</a>\n";
-            }
+        $text .= 'Idee: <b>' . count($ideas) . '</b> · Pubblicati: <b>' . count($published) . '</b> · Costo stimato: ~$' . number_format((float) ($report['cost_total'] ?? 0), 4) . "\n";
+        // Elenco dei soli articoli pubblicati, con link alla visualizzazione.
+        foreach (array_slice($published, 0, 10) as $draft) {
+            $post_id = (int) $draft['post_id'];
+            $edit_url = admin_url('post.php?post=' . $post_id . '&action=edit');
+            $text .= '📣 <a href="' . esc_url(get_permalink($post_id)) . '">' . self::esc($draft['titolo']) . '</a> · <a href="' . esc_url($edit_url) . '">✏️ Modifica</a>' . "\n";
         }
-        // Il PERCHÉ delle bozze mancate, sempre visibile: programmate per un
-        // altro giorno o fallite (queste ultime vengono ritentate in automatico).
+        if ($unpublished > 0) {
+            $text .= '📝 ' . (int) $unpublished . ' bozze create in attesa di revisione (usa /bozze per pubblicarle).' . "\n";
+        }
+        // Il PERCHÉ delle bozze mancate, sempre visibile: fallite (ritentate in
+        // automatico). Le idee non vengono elencate.
         foreach ((array) ($report['drafts_created'] ?? array()) as $draft_row) {
             if (!empty($draft_row['post_id'])) { continue; }
-            if (!empty($draft_row['programmata'])) {
-                $text .= '📅 ' . self::esc((string) $draft_row['titolo']) . ' — bozza in programma il ' . self::esc((string) $draft_row['programmata']) . "\n";
-            } elseif (!empty($draft_row['error'])) {
+            if (!empty($draft_row['error'])) {
                 $text .= '⚠️ Bozza NON creata per "' . self::esc((string) $draft_row['titolo']) . '": ' . self::esc((string) $draft_row['error']) . ' — verrà ritentata automaticamente entro pochi minuti (max 3 tentativi).' . "\n";
             }
         }
         if (!empty($report['error'])) { $text .= '⚠️ ' . self::esc($report['error']) . "\n"; }
-        if (!empty($report['summary'])) { $text .= "\n" . self::esc(wp_trim_words($report['summary'], 80, '…')); }
         return $text;
     }
 

--- a/includes/class-travelpayouts-importer.php
+++ b/includes/class-travelpayouts-importer.php
@@ -1,0 +1,529 @@
+<?php
+/**
+ * Importazione massiva di link affiliati da CSV con conversione Travelpayouts.
+ *
+ * Flusso:
+ *  1) l'admin carica un CSV con colonne: Nome, descrizione, città, url,
+ *     tipologia link (intestazioni riconosciute in modo flessibile);
+ *  2) ogni riga crea un Link Affiliato (titolo, descrizione, tipologia,
+ *     geolocalizzazione dalla città) con l'URL ORIGINALE e un flag di
+ *     conversione pendente;
+ *  3) un job in background chiama l'API Travelpayouts
+ *     (POST https://api.travelpayouts.com/links/v1/create, max 10 link per
+ *     richiesta, 100 richieste/minuto) che converte l'URL diretto in URL
+ *     affiliato (partner_url) e AGGIORNA il link affiliato.
+ *
+ * Il job è interrompibile, con cursore e lock atomico a TTL (mai job
+ * invisibili): stato e ultimo esito sono mostrati nella pagina.
+ */
+if (!defined('ABSPATH')) { exit; }
+
+class ALMA_Travelpayouts_Importer {
+    const MENU_SLUG = 'alma-travelpayouts-import';
+    const OPTION_TOKEN = 'alma_tp_api_token';
+    const OPTION_TRS = 'alma_tp_trs';
+    const OPTION_MARKER = 'alma_tp_marker';
+    const OPTION_SHORTEN = 'alma_tp_shorten';
+    const OPTION_STATUS = 'alma_tp_import_status';   // ultimo esito import + conversione
+    const CRON_HOOK = 'alma_tp_convert_links';
+    const LOCK_OPTION = 'alma_tp_convert_lock';
+    const LOCK_TTL = 300;
+    const META_PENDING = '_alma_tp_convert_pending';   // 1 = da convertire
+    const META_ORIGINAL_URL = '_alma_tp_original_url';  // URL diretto pre-conversione
+    const META_CONVERT_ERROR = '_alma_tp_convert_error';
+    const SOURCE = 'travelpayouts_csv';
+    const API_ENDPOINT = 'https://api.travelpayouts.com/links/v1/create';
+    const API_CHUNK = 10;         // max link per richiesta (limite API)
+    const CONVERT_BATCH = 40;     // link per esecuzione del job (4 richieste API)
+    const MAX_ROWS = 1000;        // tetto per upload
+
+    public static function init() {
+        add_action('admin_menu', array(__CLASS__, 'add_menu'), 60);
+        add_action('admin_post_alma_tp_save_settings', array(__CLASS__, 'handle_settings'));
+        add_action('admin_post_alma_tp_upload', array(__CLASS__, 'handle_upload'));
+        add_action('admin_post_alma_tp_convert_now', array(__CLASS__, 'handle_convert_now'));
+        add_action('admin_post_alma_tp_download_demo', array(__CLASS__, 'handle_download_demo'));
+        add_action(self::CRON_HOOK, array(__CLASS__, 'run_conversion'));
+    }
+
+    public static function add_menu() {
+        add_submenu_page(
+            'edit.php?post_type=affiliate_link',
+            __('Import Travelpayouts', 'affiliate-link-manager-ai'),
+            __('Import Travelpayouts', 'affiliate-link-manager-ai'),
+            'manage_options',
+            self::MENU_SLUG,
+            array(__CLASS__, 'render_page')
+        );
+    }
+
+    /* ---------------------------------------------------------------------
+     * Configurazione
+     * ------------------------------------------------------------------ */
+
+    public static function is_configured() {
+        return trim((string) get_option(self::OPTION_TOKEN, '')) !== ''
+            && absint(get_option(self::OPTION_TRS, 0)) > 0
+            && absint(get_option(self::OPTION_MARKER, 0)) > 0;
+    }
+
+    public static function pending_count() {
+        $q = new WP_Query(array(
+            'post_type' => 'affiliate_link',
+            'post_status' => 'any',
+            'fields' => 'ids',
+            'posts_per_page' => 1,
+            'no_found_rows' => false,
+            'meta_query' => array(array('key' => self::META_PENDING, 'value' => '1')),
+        ));
+        return (int) $q->found_posts;
+    }
+
+    public static function handle_settings() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_tp_settings');
+        update_option(self::OPTION_TOKEN, trim(sanitize_text_field(wp_unslash($_POST['tp_token'] ?? ''))), false);
+        update_option(self::OPTION_TRS, absint($_POST['tp_trs'] ?? 0), false);
+        update_option(self::OPTION_MARKER, absint($_POST['tp_marker'] ?? 0), false);
+        update_option(self::OPTION_SHORTEN, empty($_POST['tp_shorten']) ? '0' : '1', false);
+        self::redirect_back(array('type' => 'success', 'message' => __('Impostazioni Travelpayouts salvate.', 'affiliate-link-manager-ai')));
+    }
+
+    /* ---------------------------------------------------------------------
+     * Import CSV
+     * ------------------------------------------------------------------ */
+
+    public static function handle_upload() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_tp_upload');
+        if (empty($_FILES['tp_csv']['tmp_name']) || !is_uploaded_file($_FILES['tp_csv']['tmp_name'])) {
+            self::redirect_back(array('type' => 'error', 'message' => __('Nessun file CSV caricato.', 'affiliate-link-manager-ai')));
+        }
+        $rows = self::parse_csv($_FILES['tp_csv']['tmp_name']);
+        if (empty($rows)) {
+            self::redirect_back(array('type' => 'error', 'message' => __('CSV vuoto o intestazioni non riconosciute (attese: Nome, descrizione, città, url, tipologia link).', 'affiliate-link-manager-ai')));
+        }
+        $created = 0; $skipped = 0; $link_ids = array();
+        foreach ($rows as $row) {
+            $id = self::create_link_from_row($row);
+            if ($id > 0) { $created++; $link_ids[] = $id; } else { $skipped++; }
+        }
+        $status = array(
+            'imported_at' => current_time('mysql'),
+            'created' => $created,
+            'skipped' => $skipped,
+            'convert_state' => self::is_configured() ? 'in_coda' : 'in_attesa_config',
+            'convert_detail' => '',
+            'converted' => 0,
+            'convert_errors' => 0,
+            'convert_finished_at' => '',
+        );
+        update_option(self::OPTION_STATUS, $status, false);
+        // Avvia subito la conversione se le API sono configurate.
+        if ($created > 0 && self::is_configured()) {
+            self::schedule_conversion();
+        }
+        $msg = sprintf(__('Import completato: %1$d link creati, %2$d righe saltate.', 'affiliate-link-manager-ai'), $created, $skipped);
+        if ($created > 0 && !self::is_configured()) {
+            $msg .= ' ' . __('Configura le API Travelpayouts per convertire gli URL in link affiliati.', 'affiliate-link-manager-ai');
+        } elseif ($created > 0) {
+            $msg .= ' ' . __('Conversione degli URL in corso in background.', 'affiliate-link-manager-ai');
+        }
+        self::redirect_back(array('type' => $created > 0 ? 'success' : 'error', 'message' => $msg));
+    }
+
+    /**
+     * Legge il CSV e mappa le intestazioni (italiane/flessibili) sui campi
+     * interni. Rileva il delimitatore tra , e ; .
+     *
+     * @return array<int,array{title,description,city,url,link_type}>
+     */
+    public static function parse_csv($path) {
+        $handle = @fopen($path, 'r');
+        if (!$handle) { return array(); }
+        $first = fgets($handle);
+        if ($first === false) { fclose($handle); return array(); }
+        $first = preg_replace('/^\xEF\xBB\xBF/', '', $first); // via BOM
+        $delimiter = (substr_count($first, ';') > substr_count($first, ',')) ? ';' : ',';
+        $header = str_getcsv($first, $delimiter, '"', '\\');
+        $map = self::map_headers($header);
+        if (!isset($map['url']) || (!isset($map['title']) && !isset($map['url']))) { fclose($handle); return array(); }
+        $rows = array();
+        while (($data = fgetcsv($handle, 0, $delimiter, '"', '\\')) !== false) {
+            if (count($rows) >= self::MAX_ROWS) { break; }
+            $get = function ($key) use ($map, $data) {
+                return isset($map[$key], $data[$map[$key]]) ? trim((string) $data[$map[$key]]) : '';
+            };
+            $url = $get('url');
+            if ($url === '') { continue; }
+            $rows[] = array(
+                'title' => $get('title'),
+                'description' => $get('description'),
+                'city' => $get('city'),
+                'url' => $url,
+                'link_type' => $get('link_type'),
+            );
+        }
+        fclose($handle);
+        return $rows;
+    }
+
+    /** Mappa nome-colonna → indice, tollerante a varianti/accenti/maiuscole. */
+    private static function map_headers($header) {
+        $aliases = array(
+            'title' => array('nome', 'titolo', 'title', 'name'),
+            'description' => array('descrizione', 'description', 'desc'),
+            'city' => array('citta', 'città', 'city', 'localita', 'località'),
+            'url' => array('url', 'link', 'indirizzo'),
+            'link_type' => array('tipologia link', 'tipologia', 'tipo', 'link type', 'link_type', 'type'),
+        );
+        $map = array();
+        foreach ((array) $header as $i => $col) {
+            $norm = self::normalize_header((string) $col);
+            foreach ($aliases as $field => $names) {
+                if (isset($map[$field])) { continue; }
+                foreach ($names as $n) {
+                    if ($norm === self::normalize_header($n)) { $map[$field] = $i; break; }
+                }
+            }
+        }
+        return $map;
+    }
+
+    private static function normalize_header($s) {
+        $s = strtolower(trim((string) $s));
+        $s = strtr($s, array('à' => 'a', 'è' => 'e', 'é' => 'e', 'ì' => 'i', 'ò' => 'o', 'ù' => 'u'));
+        return preg_replace('/\s+/', ' ', $s);
+    }
+
+    /**
+     * Crea un Link Affiliato da una riga: titolo, descrizione, URL originale
+     * (in attesa di conversione), tipologia e geolocalizzazione dalla città.
+     *
+     * @return int ID del post creato, 0 se scartata.
+     */
+    public static function create_link_from_row($row) {
+        $url = esc_url_raw((string) ($row['url'] ?? ''));
+        if ($url === '' || !wp_http_validate_url($url)) { return 0; }
+        $title = sanitize_text_field((string) ($row['title'] ?? '')) ?: wp_parse_url($url, PHP_URL_HOST);
+        $post_id = wp_insert_post(array(
+            'post_type' => 'affiliate_link',
+            'post_status' => 'publish',
+            'post_title' => $title,
+            'post_content' => wp_kses_post((string) ($row['description'] ?? '')),
+        ), true);
+        if (is_wp_error($post_id) || !$post_id) { return 0; }
+
+        update_post_meta($post_id, '_affiliate_url', $url);
+        update_post_meta($post_id, self::META_ORIGINAL_URL, $url);
+        update_post_meta($post_id, self::META_PENDING, '1');
+        update_post_meta($post_id, '_alma_source_provenance', self::SOURCE);
+        // Contesto AI per bozze/arricchimento (descrizione).
+        $desc = trim(wp_strip_all_tags((string) ($row['description'] ?? '')));
+        if ($desc !== '') { update_post_meta($post_id, '_alma_ai_context', $desc); }
+
+        // Tipologia: crea/associa il termine link_type.
+        $type_name = sanitize_text_field((string) ($row['link_type'] ?? ''));
+        if ($type_name !== '') {
+            $term = self::resolve_link_type_term($type_name);
+            if ($term > 0) { wp_set_object_terms($post_id, array($term), 'link_type', false); }
+        }
+        // Geolocalizzazione dalla città (in coda al geocoding automatico).
+        $city = sanitize_text_field((string) ($row['city'] ?? ''));
+        if ($city !== '') { self::assign_city_geo($post_id, $city); }
+
+        return (int) $post_id;
+    }
+
+    private static function resolve_link_type_term($name) {
+        $existing = get_term_by('name', $name, 'link_type');
+        if ($existing && !is_wp_error($existing)) { return (int) $existing->term_id; }
+        $created = wp_insert_term($name, 'link_type');
+        return (is_array($created) && !empty($created['term_id'])) ? (int) $created['term_id'] : 0;
+    }
+
+    private static function assign_city_geo($post_id, $city) {
+        if (!class_exists('ALMA_Geo_Index_Store')) { return; }
+        $store = new ALMA_Geo_Index_Store();
+        $store->save_geo_meta_for_object((int) $post_id, ALMA_Geo_Index_Store::OBJECT_TYPE_AFFILIATE_LINK, array(
+            'primary_location' => array(
+                'name' => $city,
+                'canonical_name' => $city,
+                'type' => 'city',
+                'geocoding_status' => 'pending',
+                'suggested_geocoding_query' => $city,
+            ),
+        ), self::SOURCE);
+    }
+
+    /* ---------------------------------------------------------------------
+     * Conversione via API (job in background)
+     * ------------------------------------------------------------------ */
+
+    public static function schedule_conversion() {
+        if (!wp_next_scheduled(self::CRON_HOOK)) {
+            wp_schedule_single_event(time() + 5, self::CRON_HOOK, array('run-' . time()));
+        }
+        if (function_exists('spawn_cron')) { spawn_cron(); }
+    }
+
+    public static function handle_convert_now() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_tp_convert_now');
+        if (!self::is_configured()) {
+            self::redirect_back(array('type' => 'error', 'message' => __('Configura prima token, trs e marker Travelpayouts.', 'affiliate-link-manager-ai')));
+        }
+        // Evento con argomento unico: WP-Cron non lo deduplica come identico.
+        wp_schedule_single_event(time() + 2, self::CRON_HOOK, array('manual-' . time()));
+        if (function_exists('spawn_cron')) { spawn_cron(); }
+        self::redirect_back(array('type' => 'success', 'message' => __('Conversione avviata: gli URL verranno convertiti in background.', 'affiliate-link-manager-ai')));
+    }
+
+    /** ID dei link ancora da convertire (limite $limit). */
+    private static function pending_ids($limit) {
+        $q = new WP_Query(array(
+            'post_type' => 'affiliate_link',
+            'post_status' => 'any',
+            'fields' => 'ids',
+            'posts_per_page' => max(1, (int) $limit),
+            'no_found_rows' => true,
+            'orderby' => 'ID',
+            'order' => 'ASC',
+            'meta_query' => array(array('key' => self::META_PENDING, 'value' => '1')),
+        ));
+        return array_map('intval', (array) $q->posts);
+    }
+
+    /**
+     * Runner del job: converte fino a CONVERT_BATCH link a chiamata, in
+     * blocchi di API_CHUNK (10). Lock atomico con TTL; se restano link
+     * pendenti richiama sé stesso.
+     */
+    public static function run_conversion() {
+        if (!self::is_configured()) { return; }
+        if (!add_option(self::LOCK_OPTION, (string) time(), '', 'no')) {
+            $started = absint(get_option(self::LOCK_OPTION, 0));
+            if ($started > 0 && (time() - $started) <= self::LOCK_TTL) { return; }
+            update_option(self::LOCK_OPTION, (string) time(), false);
+        }
+        $status = (array) get_option(self::OPTION_STATUS, array());
+        $converted = (int) ($status['converted'] ?? 0);
+        $errors = (int) ($status['convert_errors'] ?? 0);
+        try {
+            $ids = self::pending_ids(self::CONVERT_BATCH);
+            foreach (array_chunk($ids, self::API_CHUNK) as $chunk) {
+                $url_by_id = array();
+                foreach ($chunk as $id) {
+                    $u = (string) get_post_meta($id, self::META_ORIGINAL_URL, true);
+                    if ($u === '') { $u = (string) get_post_meta($id, '_affiliate_url', true); }
+                    if ($u !== '') { $url_by_id[$id] = $u; }
+                }
+                if (empty($url_by_id)) { continue; }
+                $result = self::api_convert(array_values($url_by_id));
+                if (!empty($result['fatal'])) {
+                    // Errore globale (token/trs/marker): ferma e riporta.
+                    $status['convert_state'] = 'errore';
+                    $status['convert_detail'] = sanitize_text_field((string) $result['fatal']);
+                    $status['converted'] = $converted;
+                    $status['convert_errors'] = $errors;
+                    update_option(self::OPTION_STATUS, $status, false);
+                    return;
+                }
+                $map = (array) ($result['map'] ?? array());
+                foreach ($url_by_id as $id => $orig) {
+                    $partner = isset($map[$orig]) ? (string) $map[$orig] : '';
+                    if ($partner !== '') {
+                        update_post_meta($id, '_affiliate_url', esc_url_raw($partner));
+                        delete_post_meta($id, self::META_PENDING);
+                        delete_post_meta($id, self::META_CONVERT_ERROR);
+                        $converted++;
+                    } else {
+                        // Non convertibile (brand non supportato / non iscritto):
+                        // esce dalla coda per non bloccarla, con motivo salvato.
+                        delete_post_meta($id, self::META_PENDING);
+                        update_post_meta($id, self::META_CONVERT_ERROR, isset($result['messages'][$orig]) ? sanitize_text_field((string) $result['messages'][$orig]) : 'conversione non riuscita');
+                        $errors++;
+                    }
+                }
+            }
+        } catch (Throwable $e) {
+            $status['convert_state'] = 'errore';
+            $status['convert_detail'] = sanitize_text_field($e->getMessage());
+        } finally {
+            delete_option(self::LOCK_OPTION);
+        }
+        $remaining = self::pending_count();
+        $status['converted'] = $converted;
+        $status['convert_errors'] = $errors;
+        if ($remaining > 0) {
+            $status['convert_state'] = 'in_corso';
+            $status['convert_detail'] = sprintf(__('%d link ancora da convertire.', 'affiliate-link-manager-ai'), $remaining);
+            update_option(self::OPTION_STATUS, $status, false);
+            // Catena: rispetta il rate limit dell'API (100 req/min).
+            wp_schedule_single_event(time() + 20, self::CRON_HOOK, array('chain-' . time()));
+            if (function_exists('spawn_cron')) { spawn_cron(); }
+        } else {
+            $status['convert_state'] = 'completata';
+            $status['convert_detail'] = '';
+            $status['convert_finished_at'] = current_time('mysql');
+            update_option(self::OPTION_STATUS, $status, false);
+        }
+    }
+
+    /**
+     * Chiama l'API Travelpayouts per convertire un lotto di URL (max 10).
+     *
+     * @return array{map:array<string,string>,messages:array<string,string>,fatal?:string}
+     */
+    public static function api_convert($urls) {
+        $token = trim((string) get_option(self::OPTION_TOKEN, ''));
+        $trs = absint(get_option(self::OPTION_TRS, 0));
+        $marker = absint(get_option(self::OPTION_MARKER, 0));
+        $shorten = get_option(self::OPTION_SHORTEN, '1') === '1';
+        $links = array();
+        foreach (array_slice((array) $urls, 0, self::API_CHUNK) as $u) {
+            $links[] = array('url' => (string) $u, 'sub_id' => 'alma_import');
+        }
+        $body = wp_json_encode(array('trs' => $trs, 'marker' => $marker, 'shorten' => $shorten, 'links' => $links));
+        $res = wp_remote_post(self::API_ENDPOINT, array(
+            'timeout' => 30,
+            'headers' => array(
+                'Content-Type' => 'application/json',
+                'X-Access-Token' => $token,
+            ),
+            'body' => $body,
+        ));
+        if (is_wp_error($res)) {
+            return array('map' => array(), 'messages' => array(), 'fatal' => $res->get_error_message());
+        }
+        $code = (int) wp_remote_retrieve_response_code($res);
+        $json = json_decode((string) wp_remote_retrieve_body($res), true);
+        if ($code === 401) { return array('map' => array(), 'messages' => array(), 'fatal' => __('Token API non valido (401).', 'affiliate-link-manager-ai')); }
+        if ($code === 400) {
+            $err = is_array($json) ? (string) ($json['error'] ?? 'richiesta non valida') : 'richiesta non valida';
+            return array('map' => array(), 'messages' => array(), 'fatal' => sprintf(__('Richiesta non valida (400): %s. Verifica trs e marker.', 'affiliate-link-manager-ai'), $err));
+        }
+        $map = array(); $messages = array();
+        $items = (is_array($json) && isset($json['result']['links'])) ? (array) $json['result']['links'] : array();
+        foreach ($items as $item) {
+            $u = (string) ($item['url'] ?? '');
+            if ($u === '') { continue; }
+            if (($item['code'] ?? '') === 'success' && !empty($item['partner_url'])) {
+                $map[$u] = (string) $item['partner_url'];
+            } else {
+                $messages[$u] = (string) ($item['message'] ?? 'conversione non riuscita');
+            }
+        }
+        return array('map' => $map, 'messages' => $messages);
+    }
+
+    /* ---------------------------------------------------------------------
+     * CSV demo
+     * ------------------------------------------------------------------ */
+
+    public static function handle_download_demo() {
+        if (!current_user_can('manage_options')) { wp_die('forbidden'); }
+        check_admin_referer('alma_tp_download_demo');
+        $rows = array(
+            array('Nome', 'descrizione', 'città', 'url', 'tipologia link'),
+            array('Hotel Le Marais', 'Boutique hotel nel cuore del Marais, a due passi da Notre-Dame.', 'Parigi', 'https://www.booking.com/hotel/fr/le-marais.it.html', 'Hotel e Resort'),
+            array('Tour guidato del Louvre', 'Visita guidata salta-fila alle opere principali del Louvre.', 'Parigi', 'https://www.getyourguide.it/parigi-l16/louvre-t1234/', 'Tour e attività'),
+            array('eSIM Francia 5GB', 'Connessione dati per il tuo viaggio in Francia, attivazione immediata.', '', 'https://yesim.app/country/france/5gb-esim-data-plan/', 'eSIM'),
+        );
+        nocache_headers();
+        header('Content-Type: text/csv; charset=utf-8');
+        header('Content-Disposition: attachment; filename="travelpayouts-demo.csv"');
+        $out = fopen('php://output', 'w');
+        fwrite($out, "\xEF\xBB\xBF"); // BOM per Excel
+        foreach ($rows as $r) { fputcsv($out, $r); }
+        fclose($out);
+        exit;
+    }
+
+    /* ---------------------------------------------------------------------
+     * Pagina admin
+     * ------------------------------------------------------------------ */
+
+    private static function redirect_back($notice) {
+        set_transient('alma_tp_notice_' . get_current_user_id(), $notice, 60);
+        wp_safe_redirect(admin_url('edit.php?post_type=affiliate_link&page=' . self::MENU_SLUG));
+        exit;
+    }
+
+    public static function render_page() {
+        if (!current_user_can('manage_options')) { return; }
+        $notice = get_transient('alma_tp_notice_' . get_current_user_id());
+        if ($notice) { delete_transient('alma_tp_notice_' . get_current_user_id()); }
+        $token = (string) get_option(self::OPTION_TOKEN, '');
+        $trs = absint(get_option(self::OPTION_TRS, 0));
+        $marker = absint(get_option(self::OPTION_MARKER, 0));
+        $shorten = get_option(self::OPTION_SHORTEN, '1') === '1';
+        $status = (array) get_option(self::OPTION_STATUS, array());
+        $pending = self::pending_count();
+        $action = esc_url(admin_url('admin-post.php'));
+
+        echo '<div class="wrap"><h1>' . esc_html__('Import Travelpayouts', 'affiliate-link-manager-ai') . '</h1>';
+        echo '<p class="description">' . esc_html__('Importa link affiliati in massa da un CSV. Dopo l\'import, le API Travelpayouts convertono ogni URL diretto in URL affiliato e aggiornano il link.', 'affiliate-link-manager-ai') . '</p>';
+
+        if (is_array($notice)) {
+            echo '<div class="notice notice-' . esc_attr($notice['type'] === 'error' ? 'error' : 'success') . ' is-dismissible"><p>' . esc_html($notice['message']) . '</p></div>';
+        }
+
+        // --- Impostazioni API ---
+        echo '<h2>' . esc_html__('1. Credenziali API', 'affiliate-link-manager-ai') . '</h2>';
+        echo '<form method="post" action="' . $action . '">';
+        wp_nonce_field('alma_tp_settings');
+        echo '<input type="hidden" name="action" value="alma_tp_save_settings">';
+        echo '<table class="form-table"><tbody>';
+        echo '<tr><th><label for="tp_token">' . esc_html__('API token', 'affiliate-link-manager-ai') . '</label></th><td><input type="text" id="tp_token" name="tp_token" class="regular-text" value="' . esc_attr($token) . '" autocomplete="off"><p class="description">' . esc_html__('Profilo Travelpayouts → API token.', 'affiliate-link-manager-ai') . '</p></td></tr>';
+        echo '<tr><th><label for="tp_trs">' . esc_html__('trs (Project ID)', 'affiliate-link-manager-ai') . '</label></th><td><input type="number" id="tp_trs" name="tp_trs" value="' . esc_attr((string) $trs) . '"></td></tr>';
+        echo '<tr><th><label for="tp_marker">' . esc_html__('marker (Partner ID)', 'affiliate-link-manager-ai') . '</label></th><td><input type="number" id="tp_marker" name="tp_marker" value="' . esc_attr((string) $marker) . '"></td></tr>';
+        echo '<tr><th>' . esc_html__('Link brevi', 'affiliate-link-manager-ai') . '</th><td><label><input type="checkbox" name="tp_shorten" value="1" ' . checked($shorten, true, false) . '> ' . esc_html__('Genera link affiliati brevi (shorten)', 'affiliate-link-manager-ai') . '</label></td></tr>';
+        echo '</tbody></table>';
+        submit_button(__('Salva credenziali', 'affiliate-link-manager-ai'));
+        echo '</form>';
+        echo '<p>' . (self::is_configured() ? '<span style="color:#1a7f37;">✅ ' . esc_html__('API configurate.', 'affiliate-link-manager-ai') . '</span>' : '<span style="color:#d63638;">⚠️ ' . esc_html__('API non ancora configurate: l\'import creerà i link con l\'URL originale, la conversione partirà dopo la configurazione.', 'affiliate-link-manager-ai') . '</span>') . '</p>';
+
+        // --- Upload CSV ---
+        echo '<hr><h2>' . esc_html__('2. Carica il CSV', 'affiliate-link-manager-ai') . '</h2>';
+        echo '<p class="description">' . esc_html__('Colonne attese: Nome, descrizione, città, url, tipologia link. La prima riga è l\'intestazione.', 'affiliate-link-manager-ai') . ' ';
+        echo '<a href="' . esc_url(wp_nonce_url(admin_url('admin-post.php?action=alma_tp_download_demo'), 'alma_tp_download_demo')) . '">' . esc_html__('Scarica un CSV demo', 'affiliate-link-manager-ai') . '</a>.</p>';
+        echo '<form method="post" action="' . $action . '" enctype="multipart/form-data">';
+        wp_nonce_field('alma_tp_upload');
+        echo '<input type="hidden" name="action" value="alma_tp_upload">';
+        echo '<input type="file" name="tp_csv" accept=".csv,text/csv" required> ';
+        submit_button(__('Importa i link', 'affiliate-link-manager-ai'), 'primary', 'submit', false);
+        echo '</form>';
+
+        // --- Stato conversione ---
+        echo '<hr><h2>' . esc_html__('3. Conversione URL → affiliati', 'affiliate-link-manager-ai') . '</h2>';
+        if (!empty($status['imported_at'])) {
+            echo '<p>' . esc_html(sprintf(__('Ultimo import: %1$s — %2$d link creati, %3$d saltati.', 'affiliate-link-manager-ai'), (string) $status['imported_at'], (int) ($status['created'] ?? 0), (int) ($status['skipped'] ?? 0))) . '</p>';
+        }
+        $state = (string) ($status['convert_state'] ?? '');
+        $state_labels = array(
+            'in_coda' => __('in coda', 'affiliate-link-manager-ai'),
+            'in_corso' => __('in corso', 'affiliate-link-manager-ai'),
+            'completata' => __('completata', 'affiliate-link-manager-ai'),
+            'errore' => __('errore', 'affiliate-link-manager-ai'),
+            'in_attesa_config' => __('in attesa di configurazione API', 'affiliate-link-manager-ai'),
+        );
+        if ($state !== '') {
+            $color = $state === 'errore' ? '#d63638' : ($state === 'completata' ? '#1a7f37' : '#2271b1');
+            echo '<p>' . esc_html__('Stato conversione:', 'affiliate-link-manager-ai') . ' <strong style="color:' . esc_attr($color) . ';">' . esc_html($state_labels[$state] ?? $state) . '</strong>';
+            echo ' · ' . esc_html(sprintf(__('convertiti: %1$d · non convertibili: %2$d · in attesa: %3$d', 'affiliate-link-manager-ai'), (int) ($status['converted'] ?? 0), (int) ($status['convert_errors'] ?? 0), $pending));
+            echo '</p>';
+            if (!empty($status['convert_detail'])) { echo '<p class="description">' . esc_html((string) $status['convert_detail']) . '</p>'; }
+        } else {
+            echo '<p>' . esc_html(sprintf(__('Link in attesa di conversione: %d', 'affiliate-link-manager-ai'), $pending)) . '</p>';
+        }
+        if ($pending > 0 && self::is_configured()) {
+            echo '<form method="post" action="' . $action . '">';
+            wp_nonce_field('alma_tp_convert_now');
+            echo '<input type="hidden" name="action" value="alma_tp_convert_now">';
+            submit_button(__('Converti ora', 'affiliate-link-manager-ai'), 'secondary', 'submit', false);
+            echo '</form>';
+        }
+        echo '</div>';
+    }
+}


### PR DESCRIPTION
Due blocchi dallo stesso messaggio (PR #381 non ancora mergiata quando la seconda feature è stata completata, quindi impilata qui).

## v2.100.0 — Telegram
- **Report agente**: `format_agent_report` elenca SOLO gli articoli pubblicati, con link view + Modifica; le idee non vengono più inviate; le bozze non pubblicate solo come conteggio; errori mantenuti; rimossi riassunto e righe idee/programmate.
- **`/agente <tema>` senza date crea subito**: in `command_agent`, `immediate = (days_span > 0 ? 0 : 1)` — il comando `/agente` (nessuna finestra giorni) genera le bozze subito; `/piano N G` resta distribuito.

## v2.101.0 — Import massivo Travelpayouts da CSV
- Nuova pagina **Link Affiliati → Import Travelpayouts** (`ALMA_Travelpayouts_Importer`, file nuovo).
- **CSV**: Nome, descrizione, città, url, tipologia link — intestazioni flessibili (alias italiani/inglesi, accenti, delimitatore `,` o `;`, BOM). CSV **demo** scaricabile.
- Ogni riga crea un **Link Affiliato** con titolo, descrizione (+ contesto AI), **tipologia** (`link_type` creato se assente) e **geo dalla città** (coda geocoding). URL originale conservato in attesa di conversione.
- **Conversione API** (`POST https://api.travelpayouts.com/links/v1/create`, header `X-Access-Token`; `trs`/`marker`/`shorten` da impostazioni): job in background che converte l'URL diretto in `partner_url` e aggiorna `_affiliate_url`. Rispetta i limiti (max 10 link/richiesta, 100/min): blocchi da 10, catena con pausa, **lock atomico con TTL**, cursore, stato visibile (mai job invisibili). I non convertibili (brand non supportato/non iscritto) escono dalla coda col motivo salvato. Se le API non sono configurate, i link vengono creati con l'URL originale e la conversione parte dopo (o con "Converti ora").

## Verifiche
- `php -l` su tutti i file (incluso il nuovo): OK
- Test standalone: 13/13 (Telegram) + 27/27 (Travelpayouts) — parsing CSV con alias/accenti/delimitatori, righe senza URL scartate, parsing risposta success/failed, errori 401/400, chunking, wiring creazione link/tipologia/geo/flag e catena job
- Retrocompatibilità: nessuna option/API rimossa; feature Travelpayouts interamente additiva (nuova pagina/opzioni)

## Versione
`2.99.0` → `2.100.0` → `2.101.0` + sezioni CHANGELOG.md e README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM