### PR TITLE
Regia sbloccata: lock stantio, eventi cron identici, piani mai persi …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.106.1 - 2026-07-11
+
+### Verifica flusso regia → idee → post: sbloccati i piani editoriali
+- **Verifica richiesta**: regia, creazione idee e post con pubblicazione, con sospetto su apici/virgolette nel testo del comando. **Esito su apici e virgolette: gestiti correttamente in TUTTI i passaggi** (regia: `wp_unslash` + sanitize; Telegram: JSON REST senza slash; prompt per concatenazione semplice con `wp_json_encode` a livello HTTP; argomenti tool decodificati da JSON; titolo/prompt idea sanificati; bozze salvate con `wp_slash` dalla v2.104; `data-obiettivo` con `esc_attr`). Non erano loro la causa del blocco.
+- **Causa reale n.1 — lock stantio**: se un run veniva ucciso dall'hosting (timeout/kill, il `finally` non gira), l'opzione di lock restava per sempre: ogni piano successivo (regia o Telegram) veniva "accodato" senza che nulla lo facesse mai partire, la regia mostrava "in esecuzione" all'infinito e la coda si riempiva. Nuovo `is_running()` (lock presente E non scaduto oltre `LOCK_TTL` 600s, con pulizia del lock scaduto) usato da avvio piani, pagina Regia, card Idee, `/stato`, `/stop` e stop admin.
+- **Causa reale n.2 — piani identici persi in silenzio**: WP-Cron rifiuta un evento identico (stesso hook + stessi argomenti) entro 10 minuti: ripetere lo stesso comando (tipico proprio quando "non parte nulla") perdeva il piano mostrando comunque il messaggio di successo. Ora ogni schedulazione aggiunge un token univoco come 9° argomento (il callback ne accetta 8: ignorato) e il rifiuto dell'evento produce un errore esplicito invece di un falso successo.
+- **Piani mai persi**: se la schedulazione del prossimo piano in coda fallisce, il piano torna in testa alla coda; se due eventi partono in corsa e il lock è conteso, il piano perdente si ri-accoda invece di sparire.
+- **`/stop` Telegram allineato alla Regia**: svuota anche i piani in coda e risponde correttamente quando non c'è nessuna esecuzione (prima, con lock stantio, chiedeva un arresto che non sarebbe mai avvenuto).
+- Test standalone 28/28 (lock stantio, token univoco, rifiuto cron esplicito, coda senza perdite, smoke su apici/virgolette lungo tutto il flusso).
+- Versione plugin aggiornata a `2.106.1`.
+
 ## 2.106.0 - 2026-07-10
 
 ### Pagina «Configura provider» separata + UI/UX Affiliate Sources

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.106.1 - 2026-07-11
+
+### Regia sbloccata: piani editoriali che non partivano
+- Verificato tutto il flusso regia → idee → bozze → pubblicazione: apici e virgolette nel comando sono gestiti correttamente ovunque e non bloccavano nulla. Le cause reali erano un lock rimasto appeso dopo un run ucciso dall'hosting (ogni piano successivo veniva accodato per sempre) e il rifiuto silenzioso di WP-Cron per comandi identici ripetuti entro 10 minuti. Ora il lock scaduto si sblocca da solo, ogni piano ha un token univoco, i fallimenti di schedulazione sono espliciti e i piani in coda non vanno mai persi; `/stop` su Telegram svuota anche la coda.
+- Versione plugin aggiornata a `2.106.1`.
+
 ## 2.106.0 - 2026-07-10
 
 ### Pagina «Configura provider» + Affiliate Sources più chiari

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.106.0
+ * Version: 2.106.1
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.106.0');
+define('ALMA_VERSION', '2.106.1');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-agent-control-room.php
+++ b/includes/class-ai-agent-control-room.php
@@ -250,8 +250,8 @@ class ALMA_AI_Agent_Control_Room {
 
     public static function render_page() {
         if (!current_user_can('manage_options')) { wp_die('forbidden'); }
-        $running = (bool) get_option(ALMA_AI_Idea_Agent::LOCK_OPTION);
-        $stopping = (bool) get_option(ALMA_AI_Idea_Agent::OPTION_CANCEL);
+        $running = ALMA_AI_Idea_Agent::is_running();
+        $stopping = $running && (bool) get_option(ALMA_AI_Idea_Agent::OPTION_CANCEL);
         $runs_today = ALMA_AI_Idea_Agent::runs_today();
         $draft_counter = get_option('alma_ai_ideas_draft_counter', array());
         $drafts_today = (is_array($draft_counter) && ($draft_counter['date'] ?? '') === current_time('Y-m-d')) ? (int) $draft_counter['count'] : 0;

--- a/includes/class-ai-idea-agent.php
+++ b/includes/class-ai-idea-agent.php
@@ -110,11 +110,44 @@ class ALMA_AI_Idea_Agent {
     }
 
     /**
+     * Lock di esecuzione "vivo": presente E non scaduto (LOCK_TTL). Un run
+     * ucciso dall'hosting (timeout/kill: il finally non gira) lasciava il
+     * lock per sempre: ogni piano successivo veniva accodato senza che
+     * nulla lo facesse mai partire e la regia risultava bloccata. Un lock
+     * scaduto viene rimosso e trattato come libero.
+     */
+    public static function is_running() {
+        $started = absint(get_option(self::LOCK_OPTION, 0));
+        if ($started < 1) { return false; }
+        if ((time() - $started) > self::LOCK_TTL) {
+            delete_option(self::LOCK_OPTION);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Programma l'esecuzione del piano come evento cron singolo. Un token
+     * univoco viene aggiunto come 9° argomento (il callback ne accetta 8 e
+     * lo ignora) perché WP-Cron rifiuta in silenzio un evento identico
+     * (stesso hook + stessi argomenti) entro 10 minuti: ripetere lo stesso
+     * comando faceva perdere il piano con messaggio di successo.
+     */
+    private static function schedule_run($args, $delay) {
+        $args = array_values((array) $args);
+        $args[] = uniqid('plan_', true);
+        $scheduled = wp_schedule_single_event(time() + max(1, (int) $delay), self::CRON_HOOK, $args);
+        if (false === $scheduled || is_wp_error($scheduled)) { return false; }
+        if (function_exists('spawn_cron')) { spawn_cron(); }
+        return true;
+    }
+
+    /**
      * Avvia un piano subito se libero, altrimenti lo ACCODA (i piani si
      * sommano). Ritorna array('type','message','queued'=>bool,'position'=>int).
      */
     public static function enqueue_or_start_plan($args) {
-        if (get_option(self::LOCK_OPTION)) {
+        if (self::is_running()) {
             $queue = array_values((array) get_option(self::OPTION_QUEUE, array()));
             if (count($queue) >= self::QUEUE_MAX) {
                 return array('type' => 'error', 'message' => sprintf(__('Coda piani piena (max %d in attesa): attendi che ne partano alcuni.', 'affiliate-link-manager-ai'), self::QUEUE_MAX), 'queued' => false, 'position' => 0);
@@ -124,8 +157,9 @@ class ALMA_AI_Idea_Agent {
             return array('type' => 'success', 'message' => sprintf(__('Un piano è già in corso: questo è stato accodato (posizione %d). Partirà automaticamente al termine di quello attuale.', 'affiliate-link-manager-ai'), count($queue)), 'queued' => true, 'position' => count($queue));
         }
         delete_option(self::OPTION_CANCEL);
-        wp_schedule_single_event(time() + 5, self::CRON_HOOK, array_values((array) $args));
-        if (function_exists('spawn_cron')) { spawn_cron(); }
+        if (!self::schedule_run($args, 5)) {
+            return array('type' => 'error', 'message' => __('Impossibile programmare l\'esecuzione (evento cron rifiutato): riprova tra qualche istante.', 'affiliate-link-manager-ai'), 'queued' => false, 'position' => 0);
+        }
         return array('type' => 'success', 'message' => __('Agente ideazione avviato in background: il report comparirà nella Regia AI entro qualche minuto.', 'affiliate-link-manager-ai'), 'queued' => false, 'position' => 0);
     }
 
@@ -146,8 +180,12 @@ class ALMA_AI_Idea_Agent {
         update_option(self::OPTION_QUEUE, $queue, false);
         if (!is_array($next) || empty($next)) { return; }
         delete_option(self::OPTION_CANCEL);
-        wp_schedule_single_event(time() + 10, self::CRON_HOOK, array_values($next));
-        if (function_exists('spawn_cron')) { spawn_cron(); }
+        if (!self::schedule_run($next, 10)) {
+            // Evento rifiutato: il piano torna in testa alla coda invece di
+            // andare perso (riproverà al termine del prossimo run).
+            array_unshift($queue, $next);
+            update_option(self::OPTION_QUEUE, $queue, false);
+        }
     }
 
     /**
@@ -162,7 +200,7 @@ class ALMA_AI_Idea_Agent {
         $queued = self::queued_count();
         delete_option(self::OPTION_QUEUE);
         $queue_note = $queued > 0 ? sprintf(__(' Svuotati anche %d piani in coda.', 'affiliate-link-manager-ai'), $queued) : '';
-        if (get_option(self::LOCK_OPTION)) {
+        if (self::is_running()) {
             update_option(self::OPTION_CANCEL, (string) time(), false);
             $notice = array('type' => 'success', 'message' => __('Richiesta di stop inviata: l\'agente si fermerà entro pochi secondi (al termine del passo in corso).', 'affiliate-link-manager-ai') . $queue_note);
         } else {
@@ -197,7 +235,17 @@ class ALMA_AI_Idea_Agent {
     }
 
     public static function run($user_id = 0, $objective = '', $create_drafts = 0, $force = 0, $num_ideas = 0, $days_span = 0, $start_date = '', $immediate = 0) {
-        if (!self::acquire_lock()) { return; }
+        if (!self::acquire_lock()) {
+            // Un altro piano è partito nel frattempo (corsa tra eventi cron):
+            // questo torna in coda invece di andare perso — verrà avviato
+            // dal finally del run in corso.
+            $queue = array_values((array) get_option(self::OPTION_QUEUE, array()));
+            if (count($queue) < self::QUEUE_MAX) {
+                $queue[] = array(absint($user_id), (string) $objective, (int) $create_drafts, (int) $force, (int) $num_ideas, (int) $days_span, (string) $start_date, (int) $immediate);
+                update_option(self::OPTION_QUEUE, $queue, false);
+            }
+            return;
+        }
         $started_at = current_time('mysql');
         $report = array(
             'started_at' => $started_at, 'finished_at' => '', 'rounds' => 0,
@@ -654,7 +702,7 @@ class ALMA_AI_Idea_Agent {
      */
     public static function render_panel() {
         if (!current_user_can('manage_options')) { return; }
-        $running = (bool) get_option(self::LOCK_OPTION);
+        $running = self::is_running();
         $last = self::get_last_run();
         echo '<div class="alma-ideas-card" style="border:1px solid #c3c4c7;border-radius:6px;background:#fff;padding:12px 16px;margin:12px 0;display:flex;gap:14px;align-items:center;flex-wrap:wrap;">';
         echo '<span style="font-size:1.05em;"><strong>🤖 Agente ideazione AI</strong></span>';

--- a/includes/class-telegram-bot.php
+++ b/includes/class-telegram-bot.php
@@ -317,8 +317,8 @@ class ALMA_Telegram_Bot {
      * /stato — fotografia operativa: agente, bozze programmate, immagini, link.
      */
     private static function command_status($chat_id) {
-        $running = class_exists('ALMA_AI_Idea_Agent') && get_option(ALMA_AI_Idea_Agent::LOCK_OPTION);
-        $stopping = class_exists('ALMA_AI_Idea_Agent') && get_option(ALMA_AI_Idea_Agent::OPTION_CANCEL);
+        $running = class_exists('ALMA_AI_Idea_Agent') && ALMA_AI_Idea_Agent::is_running();
+        $stopping = $running && get_option(ALMA_AI_Idea_Agent::OPTION_CANCEL);
         $text = "<b>📡 Stato operativo</b>\n";
         $text .= '🤖 Agente: ' . ($running ? ($stopping ? '<b>in arresto…</b>' : '<b>in esecuzione</b> (usa /stop per fermarlo)') : 'fermo') . "\n";
         if (class_exists('ALMA_AI_Content_Agent_Idea_Importer') && method_exists('ALMA_AI_Content_Agent_Idea_Importer', 'due_ideas_count')) {
@@ -349,12 +349,16 @@ class ALMA_Telegram_Bot {
             self::send_message($chat_id, 'Agente non disponibile.');
             return;
         }
-        if (!get_option(ALMA_AI_Idea_Agent::LOCK_OPTION)) {
-            self::send_message($chat_id, 'ℹ️ Nessuna esecuzione dell\'agente in corso.');
+        // Come il pulsante in Regia AI: lo stop ferma anche i piani accodati.
+        $queued = ALMA_AI_Idea_Agent::queued_count();
+        delete_option(ALMA_AI_Idea_Agent::OPTION_QUEUE);
+        $queue_note = $queued > 0 ? sprintf(' Svuotati anche %d piani in coda.', $queued) : '';
+        if (!ALMA_AI_Idea_Agent::is_running()) {
+            self::send_message($chat_id, 'ℹ️ Nessuna esecuzione dell\'agente in corso.' . $queue_note);
             return;
         }
         update_option(ALMA_AI_Idea_Agent::OPTION_CANCEL, (string) time(), false);
-        self::send_message($chat_id, '🛑 Arresto richiesto: l\'agente si fermerà al prossimo punto sicuro (le idee già create restano).');
+        self::send_message($chat_id, '🛑 Arresto richiesto: l\'agente si fermerà al prossimo punto sicuro (le idee già create restano).' . $queue_note);
     }
 
     /**


### PR DESCRIPTION
…(v2.106.1)

Verifica completa del flusso regia → idee → bozze → pubblicazione: apici e virgolette nel comando risultano gestiti correttamente in ogni passaggio e non erano la causa del blocco. Le cause reali:

- Lock stantio: un run ucciso dall'hosting (timeout/kill, il finally non gira) lasciava il lock per sempre; ogni piano successivo veniva accodato senza mai partire. Nuovo is_running() (lock vivo entro LOCK_TTL, pulizia del lock scaduto) usato da avvio piani, Regia, card Idee, /stato, /stop e stop admin.
- WP-Cron rifiuta in silenzio un evento identico entro 10 minuti: ripetere lo stesso comando perdeva il piano con messaggio di successo. Ogni schedulazione ora aggiunge un token univoco come 9° argomento (il callback ne accetta 8) e il rifiuto produce un errore esplicito.
- Piani mai persi: ri-accodamento se la schedulazione del prossimo piano fallisce o se il lock è conteso tra eventi in corsa.
- /stop Telegram allineato alla Regia: svuota anche la coda.

Test standalone 28/28, php -l ok.


Claude-Session: https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM