### PR TITLE
Idee senza link affiliati creano comunque l'articolo + pulsanti bozza…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.106.2 - 2026-07-11
+
+### Fix: le idee senza link affiliati pertinenti ora creano comunque l'articolo
+- **Segnalazione** (idea "Viaggio in Mongolia"): bozza mai creata con errore "Seleziona almeno una fonte prima di creare la bozza", e pulsanti manuali rotti ("Idea non trovata." dall'elenco, "Nessuna sessione contenuto attiva." dal workspace). Per quel tema non esistono link affiliati coerenti — correttamente — ma il flusso lo trattava come errore.
+- **Causa n.1 — candidato universale scartato in silenzio**: il candidato di tipologia universale (assicurazioni/eSIM) costruito dal runner non aveva `result_key`/`source_group`, e la sessione di selezione scarta le righe senza chiave: quando era l'UNICO candidato la selezione arrivava vuota e la bozza falliva. Ora il candidato ha le chiavi corrette e, in difesa, la sessione deriva una chiave di fallback (`gruppo:id`) invece di scartare righe identificabili.
+- **Causa n.2 — zero link = blocco**: il runner falliva con "Nessun link affiliato candidato" e il draft builder esigeva almeno una fonte. Ora le idee senza link affiliati pertinenti producono comunque un **articolo informativo**: nessuna monetizzazione inventata (nota esplicita al writer: niente shortcode/link fittizi, che comunque verrebbero rimossi dal QA), link interni benvenuti, e la garanzia del link universale resta attiva quando disponibile.
+- **Pulsante «Genera bozza» dell'elenco riparato**: instradava le idee (post CPT) al flusso storico che legge la vecchia tabella idee → "Idea non trovata." per TUTTE le idee dell'agente. Ora le idee CPT passano dal flusso unificato del runner (fallback legacy conservato); il pulsante è visibile anche con 0 fonti selezionate.
+- **Pulsante «Crea bozza» del workspace**: con sessione senza fonti ma un'idea attiva, la bozza si genera direttamente dall'idea (stesso flusso unificato) invece di rispondere "Nessuna sessione contenuto attiva".
+- **Difesa anti-duplicato**: se l'idea ha già la sua bozza/articolo, i pulsanti e il runner restituiscono quella esistente invece di crearne una seconda (e lo stato dell'idea si riallinea).
+- Test standalone 21/21 (chiave di fallback in sessione, candidato universale, flusso senza fonti, routing pulsanti, anti-duplicato) + 28/28 regia ancora verdi.
+- Versione plugin aggiornata a `2.106.2`.
+
 ## 2.106.1 - 2026-07-11
 
 ### Verifica flusso regia → idee → post: sbloccati i piani editoriali

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## 2.106.2 - 2026-07-11
+
+### Idee senza link affiliati: l'articolo si crea comunque
+- Le idee su destinazioni senza link affiliati coerenti (es. Mongolia) non falliscono più con "Seleziona almeno una fonte": l'articolo viene creato in versione informativa senza monetizzazione inventata, e il candidato universale (assicurazioni/eSIM) non viene più scartato quando è l'unico. Riparati i pulsanti manuali: «Genera bozza» dall'elenco idee (rispondeva "Idea non trovata.") e «Crea bozza» dal workspace con idea attiva; in più, guardia anti-duplicato se la bozza esiste già.
+- Versione plugin aggiornata a `2.106.2`.
+
 ## 2.106.1 - 2026-07-11
 
 ### Regia sbloccata: piani editoriali che non partivano

--- a/affiliate-link-manager-ai.php
+++ b/affiliate-link-manager-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Affiliate Link Manager AI
  * Plugin URI: https://your-website.com
  * Description: Gestisce link affiliati con intelligenza artificiale per ottimizzazione e tracking automatico.
