### PR TITLE
Immagini mai ripetute (dedup post + cooldown riuso 90gg) + Telegram accorpato alle pubblicazioni (v2.105.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.105.0 - 2026-07-08
+
+### Immagini mai ripetute (nel post e tra articoli) + Telegram accorpato alle pubblicazioni
+- **Segnalazione**: l'agent riusa troppo spesso le stesse immagini tra articoli (featured inclusa) e le duplica anche nello stesso post; su Telegram arrivano ancora notifiche per le bozze/idee oltre a quelle di pubblicazione.
+- **Stessa foto mai due volte nello stesso articolo** (`remove_duplicate_images`, quality checker): le occorrenze successive alla prima vengono rimosse, riconoscendo anche le varianti ridimensionate (`-1024x683`).
+- **Featured mai duplicata nel corpo** (`remove_featured_from_content`): l'immagine scelta come in evidenza viene rimossa dal corpo articolo (il tema la mostra già in testa).
+- **Cooldown di riuso tra articoli**: ogni attachment usato in una bozza AI (featured o editoriale) viene marcato (`_alma_media_last_used_at` + contatore) e il media selector lo **esclude dalle candidate per 90 giorni** (filtro `alma_media_reuse_cooldown_days`). Con le candidate esaurite scatta il flusso esistente di **generazione AI**: featured generata sul titolo/località e immagini editoriali dai segnaposto — quindi immagini nuove invece delle solite, e riuso solo a distanza di tempo.
+- **Telegram accorpato** (richiesta): (1) niente più card-bozza per i post pubblicati subito (auto-publish) — resta SOLO la notifica di pubblicazione con link articolo + ✏️ Modifica; (2) il report di fine esecuzione dell'agente parte **solo se aggiunge informazioni** (errori, bozze in attesa di revisione): se tutti gli articoli sono stati pubblicati e notificati, nessun messaggio ripetuto. Le card con Pubblica/Cestina restano per le bozze NON pubblicate.
+- Test standalone 21/21 (dedup con varianti ridimensionate, featured dal corpo con fallback URL, guardie, wiring cooldown/tracking/telegram).
+- Versione plugin aggiornata a `2.105.0`.
+
 ## 2.104.0 - 2026-07-08
 
 ### Fix accenti corrotti negli articoli generati (pif9 → più): prevenzione + riparazione

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.105.0 - 2026-07-08
+
+### Immagini sempre nuove + Telegram senza doppioni
+- La stessa foto non compare più due volte nello stesso articolo né come featured duplicata nel corpo; le immagini usate di recente (90 giorni) sono escluse dalle candidate e al loro posto vengono generate immagini AI nuove. Su Telegram: solo la notifica di pubblicazione (link + Modifica); il report agente parte solo se ha errori o bozze in attesa da segnalare.
+- Versione plugin aggiornata a `2.105.0`.
+
 ## 2.104.0 - 2026-07-08
 
 ### Fix accenti corrotti negli articoli AI

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.104.0
+ * Version: 2.105.0
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.104.0');
+define('ALMA_VERSION', '2.105.0');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -738,6 +738,22 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         return ($total > 0 && $accommodation * 2 >= $total) ? 'destination_cards' : 'experience_cards';
     }
 
