### PR TITLE
Affiliati: diversità candidati per tipologia (hotel non più esclusi) + widget vari + profilo predefinito (v2.102.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.102.0 - 2026-07-08
+
+### Hotel finalmente selezionati e inseriti + varietà widget + profili sempre applicati
+- **Causa radice** (articolo "Parigi in 3 giorni con hotel e tour"): gli hotel NON venivano inseriti perché **non entravano nemmeno tra i candidati**. La selezione automatica prendeva i top-8 link per punteggio, dominati dai tour già cliccati; gli hotel appena importati (senza storico click) restavano fuori, quindi la garanzia di inserimento (v2.97/2.98) non li poteva vedere. Stessa dinamica nel pulsante "Proponi ottimizzazioni AI".
+- **Diversità per tipologia** (`diversify_candidates_by_type`): i candidati affiliati vengono raggruppati per `link_type` e interleavati a round-robin (preservando l'ordine per punteggio dentro ogni gruppo), così ogni tipologia pertinente (hotel, tour…) entra tra i candidati. Applicata sia alla selezione automatica delle bozze (cap alzato 8→12) sia all'optimizer ("Proponi ottimizzazioni AI"). Ora gli hotel di un articolo sugli hotel vengono davvero proposti e inseriti.
+- **Card shortcode per le strutture** (richiesta): il prompt ora indica esplicitamente di usare, per hotel/prodotti con foto, `[affiliate_link id="ID" img="yes" fields="title,content" button="yes" button_size="medium"]` (immagine + titolo + descrizione + pulsante).
+- **Varietà del widget** (`pick_widget_layout_for_links`): il widget di fallback non usa più sempre `experience_cards` — sceglie il layout in base alla tipologia prevalente dei link (hotel/mete → `destination_cards`, tour/attività → `experience_cards`, singolo → `hero_spotlight`); il prompt invita a variare il layout in base al contenuto.
+- **Istruzioni AI - Profili sempre usate** (verifica richiesta): il profilo veniva applicato solo se l'idea ne aveva uno esplicito, e l'agent spesso non lo impostava → bozze senza profilo. Ora, se l'idea non ha profilo, si applica automaticamente il **profilo predefinito attivo** (`is_default`). Nuovo `ALMA_AI_Content_Agent_Instructions_Manager::default_profile_id()`.
+- Test standalone 18/18 (diversità con hotel non esclusi, ordine per punteggio nei gruppi, link_types come array/stringa, layout per tipologia, wiring importer/optimizer/prompt/profilo).
+- Versione plugin aggiornata a `2.102.0`.
+
 ## 2.101.0 - 2026-07-08
 
 ### Import massivo link affiliati da CSV con conversione Travelpayouts

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.102.0 - 2026-07-08
+
+### Hotel selezionati e inseriti + widget vari + profili sempre attivi
+- Gli affiliati di tipologie diverse (es. hotel) non vengono più esclusi dai link più cliccati: la selezione è diversificata per tipologia (bozze e "Proponi ottimizzazioni AI"). Prompt aggiornato con la card shortcode per le strutture; il widget di fallback varia il layout in base al contenuto; se l'idea non ha un profilo istruzioni, si applica quello predefinito.
+- Versione plugin aggiornata a `2.102.0`.
+
 ## 2.101.0 - 2026-07-08
 
 ### Import Travelpayouts da CSV

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.101.0
+ * Version: 2.102.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.101.0');
+define('ALMA_VERSION', '2.102.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -413,7 +413,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'Formatta il testo per la lettura sul web: evidenzia in <strong> i concetti chiave, i nomi di luoghi/attrazioni e i dati pratici (prezzi, periodi consigliati, durate) — con misura, indicativamente una-due evidenziazioni per paragrafo, mai interi periodi.',
             'I link affiliati di tipologia universale (assicurazione viaggio, eSIM, ecc.) sono pertinenti in QUALSIASI articolo di viaggio, anche multi-destinazione: la coerenza geografica NON si applica a loro. Se ne hai uno tra affiliate_links, inseriscilo nel punto più naturale (consigli pratici, preparativi).',
             'Se è presente location_facts, integra nel testo i DATI REALI della scheda località — mesi migliori/da evitare e clima (temperature, piogge), attrazioni verificate, patrimonio UNESCO, elementi del territorio — citandoli con naturalezza per rendere l\'articolo concreto e autorevole. NON inventare numeri o fatti non presenti in location_facts.',
-            'REGOLA CRITICA di monetizzazione: OGNI link affiliato pertinente in affiliate_links va SEMPRE inserito come vero link cliccabile, non solo come fonte di foto o descrizione. Puoi usarlo anche come fonte, ma DEVI comunque linkarlo. Scegli per ogni link la modalità che converte di più e sfrutta tutto l\'arsenale: nome/anchor nel testo con lo shortcode [affiliate_link id="ID" text="…"], immagine avvolta in <a href="{affiliate_url}" target="_blank" rel="nofollow sponsored noopener">, bottone CTA (button="yes"), card (img+descrizione+bottone) e, per raccolte di più strutture/esperienze, il widget [[ALMA_WIDGET]]. MAI mostrare foto o descrizione di un affiliato senza il suo link: è guadagno perso. Usa le link_types (es. "Hotel e Resort") per capire che è una struttura prenotabile e proporre la giusta call to action.',
+            'REGOLA CRITICA di monetizzazione: OGNI link affiliato pertinente in affiliate_links va SEMPRE inserito come vero link cliccabile, non solo come fonte di foto o descrizione. Puoi usarlo anche come fonte, ma DEVI comunque linkarlo. Scegli per ogni link la modalità che converte di più e sfrutta tutto l\'arsenale: nome/anchor nel testo con lo shortcode [affiliate_link id="ID" text="…"], immagine avvolta in <a href="{affiliate_url}" target="_blank" rel="nofollow sponsored noopener">, bottone CTA (button="yes"), card e, per raccolte di più strutture/esperienze, il widget [[ALMA_WIDGET]]. Per una struttura/prodotto presentato con foto (es. un hotel) usa la CARD con lo shortcode nella forma: [affiliate_link id="ID" img="yes" fields="title,content" button="yes" button_size="medium"] — mostra immagine, titolo, descrizione e pulsante. MAI mostrare foto o descrizione di un affiliato senza il suo link: è guadagno perso. Usa le link_types (es. "Hotel e Resort") per capire che è una struttura prenotabile e proporre la giusta call to action.',
             'Varia l\'offerta: usa i DIVERSI link affiliati pertinenti disponibili, non concentrarti su uno solo. In un articolo che elenca più strutture/esperienze, linka CIASCUNA al suo affiliate_link corrispondente.',
         );
         $affiliate_rules = self::compact_rule_list(array_merge((array)($payload['affiliate_rules'] ?? array()), array($profile_rules['affiliate_rules'] ?? '')));
@@ -712,6 +712,30 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         $result['added'] = true;
         $result['link_id'] = $link_id;
         return $result;
+    }
+
+    /**
+     * Sceglie il layout del widget di fallback in base alla tipologia
+     * prevalente dei link: un solo link → hero_spotlight; alloggi/mete
+     * (hotel, resort, destinazioni) → destination_cards; altrimenti (tour,
+     * attività, esperienze) → experience_cards. Evita di usare sempre lo
+     * stesso layout.
+     */
+    private static function pick_widget_layout_for_links($link_ids) {
+        $link_ids = array_values(array_filter(array_map('absint', (array) $link_ids)));
+        if (count($link_ids) <= 1) { return 'hero_spotlight'; }
+        $accommodation = 0; $total = 0;
+        foreach ($link_ids as $id) {
+            $terms = get_the_terms($id, 'link_type');
+            if (is_wp_error($terms) || empty($terms)) { continue; }
+            foreach ($terms as $term) {
+                $total++;
+                if (preg_match('/hotel|resort|alloggi|ostell|b&b|appartament|destinazion|met[ae]|citt/i', (string) $term->name)) { $accommodation++; }
+            }
+        }
+        // Se almeno metà dei link sono strutture/mete, la griglia destinazioni
+        // valorizza meglio l'immagine; altrimenti le card esperienze.
+        return ($total > 0 && $accommodation * 2 >= $total) ? 'destination_cards' : 'experience_cards';
     }
 
     private static function candidate_affiliate_images($affiliate_links) {
@@ -1227,7 +1251,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             'seo_rules'=>$seo_rules,
             'media_rules'=>array_filter(array('Usa massimo '.$max_editorial_media_used.' immagini editoriali dalla Media Library nel corpo dell’articolo.','Usare immagini affiliate solo se pertinenti alla sezione.','Non inventare URL immagini.','Usare solo immagini presenti nei link affiliati selezionati.','Non duplicare troppe volte la stessa immagine.','Non scaricare immagini durante la generazione bozza.','Se nessuna immagine della Media Library è adatta a una sezione, puoi inserire su una riga a sé un segnaposto [Immagine: descrizione fotografica dettagliata della scena] (massimo 3 per articolo): verrà generato dall\'AI e sostituito automaticamente dopo la creazione.', $profile_payload['instruction_profile_rules']['image_rules'] ?? '')),
             'output_contract'=>array('title','slug','excerpt','content','seo_title','seo_description','featured_image_id','affiliate_shortcodes_used','affiliate_urls_used','internal_urls_used','media_used','category_ids','tag_ids','new_tags','warnings'),
-            'widget_request_contract'=>'Campo OPZIONALE widget_request nell\'output JSON: {"title":string,"layout":string,"link_ids":[int],"button_text":string,"rewritten":[{"id":int,"title":string,"description":string}]}. Scegli il layout adatto al contesto dell\'articolo: "destination_cards" = griglia di mete/destinazioni con titolo e località sull\'immagine (2-6 link); "experience_cards" = card compatte per tour e attività specifiche con pulsante, carosello su mobile (2-8 link); "hero_spotlight" = UNA sola esperienza di punta in grande evidenza con testo e pulsante (esattamente 1 link). Compilalo SOLO se hai inserito il segnaposto [[ALMA_WIDGET]] nel content; il sistema creerà il widget reale e sostituirà il segnaposto. Posiziona il segnaposto [[ALMA_WIDGET]] in un punto INTERMEDIO dell\'articolo (dopo una sezione centrale pertinente) per spezzare visivamente il testo — NON alla fine, dove è meno efficace.',
+            'widget_request_contract'=>'Campo OPZIONALE widget_request nell\'output JSON: {"title":string,"layout":string,"link_ids":[int],"button_text":string,"rewritten":[{"id":int,"title":string,"description":string}]}. Scegli il layout adatto al contesto dell\'articolo: "destination_cards" = griglia di mete/destinazioni con titolo e località sull\'immagine (2-6 link); "experience_cards" = card compatte per tour e attività specifiche con pulsante, carosello su mobile (2-8 link); "hero_spotlight" = UNA sola esperienza di punta in grande evidenza con testo e pulsante (esattamente 1 link). SCEGLI il layout in base al CONTENUTO, non usare sempre lo stesso: per hotel/alloggi e mete usa "destination_cards", per tour/attività "experience_cards", per una singola proposta di punta "hero_spotlight". Compilalo SOLO se hai inserito il segnaposto [[ALMA_WIDGET]] nel content; il sistema creerà il widget reale e sostituirà il segnaposto. Posiziona il segnaposto [[ALMA_WIDGET]] in un punto INTERMEDIO dell\'articolo (dopo una sezione centrale pertinente) per spezzare visivamente il testo — NON alla fine, dove è meno efficace.',
             'warnings'=>array_values(array_unique($warnings)),
             'agent_behavior'=>$agent_behavior,
         ), $profile_payload);