- * Version: 2.106.1
+ * Version: 2.106.2
  * Author: Cosè Murciano
  * License: GPL v2 or later
  * Text Domain: affiliate-link-manager-ai
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definisci costanti del plugin
-define('ALMA_VERSION', '2.106.1');
+define('ALMA_VERSION', '2.106.2');
 define('ALMA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ALMA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ALMA_PLUGIN_FILE', __FILE__);

--- a/includes/class-ai-content-agent-admin.php
+++ b/includes/class-ai-content-agent-admin.php
@@ -60,8 +60,17 @@ class ALMA_AI_Content_Agent_Admin {
         } elseif ($do === 'generate_brief') {
             $result = array('success'=>false,'message'=>'Step brief AI separato disattivato nel workflow corrente.');
         } elseif ($do === 'generate_draft') {
-            $result = ALMA_AI_Content_Agent_Draft_Builder::generate_for_idea(absint($_POST['idea_id'] ?? 0));
-            $result['message'] = empty($result['success']) ? ($result['error'] ?? 'Errore generazione bozza.') : 'Bozza generata: '.esc_url_raw($result['edit_url'] ?? '');
+            $idea_id = absint($_POST['idea_id'] ?? 0);
+            // Le idee contenuto sono post CPT: il flusso storico generate_for_idea
+            // legge la vecchia tabella idee e rispondeva "Idea non trovata."
+            // per TUTTE le idee dell'agente. Il CPT passa dal flusso unificato
+            // del runner (che supporta anche idee senza link affiliati).
+            if ($idea_id > 0 && get_post_type($idea_id) === 'alma_content_idea' && class_exists('ALMA_AI_Content_Agent_Idea_Importer')) {
+                $result = ALMA_AI_Content_Agent_Idea_Importer::generate_draft_now($idea_id);
+            } else {
+                $result = ALMA_AI_Content_Agent_Draft_Builder::generate_for_idea($idea_id);
+            }
+            $result['message'] = empty($result['success']) ? ($result['error'] ?? 'Errore generazione bozza.') : (!empty($result['existing']) ? 'Bozza già esistente per questa idea: nessun duplicato creato.' : 'Bozza generata: '.esc_url_raw($result['edit_url'] ?? ''));
         } elseif ($do === 'save_instruction_profile') {
             $id = absint($_POST['profile_id'] ?? 0);
             $profile_data = wp_unslash($_POST);
@@ -216,7 +225,20 @@ class ALMA_AI_Content_Agent_Admin {
             }
         } elseif ($do === 'create_draft_from_selection') {
             $summary = ALMA_AI_Content_Agent_Selection_Session::summary();
-            if (($summary['status'] ?? 'empty') === 'empty') { $result = array('success'=>false,'message'=>'Nessuna sessione contenuto attiva.'); }
+            $active_idea_id = absint(get_user_meta(get_current_user_id(), '_alma_active_idea_id', true));
+            $session_without_sources = (($summary['status'] ?? 'empty') === 'empty') || (int)($summary['selected_total'] ?? 0) < 1;
+            if ($session_without_sources && $active_idea_id > 0 && get_post_type($active_idea_id) === 'alma_content_idea' && class_exists('ALMA_AI_Content_Agent_Idea_Importer')) {
+                // Sessione senza fonti ma idea attiva (es. tema senza link
+                // affiliati pertinenti): flusso unificato del runner, che
+                // ricostruisce i candidati e supporta anche zero link.
+                if (empty(get_option('alma_openai_api_key', ''))) { $result = array('success'=>false,'message'=>'OpenAI non è configurata.'); }
+                else {
+                    $result = ALMA_AI_Content_Agent_Idea_Importer::generate_draft_now($active_idea_id);
+                    $result['message'] = empty($result['success']) ? ($result['error'] ?? 'Errore creazione bozza dall\'idea attiva.') : (!empty($result['existing']) ? 'Bozza già esistente per questa idea: nessun duplicato creato.' : 'Bozza articolo creata.');
+                    set_transient(self::RESULT_TRANSIENT_KEY . get_current_user_id(), $result, 120);
+                }
+            }
+            elseif (($summary['status'] ?? 'empty') === 'empty') { $result = array('success'=>false,'message'=>'Nessuna sessione contenuto attiva.'); }
             elseif ((int)($summary['selected_total'] ?? 0) < 1) { $result = array('success'=>false,'message'=>'Seleziona almeno una fonte prima di creare la bozza.'); }
             elseif ((int)($summary['selected_post'] ?? 0) > ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_POSTS) { $result = array('success'=>false,'message'=>'Puoi selezionare massimo 3 Post.'); }
             elseif (empty(get_option('alma_openai_api_key', ''))) { $result = array('success'=>false,'message'=>'OpenAI non è configurata.'); }
@@ -509,7 +531,9 @@ class ALMA_AI_Content_Agent_Admin {
             echo '<td>'.esc_html($idea_post->post_modified).'</td>';
             echo '<td><div class="alma-actions-inline" style="display:flex;gap:4px;flex-wrap:wrap;">';
             echo '<a class="button button-small button-primary" href="'.esc_url(add_query_arg('idea_id', (int)$idea_post->ID, $workspace_url)).'">Apri nel workspace</a>';
-            if ($selection_count > 0 && !$draft_post) {
+            if (!$draft_post) {
+                // Visibile anche con 0 fonti selezionate: le idee senza link
+                // affiliati pertinenti producono comunque un articolo.
                 echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="generate_draft"><input type="hidden" name="idea_id" value="'.(int)$idea_post->ID.'"><button class="button button-small">Genera bozza</button></form>';
             }
             echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'" onsubmit="return confirm(\'Eliminare definitivamente questa idea?\');">'.wp_nonce_field('alma_ai_agent_action','_wpnonce',true,false).'<input type="hidden" name="action" value="alma_ai_agent_action"><input type="hidden" name="do" value="delete_content_idea"><input type="hidden" name="idea_id" value="'.(int)$idea_post->ID.'"><button class="button button-small">Elimina</button></form>';

--- a/includes/class-ai-content-agent-draft-builder.php
+++ b/includes/class-ai-content-agent-draft-builder.php
@@ -1359,12 +1359,15 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         return array('success'=>true,'post_id'=>$post_id,'edit_url'=>get_edit_post_link($post_id, 'raw'),'warnings'=>array_values(array_merge((array)$clean['warnings'], (array)($parsed['warnings'] ?? array()))));
     }
 
-    public static function generate_from_selection_session($user_id = 0) {
+    public static function generate_from_selection_session($user_id = 0, $allow_no_sources = false) {
         global $wpdb;
         $user_id = absint($user_id ?: get_current_user_id());
         $session = ALMA_AI_Content_Agent_Selection_Session::build_context_package();
         $selected = array_values(array_filter((array)($session['selected_results'] ?? array()), function($r){ return !empty($r['selected']); }));
-        if (empty($selected)) { return self::fail('Seleziona almeno una fonte prima di creare la bozza.'); }
+        // $allow_no_sources: idee senza link affiliati pertinenti (es.
+        // destinazione non coperta) producono comunque un articolo
+        // informativo, senza monetizzazione inventata.
+        if (empty($selected) && !$allow_no_sources) { return self::fail('Seleziona almeno una fonte prima di creare la bozza.'); }
         $selected_posts = array_values(array_filter($selected, function($r){ return ($r['source_group'] ?? '') === 'post'; }));
         if (count($selected_posts) > ALMA_AI_Content_Agent_Selection_Session::MAX_SELECTED_POSTS) { return self::fail('Puoi selezionare massimo 3 Post.'); }
         if (empty(get_option('alma_openai_api_key', ''))) { return self::fail('OpenAI non è configurata.'); }
@@ -1420,7 +1423,11 @@ class ALMA_AI_Content_Agent_Draft_Builder {
             }
         }
         if (empty($ctx['posts']) && empty($ctx['pages']) && empty($ctx['documents']) && empty($ctx['affiliate_links']) && empty($ctx['sources_online']) && empty($ctx['media'])) {
-            return self::fail('Nessuna fonte valida disponibile nella sessione selezionata.');
+            if (!$allow_no_sources) {
+                return self::fail('Nessuna fonte valida disponibile nella sessione selezionata.');
+            }
+            $ctx['no_affiliate_links_note'] = 'Per questo tema NON sono disponibili link affiliati pertinenti: scrivi un articolo informativo completo basandoti sul prompt editoriale. NON inventare link, shortcode [affiliate_link] o [alma_widget]: verranno rimossi. I link interni ad articoli esistenti restano benvenuti.';
+            $warnings[] = 'Nessun link affiliato pertinente disponibile: articolo creato senza monetizzazione.';
         }
         $profile_id = absint($session['instruction_profile_id'] ?? 0);
         $profile = $profile_id ? ALMA_AI_Content_Agent_Instructions_Manager::get_profile($profile_id) : array();
@@ -1431,6 +1438,11 @@ class ALMA_AI_Content_Agent_Draft_Builder {
         $payload['sources_online'] = $ctx['sources_online'];
         $payload['pages'] = $ctx['pages'];
         $payload['media'] = $ctx['media'];
+        if (!empty($ctx['no_affiliate_links_note'])) {
+            // La nota viaggia in 'warnings': è l'unico canale del payload
+            // normalizzato (whitelist) che arriva al writer come istruzione.
+            $payload['warnings'] = array_merge((array)($payload['warnings'] ?? array()), array($ctx['no_affiliate_links_note']));
+        }
         $ai_payload = self::normalize_payload_for_openai($payload);
         $prompt = self::build_draft_generation_prompt();
         $configured_max_tokens = absint(get_option('alma_openai_max_output_tokens', 1800));

--- a/includes/class-ai-content-agent-idea-importer.php
+++ b/includes/class-ai-content-agent-idea-importer.php
@@ -486,6 +486,13 @@ class ALMA_AI_Content_Agent_Idea_Importer {
     private static function generate_draft_for_scheduled_idea($idea_id) {
         $idea = ALMA_AI_Content_Agent_Ideas::get($idea_id);
         if (empty($idea)) { return array('success' => false, 'error' => 'Idea non trovata'); }
+        // Difesa anti-duplicato: se l'idea ha già la sua bozza/articolo, la
+        // restituisce (successo) invece di crearne un secondo — così anche lo
+        // stato dell'idea si riallinea (executed) se era rimasto indietro.
+        $existing_draft = absint(get_post_meta($idea_id, ALMA_AI_Content_Agent_Ideas::META_DRAFT_POST_ID, true));
+        if ($existing_draft > 0 && get_post($existing_draft)) {
+            return array('success' => true, 'post_id' => $existing_draft, 'edit_url' => get_edit_post_link($existing_draft, 'raw'), 'existing' => true, 'warnings' => array('Bozza già esistente per questa idea: nessun duplicato creato.'));
+        }
         $author_id = absint(get_post_field('post_author', $idea_id)) ?: 1;
         wp_set_current_user($author_id);
 
@@ -527,7 +534,15 @@ class ALMA_AI_Content_Agent_Idea_Importer {
                 if (!is_wp_error($terms) && !empty($terms)) {
                     foreach ($terms as $term) { $term_labels[] = $term->name; }
                 }
+                // result_key/source_group sono OBBLIGATORI: la sessione di
+                // selezione scarta le righe senza chiave, e quando l'universale
+                // era l'unico candidato la bozza falliva con "Seleziona almeno
+                // una fonte" (es. destinazioni senza link coerenti).
                 $candidates[] = array(
+                    'result_key' => 'affiliate_link:' . (int) $universal_id,
+                    'source_group' => 'affiliate_link',
+                    'source_type' => 'affiliate_link',
+                    'wp_id' => (int) $universal_id,
                     'source_id' => (int) $universal_id,
                     'title' => html_entity_decode(get_the_title($universal_id), ENT_QUOTES, 'UTF-8'),
                     'link_types' => implode(', ', $term_labels),
@@ -538,10 +553,10 @@ class ALMA_AI_Content_Agent_Idea_Importer {
                 );
             }
         }
-        if (empty($candidates)) {
-            self::mark_idea_failure($idea_id, 'Nessun link affiliato candidato');
-            return array('success' => false, 'error' => 'Nessun link affiliato candidato per l\'idea #' . $idea_id);
-        }
+        // Nessun link affiliato pertinente (es. destinazione non ancora
+        // coperta): l'articolo si crea COMUNQUE, informativo e senza
+        // monetizzazione inventata — prima il piano falliva qui.
+        $no_affiliate_sources = empty($candidates);
         foreach ($candidates as &$candidate) { $candidate['selected'] = true; }
         unset($candidate);
 
@@ -561,7 +576,7 @@ class ALMA_AI_Content_Agent_Idea_Importer {
         }
         ALMA_AI_Content_Agent_Selection_Session::load_from_idea(ALMA_AI_Content_Agent_Ideas::get($idea_id));
 
-        $result = ALMA_AI_Content_Agent_Draft_Builder::generate_from_selection_session($author_id);
+        $result = ALMA_AI_Content_Agent_Draft_Builder::generate_from_selection_session($author_id, $no_affiliate_sources);
         if (!empty($result['success']) && !empty($result['post_id'])) {
             // Solo a SUCCESSO l'idea è eseguita: i fallimenti (timeout OpenAI,
             // interruzioni a cavallo di mezzanotte…) restano ritentabili dal

--- a/includes/class-ai-content-agent-selection-session.php
+++ b/includes/class-ai-content-agent-selection-session.php
@@ -38,6 +38,14 @@ class ALMA_AI_Content_Agent_Selection_Session {
         foreach ($rows as $row) {
             if (!is_array($row)) { continue; }
             $key = self::extract_result_key($row);
+            if ($key === '') {
+                // Riga senza chiave ma identificabile (es. candidato universale
+                // costruito a mano): chiave derivata invece di scartarla — lo
+                // scarto silenzioso svuotava la selezione delle idee.
+                $fallback_id = absint($row['source_id'] ?? ($row['wp_id'] ?? 0));
+                $fallback_group = sanitize_key((string) ($row['source_group'] ?? ($row['source_type'] ?? '')));
+                if ($fallback_id > 0 && $fallback_group !== '') { $key = $fallback_group . ':' . $fallback_id; }
+            }
             if ($key === '') { continue; }
             $row['result_key'] = $key;
             $row['source_group'] = self::normalize_group($row['source_group'] ?? '');


### PR DESCRIPTION
… riparati (v2.106.2)

- Il candidato universale costruito dal runner non aveva result_key/ source_group e la sessione di selezione lo scartava in silenzio: quando era l'unico candidato la bozza falliva con "Seleziona almeno una fonte". Ora ha le chiavi corrette e la sessione deriva una chiave di fallback per le righe identificabili invece di scartarle.
- Zero link affiliati pertinenti non è più un errore: l'articolo si crea informativo, con nota esplicita al writer (niente link/shortcode inventati) e garanzia del link universale quando disponibile.
- "Genera bozza" dall'elenco idee instradava le idee CPT al flusso storico su vecchia tabella ("Idea non trovata."): ora passa dal flusso unificato del runner, con fallback legacy; pulsante visibile anche con 0 fonti.
- "Crea bozza" dal workspace con sessione vuota ma idea attiva genera la bozza dall'idea invece di "Nessuna sessione contenuto attiva".
- Guardia anti-duplicato: bozza esistente restituita, mai duplicata.

Test standalone 21/21 + 28/28 regia, php -l ok.


Claude-Session: https://claude.ai/code/session_01CLTHqsi2JBe3N9XiEpN1uM