+    /**
+     * Marca gli attachment usati (featured + editoriali) con data e contatore:
+     * il media selector li esclude dalle candidate per il periodo di cooldown,
+     * così le stesse immagini non si ripetono tra gli articoli.
+     */
+    private static function mark_media_used($featured_id, $media_used) {
+        $ids = array(absint($featured_id));
+        foreach ((array) $media_used as $item) {
+            $ids[] = absint(is_array($item) ? ($item['attachment_id'] ?? 0) : $item);
+        }
+        foreach (array_values(array_unique(array_filter($ids))) as $att_id) {
+            update_post_meta($att_id, '_alma_media_last_used_at', current_time('mysql'));
+            update_post_meta($att_id, '_alma_media_use_count', absint(get_post_meta($att_id, '_alma_media_use_count', true)) + 1);
+        }
+    }
+
     private static function candidate_affiliate_images($affiliate_links) {
         $images = array();
         foreach ((array)$affiliate_links as $link) {
@@ -1338,7 +1354,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         if (!empty($clean['featured_image_id'])) set_post_thumbnail($post_id, $clean['featured_image_id']);
         if (class_exists('ALMA_AI_Seo_Bridge')) { ALMA_AI_Seo_Bridge::apply($post_id, (string)($clean['seo_title'] ?? ''), (string)($clean['seo_description'] ?? '')); }
         update_post_meta($post_id, '_alma_ai_agent_generated', 1); update_post_meta($post_id, '_alma_ai_agent_idea_id', $idea_id); update_post_meta($post_id, '_alma_ai_agent_brief_id', absint($brief['id'] ?? 0)); update_post_meta($post_id, '_alma_ai_agent_task', 'content_draft_generation'); update_post_meta($post_id, '_alma_ai_agent_model', sanitize_text_field($res['model'] ?? '')); update_post_meta($post_id, '_alma_ai_agent_instruction_profile_id', absint($brief['instruction_profile_id'] ?? $idea['instruction_profile_id'] ?? 0)); update_post_meta($post_id, '_alma_ai_agent_instruction_snapshot_hash', sanitize_text_field($brief['instruction_snapshot_hash'] ?? $idea['instruction_snapshot_hash'] ?? '')); update_post_meta($post_id, '_alma_ai_agent_affiliate_links_used', wp_json_encode($clean['affiliate_links_used'])); update_post_meta($post_id, '_alma_ai_agent_affiliate_shortcodes_used', wp_json_encode((array)($clean['affiliate_shortcodes_used'] ?? array()))); update_post_meta($post_id, '_alma_ai_agent_affiliate_urls_used', wp_json_encode((array)($clean['affiliate_urls_used'] ?? array())));
-        update_post_meta($post_id, '_alma_ai_agent_internal_urls_used', wp_json_encode((array)($clean['internal_urls_used'] ?? array()))); update_post_meta($post_id, '_alma_ai_agent_media_used', wp_json_encode((array)($clean['media_used'] ?? array()))); update_post_meta($post_id, '_alma_ai_agent_image_ids_used', wp_json_encode($clean['inline_image_ids'])); update_post_meta($post_id, '_alma_ai_agent_featured_image_id', absint($clean['featured_image_id'])); update_post_meta($post_id, '_alma_ai_agent_qa_warnings', wp_json_encode(array_merge((array)$clean['warnings'], (array)($parsed['warnings'] ?? array())))); update_post_meta($post_id, '_alma_ai_seo_title', sanitize_text_field($parsed['seo_title'] ?? '')); update_post_meta($post_id, '_alma_ai_meta_description', sanitize_text_field($parsed['meta_description'] ?? '')); update_post_meta($post_id, '_alma_ai_focus_keyword', sanitize_text_field($parsed['focus_keyword'] ?? '')); update_post_meta($post_id, '_alma_ai_generated_at', current_time('mysql')); update_post_meta($post_id, '_alma_ai_suggested_tags', wp_json_encode((array)($parsed['suggested_tags'] ?? array())));
+        update_post_meta($post_id, '_alma_ai_agent_internal_urls_used', wp_json_encode((array)($clean['internal_urls_used'] ?? array()))); update_post_meta($post_id, '_alma_ai_agent_media_used', wp_json_encode((array)($clean['media_used'] ?? array()))); update_post_meta($post_id, '_alma_ai_agent_image_ids_used', wp_json_encode($clean['inline_image_ids'])); update_post_meta($post_id, '_alma_ai_agent_featured_image_id', absint($clean['featured_image_id'])); self::mark_media_used(absint($clean['featured_image_id']), (array) ($clean['media_used'] ?? array())); update_post_meta($post_id, '_alma_ai_agent_qa_warnings', wp_json_encode(array_merge((array)$clean['warnings'], (array)($parsed['warnings'] ?? array())))); update_post_meta($post_id, '_alma_ai_seo_title', sanitize_text_field($parsed['seo_title'] ?? '')); update_post_meta($post_id, '_alma_ai_meta_description', sanitize_text_field($parsed['meta_description'] ?? '')); update_post_meta($post_id, '_alma_ai_focus_keyword', sanitize_text_field($parsed['focus_keyword'] ?? '')); update_post_meta($post_id, '_alma_ai_generated_at', current_time('mysql')); update_post_meta($post_id, '_alma_ai_suggested_tags', wp_json_encode((array)($parsed['suggested_tags'] ?? array())));
         ALMA_AI_Usage_Logger::log(array('task'=>'content_draft_generation','success'=>true,'model'=>$res['model'] ?? '','response_time'=>$res['response_time'] ?? null,'input_tokens'=>$res['usage']['input_tokens'] ?? null,'output_tokens'=>$res['usage']['output_tokens'] ?? null,'estimated_cost'=>$res['estimated_cost'] ?? null,'reference_id'=>'post:'.$post_id));
         return array('success'=>true,'post_id'=>$post_id,'edit_url'=>get_edit_post_link($post_id, 'raw'),'warnings'=>array_values(array_merge((array)$clean['warnings'], (array)($parsed['warnings'] ?? array()))));
     }
@@ -1563,6 +1579,7 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             $clean['warnings'][] = 'Immagine in evidenza non indicata dall\'AI e generazione immagini AI disattivata: bozza senza immagine in evidenza.';
         }
         update_post_meta($post_id, '_alma_ai_agent_selected_featured_image_id', $selected_featured_id);
