### PR TITLE
Fix accenti corrotti negli articoli AI: contesto senza escape unicode + wp_slash + riparazione (v2.104.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.104.0 - 2026-07-08
+
+### Fix accenti corrotti negli articoli generati (pif9 → più): prevenzione + riparazione
+- **Segnalazione** (articolo "10 hotel a Parigi"): accenti rotti in tutto il testo ("le zone pif9 centrali", "perche9", "citte0", "puf2", "Pre9s"). Non c'entra il francese: ogni lettera accentata era diventata il **residuo del suo escape JSON** (`più` → `\u00f9` → perso `\u00` → resta `f9`).
+- **Causa radice**: il CONTEXT inviato al modello era serializzato con `wp_json_encode` che di default escapa l'unicode — il modello vedeva migliaia di `\u00e8`/`\u00f9`, li riproduceva nel contenuto, e nel salvataggio la sequenza veniva mutilata.
+- **Prevenzione** (fix vero): nuovo `ALMA_OpenAI_Service::encode_context()` con `JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES`, usato in TUTTI i punti che costruiscono prompt (draft-builder ×3, optimizer/arricchimento, tool output dell'agente di ideazione): il modello ora vede e restituisce testo con accenti reali.
+- **Correttezza WordPress**: `wp_slash()` su tutti i salvataggi di contenuto AI (`wp_insert_post` ×2 nel draft-builder, `wp_update_post` in arricchimento, metabox AI Affiliati e sostituzione segnaposto immagini): senza, WordPress rimuove i backslash dal contenuto (concausa della mutilazione).
+- **Riparazione difensiva** (`repair_unicode_escape_residues` nel quality checker, applicata a titolo/excerpt/contenuto di ogni nuova bozza): decodifica gli escape sopravvissuti (`\u00e8`/`u00e8` → è) e ricostruisce i residui mutilati (`pif9`→più, `perche9`→perché, `citte0`→città, `puf2`→può, `Pre9s`→Prés, `e8` isolato→è). Guardie conservative: solo fuori dai tag HTML (mai href/attributi), solo dopo lettera minuscola, mai dentro percorsi o seguiti da cifre; `ec`/`b0` esclusi (falsi positivi). Warning con conteggio riparazioni nella diagnostica bozza.
+- Nota: l'articolo GIÀ pubblicato non si ripara da solo — va rigenerato o corretto; se ce ne sono diversi si può fare un batch di riparazione retroattiva (chiedere).
+- Test standalone 25/25 (tutti i casi reali dell'articolo, falsi positivi evitati su href/percorsi/parole normali, wiring prevenzione + wp_slash + warning).
+- Versione plugin aggiornata a `2.104.0`.
+
 ## 2.103.0 - 2026-07-08
 
 ### Import Travelpayouts integrato in Affiliate Sources (anteprima, mappatura, deduplica, avanzamento live)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.104.0 - 2026-07-08
+
+### Fix accenti corrotti negli articoli AI
+- Gli accenti diventavano residui di escape JSON ("pif9" invece di "più"): ora il contesto per il modello è serializzato senza escape unicode, i salvataggi usano wp_slash e una riparazione difensiva nel quality checker corregge eventuali residui (con guardie su URL e falsi positivi).
+- Versione plugin aggiornata a `2.104.0`.
+
 ## 2.103.0 - 2026-07-08
 
 ### Travelpayouts dentro Affiliate Sources

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.103.0
+ * Version: 2.104.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.103.0');
+define('ALMA_VERSION', '2.104.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -1323,7 +1323,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         $brief = ALMA_AI_Content_Agent_Store::get_brief_by_idea($idea_id); if (!$brief) return self::fail('Brief non trovato.', '', 'idea:'.$idea_id);
         $context = array('idea'=>$idea,'brief'=>$brief,'instruction_snapshot'=>$brief['instruction_snapshot'] ?? ($idea['instruction_snapshot'] ?? ''),'candidate_affiliate_links'=>json_decode((string)($brief['candidate_affiliate_links'] ?? '[]'), true),'candidate_images'=>json_decode((string)($brief['candidate_images'] ?? '[]'), true),'knowledge_suggestions'=>json_decode((string)($brief['suggested_knowledge_sources'] ?? '[]'), true),'warnings'=>json_decode((string)($brief['warnings'] ?? '[]'), true));
         $prompt = 'Genera JSON con: title,slug,excerpt,content_html,seo_title,meta_description,focus_keyword,suggested_tags,affiliate_links_used,featured_image_id,inline_image_ids,qa_notes,warnings. Usa solo shortcode [affiliate_link id="ID" text="anchor"]. Non inventare ID.';
-        $res = ALMA_OpenAI_Service::request(array('system_prompt'=>'Sei un content editor WordPress. Output solo JSON valido.', 'user_prompt'=>$prompt.' CONTEXT: '.wp_json_encode($context), 'json_output'=>true, 'max_output_tokens'=>1800));
+        $res = ALMA_OpenAI_Service::request(array('system_prompt'=>'Sei un content editor WordPress. Output solo JSON valido.', 'user_prompt'=>$prompt.' CONTEXT: '.ALMA_OpenAI_Service::encode_context($context), 'json_output'=>true, 'max_output_tokens'=>1800));
         if (empty($res['success'])) { return self::fail($res['error'] ?? 'Risposta OpenAI fallita.', $res['model'] ?? '', 'idea:'.$idea_id); }
         $parsed = json_decode($res['response'], true); if (!is_array($parsed)) $parsed = json_decode(ALMA_AI_Content_Agent_Text_Utils::extract_first_json($res['response']), true);
         if (!is_array($parsed)) { return self::fail('Draft JSON non valido', $res['model'] ?? '', 'idea:'.$idea_id); }
@@ -1333,7 +1333,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         $clean = ALMA_AI_Content_Agent_Draft_Quality_Checker::validate_payload($parsed, $candidate_affiliate_ids, $candidate_image_ids, $candidate_affiliate_records, array());
         if (!is_array($clean) || !array_key_exists('title', $clean) || !array_key_exists('content', $clean)) return self::fail('QA output non valido.', $res['model'] ?? '', 'idea:'.$idea_id);
         if ($clean['title'] === '' || trim(wp_strip_all_tags($clean['content'])) === '') return self::fail('Output draft non valido dopo QA.', $res['model'] ?? '', 'idea:'.$idea_id);
-        $post_id = wp_insert_post(array('post_type'=>'post','post_status'=>'draft','post_author'=>get_current_user_id(),'post_title'=>$clean['title'],'post_name'=>$clean['slug'],'post_excerpt'=>$clean['excerpt'],'post_content'=>$clean['content']), true);
+        $post_id = wp_insert_post(wp_slash(array('post_type'=>'post','post_status'=>'draft','post_author'=>get_current_user_id(),'post_title'=>$clean['title'],'post_name'=>$clean['slug'],'post_excerpt'=>$clean['excerpt'],'post_content'=>$clean['content'])), true);
         if (is_wp_error($post_id) || !$post_id) { return self::fail('Errore creazione bozza.', $res['model'] ?? '', 'idea:'.$idea_id); }
         if (!empty($clean['featured_image_id'])) set_post_thumbnail($post_id, $clean['featured_image_id']);
         if (class_exists('ALMA_AI_Seo_Bridge')) { ALMA_AI_Seo_Bridge::apply($post_id, (string)($clean['seo_title'] ?? ''), (string)($clean['seo_description'] ?? '')); }
@@ -1420,9 +1420,9 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         $configured_max_tokens = absint(get_option('alma_openai_max_output_tokens', 1800));
         $max_output_tokens = $configured_max_tokens > 0 ? $configured_max_tokens : 1800;
         $response_format = self::build_draft_response_format();
-        $res = ALMA_OpenAI_Service::request(array('system_prompt'=>'Sei un content editor WordPress per output strutturato.', 'user_prompt'=>$prompt.' CONTEXT: '.wp_json_encode($ai_payload), 'response_format'=>$response_format, 'json_output'=>true, 'max_output_tokens'=>$max_output_tokens, 'timeout'=>absint(get_option('alma_openai_timeout', 120))));
+        $res = ALMA_OpenAI_Service::request(array('system_prompt'=>'Sei un content editor WordPress per output strutturato.', 'user_prompt'=>$prompt.' CONTEXT: '.ALMA_OpenAI_Service::encode_context($ai_payload), 'response_format'=>$response_format, 'json_output'=>true, 'max_output_tokens'=>$max_output_tokens, 'timeout'=>absint(get_option('alma_openai_timeout', 120))));
         if (empty($res['success']) && (($res['error_code'] ?? '') === 'response_format_unsupported' || strpos(strtolower((string)($res['error'] ?? '')), 'response_format') !== false)) {
-            $res = ALMA_OpenAI_Service::request(array('system_prompt'=>'Sei un content editor WordPress per output strutturato.', 'user_prompt'=>$prompt.' CONTEXT: '.wp_json_encode($ai_payload), 'json_output'=>true, 'max_output_tokens'=>$max_output_tokens, 'timeout'=>absint(get_option('alma_openai_timeout', 120))));
+            $res = ALMA_OpenAI_Service::request(array('system_prompt'=>'Sei un content editor WordPress per output strutturato.', 'user_prompt'=>$prompt.' CONTEXT: '.ALMA_OpenAI_Service::encode_context($ai_payload), 'json_output'=>true, 'max_output_tokens'=>$max_output_tokens, 'timeout'=>absint(get_option('alma_openai_timeout', 120))));
             $res['response_format_used'] = 'fallback_json_object';
         }
         if (empty($res['success'])) {
@@ -1520,7 +1520,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         // default resta bozza da revisionare.
         $auto_publish = get_option('alma_ai_auto_publish', 'no') === 'yes';
         $post_status = $auto_publish ? 'publish' : 'draft';
-        $post_id = wp_insert_post(array('post_type'=>'post','post_status'=>$post_status,'post_author'=>$user_id,'post_title'=>$clean['title'],'post_name'=>$clean['slug'],'post_excerpt'=>$clean['excerpt'],'post_content'=>$clean['content']), true);
+        $post_id = wp_insert_post(wp_slash(array('post_type'=>'post','post_status'=>$post_status,'post_author'=>$user_id,'post_title'=>$clean['title'],'post_name'=>$clean['slug'],'post_excerpt'=>$clean['excerpt'],'post_content'=>$clean['content'])), true);
         if (is_wp_error($post_id) || !$post_id) { return self::fail('Errore creazione bozza.', $res['model'] ?? '', 'session:user:'.$user_id); }
         if (!empty($ai_widget_id)) { update_post_meta($post_id, '_alma_ai_agent_widget_id', (int) $ai_widget_id); }
         // I link affiliati usati nell'articolo senza immagine in evidenza vanno

--- a/includes/class-ai-content-agent-draft-quality-checker.php
+++ b/includes/class-ai-content-agent-draft-quality-checker.php
@@ -657,11 +657,56 @@ class ALMA_AI_Content_Agent_Draft_Quality_Checker {
         return array_values($out);
     }
 
+    /**
+     * Ripara gli escape unicode sopravvissuti nel testo del modello: gli
+     * escape JSON letterali (è) vengono decodificati nel carattere
+     * reale, e i residui MUTILATI (perso "\u00": "pif9"→"più",
+     * "perche9"→"perché", "citte0"→"città") vengono ricostruiti per i
+     * soli codici delle lettere accentate latine, con guardie conservative
+     * (residuo preceduto da lettera minuscola, fine parola). Difesa in
+     * profondità: la prevenzione vera è il contesto JSON_UNESCAPED_UNICODE.
+     */
+    public static function repair_unicode_escape_residues($text, &$repaired = 0) {
+        $text = (string) $text;
+        // Entrambe le regole si applicano SOLO fuori dai tag HTML: gli href
+        // e gli attributi (tracking id, hash) non vanno mai toccati.
+        $map = array('e0' => 'à', 'e8' => 'è', 'e9' => 'é', 'f2' => 'ò', 'f9' => 'ù');
+        $parts = preg_split('/(<[^>]*>)/', $text, -1, PREG_SPLIT_DELIM_CAPTURE);
+        foreach ($parts as $i => $part) {
+            if ($part === '' || $part[0] === '<') { continue; }
+            // 1) Escape letterali completi (con o senza backslash residuo).
+            $part = preg_replace_callback('/\\\\?u00([0-9a-f]{2})\b/i', function ($m) use (&$repaired) {
+                $code = hexdec($m[1]);
+                if ($code < 0xA0 || $code > 0xFF) { return $m[0]; } // solo latin-1 supplement
+                $repaired++;
+                return html_entity_decode('&#' . $code . ';', ENT_QUOTES, 'UTF-8');
+            }, $part);
+            // 2) Residui mutilati dopo lettera minuscola: e0→à, e8→è, e9→é,
+            //    f2→ò, f9→ù (ec/b0 esclusi: troppi falsi positivi). Ammessi
+            //    anche in mezzo alla parola ("Pre9s"→"Prés": le parole
+            //    naturali non contengono cifre), mai seguiti da cifre o
+            //    separatori di percorso.
+            $part = preg_replace_callback('/(?<=[a-z])(e0|e8|e9|f2|f9)(?![\/\.\-_0-9])/', function ($m) use ($map, &$repaired) {
+                $repaired++;
+                return $map[$m[1]];
+            }, $part);
+            // 2b) "e8" isolato è il verbo essere ("non e8 sempre" → "non è").
+            $part = preg_replace_callback('/(?<=\s|^)(e8|E8)(?=[\s,.;:!?])/', function ($m) use (&$repaired) {
+                $repaired++;
+                return $m[1] === 'E8' ? 'È' : 'è';
+            }, $part);
+            $parts[$i] = $part;
+        }
+        return implode('', $parts);
+    }
+
     public static function validate_payload($payload, $candidate_affiliate_ids = array(), $candidate_image_ids = array(), $candidate_affiliate_images = array(), $candidate_internal_links = array(), $featured_image_candidates = array(), $media_candidates = array(), $max_editorial_media_used = 5) {
         $warnings = array();
-        $title = sanitize_text_field($payload['title'] ?? '');
-        $excerpt = sanitize_textarea_field($payload['excerpt'] ?? '');
-        $content = self::sanitize_content_html((string)($payload['content_html'] ?? ($payload['content'] ?? '')));
+        $repaired_escapes = 0;
+        $title = self::repair_unicode_escape_residues(sanitize_text_field($payload['title'] ?? ''), $repaired_escapes);
+        $excerpt = self::repair_unicode_escape_residues(sanitize_textarea_field($payload['excerpt'] ?? ''), $repaired_escapes);
+        $content = self::repair_unicode_escape_residues(self::sanitize_content_html((string)($payload['content_html'] ?? ($payload['content'] ?? ''))), $repaired_escapes);
+        if ($repaired_escapes > 0) { $warnings[] = sprintf('%d escape unicode riparati nel testo del modello (accenti).', $repaired_escapes); }
         if ($title === '') { $warnings[] = 'Titolo vuoto.'; }
         if (trim(wp_strip_all_tags($content)) === '') { $warnings[] = 'Contenuto vuoto.'; }
         if ($excerpt === '') { $excerpt = wp_trim_words(wp_strip_all_tags($content), 30); $warnings[] = 'Excerpt generato automaticamente.'; }

--- a/includes/class-ai-idea-agent.php
+++ b/includes/class-ai-idea-agent.php
@@ -257,7 +257,7 @@ class ALMA_AI_Idea_Agent {
                     $output = self::execute_tool($name, $arguments, $ideas_created, $max_ideas);
                     $report['tool_calls'][] = array('name' => $name, 'arguments' => wp_json_encode($arguments));
                     $input_items[] = array('type' => 'function_call', 'call_id' => $call['call_id'], 'name' => $call['name'], 'arguments' => $call['arguments']);
-                    $input_items[] = array('type' => 'function_call_output', 'call_id' => $call['call_id'], 'output' => wp_json_encode($output));
+                    $input_items[] = array('type' => 'function_call_output', 'call_id' => $call['call_id'], 'output' => ALMA_OpenAI_Service::encode_context($output));
                 }
                 if ($round === self::MAX_ROUNDS) {
                     $report['error'] = 'Limite di round del loop agente raggiunto senza risposta finale.';

--- a/includes/class-ai-image-generator.php
+++ b/includes/class-ai-image-generator.php
@@ -489,7 +489,7 @@ class ALMA_AI_Image_Generator {
             $figure = '<figure class="wp-block-image size-large alma-ai-editorial-image">' . wp_get_attachment_image($attachment_id, 'large') . '</figure>';
             $new_content = str_replace($placeholder, $figure, (string) $fresh->post_content);
             if ($new_content !== $fresh->post_content) {
-                wp_update_post(array('ID' => $post_id, 'post_content' => $new_content));
+                wp_update_post(wp_slash(array('ID' => $post_id, 'post_content' => $new_content)));
             }
         }
         self::log_entry($post_id, array('status' => 'generated', 'attachment_id' => $attachment_id, 'cost' => $image['cost'], 'response_time' => (int) $image['rt']));

--- a/includes/class-ai-post-enricher.php
+++ b/includes/class-ai-post-enricher.php
@@ -321,7 +321,7 @@ class ALMA_AI_Post_Enricher {
         }
         // Solo aggiunte/sostituzioni di shortcode: il testo esistente resta
         // intatto; wp_update_post crea la revisione per il rollback.
-        $updated = wp_update_post(array('ID' => $post_id, 'post_content' => $content), true);
+        $updated = wp_update_post(wp_slash(array('ID' => $post_id, 'post_content' => $content)), true);
         if (is_wp_error($updated)) {
             $entry['error'] = sanitize_text_field($updated->get_error_message());
         } else {

--- a/includes/class-ai-post-optimizer.php
+++ b/includes/class-ai-post-optimizer.php
@@ -466,7 +466,7 @@ class ALMA_AI_Post_Optimizer {
             $prompt .= 'Puoi inoltre proporre la SOSTITUZIONE di uno shortcode esistente SOLO se il suo link è geograficamente incoerente, non valido, o esiste un candidato nettamente più pertinente: aggiungi alle proposte {"azione":"sostituisci","vecchio_link_id":int (da shortcode_esistenti),"nuovo_link_id":int (da link_candidati),"testo_anchor":string (nuova anchor descrittiva se il pattern è anchor),"motivo":string}. Non sostituire link già coerenti solo per variare. ';
             if ($budget < 1) { $prompt .= 'La densità massima è già raggiunta: NON proporre nuovi inserimenti, valuta solo eventuali sostituzioni. '; }
         }
-        $prompt .= 'Meglio poche proposte eccellenti che tante mediocri. CONTEXT: ' . wp_json_encode($context);
+        $prompt .= 'Meglio poche proposte eccellenti che tante mediocri. CONTEXT: ' . ALMA_OpenAI_Service::encode_context($context);
 
         $res = ALMA_OpenAI_Service::request(array(
             'system_prompt' => 'Sei un editor esperto di monetizzazione affiliate per blog di viaggi. Proponi inserimenti eleganti e pertinenti. Output solo JSON valido.',
@@ -790,7 +790,7 @@ class ALMA_AI_Post_Optimizer {
         }
         $new_content = self::insert_after_paragraph($post->post_content, (int)$proposal['paragraph'], $insertion, !empty($proposal['inline']));
         // wp_update_post crea automaticamente una revisione: rollback nativo.
-        $updated = wp_update_post(array('ID' => $post_id, 'post_content' => $new_content), true);
+        $updated = wp_update_post(wp_slash(array('ID' => $post_id, 'post_content' => $new_content)), true);
         if (is_wp_error($updated)) {
             wp_send_json_error(array('message' => sanitize_text_field($updated->get_error_message())));
         }

--- a/includes/class-openai-service.php
+++ b/includes/class-openai-service.php
@@ -2,6 +2,17 @@
 if (!defined('ABSPATH')) { exit; }
 
 class ALMA_OpenAI_Service {
+    /**
+     * Serializza il contesto per i prompt SENZA escape unicode: con il
+     * default di wp_json_encode ogni accento diventava \u00e8/\u00f9 e il
+     * modello, imitando il contesto, riproduceva gli escape nel contenuto
+     * che poi arrivavano mutilati nel post ("più" -> "pif9"). Con
+     * JSON_UNESCAPED_UNICODE il modello vede e restituisce testo reale.
+     */
+    public static function encode_context($data) {
+        return wp_json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+
     public static function request($args = array()) {
         $api_key = trim((string) get_option('alma_openai_api_key', ''));
         if ($api_key === '') {


### PR DESCRIPTION
## Diagnosi (articolo "10 hotel a Parigi")

Accenti rotti in tutto il testo: "le zone **pif9** centrali", "**perche9**", "**citte0**", "**puf2**", "Saint-Germain-des-**Pre9s**". Il francese non c'entra: ogni lettera accentata è diventata il **residuo del suo escape JSON** — `più` → `ù` → persa la sequenza `\u00` → resta `f9`. Pattern verificato byte-per-byte su tutte le occorrenze (45× f9=ù, 300× e8=è, 217× e0=à, …).

**Causa radice**: il CONTEXT inviato al modello era serializzato con `wp_json_encode`, che di default escapa l'unicode. Il modello vedeva un contesto pieno di `è`/`ù`, riproduceva gli escape nel contenuto, e nel salvataggio la sequenza veniva mutilata.

## Fix (tre livelli)

### 1. Prevenzione (il fix vero)
Nuovo `ALMA_OpenAI_Service::encode_context()` con `JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES`, usato in **tutti** i punti che costruiscono prompt: draft-builder (×3), optimizer/arricchimento, tool output dell'agente di ideazione. Il modello ora vede e restituisce testo con accenti reali.

### 2. Correttezza WordPress
`wp_slash()` su tutti i salvataggi di contenuto AI (`wp_insert_post` ×2 nel draft-builder; `wp_update_post` in arricchimento, metabox AI Affiliati, sostituzione segnaposto immagini): senza, WordPress rimuove i backslash dal contenuto (concausa della mutilazione).

### 3. Riparazione difensiva
`repair_unicode_escape_residues()` nel quality checker, applicata a titolo/excerpt/contenuto di ogni nuova bozza:
- decodifica gli escape sopravvissuti (`è`/`u00e8` → è, solo latin-1 supplement);
- ricostruisce i residui mutilati (`pif9`→più, `perche9`→perché, `citte0`→città, `puf2`→può, `Pre9s`→Prés, `e8`/`E8` isolati→è/È).
- **Guardie conservative**: solo fuori dai tag HTML (mai href/attributi), solo dopo lettera minuscola, mai dentro percorsi o seguiti da cifre; `ec`/`b0` esclusi (falsi positivi tipo "Dec"). Warning con conteggio riparazioni nella diagnostica bozza.

## Nota
L'articolo **già pubblicato** non si ripara da solo: va rigenerato o corretto a mano. Se gli articoli danneggiati sono più d'uno, posso fornire un batch di riparazione retroattiva come follow-up.

## Verifiche
- `php -l` sui 7 file: OK
- Test standalone 25/25 (tutti i casi reali dell'articolo; falsi positivi evitati su href, percorsi, "Dec", parole normali; wiring prevenzione + wp_slash + warning)
- Retrocompatibilità: `encode_context` è additivo; `wp_slash` è il comportamento corretto WP; la riparazione agisce solo sui pattern descritti

## Versione
`2.103.0` → `2.104.0` (minor) + CHANGELOG/README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_