@@ -1444,9 +1468,13 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             $rules_snapshot = ALMA_AI_Insertion_Rules::get_rules();
             if ($ai_widget_id < 1 && in_array('widget', (array) $rules_snapshot['patterns'], true) && !empty($candidate_affiliate_ids)) {
                 $fallback_ids = array_slice(array_map('absint', (array) $candidate_affiliate_ids), 0, 4);
+                // Layout scelto in base alla tipologia prevalente dei link
+                // (non sempre lo stesso): alloggi/mete → destination_cards,
+                // tour/attività → experience_cards, singolo → hero_spotlight.
+                $fallback_layout = self::pick_widget_layout_for_links($fallback_ids);
                 $fallback_request = array(
-                    'title' => __('Esperienze consigliate', 'affiliate-link-manager-ai'),
-                    'layout' => count($fallback_ids) === 1 ? 'hero_spotlight' : 'experience_cards',
+                    'title' => __('Le migliori proposte per te', 'affiliate-link-manager-ai'),
+                    'layout' => $fallback_layout,
                     'link_ids' => $fallback_ids,
                 );
                 $fallback_result = ALMA_AI_Insertion_Rules::apply_widget_request($clean['content'], $fallback_request, $candidate_affiliate_ids);

--- a/includes/class-ai-content-agent-idea-importer.php
+++ b/includes/class-ai-content-agent-idea-importer.php
@@ -29,7 +29,7 @@ class ALMA_AI_Content_Agent_Idea_Importer {
     const LOCK_TTL = 600;
     const REPORT_TRANSIENT = 'alma_ai_ideas_import_report_';
     const MAX_ROWS = 500;
-    const MAX_AUTO_CANDIDATES = 8;
+    const MAX_AUTO_CANDIDATES = 12;
 
     public static function init() {
         add_action('init', array(__CLASS__, 'maybe_schedule_cron'));
@@ -450,6 +450,39 @@ class ALMA_AI_Content_Agent_Idea_Importer {
      *    dell'autore dell'idea, come farebbe dall'admin);
      * 3. bozza generata dal Draft Builder esistente; meta idea aggiornate.
      */
+    /**
+     * Riordina i candidati affiliati garantendo la diversità per tipologia:
+     * raggruppa per link_type (preservando l'ordine per punteggio dentro
+     * ogni gruppo) e li interleava a round-robin, così una singola tipologia
+     * molto cliccata non satura i primi $cap posti. Ritorna i primi $cap.
+     */
+    public static function diversify_candidates_by_type($rows, $cap) {
+        $rows = array_values((array) $rows);
+        if (count($rows) <= $cap) { return $rows; }
+        $groups = array();
+        $order = array();
+        foreach ($rows as $row) {
+            $types = $row['link_types'] ?? '';
+            $first = is_array($types) ? (string) reset($types) : (string) (explode(',', (string) $types)[0]);
+            $key = strtolower(trim($first)); // tipologia primaria
+            if ($key === '') { $key = '_senza_tipo'; }
+            if (!isset($groups[$key])) { $groups[$key] = array(); $order[] = $key; }
+            $groups[$key][] = $row;
+        }
+        $out = array();
+        $exhausted = false;
+        while (count($out) < $cap && !$exhausted) {
+            $exhausted = true;
+            foreach ($order as $key) {
+                if (empty($groups[$key])) { continue; }
+                $out[] = array_shift($groups[$key]);
+                $exhausted = false;
+                if (count($out) >= $cap) { break; }
+            }
+        }
+        return $out;
+    }
+
     private static function generate_draft_for_scheduled_idea($idea_id) {
         $idea = ALMA_AI_Content_Agent_Ideas::get($idea_id);
         if (empty($idea)) { return array('success' => false, 'error' => 'Idea non trovata'); }
@@ -471,7 +504,11 @@ class ALMA_AI_Content_Agent_Idea_Importer {
             'geo_location_label' => (string)($idea['location_label'] ?? ''),
             'geo_link_ids' => $geo_link_ids,
         ));
-        $candidates = array_slice((array)($search['groups']['affiliate_link'] ?? array()), 0, self::MAX_AUTO_CANDIDATES);
+        // Diversità per TIPOLOGIA: i top per punteggio erano dominati dai
+        // link più cliccati (es. tour), lasciando fuori gli hotel appena
+        // importati (senza storico). Il round-robin per link_type garantisce
+        // che ogni tipologia pertinente entri tra i candidati.
+        $candidates = self::diversify_candidates_by_type((array)($search['groups']['affiliate_link'] ?? array()), self::MAX_AUTO_CANDIDATES);
         // Verifica LIVE al momento della creazione dell'articolo: i link
         // morti vengono scartati (e marcati) prima di entrare nella bozza.
         if (class_exists('ALMA_Link_Health_Checker')) {
@@ -511,6 +548,17 @@ class ALMA_AI_Content_Agent_Idea_Importer {
         update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_RESULTS, $candidates);
         update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_SELECTION, $candidates);
         update_user_meta($author_id, '_alma_active_idea_id', $idea_id);
+
+        // Profilo istruzioni: se l'idea non ne ha uno (l'agent non lo ha
+        // scelto), applica il profilo PREDEFINITO attivo, così le Istruzioni
+        // AI - Profili vengono sempre usate anche nelle bozze automatiche.
+        $idea_for_profile = ALMA_AI_Content_Agent_Ideas::get($idea_id);
+        if (empty($idea_for_profile['profile_id']) && class_exists('ALMA_AI_Content_Agent_Instructions_Manager')) {
+            $default_pid = ALMA_AI_Content_Agent_Instructions_Manager::default_profile_id();
+            if ($default_pid > 0) {
+                update_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_PROFILE_ID, $default_pid);
+            }
+        }
         ALMA_AI_Content_Agent_Selection_Session::load_from_idea(ALMA_AI_Content_Agent_Ideas::get($idea_id));
 
         $result = ALMA_AI_Content_Agent_Draft_Builder::generate_from_selection_session($author_id);

--- a/includes/class-ai-content-agent-instructions-manager.php
+++ b/includes/class-ai-content-agent-instructions-manager.php
@@ -21,6 +21,8 @@ class ALMA_AI_Content_Agent_Instructions_Manager {
     }
     public static function get_profile($id){ global $wpdb; $t=ALMA_AI_Content_Agent_Store::table('instruction_profiles'); $exists=$wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s',$t)); if($exists!==$t){return array();} $r=$wpdb->get_row($wpdb->prepare("SELECT * FROM $t WHERE id=%d",absint($id)),ARRAY_A); return is_array($r)?$r:array(); }
     public static function get_active_profiles($limit = 100, $offset = 0){ global $wpdb; $t=ALMA_AI_Content_Agent_Store::table('instruction_profiles'); $exists=$wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s',$t)); if($exists!==$t){return array();} $rows=$wpdb->get_results($wpdb->prepare("SELECT * FROM $t WHERE is_active=1 ORDER BY is_default DESC, profile_name ASC, id DESC LIMIT %d OFFSET %d", max(1, absint($limit)), max(0, absint($offset))),ARRAY_A); return is_array($rows)?$rows:array(); }
+    /** ID del profilo predefinito ATTIVO (is_default), 0 se nessuno. */
+    public static function default_profile_id(){ global $wpdb; $t=ALMA_AI_Content_Agent_Store::table('instruction_profiles'); $exists=$wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s',$t)); if($exists!==$t){return 0;} $id=(int)$wpdb->get_var("SELECT id FROM $t WHERE is_active=1 ORDER BY is_default DESC, id ASC LIMIT 1"); return $id>0?$id:0; }
     public static function get_active_profile(){ $profiles=self::get_active_profiles(1,0); return !empty($profiles[0]) && is_array($profiles[0]) ? $profiles[0] : array(); }
 
     public static function sanitize_profile_textarea($value) {

--- a/includes/class-ai-post-optimizer.php
+++ b/includes/class-ai-post-optimizer.php
@@ -611,11 +611,19 @@ class ALMA_AI_Post_Optimizer {
             'search_scope' => 'affiliate_links_only',
             'geo_link_ids' => $geo_link_ids,
         ));
-        foreach (array_slice((array)($search['groups']['affiliate_link'] ?? array()), 0, self::MAX_CANDIDATES) as $row) {
+        // Diversità per tipologia: evita che i link più cliccati (es. tour)
+        // saturino i candidati escludendo gli hotel/altre tipologie pertinenti.
+        $search_rows = (array)($search['groups']['affiliate_link'] ?? array());
+        if (class_exists('ALMA_AI_Content_Agent_Idea_Importer')) {
+            $search_rows = ALMA_AI_Content_Agent_Idea_Importer::diversify_candidates_by_type($search_rows, self::MAX_CANDIDATES);
+        } else {
+            $search_rows = array_slice($search_rows, 0, self::MAX_CANDIDATES);
+        }
+        foreach ($search_rows as $row) {
             $candidates[] = array(
                 'id' => (int)$row['source_id'],
                 'titolo' => sanitize_text_field((string)$row['title']),
-                'tipologie' => is_array($row['link_types'] ?? null) ? implode(', ', $row['link_types']) : '',
+                'tipologie' => is_array($row['link_types'] ?? null) ? implode(', ', $row['link_types']) : (string)($row['link_types'] ?? ''),
                 'descrizione' => self::candidate_description((int)$row['source_id']),
             );
         }


### PR DESCRIPTION
## Diagnosi (articolo "Parigi in 3 giorni con hotel e tour")

Gli hotel **non venivano inseriti** perché — analizzando l'HTML — le immagini/nomi degli hotel sono ancora `<img>` nudi / `<strong>` non linkati, mentre tutti i 24 link tracciati sono tour GYG. La causa **non** è l'inserimento (la garanzia v2.97/2.98 funziona), ma la **selezione**: gli hotel non entravano nemmeno tra i candidati.

**Causa radice**: la selezione automatica prende i top-8 link per punteggio, dominati dai tour già cliccati; gli hotel appena importati (senza storico click) restano fuori → non entrano in `affiliate_links` → la garanzia non li può inserire. Stessa dinamica nell'optimizer.

## Modifiche

### 1. Diversità per tipologia (root cause)
`ALMA_AI_Content_Agent_Idea_Importer::diversify_candidates_by_type()`: raggruppa i candidati per `link_type` e li interleava a round-robin (mantenendo l'ordine per punteggio dentro ogni gruppo), così ogni tipologia pertinente entra tra i candidati. Applicata a:
- selezione automatica delle bozze (`MAX_AUTO_CANDIDATES` 8 → 12);
- `collect_candidates` dell'optimizer ("Proponi ottimizzazioni AI").

### 2. Card shortcode per le strutture (richiesta)
Il prompt indica ora esplicitamente, per hotel/prodotti con foto, la card: `[affiliate_link id="ID" img="yes" fields="title,content" button="yes" button_size="medium"]`.

### 3. Varietà del widget
`pick_widget_layout_for_links()`: il widget di fallback non usa più sempre `experience_cards` — sceglie il layout dalla tipologia prevalente (hotel/mete → `destination_cards`, tour → `experience_cards`, singolo → `hero_spotlight`); il contract invita a variare in base al contenuto.

### 4. Istruzioni AI - Profili sempre usate (verifica)
Confermato: il profilo si applicava solo se l'idea ne aveva uno esplicito, e l'agent spesso non lo imposta → bozze senza profilo. Ora, se l'idea non ha profilo, si applica automaticamente il **profilo predefinito attivo** (`is_default`). Nuovo `default_profile_id()`.

## Content Analysis AI — "Articoli"
(risposta alla domanda, senza modifiche codice: consiglio di spuntarlo — vedi commento nella conversazione)

## Verifiche
- `php -l` su tutti i file: OK
- Test standalone 18/18 (diversità con hotel non esclusi, ordine per punteggio nei gruppi, link_types array/stringa, layout per tipologia, wiring)
- Retrocompatibilità: la diversità agisce solo sopra il cap; nessuna option/API rimossa; il profilo predefinito si applica solo in assenza di scelta

## Versione
`2.101.0` → `2.102.0` (minor) + CHANGELOG/README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_