+        self::mark_media_used($selected_featured_id, (array) ($clean['media_used'] ?? array()));
         if ($selected_featured_id > 0) {
             $selected_featured_url = function_exists('wp_get_attachment_image_url') ? wp_get_attachment_image_url($selected_featured_id, 'full') : '';
             if (!$selected_featured_url && function_exists('wp_get_attachment_url')) { $selected_featured_url = wp_get_attachment_url($selected_featured_id); }

--- a/includes/class-ai-content-agent-draft-quality-checker.php
+++ b/includes/class-ai-content-agent-draft-quality-checker.php
@@ -700,6 +700,59 @@ class ALMA_AI_Content_Agent_Draft_Quality_Checker {
         return implode('', $parts);
     }
 
+    /** Nome file senza dimensione/estensione: identifica l'immagine anche nelle varianti ridimensionate. */
+    private static function image_src_token($src) {
+        $path = function_exists('wp_parse_url') ? wp_parse_url((string)$src, PHP_URL_PATH) : parse_url((string)$src, PHP_URL_PATH);
+        $file = basename((string)($path ?: $src));
+        $file = preg_replace('/\.(webp|jpe?g|png|gif|avif)$/i', '', $file);
+        return strtolower((string) preg_replace('/-\d+x\d+$/', '', (string)$file));
+    }
+
+    /**
+     * La stessa immagine non deve comparire due volte nello stesso articolo:
+     * le occorrenze successive alla prima (stessa src, anche in variante
+     * ridimensionata) vengono rimosse.
+     */
+    public static function remove_duplicate_images($content, &$warnings) {
+        $seen = array();
+        $removed = 0;
+        $content = preg_replace_callback('/<img\b[^>]*>/i', function ($m) use (&$seen, &$removed) {
+            if (!preg_match('/\ssrc=["\']([^"\']+)["\']/i', $m[0], $src)) { return $m[0]; }
+            $token = self::image_src_token($src[1]);
+            if ($token === '') { return $m[0]; }
+            if (isset($seen[$token])) { $removed++; return ''; }
+            $seen[$token] = true;
+            return $m[0];
+        }, (string)$content);
+        if ($removed > 0) { $warnings[] = sprintf('%d immagini duplicate rimosse (stessa foto ripetuta nell\'articolo).', $removed); }
+        return $content;
+    }
+
+    /**
+     * L'immagine scelta come featured non deve comparire anche nel corpo
+     * (WordPress/il tema la mostra già in testa all'articolo).
+     */
+    public static function remove_featured_from_content($content, $featured_image_id, $featured_candidates, &$warnings) {
+        $featured_image_id = absint($featured_image_id);
+        if ($featured_image_id < 1) { return $content; }
+        $featured_url = '';
+        foreach ((array)$featured_candidates as $candidate) {
+            if (absint($candidate['attachment_id'] ?? 0) === $featured_image_id) { $featured_url = (string)($candidate['url'] ?? ''); break; }
+        }
+        if ($featured_url === '' && function_exists('wp_get_attachment_url')) { $featured_url = (string) wp_get_attachment_url($featured_image_id); }
+        $token = self::image_src_token($featured_url);
+        if ($token === '') { return $content; }
+        $removed = 0;
+        $content = preg_replace_callback('/<img\b[^>]*>/i', function ($m) use ($token, &$removed) {
+            if (!preg_match('/\ssrc=["\']([^"\']+)["\']/i', $m[0], $src)) { return $m[0]; }
+            if (self::image_src_token($src[1]) !== $token) { return $m[0]; }
+            $removed++;
+            return '';
+        }, (string)$content);
+        if ($removed > 0) { $warnings[] = 'Immagine in evidenza rimossa dal corpo articolo (il tema la mostra già in testa).'; }
+        return $content;
+    }
+
     public static function validate_payload($payload, $candidate_affiliate_ids = array(), $candidate_image_ids = array(), $candidate_affiliate_images = array(), $candidate_internal_links = array(), $featured_image_candidates = array(), $media_candidates = array(), $max_editorial_media_used = 5) {
         $warnings = array();
         $repaired_escapes = 0;
@@ -766,6 +819,10 @@ class ALMA_AI_Content_Agent_Draft_Quality_Checker {
 
         $content = self::sanitize_content_html($content);
         list($content, $retained_editorial_media) = self::enforce_editorial_media_limit_in_content($content, $editorial_index, $index, $max_editorial_media_used, $warnings);
+        // Mai la stessa foto due volte nell'articolo, e mai la featured
+        // duplicata nel corpo (il tema la mostra già in testa).
+        $content = self::remove_duplicate_images($content, $warnings);
+        $content = self::remove_featured_from_content($content, absint($payload['featured_image_id'] ?? 0), $featured_image_candidates, $warnings);
         $content = self::sanitize_content_html($content);
         $final_editorial_media = self::collect_editorial_media_from_content($content, $editorial_index, $index);
         if (count($final_editorial_media) < count($retained_editorial_media)) {

--- a/includes/class-ai-content-agent-media-selector.php
+++ b/includes/class-ai-content-agent-media-selector.php
@@ -24,11 +24,27 @@ class ALMA_AI_Content_Agent_Media_Selector {
         }
 
         $rows = self::fetch_rows($table, $query_terms, max(40, ($featured_limit + $media_limit) * 5));
+        // Cooldown di riuso: un'immagine già usata di recente in un articolo
+        // AI (featured o editoriale) non viene ricandidata prima di N giorni
+        // (default 90, filtro alma_media_reuse_cooldown_days). Con candidate
+        // esaurite, featured e immagini editoriali vengono GENERATE dall'AI:
+        // così le stesse foto non si ripetono tra gli articoli.
+        $cooldown_days = max(0, absint(apply_filters('alma_media_reuse_cooldown_days', 90, $args)));
+        $cooldown_cutoff = $cooldown_days > 0 ? (current_time('timestamp') - $cooldown_days * DAY_IN_SECONDS) : 0;
+        $recently_used = 0;
         $scored = array();
         foreach ($rows as $row) {
             $candidate = self::score_row($row, $query_terms);
             if (empty($candidate) || (int)$candidate['score'] < (int)apply_filters('alma_ai_media_candidate_min_score', self::DEFAULT_MIN_SCORE, $args)) { continue; }
+            if ($cooldown_cutoff > 0) {
+                $last_used = strtotime((string) get_post_meta(absint($candidate['attachment_id'] ?? 0), '_alma_media_last_used_at', true));
+                if ($last_used && $last_used > $cooldown_cutoff) { $recently_used++; continue; }
+            }
             $scored[] = $candidate;
+        }
+        if ($recently_used > 0) {
+            $warnings[] = sprintf('%d immagini escluse dalle candidate perché usate di recente (cooldown %d giorni): le nuove immagini verranno generate dall\'AI.', $recently_used, $cooldown_days);
+            $debug['recently_used_excluded'] = $recently_used;
         }
 
         usort($scored, function($a, $b) {

--- a/includes/class-telegram-bot.php
+++ b/includes/class-telegram-bot.php
@@ -556,6 +556,10 @@ class ALMA_Telegram_Bot {
 
     public static function notify_draft_created($post_id, $post_status = 'draft') {
         if (!self::is_enabled() || get_option(self::OPTION_NOTIFY_DRAFTS, '1') !== '1') { return; }
+        // Post pubblicato subito (auto-publish): nessuna card bozza — la
+        // notifica di pubblicazione (link articolo + Modifica) è l'unico
+        // messaggio, mai doppioni.
+        if ($post_status === 'publish' || get_post_status($post_id) === 'publish') { return; }
         foreach (self::get_chat_ids() as $chat_id) {
             self::send_draft_card($chat_id, $post_id);
         }
@@ -563,7 +567,19 @@ class ALMA_Telegram_Bot {
 
     public static function notify_agent_report($report) {
         if (!self::is_enabled()) { return; }
-        self::broadcast(self::format_agent_report((array) $report));
+        $report = (array) $report;
+        // Accorpamento con le notifiche di pubblicazione: ogni articolo
+        // pubblicato è GIÀ arrivato in chat (link + Modifica). Il report di
+        // fine esecuzione parte solo se aggiunge informazioni: errori,
+        // bozze in attesa di revisione o esecuzione fallita.
+        $has_extra = !empty($report['error']);
+        foreach ((array) ($report['drafts_created'] ?? array()) as $draft_row) {
+            $post_id = (int) ($draft_row['post_id'] ?? 0);
+            if ($post_id > 0 && get_post_status($post_id) !== 'publish') { $has_extra = true; break; }
+            if ($post_id < 1 && !empty($draft_row['error'])) { $has_extra = true; break; }
+        }
+        if (!$has_extra) { return; }
+        self::broadcast(self::format_agent_report($report));
     }
 
     /**


### PR DESCRIPTION
## Contesto

Due segnalazioni: (1) l'agent riusa troppo spesso le stesse immagini tra articoli — featured inclusa — e le duplica anche nello stesso post; (2) su Telegram arrivano ancora notifiche per le bozze/idee create, mentre devono arrivare solo link al post pubblicato + Modifica, con il report agente accorpato senza ripetizioni.

## Immagini (`quality-checker`, `media-selector`, `draft-builder`)

- **Stessa foto mai due volte nello stesso articolo** — `remove_duplicate_images`: le occorrenze successive alla prima vengono rimosse, riconoscendo anche le **varianti ridimensionate** (`foto-1024x683.webp` ≡ `foto.webp`).
- **Featured mai duplicata nel corpo** — `remove_featured_from_content`: l'immagine scelta come in evidenza viene tolta dal corpo (il tema la mostra già in testa). URL risolto dai candidati o via `wp_get_attachment_url`.
- **Cooldown di riuso tra articoli**: ogni attachment usato in una bozza AI (featured o editoriale) viene marcato (`_alma_media_last_used_at` + `_alma_media_use_count`, in entrambi i flussi di generazione) e il media selector lo **esclude dalle candidate per 90 giorni** (filtro `alma_media_reuse_cooldown_days`, warning con conteggio esclusi). Con candidate esaurite scatta il flusso esistente di **generazione AI** (featured sul titolo/località, editoriali dai segnaposto) → immagini nuove invece delle solite; riuso solo a distanza di tempo.

## Telegram (`telegram-bot`)

- **Niente card-bozza per i post pubblicati subito** (auto-publish): resta SOLO la notifica di pubblicazione (titolo + 🔗 Apri articolo + ✏️ Modifica). Le card con Pubblica/Cestina restano per le bozze NON pubblicate (servono alla revisione).
- **Report agente accorpato**: parte **solo se aggiunge informazioni** — errori di esecuzione, bozze fallite o bozze in attesa di revisione. Se tutti gli articoli del run sono stati pubblicati (e quindi già notificati uno a uno), nessun messaggio duplicato.

## Verifiche
- `php -l` sui 4 file: OK
- Test standalone 21/21 (dedup con varianti ridimensionate, featured dal corpo con fallback URL e guardie, wiring cooldown/tracking nei due flussi, condizioni del report)
- Retrocompatibilità: cooldown disattivabile via filtro (0 = off); nessuna option/API rimossa; card bozze in revisione invariate

## Versione
`2.104.0` → `2.105.0` (minor) + CHANGELOG/README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM)_